### PR TITLE
Buff Steam Multiblock Durations Back to Normal

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -12,7 +12,7 @@ import gregtech.api.recipes.logic.IParallelableRecipeLogic;
  * Not recommended to use this Handler if you do not
  * need multi-recipe logic for your Multi.
  */
-public class SteamMultiWorkable extends SteamMultiblockRecipeLogic implements IParallelableRecipeLogic {
+public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
 
     public SteamMultiWorkable(RecipeMapSteamMultiblockController tileEntity, double conversionRate) {
         super(tileEntity, tileEntity.recipeMap, tileEntity.getSteamFluidTank(), conversionRate);

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -3,6 +3,7 @@ package gregtech.api.capability.impl;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.recipes.RecipeBuilder;
+import gregtech.api.recipes.logic.IParallelableRecipeLogic;
 
 
 /**
@@ -11,7 +12,7 @@ import gregtech.api.recipes.RecipeBuilder;
  * Not recommended to use this Handler if you do not
  * need multi-recipe logic for your Multi.
  */
-public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
+public class SteamMultiWorkable extends SteamMultiblockRecipeLogic implements IParallelableRecipeLogic {
 
     public SteamMultiWorkable(RecipeMapSteamMultiblockController tileEntity, double conversionRate) {
         super(tileEntity, tileEntity.recipeMap, tileEntity.getSteamFluidTank(), conversionRate);
@@ -25,7 +26,8 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     @Override
     public void applyParallelBonus(RecipeBuilder<?> builder) {
         int currentRecipeEU = builder.getEUt();
-        int currentRecipeDuration = builder.getDuration();
-        builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU) * 1.33)).duration((int) (currentRecipeDuration * 1.5));
+        int currentRecipeDuration = builder.getDuration() / getParallelLimit();
+        builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU) * 1.33))
+           .duration((int) (currentRecipeDuration * 1.5));
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -3,7 +3,6 @@ package gregtech.api.capability.impl;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.recipes.RecipeBuilder;
-import gregtech.api.recipes.logic.IParallelableRecipeLogic;
 
 
 /**


### PR DESCRIPTION
This fixes the extremely long durations experienced with the steam oven and grinder. With this, full oven recipes should only take 10 seconds.