### PR TITLE
Don't show LCR for all CR recipes separately

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -76,6 +76,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     protected SoundEvent sound;
 
+    private RecipeMap<?> smallRecipeMap;
+
     public RecipeMap(String unlocalizedName,
                     int minInputs, int maxInputs, int minOutputs, int maxOutputs,
                     int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs,
@@ -155,6 +157,15 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public RecipeMap<R> onRecipeBuild(Consumer<RecipeBuilder<?>> consumer) {
         onRecipeBuildAction = consumer;
         return this;
+    }
+
+    public RecipeMap<R> setSmallRecipeMap(RecipeMap<?> recipeMap) {
+        this.smallRecipeMap = recipeMap;
+        return this;
+    }
+
+    public RecipeMap<?> getSmallRecipeMap() {
+        return smallRecipeMap;
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -508,7 +508,8 @@ public class RecipeMaps {
             .setSlotOverlay(true, false, GuiTextures.VIAL_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.VIAL_OVERLAY_2)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
-            .setSound(GTSounds.CHEMICAL_REACTOR);
+            .setSound(GTSounds.CHEMICAL_REACTOR)
+            .setSmallRecipeMap(CHEMICAL_RECIPES);
 
     /**
      * If universal every Fluid also gets separate distillation recipes

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -138,14 +138,12 @@ public class GTJeiPlugin implements IModPlugin {
                 if (workableCapability instanceof AbstractRecipeLogic) {
                     if (metaTileEntity instanceof SteamMetaTileEntity) {
                         deferredCatalysts.add(metaTileEntity);
-                    } else {
-                        RecipeMap<?>[] recipeMaps = (metaTileEntity instanceof IMultipleRecipeMaps && ((IMultipleRecipeMaps) metaTileEntity).hasMultipleRecipeMaps()) ?
-                                ((IMultipleRecipeMaps) metaTileEntity).getAvailableRecipeMaps() :
-                                new RecipeMap<?>[]{((AbstractRecipeLogic) workableCapability).getRecipeMap()};
-
-                        for (RecipeMap<?> recipeMap : recipeMaps) {
+                    } else if (metaTileEntity instanceof IMultipleRecipeMaps && ((IMultipleRecipeMaps) metaTileEntity).hasMultipleRecipeMaps()) {
+                        for (RecipeMap<?> recipeMap : ((IMultipleRecipeMaps) metaTileEntity).getAvailableRecipeMaps()) {
                             registerRecipeMapCatalyst(registry, recipeMap, metaTileEntity);
                         }
+                    } else {
+                        registerRecipeMapCatalyst(registry, ((AbstractRecipeLogic) workableCapability).getRecipeMap(), metaTileEntity);
                     }
                 } else if (workableCapability instanceof FuelRecipeLogic) {
                     FuelRecipeMap recipeMap = ((FuelRecipeLogic) workableCapability).recipeMap;

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -11,6 +11,7 @@ import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultipleRecipeMaps;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
@@ -50,6 +51,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @JEIPlugin
 public class GTJeiPlugin implements IModPlugin {
@@ -104,12 +106,18 @@ public class GTJeiPlugin implements IModPlugin {
 
         for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
             if(!recipeMap.isHidden) {
-                List<GTRecipeWrapper> recipesList = recipeMap.getRecipeList()
-                        .stream()
-                        .filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay())
-                        .map(r -> new GTRecipeWrapper(recipeMap, r))
-                        .collect(Collectors.toList());
-                registry.addRecipes(recipesList, GTValues.MODID + ":" + recipeMap.unlocalizedName);
+                Stream<Recipe> recipeStream = recipeMap.getRecipeList().stream()
+                        .filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay());
+
+                if (recipeMap.getSmallRecipeMap() != null) {
+                    List<Recipe> smallRecipes = recipeMap.getSmallRecipeMap().getRecipeList();
+                    recipeStream = recipeStream.filter(recipe -> !smallRecipes.contains(recipe));
+                }
+
+                registry.addRecipes(
+                        recipeStream.map(r -> new GTRecipeWrapper(recipeMap, r)).collect(Collectors.toList()),
+                        GTValues.MODID + ":" + recipeMap.unlocalizedName
+                );
             }
         }
 
@@ -121,7 +129,6 @@ public class GTJeiPlugin implements IModPlugin {
         }
 
         List<MetaTileEntity> deferredCatalysts = new ArrayList<>();
-        List<MetaTileEntity> multipleRecipeMapCatalysts = new ArrayList<>();
         for (ResourceLocation metaTileEntityId : GregTechAPI.MTE_REGISTRY.getKeys()) {
             MetaTileEntity metaTileEntity = GregTechAPI.MTE_REGISTRY.getObject(metaTileEntityId);
             assert metaTileEntity != null;
@@ -131,13 +138,13 @@ public class GTJeiPlugin implements IModPlugin {
                 if (workableCapability instanceof AbstractRecipeLogic) {
                     if (metaTileEntity instanceof SteamMetaTileEntity) {
                         deferredCatalysts.add(metaTileEntity);
-                    } else if (metaTileEntity instanceof IMultipleRecipeMaps && ((IMultipleRecipeMaps) metaTileEntity).hasMultipleRecipeMaps()) {
-                        multipleRecipeMapCatalysts.add(metaTileEntity);
                     } else {
-                        RecipeMap<?> recipeMap = ((AbstractRecipeLogic) workableCapability).getRecipeMap();
-                        registry.addRecipeCatalyst(metaTileEntity.getStackForm(), GTValues.MODID + ":" + recipeMap.unlocalizedName);
-                        if (recipeMap instanceof RecipeMapFurnace) {
-                            registry.addRecipeCatalyst(metaTileEntity.getStackForm(), VanillaRecipeCategoryUid.SMELTING);
+                        RecipeMap<?>[] recipeMaps = (metaTileEntity instanceof IMultipleRecipeMaps && ((IMultipleRecipeMaps) metaTileEntity).hasMultipleRecipeMaps()) ?
+                                ((IMultipleRecipeMaps) metaTileEntity).getAvailableRecipeMaps() :
+                                new RecipeMap<?>[]{((AbstractRecipeLogic) workableCapability).getRecipeMap()};
+
+                        for (RecipeMap<?> recipeMap : recipeMaps) {
+                            registerRecipeMapCatalyst(registry, recipeMap, metaTileEntity);
                         }
                     }
                 } else if (workableCapability instanceof FuelRecipeLogic) {
@@ -149,19 +156,7 @@ public class GTJeiPlugin implements IModPlugin {
         for (MetaTileEntity deferredMetaTileEntity : deferredCatalysts) {
             IControllable workableCapability = deferredMetaTileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_CONTROLLABLE, null);
             RecipeMap<?> recipeMap = ((AbstractRecipeLogic) workableCapability).getRecipeMap();
-            registry.addRecipeCatalyst(deferredMetaTileEntity.getStackForm(), GTValues.MODID + ":" + recipeMap.unlocalizedName);
-            if (recipeMap instanceof RecipeMapFurnace) {
-                registry.addRecipeCatalyst(deferredMetaTileEntity.getStackForm(), VanillaRecipeCategoryUid.SMELTING);
-            }
-        }
-
-        for (MetaTileEntity multipleRecipeMapCatalyst : multipleRecipeMapCatalysts) {
-            for (RecipeMap<?> recipeMap : ((IMultipleRecipeMaps) multipleRecipeMapCatalyst).getAvailableRecipeMaps()) {
-                registry.addRecipeCatalyst(multipleRecipeMapCatalyst.getStackForm(), GTValues.MODID + ":" + recipeMap.getUnlocalizedName());
-                if (recipeMap instanceof RecipeMapFurnace) {
-                    registry.addRecipeCatalyst(multipleRecipeMapCatalyst.getStackForm(), VanillaRecipeCategoryUid.SMELTING);
-                }
-            }
+            registerRecipeMapCatalyst(registry, recipeMap, deferredMetaTileEntity);
         }
 
         String semiFluidMapId = GTValues.MODID + ":" + RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.getUnlocalizedName();
@@ -245,5 +240,15 @@ public class GTJeiPlugin implements IModPlugin {
                     VanillaTypes.ITEM,
                     infoPage.getDescription());
         });
+    }
+
+    private static void registerRecipeMapCatalyst(IModRegistry registry, RecipeMap<?> recipeMap, MetaTileEntity metaTileEntity) {
+        registry.addRecipeCatalyst(metaTileEntity.getStackForm(), GTValues.MODID + ":" + recipeMap.unlocalizedName);
+        if (recipeMap instanceof RecipeMapFurnace) {
+            registry.addRecipeCatalyst(metaTileEntity.getStackForm(), VanillaRecipeCategoryUid.SMELTING);
+        }
+        if (recipeMap.getSmallRecipeMap() != null) {
+            registry.addRecipeCatalyst(metaTileEntity.getStackForm(), GTValues.MODID + ":" + recipeMap.getSmallRecipeMap().unlocalizedName);
+        }
     }
 }


### PR DESCRIPTION
Allows RecipeMaps to specify their "smaller" map, i.e. Large Chemical Reactor having Chemical Reactor as a smaller map. This allows the JEI Plugin to handle how those recipes are displayed in JEI differently:

The "large" map (in this case, LCR) will have its own page, but will only have LCR-only recipes in that category. For recipes that can be run in the LCR or CR, the LCR will simply be listed as a catalyst in the CR recipe category.

To use this functionality, simply call `.setSmallRecipeMap(...)` on the large recipe map.

Additionally, I refactored some duplicate code in the JEI Plugin.