### PR TITLE
Change the signature of addBlockTooltips

### DIFF
--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
@@ -106,6 +106,6 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
         recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout, this.guiHelper);
 
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
-        itemStackGroup.addTooltipCallback((a,b,itemStack,list)->recipeWrapper.addBlockTooltips(itemStack,list));
+        itemStackGroup.addTooltipCallback(recipeWrapper::addBlockTooltips);
     }
 }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -355,13 +355,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
                     tooltip.set(k, TextFormatting.GRAY + tooltip.get(k));
                 }
             }
-            addBlockTooltips(tooltipBlockStack, tooltip);
+            addBlockTooltips(0, false, tooltipBlockStack, tooltip);
             return tooltip;
         }
         return Collections.emptyList();
     }
 
-    public void addBlockTooltips(ItemStack itemStack, List<String> tooltip) {
+    public void addBlockTooltips(int slotIndex, boolean input, ItemStack itemStack, List<String> tooltip) {
         Map<ItemStack, List<ITextComponent>> blockTooltipMap = infoPage.getBlockTooltipMap();
         if (blockTooltipMap.containsKey(itemStack)) {
             List<ITextComponent> tooltips = blockTooltipMap.get(itemStack);


### PR DESCRIPTION
**What:**
Changes the signature of MultiblockInfoRecipeWrapper#addBlockTooltips to what JEI expects to be passed to addTooltipCallback

**Outcome:**
Removes a questionable looking lambda, adds a couple dummy parameters to a method call, and allows addons to not use the questionable lambda, as they could before the change