### PR TITLE
Cleanup some legacy NBT reading

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -514,12 +514,6 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
         this.conveyorMode = ConveyorMode.values()[tagCompound.getInteger("ConveyorMode")];
         this.distributionMode = DistributionMode.values()[tagCompound.getInteger("DistributionMode")];
         this.blocksInput = tagCompound.getBoolean("BlocksInput");
-        //LEGACY SAVE FORMAT SUPPORT
-        if (tagCompound.hasKey("AllowManualIO")) {
-            this.manualImportExportMode = tagCompound.getBoolean("AllowManualIO")
-                    ? ManualImportExportMode.FILTERED
-                    : ManualImportExportMode.DISABLED;
-        }
         if (tagCompound.hasKey("FilterInventory")) {
             this.itemFilterContainer.deserializeNBT(tagCompound);
         } else {

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -115,13 +115,8 @@ public class CoverFluidFilter extends CoverBehavior implements CoverWithUI {
         super.readFromNBT(tagCompound);
         this.filterMode = FluidFilterMode.values()[tagCompound.getInteger("FilterMode")];
         this.fluidFilter.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
-        //LEGACY SAVE FORMAT SUPPORT
-        if (tagCompound.hasKey("FluidFilter")) {
-            this.fluidFilter.getFluidFilter().readFromNBT(tagCompound);
-        } else {
-            NBTTagCompound filterComponent = tagCompound.getCompoundTag("Filter");
-            this.fluidFilter.getFluidFilter().readFromNBT(filterComponent);
-        }
+        NBTTagCompound filterComponent = tagCompound.getCompoundTag("Filter");
+        this.fluidFilter.getFluidFilter().readFromNBT(filterComponent);
     }
 
     private class FluidHandlerFiltered extends FluidHandlerDelegate {

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -110,17 +110,8 @@ public class CoverItemFilter extends CoverBehavior implements CoverWithUI {
         super.readFromNBT(tagCompound);
         this.filterMode = ItemFilterMode.values()[tagCompound.getInteger("FilterMode")];
         this.itemFilter.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
-        //LEGACY SAVE FORMAT SUPPORT
-        if (tagCompound.hasKey("FilterInventory") || tagCompound.hasKey("OreDictionaryFilter")) {
-            if (tagCompound.hasKey("FilterInventory")) {
-                tagCompound.setTag("ItemFilter", tagCompound.getCompoundTag("FilterInventory"));
-                tagCompound.removeTag("FilterInventory");
-            }
-            this.itemFilter.getItemFilter().readFromNBT(tagCompound);
-        } else {
-            NBTTagCompound filterComponent = tagCompound.getCompoundTag("Filter");
-            this.itemFilter.getItemFilter().readFromNBT(filterComponent);
-        }
+        NBTTagCompound filterComponent = tagCompound.getCompoundTag("Filter");
+        this.itemFilter.getItemFilter().readFromNBT(filterComponent);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -314,17 +314,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
         this.pumpMode = PumpMode.values()[tagCompound.getInteger("PumpMode")];
         this.distributionMode = DistributionMode.values()[tagCompound.getInteger("DistributionMode")];
         this.blocksInput = tagCompound.getBoolean("BlocksInput");
-        //LEGACY SAVE FORMAT SUPPORT
-        if (tagCompound.hasKey("AllowManualIO")) {
-            this.manualImportExportMode = tagCompound.getBoolean("AllowManualIO")
-                    ? ManualImportExportMode.FILTERED
-                    : ManualImportExportMode.DISABLED;
-        }
-        if (tagCompound.hasKey("FluidFilter")) {
-            this.fluidFilter.deserializeNBT(tagCompound);
-        } else {
-            this.fluidFilter.deserializeNBT(tagCompound.getCompoundTag("Filter"));
-        }
+        this.fluidFilter.deserializeNBT(tagCompound.getCompoundTag("Filter"));
         if (tagCompound.hasKey("WorkingAllowed")) {
             this.isWorkingAllowed = tagCompound.getBoolean("WorkingAllowed");
         }

--- a/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
@@ -90,21 +90,11 @@ public class FluidFilterContainer implements INBTSerializable<NBTTagCompound> {
 
     @Override
     public void deserializeNBT(NBTTagCompound tagCompound) {
-        //LEGACY SAVE FORMAT SUPPORT
-        if (tagCompound.hasKey("FilterTypeInventory")) {
-            this.filterInventory.deserializeNBT(tagCompound.getCompoundTag("FilterTypeInventory"));
-        } else {
-            this.filterInventory.deserializeNBT(tagCompound.getCompoundTag("FilterInventory"));
-        }
+        this.filterInventory.deserializeNBT(tagCompound.getCompoundTag("FilterInventory"));
         this.filterWrapper.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
         if (filterWrapper.getFluidFilter() != null) {
-            //LEGACY SAVE FORMAT SUPPORT
-            if (tagCompound.hasKey("FluidFilter")) {
-                this.filterWrapper.getFluidFilter().readFromNBT(tagCompound);
-            } else {
-                NBTTagCompound filterInventory = tagCompound.getCompoundTag("Filter");
-                this.filterWrapper.getFluidFilter().readFromNBT(filterInventory);
-            }
+            NBTTagCompound filterInventory = tagCompound.getCompoundTag("Filter");
+            this.filterWrapper.getFluidFilter().readFromNBT(filterInventory);
         }
     }
 }

--- a/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
@@ -175,14 +175,8 @@ public class ItemFilterContainer implements INBTSerializable<NBTTagCompound> {
             setTransferStackSize(tagCompound.getInteger("TransferStackSize"));
         }
         if (filterWrapper.getItemFilter() != null) {
-            //LEGACY SAVE FORMAT SUPPORT
-            if (tagCompound.hasKey("ItemFilter") ||
-                    tagCompound.hasKey("OreDictionaryFilter")) {
-                this.filterWrapper.getItemFilter().readFromNBT(tagCompound);
-            } else {
-                NBTTagCompound filterInventory = tagCompound.getCompoundTag("Filter");
-                this.filterWrapper.getItemFilter().readFromNBT(filterInventory);
-            }
+            NBTTagCompound filterInventory = tagCompound.getCompoundTag("Filter");
+            this.filterWrapper.getItemFilter().readFromNBT(filterInventory);
         }
     }
 

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -59,12 +59,12 @@ public class OreDictionaryItemFilter extends ItemFilter {
 
     @Override
     public void writeToNBT(NBTTagCompound tagCompound) {
-        tagCompound.setString("OreDictionaryFilter", oreDictionaryFilter);
+        tagCompound.setString("Filter", oreDictionaryFilter);
     }
 
     @Override
     public void readFromNBT(NBTTagCompound tagCompound) {
-        this.oreDictionaryFilter = tagCompound.getString("OreDictionaryFilter");
+        this.oreDictionaryFilter = tagCompound.getString("Filter");
     }
 
     public static String matchesOreDictionaryFilter(String oreDictionaryFilter, ItemStack itemStack) {

--- a/src/main/java/gregtech/common/covers/filter/SimpleFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SimpleFluidFilter.java
@@ -62,11 +62,11 @@ public class SimpleFluidFilter extends FluidFilter {
                 filterSlots.appendTag(stackTag);
             }
         }
-        tagCompound.setTag("FluidFilter", filterSlots);
+        tagCompound.setTag("Filter", filterSlots);
     }
 
     public void readFromNBT(NBTTagCompound tagCompound) {
-        NBTTagList filterSlots = tagCompound.getTagList("FluidFilter", 10);
+        NBTTagList filterSlots = tagCompound.getTagList("Filter", 10);
         for (NBTBase nbtBase : filterSlots) {
             NBTTagCompound stackTag = (NBTTagCompound) nbtBase;
             FluidStack fluidStack = FluidStack.loadFluidStackFromNBT(stackTag);

--- a/src/main/java/gregtech/common/covers/filter/SimpleItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SimpleItemFilter.java
@@ -99,14 +99,14 @@ public class SimpleItemFilter extends ItemFilter {
 
     @Override
     public void writeToNBT(NBTTagCompound tagCompound) {
-        tagCompound.setTag("ItemFilter", itemFilterSlots.serializeNBT());
+        tagCompound.setTag("Filter", itemFilterSlots.serializeNBT());
         tagCompound.setBoolean("IgnoreDamage", ignoreDamage);
         tagCompound.setBoolean("IgnoreNBT", ignoreNBT);
     }
 
     @Override
     public void readFromNBT(NBTTagCompound tagCompound) {
-        this.itemFilterSlots.deserializeNBT(tagCompound.getCompoundTag("ItemFilter"));
+        this.itemFilterSlots.deserializeNBT(tagCompound.getCompoundTag("Filter"));
         this.ignoreDamage = tagCompound.getBoolean("IgnoreDamage");
         this.ignoreNBT = tagCompound.getBoolean("IgnoreNBT");
     }


### PR DESCRIPTION
**What:**
Cleans up some legacy NBT reading in the filters and covers.

One thing I am unsure about is the changes to `SimpleItemFilter`, `SimpleFluidFilter`, and `OreDictionaryItemFilter`. When the NBT they were saving was being read in the Filter classes, it was being converted into `Filter` instead of `ItemFilter`, etc. So I just made the three filters serialize `Filter` in the first place, instead of serializing their types, which I am unsure about.


**Outcome:**
Removal of some legacy filter/cover NBT reading