### PR TITLE
Allow Parallel Logic to Multiply EUt Instead of Duration

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -367,12 +367,13 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
      * Appends the passed {@link Recipe} onto the inputs and outputs, multiplied by the amount specified by multiplier
      * The duration of the multiplied {@link Recipe} is also added to the current duration
      *
-     * @param recipe     The Recipe to be multiplied
-     * @param multiplier Amount to multiply the recipe by
+     * @param recipe            The Recipe to be multiplied
+     * @param multiplier        Amount to multiply the recipe by
+     * @param multiplyDuration  Whether duration should be multiplied instead of EUt
      * @return the builder holding the multiplied recipe
      */
 
-    public R append(Recipe recipe, int multiplier) {
+    public R append(Recipe recipe, int multiplier, boolean multiplyDuration) {
         for (Map.Entry<RecipeProperty<?>, Object> property : recipe.getPropertyValues()) {
             this.applyProperty(property.getKey().getKey(), property.getValue());
         }
@@ -392,8 +393,8 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.outputs(outputItems);
         this.fluidOutputs(outputFluids);
 
-        this.EUt(recipe.getEUt());
-        this.duration(this.duration + recipe.getDuration() * multiplier);
+        this.EUt(multiplyDuration ? recipe.getEUt() : this.EUt + recipe.getEUt() * multiplier);
+        this.duration(multiplyDuration ? this.duration + recipe.getDuration() * multiplier : recipe.getDuration());
         this.parallel += multiplier;
 
         chancedOutputsMultiply(recipe, multiplier);

--- a/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
@@ -34,7 +34,7 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit) {
+    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage) {
         return ParallelLogic.doParallelRecipes(
                 currentRecipe,
                 recipeMap,
@@ -42,7 +42,8 @@ public interface IParallelableRecipeLogic {
                 fluidInputs,
                 outputs,
                 fluidOutputs,
-                parallelLimit);
+                parallelLimit,
+                maxVoltage);
     }
 
     /**
@@ -68,7 +69,7 @@ public interface IParallelableRecipeLogic {
         if (parallelLimit > 1) {
             RecipeBuilder<?> parallelBuilder = null;
             if (logic.getParallelLogicType() == ParallelLogicType.MULTIPLY) {
-                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit);
+                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage);
             } else if (logic.getParallelLogicType() == ParallelLogicType.APPEND_ITEMS) {
                 parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage);
             }

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -2,7 +2,6 @@ package gregtech.api.recipes.logic;
 
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.recipes.*;
-import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.util.*;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap;
 import net.minecraft.item.ItemStack;
@@ -363,7 +362,7 @@ public class ParallelLogic {
         return minMultiplier;
     }
 
-    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount) {
+    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage) {
         int multiplierByInputs = getMaxRecipeMultiplier(currentRecipe, importInventory, importFluids, parallelAmount);
         if (multiplierByInputs == 0) {
             return null;
@@ -372,10 +371,11 @@ public class ParallelLogic {
         // Simulate the merging of the maximum amount of recipes
         // and limit by the amount we can successfully merge
         int limitByOutput = ParallelLogic.limitByOutputMerging(currentRecipe, exportInventory, exportFluids, multiplierByInputs);
-        int parallelizable = Math.min(multiplierByInputs, limitByOutput);
+        int limitByVoltage = (int) (maxVoltage / currentRecipe.getEUt());
+        int parallelizable = Math.min(limitByVoltage, Math.min(multiplierByInputs, limitByOutput));
 
         if (parallelizable > 0) {
-            recipeBuilder.append(currentRecipe, parallelizable);
+            recipeBuilder.append(currentRecipe, parallelizable, false);
         }
 
         return recipeBuilder;
@@ -436,7 +436,7 @@ public class ParallelLogic {
             int multiplierRecipeAmount = Math.min(amountOfCurrentItem, limitByOutput);
 
             if (multiplierRecipeAmount > 0) {
-                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount);
+                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, false);
                 engagedItems += multiplierRecipeAmount;
             }
 

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -436,7 +436,7 @@ public class ParallelLogic {
             int multiplierRecipeAmount = Math.min(amountOfCurrentItem, limitByOutput);
 
             if (multiplierRecipeAmount > 0) {
-                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, false);
+                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, true);
                 engagedItems += multiplierRecipeAmount;
             }
 

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -328,11 +328,11 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
 
-        //Check that the EUt of the recipe was multiplied correctly
-        assertEquals(120, parallelRecipe.getEUt());
+        //Check that the EUt of the recipe was not modified
+        assertEquals(30, parallelRecipe.getEUt());
 
-        //Check if the recipe duration was not modified
-        assertEquals(100, parallelRecipe.getDuration());
+        //Check if the recipe duration was multiplied correctly
+        assertEquals(400, parallelRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(parallelRecipe.getOutputs().isEmpty());
@@ -379,11 +379,11 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());
 
-        //Check that the EUt of the recipe was multiplied correctly
-        assertEquals(60, parallelRecipe.getEUt());
+        //Check that the EUt of the recipe was not modified
+        assertEquals(30, parallelRecipe.getEUt());
 
-        //Check if the recipe duration was not modified
-        assertEquals(100, parallelRecipe.getDuration());
+        //Check if the recipe duration was multiplied correctly
+        assertEquals(200, parallelRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(parallelRecipe.getOutputs().isEmpty());

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -215,16 +215,16 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
 
-        //Check that the EUt of the recipe was not modified
-        assertEquals(30, parallelRecipe.getEUt());
+        //Check that the EUt of the recipe was multiplied correctly
+        assertEquals(120, parallelRecipe.getEUt());
 
-        //Check if the recipe duration was multiplied correctly
-        assertEquals(400, parallelRecipe.getDuration());
+        //Check if the recipe duration was not modified
+        assertEquals(100, parallelRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(parallelRecipe.getOutputs().isEmpty());
@@ -269,16 +269,16 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());
 
-        //Check that the EUt of the recipe was not modified
-        assertEquals(30, parallelRecipe.getEUt());
+        //Check that the EUt of the recipe was multiplied correctly
+        assertEquals(60, parallelRecipe.getEUt());
 
-        //Check if the recipe duration was multiplied correctly
-        assertEquals(200, parallelRecipe.getDuration());
+        //Check if the recipe duration was not modified
+        assertEquals(100, parallelRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(parallelRecipe.getOutputs().isEmpty());
@@ -323,16 +323,16 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 30);
+                exportItemBus.getExportItems(), parallelLimit, 120);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
 
-        //Check that the EUt of the recipe was not modified
-        assertEquals(30, parallelRecipe.getEUt());
+        //Check that the EUt of the recipe was multiplied correctly
+        assertEquals(120, parallelRecipe.getEUt());
 
-        //Check if the recipe duration was multiplied correctly
-        assertEquals(400, parallelRecipe.getDuration());
+        //Check if the recipe duration was not modified
+        assertEquals(100, parallelRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(parallelRecipe.getOutputs().isEmpty());
@@ -374,16 +374,16 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 30);
+                exportItemBus.getExportItems(), parallelLimit, 120);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());
 
-        //Check that the EUt of the recipe was not modified
-        assertEquals(30, parallelRecipe.getEUt());
+        //Check that the EUt of the recipe was multiplied correctly
+        assertEquals(60, parallelRecipe.getEUt());
 
-        //Check if the recipe duration was multiplied correctly
-        assertEquals(200, parallelRecipe.getDuration());
+        //Check if the recipe duration was not modified
+        assertEquals(100, parallelRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(parallelRecipe.getOutputs().isEmpty());
@@ -448,14 +448,14 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
 
 
         Recipe outputRecipe = findParallelRecipe(mrl, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(), exportItemBus.getExportItems(),
-                exportFluidBus.getExportFluids(), 32, parallelLimit);
+                exportFluidBus.getExportFluids(), 128, parallelLimit);
 
 
-        //Check that the EUt of the recipe was not modified
-        assertEquals(30, outputRecipe.getEUt());
+        //Check that the EUt of the recipe was multiplied correctly
+        assertEquals(120, outputRecipe.getEUt());
 
-        //Check if the recipe duration was multiplied correctly
-        assertEquals(400, outputRecipe.getDuration());
+        //Check if the recipe duration was not modified
+        assertEquals(100, outputRecipe.getDuration());
 
         //Check the recipe outputs
         assertFalse(outputRecipe.getOutputs().isEmpty());
@@ -583,7 +583,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
 
 
         Recipe outputRecipe = findParallelRecipe(mrl, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(), exportItemBus.getExportItems(),
-                exportFluidBus.getExportFluids(), 32, parallelLimit);
+                exportFluidBus.getExportFluids(), Integer.MAX_VALUE, parallelLimit);
 
         assertNull(outputRecipe);
     }
@@ -644,7 +644,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         Recipe outputRecipe = findParallelRecipe(mrl, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(), exportItemBus.getExportItems(),
-                exportFluidBus.getExportFluids(), 32, parallelLimit);
+                exportFluidBus.getExportFluids(), 128, parallelLimit);
 
 
         //Check that the EUt of the recipe was not modified


### PR DESCRIPTION
Allows EUt to be multiplied instead of duration for the multiply logic. This allows more recipes to be performed in the same amount of time, instead of having no benefit otherwise. For the multiply logic, the maximum voltage is also an additional parallel limiting factor as a result.