### PR TITLE
Energy acceptor fix

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/GTEnergyWrapper.java
+++ b/src/main/java/gregtech/api/capability/impl/GTEnergyWrapper.java
@@ -2,7 +2,6 @@ package gregtech.api.capability.impl;
 
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import net.minecraft.util.EnumFacing;

--- a/src/main/java/gregtech/api/capability/impl/GTEnergyWrapper.java
+++ b/src/main/java/gregtech/api/capability/impl/GTEnergyWrapper.java
@@ -2,6 +2,7 @@ package gregtech.api.capability.impl;
 
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import net.minecraft.util.EnumFacing;
@@ -145,7 +146,6 @@ public class GTEnergyWrapper implements IEnergyContainer {
             int consumable = container.receiveEnergy(safeCastLongToInt(maximalValue + receive), true);
 
             // Machine unable to consume any power
-            // Probably unnecessary in this case, but just to be safe
             if (consumable == 0)
                 return 0;
 
@@ -261,6 +261,14 @@ public class GTEnergyWrapper implements IEnergyContainer {
             return 0L;
 
         return (long) (cap.getEnergyStored() / ConfigHolder.U.energyOptions.rfRatio);
+    }
+
+    @Override
+    public long getEnergyCanBeInserted() {
+        // most RF/FE cables blindly try to insert energy without checking if there is space, since the recieving IEnergyStorage should handle it
+        // this simulates that behavior in most places by allowing our "is there space" checks to pass and letting the cable attempt to insert energy
+        // if the wrapped TE actually cannot accept any more energy, the energy transfer will return 0 before any changes to our internal rf buffer
+        return Math.max(1, getEnergyCapacity() - getEnergyStored());
     }
 
     @Override


### PR DESCRIPTION
**What:**
Makes native GT -> RF conversion behave more like RF cables

**How solved:**
Overrides a method to allow "is there space for energy" checks to always pass if they are checking only for > 0.  This creates similar behavior to most RF cables, in that they do not check if there is actually space in the destination before simulating insertion.

**Outcome:**
Allows the AE2 energy acceptor to work with GT cables' native RF conversion

**Additional info:**
The only place `getEnergyCanBeInserted` is used for something other than an "is there space for energy" check is in a method relating to electric items only called in `SimpleMachineMetaTileEntity`, so I do not think any issues will be caused by this

**Possible compatibility issue:**
None anticipated