### PR TITLE
Remove data receival

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -32,7 +32,6 @@ public class GregtechDataCodes {
     public static final int UPDATE_UI = 0;
     public static final int CREATE_FAKE_UI = 1;
     public static final int MOUSE_POSITION = 2;
-    public static final int DETECT_UPDATE_RECEIVED = 3;
 
     // Pump
     public static final int PUMP_HEAD_LEVEL = 200;

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -55,9 +55,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     public FakeModularGui guiCache;
     public FakeModularUIContainerClipboard guiContainerCache;
     private static final Cuboid6 pageBox = new Cuboid6(3 / 16.0, 0.25 / 16.0, 0.25 / 16.0, 13 / 16.0, 14.25 / 16.0, 0.3 / 16.0);
-    private static boolean receivesData = false;
     private static final NBTBase NO_CLIPBOARD_SIG = new NBTTagInt(0);
-
 
     public MetaTileEntityClipboard(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId);
@@ -74,9 +72,6 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
             if (guiCache != null)
                 guiCache.updateScreen();
         } else {
-            if (!receivesData)
-                this.writeCustomData(DETECT_UPDATE_RECEIVED, buffer -> {
-                }); // Doesn't do anything, just helps start updates quickly
             if (guiContainerCache != null)
                 guiContainerCache.detectAndSendChanges();
         }
@@ -340,7 +335,6 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        receivesData = true;
         if (dataId == UPDATE_UI) {
             int windowID = buf.readVarInt();
             int widgetID = buf.readVarInt();
@@ -357,6 +351,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
                 guiCache.mouseClicked(mouseX, mouseY, 0); // Left mouse button
             }
             this.scheduleRenderUpdate();
+            this.markDirty();
         }
     }
 


### PR DESCRIPTION
Apparently, it turns out that an issue with packets not being sent to the client from a clipboard until it was updated in some way was resolved in the past few months. So, this just removes a check that was being done and taking up network space.