### PR TITLE
Prevent Recipe Properties from Overlapping in JEI

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -18,7 +18,6 @@ import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.recipes.builders.IntCircuitRecipeBuilder;
-import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.recipes.crafttweaker.CTRecipe;
 import gregtech.api.recipes.crafttweaker.CTRecipeBuilder;
 import gregtech.api.unification.material.Material;
@@ -407,8 +406,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = isOutputs ? 106 : 70 - itemSlotsToLeft * 18;
         int startInputsY = 33 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
-        boolean wasGroupOutput = itemHandler.getSlots() + fluidHandler.getTanks() == 12;
-        if (wasGroupOutput && isOutputs) startInputsY -= 9;
+        boolean wasGroup = itemHandler.getSlots() + fluidHandler.getTanks() == 12;
+        if (wasGroup) startInputsY -= 9;
         if (itemHandler.getSlots() == 6 && fluidHandler.getTanks() == 2 && !isOutputs) startInputsY -= 9;
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
@@ -419,7 +418,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 addSlot(builder, x, y, slotIndex, itemHandler, fluidHandler, invertFluids, isOutputs);
             }
         }
-        if (wasGroupOutput) startInputsY += 2;
+        if (wasGroup) startInputsY += 2;
         if (fluidInputsCount > 0 || invertFluids) {
             if (itemSlotsToDown >= fluidInputsCount && itemSlotsToLeft < 3) {
                 int startSpecX = isOutputs ? startInputsX + itemSlotsToLeft * 18 : startInputsX - 18;

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -59,10 +59,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 (exportFluids = new FluidTankList(false, exportFluidTanks)), 0
         ).build(new BlankUIHolder(), Minecraft.getMinecraft().player);
         this.modularUI.initWidgets();
-        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + (FONT_HEIGHT *
-                (((recipeMap.getMaxOutputs() >= 6 || recipeMap.getMaxInputs() >= 6 ||
-                        recipeMap.getMaxFluidOutputs() >= 6 || recipeMap.getMaxFluidInputs() >= 6) && recipeMap.getRecipeList().get(0).getPropertyValues().size() > 0)
-                ? recipeMap.getRecipeList().get(0).getPropertyValues().size() : 0)));
+        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + (FONT_HEIGHT * getRecipePropertyAmount(recipeMap)));
         categoryMap.put(recipeMap, this);
     }
 
@@ -178,5 +175,16 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
 
     public static HashMap<RecipeMap<?>, RecipeMapCategory> getCategoryMap() {
         return categoryMap;
+    }
+
+    private static boolean shouldShiftWidgets(@Nonnull RecipeMap<?> recipeMap) {
+        return recipeMap.getMaxOutputs() >= 6 || recipeMap.getMaxInputs() >= 6 ||
+                recipeMap.getMaxFluidOutputs() >= 6 || recipeMap.getMaxFluidInputs() >= 6;
+    }
+
+    private static int getRecipePropertyAmount(RecipeMap<?> recipeMap) {
+        if (shouldShiftWidgets(recipeMap))
+            return recipeMap.getRecipeList().get(0).getPropertyValues().size();
+        return 0;
     }
 }

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -41,9 +41,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     private final FluidTankList importFluids, exportFluids;
     private final IDrawable backgroundDrawable;
 
-    private final int FONT_HEIGHT = 9;
+    private static final int FONT_HEIGHT = 9;
     private static final HashMap<RecipeMap<?>, RecipeMapCategory> categoryMap = new HashMap<>();
-    private double timer = 0;
 
     public RecipeMapCategory(RecipeMap<?> recipeMap, IGuiHelper guiHelper) {
         this.recipeMap = recipeMap;
@@ -57,12 +56,13 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 (importItems = new ItemStackHandler(recipeMap.getMaxInputs())),
                 (exportItems = new ItemStackHandler(recipeMap.getMaxOutputs())),
                 (importFluids = new FluidTankList(false, importFluidTanks)),
-                (exportFluids = new FluidTankList(false, exportFluidTanks)),
-                (recipeMap.getMaxOutputs() >= 6 || recipeMap.getMaxInputs() >= 6 ||
-                        recipeMap.getMaxFluidOutputs() >= 6 || recipeMap.getMaxFluidInputs() >= 6) ? FONT_HEIGHT : 0
+                (exportFluids = new FluidTankList(false, exportFluidTanks)), 0
         ).build(new BlankUIHolder(), Minecraft.getMinecraft().player);
         this.modularUI.initWidgets();
-        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3);
+        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + (FONT_HEIGHT *
+                (((recipeMap.getMaxOutputs() >= 6 || recipeMap.getMaxInputs() >= 6 ||
+                        recipeMap.getMaxFluidOutputs() >= 6 || recipeMap.getMaxFluidInputs() >= 6) && recipeMap.getRecipeList().get(0).getPropertyValues().size() > 0)
+                ? recipeMap.getRecipeList().get(0).getPropertyValues().size() : 0)));
         categoryMap.put(recipeMap, this);
     }
 

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -9,6 +9,7 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
@@ -59,7 +60,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 (exportFluids = new FluidTankList(false, exportFluidTanks)), 0
         ).build(new BlankUIHolder(), Minecraft.getMinecraft().player);
         this.modularUI.initWidgets();
-        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + (FONT_HEIGHT * getRecipePropertyAmount(recipeMap)));
+        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + getPropertyShiftAmount(recipeMap));
         categoryMap.put(recipeMap, this);
     }
 
@@ -182,9 +183,14 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 recipeMap.getMaxFluidOutputs() >= 6 || recipeMap.getMaxFluidInputs() >= 6;
     }
 
-    private static int getRecipePropertyAmount(RecipeMap<?> recipeMap) {
-        if (shouldShiftWidgets(recipeMap))
-            return recipeMap.getRecipeList().get(0).getPropertyValues().size();
-        return 0;
+    private static int getPropertyShiftAmount(@Nonnull RecipeMap<?> recipeMap) {
+        int maxPropertyCount = 0;
+        if (shouldShiftWidgets(recipeMap)) {
+            for (Recipe recipe : recipeMap.getRecipeList()) {
+                if (recipe.getPropertyCount() > maxPropertyCount)
+                    maxPropertyCount = recipe.getPropertyCount();
+            }
+        }
+        return maxPropertyCount * FONT_HEIGHT;
     }
 }


### PR DESCRIPTION
**What:**
This PR prevents recipes with properties from overlapping with the recipe display. Previously, 4 or more columns of inputs, and/or sometimes outputs, would have property text on top of slot widgets. This PR resolves this. It also allows the `groupOutput` to be applied to inputs for any purpose. This PR no longer offsets the recipe display for group output, as it was unneeded. 

**How solved:**
The size of the JEI page for the recipemap is lengthened based on the number of properties it has, while leaving the recipe itself in the same location at the top of the page. 

**Outcome:**
Prevents Recipe Properties from overlapping in JEI.

**Additional info:**
An example of the PR working. Without the changes made in this PR, the temperature property's shifting of the total energy amount would have overlapped with the fluid input slots.
![image](https://user-images.githubusercontent.com/37029404/143735590-96564de3-8f81-4b83-8d30-26f8d8cb4d96.png)

**Possible compatibility issue:**
Currently it goes off of the first recipe's properties of a given RecipeMap, as there was no other way to determine the amount of expected properties. This could result in some recipes with properties not being correctly caught.