### PR TITLE
Multiblock Logic for Multiple Recipemaps

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechTileCapabilities.java
+++ b/src/main/java/gregtech/api/capability/GregtechTileCapabilities.java
@@ -2,6 +2,7 @@ package gregtech.api.capability;
 
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.cover.ICoverable;
+import gregtech.api.metatileentity.multiblock.IMultipleRecipeMaps;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 
@@ -21,5 +22,8 @@ public class GregtechTileCapabilities {
 
     @CapabilityInject(AbstractRecipeLogic.class)
     public static Capability<AbstractRecipeLogic> CAPABILITY_RECIPE_LOGIC = null;
+
+    @CapabilityInject(IMultipleRecipeMaps.class)
+    public static Capability<IMultipleRecipeMaps> MULTIPLE_RECIPEMAPS = null;
 
 }

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -228,6 +228,14 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         }
     }
 
+    /**
+     * used to force the workable to search for new recipes
+     * use sparingly
+     */
+    public void forceRecipeRecheck() {
+        trySearchNewRecipe();
+    }
+
     protected void trySearchNewRecipe() {
         long maxVoltage = getMaxVoltage();
         Recipe currentRecipe;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -3,11 +3,13 @@ package gregtech.api.capability.impl;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMaintenanceHatch;
 import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.metatileentity.multiblock.IMultipleRecipeMaps;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.RecipeMap;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
@@ -298,5 +300,13 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     @Override
     protected long getMaxVoltage() {
         return Math.max(getEnergyContainer().getInputVoltage(), getEnergyContainer().getOutputVoltage());
+    }
+
+    @Override
+    public RecipeMap<?> getRecipeMap() {
+        // if the multiblock has more than one RecipeMap, return the currently selected one
+        if (metaTileEntity instanceof IMultipleRecipeMaps && ((IMultipleRecipeMaps) metaTileEntity).hasMultipleRecipeMaps())
+                return ((IMultipleRecipeMaps) metaTileEntity).getCurrentRecipeMap();
+        return super.getRecipeMap();
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/IMultipleRecipeMaps.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IMultipleRecipeMaps.java
@@ -1,0 +1,48 @@
+package gregtech.api.metatileentity.multiblock;
+
+import gregtech.api.recipes.RecipeMap;
+
+public interface IMultipleRecipeMaps {
+
+    /**
+     *
+     * @return whether the Multiblock has more than one {@link RecipeMap}
+     */
+    default boolean hasMultipleRecipeMaps() {
+        return false;
+    }
+
+    /**
+     * Used to get all possible RecipeMaps a Multiblock can run
+     * @return array of RecipeMaps
+     */
+    @SuppressWarnings("unused")
+    RecipeMap<?>[] getAvailableRecipeMaps();
+
+    /**
+     * Used to get the current index of the selected RecipeMap
+     * @return index of the current recipe
+     */
+    @SuppressWarnings("unused")
+    int getRecipeMapIndex();
+
+
+    /**
+     * Used to add new RecipeMaps to a given Multiblock,
+     * @param recipeMaps to add to the Multiblock
+     */
+    @SuppressWarnings("unused")
+    void addRecipeMaps(RecipeMap<?>[] recipeMaps);
+
+    /**
+     * sets the current RecipeMap index to a new one
+     * @param index the index to set
+     */
+    void setRecipeMapIndex(int index);
+
+    /**
+     *
+     * @return the currently selected RecipeMap
+     */
+    RecipeMap<?> getCurrentRecipeMap();
+}

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -292,7 +292,7 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     private void addMaintenanceText(List<ITextComponent> textList) {
         if (!hasMaintenanceProblems()) {
             textList.add(new TextComponentTranslation("gregtech.multiblock.universal.no_problems")
-                    .setStyle(new Style().setColor(TextFormatting.AQUA))
+                    .setStyle(new Style().setColor(TextFormatting.GREEN))
             );
         } else {
 

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -1,10 +1,13 @@
 package gregtech.api.metatileentity.multiblock;
 
+import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import com.google.common.collect.Lists;
 import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechDataCodes;
+import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.EnergyContainerList;
@@ -21,24 +24,34 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockFireboxCasing;
 import gregtech.common.blocks.VariantActiveBlock;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.event.HoverEvent;
+import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Stream;
 
-public abstract class RecipeMapMultiblockController extends MultiblockWithDisplayBase {
+public abstract class RecipeMapMultiblockController extends MultiblockWithDisplayBase implements IMultipleRecipeMaps {
 
     public final RecipeMap<?> recipeMap;
     protected MultiblockRecipeLogic recipeMapWorkable;
@@ -53,10 +66,18 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
 
     private boolean isDistinct = false;
 
+    // array of possible recipes, specific to each multi - used when the multi has multiple RecipeMaps
+    protected RecipeMap<?>[] recipeMaps;
+
+    // index of the current selected recipe - used when the multi has multiple RecipeMaps
+    private int recipeMapIndex;
+
     public RecipeMapMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap) {
         super(metaTileEntityId);
         this.recipeMap = recipeMap;
         this.recipeMapWorkable = new MultiblockRecipeLogic(this);
+        this.recipeMapIndex = 0;
+        this.recipeMaps = null;
         resetTileAbilities();
     }
 
@@ -184,6 +205,14 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 textList.add(buttonText);
             }
 
+            if (hasMultipleRecipeMaps()) {
+                textList.add(new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps",
+                        new TextComponentTranslation("recipemap." + this.recipeMaps[this.recipeMapIndex].getUnlocalizedName() + ".name")
+                        .setStyle(new Style().setColor(TextFormatting.AQUA)))
+                        .setStyle(new Style().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                                new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.tooltip")))));
+            }
+
             if (!recipeMapWorkable.isWorkingEnabled()) {
                 textList.add(new TextComponentTranslation("gregtech.multiblock.work_paused"));
 
@@ -202,6 +231,13 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 textList.add(new TextComponentTranslation("gregtech.multiblock.not_enough_energy").setStyle(new Style().setColor(TextFormatting.RED)));
             }
         }
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
+        super.addInformation(stack, player, tooltip, advanced);
+        if (this.hasMultipleRecipeMaps())
+            tooltip.add(I18n.format("gregtech.multiblock.multiple_recipemaps_recipes.tooltip", this.recipeMapsToString()));
     }
 
     @Override
@@ -235,6 +271,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
         data.setBoolean("isDistinct", isDistinct);
+        data.setTag("RecipeMapIndex", new NBTTagInt(recipeMapIndex));
         return data;
     }
 
@@ -242,18 +279,39 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
         isDistinct = data.getBoolean("isDistinct");
+        recipeMapIndex = data.getInteger("RecipeMapIndex");
     }
 
     @Override
     public void writeInitialSyncData(PacketBuffer buf) {
         super.writeInitialSyncData(buf);
         buf.writeBoolean(isDistinct);
+        buf.writeByte(recipeMapIndex);
     }
 
     @Override
     public void receiveInitialSyncData(PacketBuffer buf) {
         super.receiveInitialSyncData(buf);
         isDistinct = buf.readBoolean();
+        recipeMapIndex = buf.readByte();
+    }
+
+    @Override
+    public void receiveCustomData(int dataId, PacketBuffer buf) {
+        super.receiveCustomData(dataId, buf);
+        if (dataId == GregtechDataCodes.RECIPE_MAP_INDEX) {
+            recipeMapIndex = buf.readInt();
+            scheduleRenderUpdate();
+        }
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing side) {
+        T capabilityResult = super.getCapability(capability, side);
+        if (capabilityResult == null && capability == GregtechTileCapabilities.MULTIPLE_RECIPEMAPS) {
+            return (T) this;
+        }
+        return capabilityResult;
     }
 
     public boolean canBeDistinct() {
@@ -273,5 +331,62 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
         } else {
             this.notifiedItemInputList.add(this.inputInventory);
         }
+    }
+
+    @Override
+    public RecipeMap<?>[] getAvailableRecipeMaps() {
+        return hasMultipleRecipeMaps() ? this.recipeMaps : null;
+    }
+
+    @Override
+    public int getRecipeMapIndex() {
+        return recipeMapIndex;
+    }
+
+    @Override
+    public void addRecipeMaps(RecipeMap<?>... recipeMaps) {
+        if (hasMultipleRecipeMaps())
+            this.recipeMaps = Stream.concat(Arrays.stream(this.recipeMaps), Arrays.stream(recipeMaps)).toArray(RecipeMap<?>[]::new);
+    }
+
+    @Override
+    public void setRecipeMapIndex(int index) {
+        this.recipeMapIndex = index;
+        if (!getWorld().isRemote) {
+            writeCustomData(GregtechDataCodes.RECIPE_MAP_INDEX, buf -> buf.writeInt(index));
+            markDirty();
+        }
+    }
+
+    @Override
+    public RecipeMap<?> getCurrentRecipeMap() {
+        return recipeMaps[recipeMapIndex];
+    }
+
+    @SideOnly(Side.CLIENT)
+    public String recipeMapsToString() {
+        StringBuilder recipeMapsString = new StringBuilder();
+        for(int i = 0; i < recipeMaps.length; i++) {
+            recipeMapsString.append(recipeMaps[i].getLocalizedName());
+            if(recipeMaps.length - 1 != i)
+                recipeMapsString.append(", "); // For delimiting
+        }
+        return recipeMapsString.toString();
+    }
+
+    @Override
+    public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
+        if (!getWorld().isRemote && this.hasMultipleRecipeMaps() && !this.isActive()) {
+
+            int index;
+            if (playerIn.isSneaking()) // cycle recipemaps backwards
+                index = (recipeMapIndex - 1 < 0 ? recipeMaps.length - 1 : recipeMapIndex - 1) % recipeMaps.length;
+            else // cycle recipemaps forwards
+                index = (recipeMapIndex + 1) % recipeMaps.length;
+
+            setRecipeMapIndex(index);
+        }
+
+        return true; // return true here on the client to keep the GUI closed
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -206,10 +206,13 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
             }
 
             if (hasMultipleRecipeMaps()) {
-                textList.add(new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps",
-                        new TextComponentTranslation("recipemap." + this.recipeMaps[this.recipeMapIndex].getUnlocalizedName() + ".name")
-                        .setStyle(new Style().setColor(TextFormatting.AQUA)))
+                textList.add(new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.header")
                         .setStyle(new Style().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                                new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.tooltip")))));
+
+                textList.add(new TextComponentTranslation("recipemap." + this.recipeMaps[this.recipeMapIndex].getUnlocalizedName() + ".name")
+                        .setStyle(new Style().setColor(TextFormatting.AQUA)
+                                .setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
                                 new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.tooltip")))));
             }
 

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -376,15 +376,19 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
 
     @Override
     public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
-        if (!getWorld().isRemote && this.hasMultipleRecipeMaps() && !this.isActive()) {
+        if (!getWorld().isRemote && this.hasMultipleRecipeMaps()) {
+            if (!this.recipeMapWorkable.isActive()) {
+                int index;
+                if (playerIn.isSneaking()) // cycle recipemaps backwards
+                    index = (recipeMapIndex - 1 < 0 ? recipeMaps.length - 1 : recipeMapIndex - 1) % recipeMaps.length;
+                else // cycle recipemaps forwards
+                    index = (recipeMapIndex + 1) % recipeMaps.length;
 
-            int index;
-            if (playerIn.isSneaking()) // cycle recipemaps backwards
-                index = (recipeMapIndex - 1 < 0 ? recipeMaps.length - 1 : recipeMapIndex - 1) % recipeMaps.length;
-            else // cycle recipemaps forwards
-                index = (recipeMapIndex + 1) % recipeMaps.length;
-
-            setRecipeMapIndex(index);
+                setRecipeMapIndex(index);
+                this.recipeMapWorkable.forceRecipeRecheck();
+            } else {
+                playerIn.sendMessage(new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.switch_message"));
+            }
         }
 
         return true; // return true here on the client to keep the GUI closed

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
@@ -7,7 +7,6 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.multiblock.BlockPattern;
 import gregtech.api.multiblock.FactoryBlockPattern;
-import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.api.render.OrientedOverlayRenderer;
@@ -29,7 +28,6 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
 
     public MetaTileEntityImplosionCompressor(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.IMPLOSION_RECIPES);
-        this.recipeMaps = new RecipeMap[]{RecipeMaps.IMPLOSION_RECIPES, RecipeMaps.BENDER_RECIPES};
     }
 
     @Override
@@ -64,7 +62,7 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
     @Nonnull
     @Override
     protected OrientedOverlayRenderer getFrontOverlay() {
-        return this.getCurrentRecipeMap().equals(RecipeMaps.IMPLOSION_RECIPES) ? Textures.IMPLOSION_COMPRESSOR_OVERLAY : Textures.BENDER_OVERLAY;
+        return Textures.IMPLOSION_COMPRESSOR_OVERLAY;
     }
 
     @Override
@@ -74,11 +72,6 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
 
     @Override
     public boolean canBeDistinct() {
-        return true;
-    }
-
-    @Override
-    public boolean hasMultipleRecipeMaps() {
         return true;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
@@ -7,6 +7,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.multiblock.BlockPattern;
 import gregtech.api.multiblock.FactoryBlockPattern;
+import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.api.render.OrientedOverlayRenderer;
@@ -28,6 +29,7 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
 
     public MetaTileEntityImplosionCompressor(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.IMPLOSION_RECIPES);
+        this.recipeMaps = new RecipeMap[]{RecipeMaps.IMPLOSION_RECIPES, RecipeMaps.BENDER_RECIPES};
     }
 
     @Override
@@ -62,7 +64,7 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
     @Nonnull
     @Override
     protected OrientedOverlayRenderer getFrontOverlay() {
-        return Textures.IMPLOSION_COMPRESSOR_OVERLAY;
+        return this.getCurrentRecipeMap().equals(RecipeMaps.IMPLOSION_RECIPES) ? Textures.IMPLOSION_COMPRESSOR_OVERLAY : Textures.BENDER_OVERLAY;
     }
 
     @Override
@@ -72,6 +74,11 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
 
     @Override
     public boolean canBeDistinct() {
+        return true;
+    }
+
+    @Override
+    public boolean hasMultipleRecipeMaps() {
         return true;
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
@@ -16,5 +16,6 @@ public class TheOneProbeCompatibility {
         oneProbe.registerProvider(new TransformerInfoProvider());
         oneProbe.registerProvider(new DiodeInfoProvider());
         oneProbe.registerProvider(new MultiblockInfoProvider());
+        oneProbe.registerProvider(new MultiRecipeMapInfoProvider());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -1,0 +1,54 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.metatileentity.multiblock.IMultipleRecipeMaps;
+import gregtech.api.recipes.RecipeMap;
+import gregtech.api.util.GTLog;
+import mcjty.theoneprobe.api.*;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+
+public class MultiRecipeMapInfoProvider implements IProbeInfoProvider {
+
+    @Override
+    public String getID() {
+        return String.format("%s:multi_recipemap_provider", GTValues.MODID);
+    }
+
+    @Override
+    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, @Nonnull IBlockState blockState, IProbeHitData data) {
+        if (blockState.getBlock().hasTileEntity(blockState)) {
+            EnumFacing sideHit = data.getSideHit();
+            TileEntity tileEntity = world.getTileEntity(data.getPos());
+            if (tileEntity == null) return;
+            try {
+                IMultipleRecipeMaps resultCapability = tileEntity.getCapability(GregtechTileCapabilities.MULTIPLE_RECIPEMAPS, null);
+                if (resultCapability != null) {
+                    addProbeInfo(resultCapability, probeInfo, tileEntity, sideHit);
+                }
+            } catch (ClassCastException ignored) {
+
+            } catch (Throwable e) {
+                GTLog.logger.error("Bad One probe Implem: {} {} {}", e.getClass().toGenericString(), e.getMessage(), e.getStackTrace()[0].getClassName());
+            }
+        }
+    }
+
+
+    protected void addProbeInfo(@Nonnull IMultipleRecipeMaps iMultipleRecipeMaps, IProbeInfo iProbeInfo, TileEntity tileEntity, EnumFacing enumFacing) {
+        if (iMultipleRecipeMaps.hasMultipleRecipeMaps()) {
+            for (RecipeMap<?> recipeMap : iMultipleRecipeMaps.getAvailableRecipeMaps()) {
+                if (recipeMap.equals(iMultipleRecipeMaps.getCurrentRecipeMap()))
+                    iProbeInfo.text(TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");
+                else
+                    iProbeInfo.text(TextStyleClass.INFO + recipeMap.getLocalizedName());
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -7,6 +7,7 @@ import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTLog;
 import mcjty.theoneprobe.api.*;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -42,12 +43,13 @@ public class MultiRecipeMapInfoProvider implements IProbeInfoProvider {
 
 
     protected void addProbeInfo(@Nonnull IMultipleRecipeMaps iMultipleRecipeMaps, IProbeInfo iProbeInfo, TileEntity tileEntity, EnumFacing enumFacing) {
+        iProbeInfo.text(TextStyleClass.INFO + I18n.format("gregtech.multiblock.multiple_recipemaps.header"));
         if (iMultipleRecipeMaps.hasMultipleRecipeMaps()) {
             for (RecipeMap<?> recipeMap : iMultipleRecipeMaps.getAvailableRecipeMaps()) {
                 if (recipeMap.equals(iMultipleRecipeMaps.getCurrentRecipeMap()))
-                    iProbeInfo.text(TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");
+                    iProbeInfo.text("   " + TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");
                 else
-                    iProbeInfo.text(TextStyleClass.INFO + recipeMap.getLocalizedName());
+                    iProbeInfo.text( "   " + TextStyleClass.LABEL + recipeMap.getLocalizedName());
             }
         }
     }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3937,6 +3937,9 @@ gregtech.multiblock.universal.distinct.no=No
 gregtech.multiblock.universal.distinct.yes=Yes
 gregtech.multiblock.universal.distinct.info=If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.
 gregtech.multiblock.parallel=Performing up to %d Recipes in Parallel
+gregtech.multiblock.multiple_recipemaps=Running %s Recipes
+gregtech.multiblock.multiple_recipemaps.tooltip=Use a screwdriver on the controller to change which recipes to run.
+gregtech.multiblock.multiple_recipemaps_recipes.tooltip=Available Recipes: §e%s§r
 
 gregtech.multiblock.preview.zoom=Use mousewheel or right-click+Drag to zoom
 gregtech.multiblock.preview.rotate=Click and drag to rotate

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3937,10 +3937,10 @@ gregtech.multiblock.universal.distinct.no=No
 gregtech.multiblock.universal.distinct.yes=Yes
 gregtech.multiblock.universal.distinct.info=If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.
 gregtech.multiblock.parallel=Performing up to %d Recipes in Parallel
-gregtech.multiblock.multiple_recipemaps=Running %s Recipes
-gregtech.multiblock.multiple_recipemaps.tooltip=Screwdriver the controller to change which recipes to use.
-gregtech.multiblock.multiple_recipemaps_recipes.tooltip=Available Recipes: §e%s§r
-gregtech.multiblock.multiple_recipemaps.switch_message=The machine must be off to switch recipes!
+gregtech.multiblock.multiple_recipemaps.header=Machine Mode:
+gregtech.multiblock.multiple_recipemaps.tooltip=Screwdriver the controller to change which machine mode to use.
+gregtech.multiblock.multiple_recipemaps_recipes.tooltip=Machine Modes: §e%s§r
+gregtech.multiblock.multiple_recipemaps.switch_message=The machine must be off to switch modes!
 
 gregtech.multiblock.preview.zoom=Use mousewheel or right-click+Drag to zoom
 gregtech.multiblock.preview.rotate=Click and drag to rotate

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3940,6 +3940,7 @@ gregtech.multiblock.parallel=Performing up to %d Recipes in Parallel
 gregtech.multiblock.multiple_recipemaps=Running %s Recipes
 gregtech.multiblock.multiple_recipemaps.tooltip=Use a screwdriver on the controller to change which recipes to run.
 gregtech.multiblock.multiple_recipemaps_recipes.tooltip=Available Recipes: §e%s§r
+gregtech.multiblock.multiple_recipemaps.switch_message=The machine must be off to switch recipes!
 
 gregtech.multiblock.preview.zoom=Use mousewheel or right-click+Drag to zoom
 gregtech.multiblock.preview.rotate=Click and drag to rotate

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3938,7 +3938,7 @@ gregtech.multiblock.universal.distinct.yes=Yes
 gregtech.multiblock.universal.distinct.info=If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.
 gregtech.multiblock.parallel=Performing up to %d Recipes in Parallel
 gregtech.multiblock.multiple_recipemaps=Running %s Recipes
-gregtech.multiblock.multiple_recipemaps.tooltip=Use a screwdriver on the controller to change which recipes to run.
+gregtech.multiblock.multiple_recipemaps.tooltip=Screwdriver the controller to change which recipes to use.
 gregtech.multiblock.multiple_recipemaps_recipes.tooltip=Available Recipes: §e%s§r
 gregtech.multiblock.multiple_recipemaps.switch_message=The machine must be off to switch recipes!
 


### PR DESCRIPTION
This PR adds logic for allowing multiblocks to use more than one recipemap. TOP integration is also added, and all multiblocks with more than one recipemap are registered to all of their recipemaps' categories as catalysts. The implementation is very similar to the on in Gregicality, except implementing the selection logic is much simpler.

While the machine is running, switching the recipemap is disallowed, even when paused. When successfully switched, the multiblock will search for new recipes using the new recipemap.

Currently, a demo setup with the implosion compressor has been implemented. Before merging, this should be removed.