### PR TITLE
First pass at allowing addons to register/remove ore veins

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 
 @ZenClass("mods.gregtech.ore.BedrockFluidDepositDefinition")
 @ZenRegister
-public class BedrockFluidDepositDefinition { //todo re-balance depletion rates of default veins
+public class BedrockFluidDepositDefinition implements IWorldgenDefinition { //todo re-balance depletion rates of default veins
 
     private final String depositName;
 
@@ -88,6 +88,7 @@ public class BedrockFluidDepositDefinition { //todo re-balance depletion rates o
     }
 
     //This is the file name
+    @Override
     @ZenGetter("depositName")
     public String getDepositName() {
         return depositName;
@@ -184,9 +185,13 @@ public class BedrockFluidDepositDefinition { //todo re-balance depletion rates o
             return false;
         if (!this.storedFluid.equals(objDeposit.getStoredFluid()))
             return false;
-        if (!this.assignedName.equals(objDeposit.getAssignedName()))
+        if ((this.assignedName == null && objDeposit.getAssignedName() != null) ||
+                (this.assignedName != null && objDeposit.getAssignedName() == null) ||
+                (this.assignedName != null && objDeposit.getAssignedName() != null && !this.assignedName.equals(objDeposit.getAssignedName())))
             return false;
-        if (!this.description.equals(objDeposit.getDescription()))
+        if ((this.description == null && objDeposit.getDescription() != null) ||
+                (this.description != null && objDeposit.getDescription() == null) ||
+                (this.description != null && objDeposit.getDescription() != null && !this.description.equals(objDeposit.getDescription())))
             return false;
         if (this.depletedProductionRate != objDeposit.getDepletedProductionRate())
             return false;

--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -197,9 +197,13 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition { //to
             return false;
         if (this.depletedProductionRate != objDeposit.getDepletedProductionRate())
             return false;
-        if (!this.biomeWeightModifier.equals(objDeposit.getBiomeWeightModifier()))
+        if ((this.biomeWeightModifier == null && objDeposit.getBiomeWeightModifier() != null) ||
+                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() == null) ||
+                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() != null && !this.biomeWeightModifier.equals(objDeposit.getBiomeWeightModifier())))
             return false;
-        if (!this.dimensionFilter.equals(objDeposit.getDimensionFilter()))
+        if ((this.dimensionFilter == null && objDeposit.getDimensionFilter() != null) ||
+                (this.dimensionFilter != null && objDeposit.getDimensionFilter() == null) ||
+                (this.dimensionFilter != null && objDeposit.getDimensionFilter() != null && !this.dimensionFilter.equals(objDeposit.getDimensionFilter())))
             return false;
 
         return super.equals(obj);

--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -18,6 +18,7 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+import javax.annotation.Nonnull;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -44,7 +45,8 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition { //to
         this.depositName = depositName;
     }
 
-    public boolean initializeFromConfig(JsonObject configRoot) {
+    @Override
+    public boolean initializeFromConfig(@Nonnull JsonObject configRoot) {
         // the weight value for determining which vein will appear
         this.weight = configRoot.get("weight").getAsInt();
         // the [minimum, maximum) production rate of the vein

--- a/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
@@ -1,0 +1,10 @@
+package gregtech.api.worldgen.config;
+
+import stanhebben.zenscript.annotations.ZenGetter;
+
+public interface IWorldgenDefinition {
+
+    //This is the file name
+    @ZenGetter("depositName")
+    String getDepositName();
+}

--- a/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
@@ -1,10 +1,13 @@
 package gregtech.api.worldgen.config;
 
-import stanhebben.zenscript.annotations.ZenGetter;
+import com.google.gson.JsonObject;
+
+import javax.annotation.Nonnull;
 
 public interface IWorldgenDefinition {
 
     //This is the file name
-    @ZenGetter("depositName")
     String getDepositName();
+
+    boolean initializeFromConfig(@Nonnull JsonObject configRoot);
 }

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -22,6 +22,7 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+import javax.annotation.Nonnull;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -55,7 +56,8 @@ public class OreDepositDefinition implements IWorldgenDefinition {
         this.depositName = depositName;
     }
 
-    public void initializeFromConfig(JsonObject configRoot) {
+    @Override
+    public boolean initializeFromConfig(@Nonnull JsonObject configRoot) {
         this.weight = configRoot.get("weight").getAsInt();
         this.density = configRoot.get("density").getAsFloat();
         if (configRoot.has("name")) {
@@ -95,6 +97,7 @@ public class OreDepositDefinition implements IWorldgenDefinition {
         if (veinPopulator != null) {
             veinPopulator.initializeForVein(this);
         }
+        return true;
     }
 
     //This is the file name

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -204,4 +204,50 @@ public class OreDepositDefinition implements IWorldgenDefinition {
     public ShapeGenerator getShapeGenerator() {
         return shapeGenerator;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof OreDepositDefinition))
+            return false;
+
+        OreDepositDefinition objDeposit = (OreDepositDefinition) obj;
+        if (this.weight != objDeposit.getWeight())
+            return false;
+        if (this.density != objDeposit.getDensity())
+            return false;
+        if (this.priority != objDeposit.getPriority())
+            return false;
+        if (this.countAsVein != objDeposit.isVein())
+            return false;
+        if (this.getMinimumHeight() != objDeposit.getMinimumHeight())
+            return false;
+        if (this.getMaximumHeight() != objDeposit.getMaximumHeight())
+            return false;
+        if ((this.assignedName == null && objDeposit.getAssignedName() != null) ||
+                (this.assignedName != null && objDeposit.getAssignedName() == null) ||
+                (this.assignedName != null && objDeposit.getAssignedName() != null && !this.assignedName.equals(objDeposit.getAssignedName())))
+            return false;
+        if ((this.description == null && objDeposit.getDescription() != null) ||
+                (this.description != null && objDeposit.getDescription() == null) ||
+                (this.description != null && objDeposit.getDescription() != null && !this.description.equals(objDeposit.getDescription())))
+            return false;
+        if ((this.biomeWeightModifier == null && objDeposit.getBiomeWeightModifier() != null) ||
+                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() == null) ||
+                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() != null && !this.biomeWeightModifier.equals(objDeposit.getBiomeWeightModifier())))
+            return false;
+        if ((this.dimensionFilter == null && objDeposit.getDimensionFilter() != null) ||
+                (this.dimensionFilter != null && objDeposit.getDimensionFilter() == null) ||
+                (this.dimensionFilter != null && objDeposit.getDimensionFilter() != null && !this.dimensionFilter.equals(objDeposit.getDimensionFilter())))
+            return false;
+        if ((this.generationPredicate == null && objDeposit.getGenerationPredicate() != null) ||
+                (this.generationPredicate != null && objDeposit.getGenerationPredicate() == null) ||
+                (this.generationPredicate != null && objDeposit.getGenerationPredicate() != null && !this.generationPredicate.equals(objDeposit.getGenerationPredicate())))
+            return false;
+        if ((this.veinPopulator == null && objDeposit.getVeinPopulator() != null) ||
+                (this.veinPopulator != null && objDeposit.getVeinPopulator() == null) ||
+                (this.veinPopulator != null && objDeposit.getVeinPopulator() != null && !this.veinPopulator.equals(objDeposit.getVeinPopulator())))
+            return false;
+
+        return super.equals(obj);
+    }
 }

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 
 @ZenClass("mods.gregtech.ore.OreDepositDefinition")
 @ZenRegister
-public class OreDepositDefinition {
+public class OreDepositDefinition implements IWorldgenDefinition {
 
     public static final Function<Biome, Integer> NO_BIOME_INFLUENCE = biome -> 0;
     public static final Predicate<WorldProvider> PREDICATE_SURFACE_WORLD = WorldProvider::isSurfaceWorld;
@@ -98,6 +98,7 @@ public class OreDepositDefinition {
     }
 
     //This is the file name
+    @Override
     @ZenGetter("depositName")
     public String getDepositName() {
         return depositName;

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -123,6 +123,7 @@ public class WorldGenRegistry {
     public void reinitializeRegisteredVeins() throws IOException {
         GTLog.logger.info("Reloading ore generation files from config...");
         registeredVeinDefinitions.clear();
+        registeredBedrockVeinDefinitions.clear();
         oreVeinCache.clear();
         Path configPath = Loader.instance().getConfigDir().toPath().resolve(GTValues.MODID);
         // The Path for the file used to name dimensions for the JEI ore gen page

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -235,8 +235,8 @@ public class WorldGenRegistry {
             }
         }
 
-        addAddonFiles(veinPath, addonRegisteredDefinitions, registeredVeinDefinitions);
-        addAddonFiles(bedrockVeinPath, addonRegisteredBedrockVeinDefinitions, registeredBedrockVeinDefinitions);
+        addAddonFiles(worldgenRootPath, addonRegisteredDefinitions, registeredVeinDefinitions);
+        addAddonFiles(worldgenRootPath, addonRegisteredBedrockVeinDefinitions, registeredBedrockVeinDefinitions);
 
         GTLog.logger.info("Loaded {} bedrock worldgen definitions", registeredBedrockVeinDefinitions.size());
         GTLog.logger.info("Loaded {} worldgen definitions from addon mods", addonRegisteredDefinitions.size());

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -424,7 +424,7 @@ public class WorldGenRegistry {
      */
     @SuppressWarnings("unused")
     public void addVeinDefinitions(OreDepositDefinition definition) {
-        if(registeredVeinDefinitions.contains(definition)) {
+        if(!registeredVeinDefinitions.contains(definition)) {
             addonRegisteredDefinitions.add(definition);
         }
         else {

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -231,7 +231,7 @@ public class WorldGenRegistry {
             if(element == null) {
                 GTLog.logger.error("Addon mod tried to register bad ore definition at {}", definition.getDepositName());
                 addonRegisteredDefinitions.remove(definition);
-                break; //break or continue?
+                continue;
             }
 
             definition.initializeFromConfig(element);

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -164,6 +164,12 @@ public class WorldGenRegistry {
         // Read the dimensions name from the dimensions file
         gatherNamedDimensions(dimensionsFile);
 
+        // Will always fail when called from initializeRegistry
+        // Placed here to delete the file before being gathered and having its definition initialized
+        if(!removedDefinitions.isEmpty()) {
+            removeExistingFiles(worldgenRootPath);
+        }
+
         // Gather the worldgen vein files from the various folders in the config
         List<Path> veinFiles = Files.walk(veinPath)
                 .filter(path -> path.toString().endsWith(".json"))
@@ -246,10 +252,6 @@ public class WorldGenRegistry {
         GTLog.logger.info("Loaded {} total worldgen definitions", registeredVeinDefinitions.size() + registeredBedrockVeinDefinitions.size());
         GTLog.logger.info("Loaded {} worldgen definitions from addon mods", addonRegisteredDefinitions.size());
 
-        //After initializing default GTCE worldgen or added veins, load attempts to remove worldgen from addon mods
-        if(!removedDefinitions.isEmpty()) {
-            removeExistingFiles(worldgenRootPath);
-        }
     }
 
     /**

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -410,6 +410,9 @@ public class WorldGenRegistry {
             registeredVeinDefinitions.remove(definition);
             removedDefinitions.add(definition);
         }
+        else {
+            GTLog.logger.error("Failed to remove OreDepositDefinition at {}. Deposit was not in list of registered veins.", definition.getDepositName());
+        }
     }
 
     /**


### PR DESCRIPTION
**What:**
This PR attempts to add method for addon mods to register/remove ore vein definitions and easily add/remove files to the gregtech worldgen folder.

For this, a few new helper variables were introduced:
- `definitionMap` is a `Map<String, OreDepositDefinition>` with the keys being the relative path from the `worldgen` folder in the gregtech config folder to a registered definition, with no leading separator. This is essentially `OreDepositDefinition.getDepositName()`. The values in this map are the registered ore definitions
- `removedDefinitions` is a list of all definitions that have been marked for removal by addon mods.
- `addonRegisteredVeins` is a list of all definitions registered from addon mods via `addVeinDefinitions()`

### Removing existing veins
To remove existing veins, addon mods simply need to call `removeVeinDefinitions(OreDepositDefinition definition)` after Gregtech has initialized its own ore veins and the ore definition at the existing path will be removed if there is a matching definition in `registeredDefinitions`.

The addon mod then needs to call `WorldGenRegistry#reinitializeRegisteredVeins()` to delete the file from the existing world gen folder.

An example of this would be adding the following lines in `GregTechMod.java` after the WorldGenRegistry has been initialized at line 160.

```java
   WorldGenRegistry.INSTANCE.removeVeinDefinitions(definition);
   try {
       WorldGenRegistry.INSTANCE.reinitializeRegisteredVeins();
   }
   catch (IOException e) {
       //log possible error here
   }
```
It should be noted that this should and will fail if a modpack maker removes the existing definition, or changes the filename away from what the addon mod expects the name to be.

I am considering making `registeredDefinitions` public, so that addon mods can easily get to the list of all registered definitions so that they can easily pass the definition to the remove method. I would like some feedback on this.



### Adding new veins
To add new veins, addon mods will have to pass the `OreDepositDefinition` to `WorldGenRegistry#addVeinDefintions(OreDepositDefinition definition)` either before GTCEu does its vein initialization (This needs testing, it is just my hypothesis right now), which should not require a call to `WorldGenRegistry#reinitializeRegisteredVeins()`, or after GTCEu has initialized its veins and then call `WorldGenRegistry#reinitializeRegisteredVeins()`.

The approach that I took for this method does enforce that `OreDepositDefinition.depositName` needs to be the relative path from the `worldgen` folder to the definition file with no leading separator.

As a note, addon mods will not be able to add veins to the same file location as existing ore definitions.

This does bring up a point that I want to try and enforce as a bit of organization however. Addon mods registering veins should add all the veins that they register to a new folder in the `worldgen` folder in the gregtech config file named after their mod id, and then with subfolders for the different dimensions. This will make it much easier for modpack makers to see which veins are being added by the various addon mods.

**Outcome:**
Allow addon mods to easily register their own ore veins and provide a method for addon mods to remove existing ore vein definitions.