### PR TITLE
Nerf mining hammer recipes significantly

### DIFF
--- a/src/main/java/gregtech/common/items/MetaTool.java
+++ b/src/main/java/gregtech/common/items/MetaTool.java
@@ -125,7 +125,7 @@ public class MetaTool extends ToolMetaItem<ToolMetaItem<?>.MetaToolValueItem> {
                 .setSound(GTSounds.PLUNGER_TOOL);
 
         MINING_HAMMER = addItem(19, "tool.mining_hammer").setToolStats(new ToolMiningHammer())
-                .setFullRepairCost(14);
+                .setFullRepairCost(6);
 
         DRILL_LV = addItem(20, "tool.drill.lv").setToolStats(new ToolDrills.ToolDrillLV())
                 .setFullRepairCost(4)

--- a/src/main/java/gregtech/loaders/oreprocessing/ToolRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ToolRecipeHandler.java
@@ -179,11 +179,9 @@ public class ToolRecipeHandler {
     public static void processPlate(OrePrefix platePrefix, Material material, ToolProperty property) {
         ModHandler.addShapedRecipe(String.format("mining_hammer_%s", material.toString()),
                 MetaItems.MINING_HAMMER.getStackForm(material),
-                "PIP", "IBI", "fRh",
-                'I', new UnificationEntry(OrePrefix.ingot, material),
-                'B', new UnificationEntry(OrePrefix.block, material),
+                "PP ", "PPR", "PP ",
                 'P', new UnificationEntry(OrePrefix.plate, material),
-                'R', new UnificationEntry(OrePrefix.stick, Materials.Iron));
+                'R', new UnificationEntry(OrePrefix.stick, Materials.Wood));
     }
 
 


### PR DESCRIPTION
Makes mining hammers require 6 plates, rather than an equivalent of 14 ingots.