### PR TITLE
Material Tree Adjustments

### DIFF
--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -205,7 +205,7 @@ public class GTJeiPlugin implements IModPlugin {
         //Material Tree
         List<MaterialTree> materialTreeList = new CopyOnWriteArrayList<>();
         for (Material material : GregTechAPI.MATERIAL_REGISTRY) {
-            if (material.hasProperty(PropertyKey.DUST)) {
+            if (material.hasProperty(PropertyKey.DUST) && !material.isHidden()) {
                 materialTreeList.add(new MaterialTree(material));
             }
         }

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTree.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTree.java
@@ -62,14 +62,7 @@ public class MaterialTree implements IRecipeWrapper {
         // adding an empty list to itemInputs/fluidInputs makes checking if a prefix exists later much easier
         List<ItemStack> inputDusts = new ArrayList<>();
         for (OrePrefix prefix : PREFIXES) {
-            if(prefix == OrePrefix.ingot && OreDictUnifier.get(prefix, material).isEmpty()) {
-                if(material.hasProperty(PropertyKey.ORE) && material.getProperty(PropertyKey.ORE).getDirectSmeltResult() != null) {
-                    inputDusts.add(OreDictUnifier.get(OrePrefix.ingot, material.getProperty(PropertyKey.ORE).getDirectSmeltResult()));
-                }
-            }
-            else {
-                inputDusts.add(OreDictUnifier.get(prefix, material));
-            }
+            inputDusts.add(OreDictUnifier.get(prefix, material));
         }
         for (ItemStack stack : inputDusts) {
             List<ItemStack> matItemsStack = new ArrayList<>();

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTree.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTree.java
@@ -62,7 +62,14 @@ public class MaterialTree implements IRecipeWrapper {
         // adding an empty list to itemInputs/fluidInputs makes checking if a prefix exists later much easier
         List<ItemStack> inputDusts = new ArrayList<>();
         for (OrePrefix prefix : PREFIXES) {
-            inputDusts.add(OreDictUnifier.get(prefix, material));
+            if(prefix == OrePrefix.ingot && OreDictUnifier.get(prefix, material).isEmpty()) {
+                if(material.hasProperty(PropertyKey.ORE) && material.getProperty(PropertyKey.ORE).getDirectSmeltResult() != null) {
+                    inputDusts.add(OreDictUnifier.get(OrePrefix.ingot, material.getProperty(PropertyKey.ORE).getDirectSmeltResult()));
+                }
+            }
+            else {
+                inputDusts.add(OreDictUnifier.get(prefix, material));
+            }
         }
         for (ItemStack stack : inputDusts) {
             List<ItemStack> matItemsStack = new ArrayList<>();


### PR DESCRIPTION
**What:**
Prevents the creation of material tree pages for hidden materials.
Adds a line from dust -> smelting result if the material does not have an ingot and instead directly smelts into a different material