### PR TITLE
Tool sound fixes

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -15,7 +15,6 @@ import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.cover.IFacadeCover;
 import gregtech.api.items.toolitem.IToolStats;
-import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.pipenet.block.BlockPipe;
@@ -328,6 +327,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
             if (screwdriver.damageItem(DamageValues.DAMAGE_FOR_SCREWDRIVER, true) &&
                     metaTileEntity.onCoverScrewdriverClick(playerIn, hand, rayTraceResult)) {
                 screwdriver.damageItem(DamageValues.DAMAGE_FOR_SCREWDRIVER, false);
+                IToolStats.onOtherUse(itemStack, worldIn, pos);
                 return true;
             }
             return false;
@@ -340,11 +340,8 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
             if (wrenchItem.damageItem(DamageValues.DAMAGE_FOR_WRENCH, true) &&
                     metaTileEntity.onWrenchClick(playerIn, hand, wrenchDirection, rayTraceResult)) {
 
-                if(itemStack.getItem() instanceof ToolMetaItem<?>) {
-                    IToolStats stats = ((ToolMetaItem<?>) itemStack.getItem()).getItem(itemStack).getToolStats();
-                    stats.onBreakingUse(itemStack, worldIn, pos);
-                }
                 wrenchItem.damageItem(DamageValues.DAMAGE_FOR_WRENCH, false);
+                IToolStats.onOtherUse(itemStack, worldIn, pos);
                 return true;
             }
             return false;

--- a/src/main/java/gregtech/api/items/IToolItem.java
+++ b/src/main/java/gregtech/api/items/IToolItem.java
@@ -1,5 +1,6 @@
 package gregtech.api.items;
 
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -14,8 +15,8 @@ public interface IToolItem {
      * DO NOT USE METHODS BELOW TO CHECK IF TOOL CAN RECEIVE SPECIFIED AMOUNT OF DAMAGE,
      * Use this method with simulate = true to check so, because it can be different for electric items!
      */
-    default boolean damageItem(ItemStack stack, int damage, boolean simulate) {
-        return damageItem(stack, damage, false, simulate) > 0;
+    default boolean damageItem(ItemStack stack, EntityLivingBase entity, int damage, boolean simulate) {
+        return damageItem(stack, entity, damage, false, simulate) > 0;
     }
 
     /**
@@ -33,7 +34,7 @@ public interface IToolItem {
      * @param simulate     pass true to do a dry run of the process
      * @return the actual damage applied
      */
-    int damageItem(ItemStack stack, int damage, boolean allowPartial, boolean simulate);
+    int damageItem(ItemStack stack, EntityLivingBase entity, int damage, boolean allowPartial, boolean simulate);
 
     /**
      * @return amount of internal damage this item have

--- a/src/main/java/gregtech/api/items/toolitem/AbstractToolItemCapabilityProvider.java
+++ b/src/main/java/gregtech/api/items/toolitem/AbstractToolItemCapabilityProvider.java
@@ -20,7 +20,7 @@ public abstract class AbstractToolItemCapabilityProvider<T> implements ICapabili
     protected abstract Capability<T> getCapability();
 
     public boolean damageItem(int damage, boolean simulate) {
-        return ((IToolItem) itemStack.getItem()).damageItem(itemStack, damage, simulate);
+        return ((IToolItem) itemStack.getItem()).damageItem(itemStack, null, damage, simulate);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -5,7 +5,6 @@ import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.unification.material.Material;
 import gregtech.common.ConfigHolder;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,6 +15,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -184,5 +184,12 @@ public interface IToolStats {
     default void onBreakingUse(ItemStack stack, World world, BlockPos pos) {
         if (ConfigHolder.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?>)
             world.playSound(null, pos, ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
+    }
+
+    static void onOtherUse(@Nonnull ItemStack stack, World world, BlockPos pos) {
+        if (stack.getItem() instanceof ToolMetaItem<?>) {
+            IToolStats stats = ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getToolStats();
+            stats.onBreakingUse(stack, world, pos);
+        }
     }
 }

--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -176,9 +176,10 @@ public interface IToolStats {
     }
 
     default void onCraftingUse(ItemStack stack) {
-        if (ConfigHolder.toolCraftingSounds && ForgeHooks.getCraftingPlayer() != null && stack.getItem() instanceof ToolMetaItem<?>)
-            ForgeHooks.getCraftingPlayer().playSound(((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), 1, 1);
-
+        if (ConfigHolder.toolCraftingSounds && ForgeHooks.getCraftingPlayer() != null && stack.getItem() instanceof ToolMetaItem<?>) {
+            EntityPlayer player = ForgeHooks.getCraftingPlayer();
+            player.getEntityWorld().playSound(player, player.getPosition(), ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
+        }
     }
 
     default void onBreakingUse(ItemStack stack, World world, BlockPos pos) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -364,7 +364,7 @@ public class GTUtility {
         if (item instanceof IToolItem) {
             //if item implements IDamagableItem, it manages it's own durability itself
             IToolItem damagableItem = (IToolItem) item;
-            return damagableItem.damageItem(itemStack, vanillaDamage, simulate);
+            return damagableItem.damageItem(itemStack, null, vanillaDamage, simulate);
 
         } else if (itemStack.hasCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null)) {
             //if we're using electric item, use default energy multiplier for textures

--- a/src/main/java/gregtech/common/items/behaviors/CrowbarBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/CrowbarBehaviour.java
@@ -3,6 +3,7 @@ package gregtech.common.items.behaviors;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
+import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.util.GTUtility;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRailBase;
@@ -43,6 +44,7 @@ public class CrowbarBehaviour implements IItemBehaviour {
                 } else {
                     if (tryRotateRailBlock(blockState, world, blockPos)) {
                         GTUtility.doDamageItem(stack, cost, false);
+                        IToolStats.onOtherUse(stack, world, blockPos);
                         return EnumActionResult.SUCCESS;
                     }
                     return EnumActionResult.FAIL;
@@ -58,6 +60,7 @@ public class CrowbarBehaviour implements IItemBehaviour {
                 }
                 boolean result = coverable.removeCover(coverSide);
                 GTUtility.doDamageItem(stack, cost, false);
+                IToolStats.onOtherUse(stack, world, blockPos);
                 return result ? EnumActionResult.SUCCESS : EnumActionResult.PASS;
             }
         }

--- a/src/main/java/gregtech/common/items/behaviors/PlungerBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/PlungerBehaviour.java
@@ -79,7 +79,7 @@ public class PlungerBehaviour implements IItemBehaviour, IItemCapabilityProvider
                     double operations = result;
                     operations /= 1000;
                     final int damage = (int) Math.ceil(operations);
-                    result = 1000 * plunger.damageItem(container, damage, true, !doFill);
+                    result = 1000 * plunger.damageItem(container, null, damage, true, !doFill);
                 }
                 // TODO play sound (how to get the player?)
                 return result;

--- a/src/main/java/gregtech/common/items/behaviors/SoftHammerBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/SoftHammerBehaviour.java
@@ -3,6 +3,7 @@ package gregtech.common.items.behaviors;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
+import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.util.GTUtility;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -42,6 +43,7 @@ public class SoftHammerBehaviour implements IItemBehaviour {
                         new TextComponentTranslation("behaviour.soft_hammer.enabled") :
                         new TextComponentTranslation("behaviour.soft_hammer.disabled"));
                 GTUtility.doDamageItem(stack, cost, false);
+                IToolStats.onOtherUse(stack, world, pos);
                 return EnumActionResult.SUCCESS;
             }
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -275,7 +275,7 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     private void damageTool(ItemStack itemStack) {
         if (itemStack.getItem() instanceof ToolMetaItem) {
             ToolMetaItem<?> toolMetaItem = (ToolMetaItem<?>) itemStack.getItem();
-            toolMetaItem.damageItem(itemStack, 1, true, false);
+            toolMetaItem.damageItem(itemStack, null, 1, true, false);
         }
     }
 

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -6,6 +6,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.tool.ICutterItem;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.damagesources.DamageSources;
+import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.pipenet.block.material.BlockMaterialPipe;
 import gregtech.api.pipenet.tile.AttachmentType;
 import gregtech.api.pipenet.tile.IPipeTile;
@@ -96,15 +97,17 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     @Override
-    public int onPipeToolUsed(ItemStack stack, EnumFacing coverSide, IPipeTile<Insulation, WireProperties> pipeTile, EntityPlayer entityPlayer) {
+    public int onPipeToolUsed(World world, BlockPos pos, ItemStack stack, EnumFacing coverSide, IPipeTile<Insulation, WireProperties> pipeTile, EntityPlayer entityPlayer) {
         ICutterItem cutterItem = stack.getCapability(GregtechCapabilities.CAPABILITY_CUTTER, null);
         if (cutterItem != null) {
             if (cutterItem.damageItem(DamageValues.DAMAGE_FOR_CUTTER, true)) {
                 if (!entityPlayer.world.isRemote) {
                     boolean isOpen = pipeTile.isConnectionOpen(AttachmentType.PIPE, coverSide);
-                    if (isOpen || canConnect(pipeTile, coverSide))
+                    if (isOpen || canConnect(pipeTile, coverSide)) {
                         pipeTile.setConnectionBlocked(AttachmentType.PIPE, coverSide, isOpen, false);
-                    cutterItem.damageItem(DamageValues.DAMAGE_FOR_CUTTER, false);
+                        cutterItem.damageItem(DamageValues.DAMAGE_FOR_CUTTER, false);
+                        IToolStats.onOtherUse(stack, world, pos);
+                    }
                 }
                 return 1;
             }

--- a/src/main/java/gregtech/common/tools/HardHammerBehavior.java
+++ b/src/main/java/gregtech/common/tools/HardHammerBehavior.java
@@ -1,10 +1,7 @@
 package gregtech.common.tools;
 
-import gregtech.api.GTValues;
-import gregtech.api.capability.GregtechTileCapabilities;
-import gregtech.api.capability.IControllable;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
-import gregtech.api.items.metaitem.stats.IItemComponent;
+import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.util.GTUtility;
@@ -30,27 +27,21 @@ public class HardHammerBehavior implements IItemBehaviour {
     }
 
     public EnumActionResult onItemUseFirst(EntityPlayer player, World world, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ, EnumHand hand) {
-        if (world.isAirBlock(pos)) {
+        if (world.isRemote || world.isAirBlock(pos)) {
             return EnumActionResult.PASS;
         }
-
         ItemStack stack = player.getHeldItem(hand);
 
         TileEntity tileEntity = world.getTileEntity(pos);
         if (tileEntity instanceof MetaTileEntityHolder) {
             MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
-            if (metaTileEntity != null) {
-                if(!world.isRemote) { // If it gets to this point, it will run on the client thread and do what it's supposed to, but we don't want this to pull up the GUI.
-                    return EnumActionResult.SUCCESS;
-                }
-                metaTileEntity.toggleMuffled();
-                if(metaTileEntity.isMuffled())
-                    player.sendMessage(new TextComponentTranslation("gregtech.machine.muffle.on"));
-                else
-                    player.sendMessage(new TextComponentTranslation("gregtech.machine.muffle.off"));
-                GTUtility.doDamageItem(stack, cost, false);
-                return EnumActionResult.SUCCESS;
-            }
+            metaTileEntity.toggleMuffled();
+            player.sendMessage(metaTileEntity.isMuffled() ?
+                    new TextComponentTranslation("behaviour.soft_hammer.enabled") :
+                    new TextComponentTranslation("behaviour.soft_hammer.disabled"));
+            GTUtility.doDamageItem(stack, cost, false);
+            IToolStats.onOtherUse(stack, world, pos);
+            return EnumActionResult.SUCCESS;
         }
         return EnumActionResult.PASS;
     }

--- a/src/main/java/gregtech/common/tools/ToolMiningHammer.java
+++ b/src/main/java/gregtech/common/tools/ToolMiningHammer.java
@@ -17,7 +17,10 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 public class ToolMiningHammer extends ToolBase {
 
@@ -150,7 +153,7 @@ public class ToolMiningHammer extends ToolBase {
                             blockState.getPlayerRelativeBlockHardness(entityPlayer, world, offsetPos) > 0.0f &&
                             stack.canHarvestBlock(blockState)) {
                         GTUtility.harvestBlock(world, offsetPos, entityPlayer);
-                        ((ToolMetaItem) stack.getItem()).damageItem(stack, damagePerBlockBreak, false);
+                        ((ToolMetaItem<?>) stack.getItem()).damageItem(stack, entityPlayer, damagePerBlockBreak, false);
                     }
                 }
             }

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -67,7 +67,7 @@ public class ToolSaw extends ToolBase {
         if (result) {
             ToolMetaItem<?> toolMetaItem = (ToolMetaItem<?>) stack.getItem();
             int damagePerBlockBreak = getToolDamagePerBlockBreak(stack);
-            toolMetaItem.damageItem(stack, damagePerBlockBreak, false);
+            toolMetaItem.damageItem(stack, player, damagePerBlockBreak, false);
         }
         return result;
     }

--- a/src/main/java/gregtech/common/tools/ToolSense.java
+++ b/src/main/java/gregtech/common/tools/ToolSense.java
@@ -46,7 +46,7 @@ public class ToolSense extends ToolBase {
 
                             player.world.playEvent(2001, offsetPos, Block.getStateId(blockState));
                             ToolUtility.applyHarvestBehavior(offsetPos, player);
-                            toolMetaItem.damageItem(stack, damagePerBlockBreak, false);
+                            toolMetaItem.damageItem(stack, player, damagePerBlockBreak, false);
 
                         } else if (blockState.getMaterial() == Material.PLANTS ||
                                 blockState.getMaterial() == Material.LEAVES ||
@@ -54,7 +54,7 @@ public class ToolSense extends ToolBase {
 
                             player.world.playEvent(2001, offsetPos, Block.getStateId(blockState));
                             player.world.setBlockToAir(offsetPos);
-                            toolMetaItem.damageItem(stack, damagePerBlockBreak, false);
+                            toolMetaItem.damageItem(stack, player, damagePerBlockBreak, false);
                         }
                     }
 

--- a/src/main/java/gregtech/common/tools/TreeChopTask.java
+++ b/src/main/java/gregtech/common/tools/TreeChopTask.java
@@ -75,7 +75,7 @@ public class TreeChopTask implements Task {
             return true;
         }
         if (toolMetaItem.isUsable(itemInMainHand, damagePerBlockBreak) && tryBreakAny()) {
-            toolMetaItem.damageItem(itemInMainHand, damagePerBlockBreak, false);
+            toolMetaItem.damageItem(itemInMainHand, player, damagePerBlockBreak, false);
             return true;
         }
         return false;

--- a/src/main/java/gregtech/common/tools/largedrills/ToolDrillLarge.java
+++ b/src/main/java/gregtech/common/tools/largedrills/ToolDrillLarge.java
@@ -226,7 +226,7 @@ public abstract class ToolDrillLarge<E extends Enum<E> & IDrillMode> extends Too
                         blockState.getPlayerRelativeBlockHardness(entityPlayer, world, currentPos) > 0.0f &&
                         stack.canHarvestBlock(blockState)) {
                     GTUtility.harvestBlock(world, currentPos, entityPlayer);
-                    ((ToolMetaItem<?>) stack.getItem()).damageItem(stack, damagePerBlockBreak, false);
+                    ((ToolMetaItem<?>) stack.getItem()).damageItem(stack, entityPlayer, damagePerBlockBreak, false);
                 }
             });
             /*


### PR DESCRIPTION
Fixes:
1. Soft Hammers not playing sounds when enabling/disabling machines
2. Screwdrivers not playing sounds when adjusting allowing input from output side, configuring covers
3. Crowbars not playing sounds when rotating rails, removing covers
4. Cutters when adjusting wires/cables
5. Wrenches when adjusting pipes
6. Hard Hammer not playing sound when muffling machines.

Adds:
1. The tool vanilla breaking sound when tools are broken