### PR TITLE
Do not load before CTM

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -49,7 +49,7 @@ import static gregtech.api.GregTechAPI.*;
 @Mod(modid = GTValues.MODID,
         name = "GregTech",
         acceptedMinecraftVersions = "[1.12,1.13)",
-        dependencies = "required:forge@[14.23.5.2847,);" + CodeChickenLib.MOD_VERSION_DEP + "after:forestry;after:jei@[4.15.0,);after:crafttweaker;before:ctm")
+        dependencies = "required:forge@[14.23.5.2847,);" + CodeChickenLib.MOD_VERSION_DEP + "after:forestry;after:jei@[4.15.0,);after:crafttweaker")
 public class GregTechMod {
 
     static {


### PR DESCRIPTION
**What:**
Fixes the bizarre server issue where the client could not connect due to mods loading in different orders on the server and client, causing a different mod to own a fluid on each side

**How solved:**
Do not require Gregtech to load before CTM, which is what causes the issue due to CTM being client side only
