### PR TITLE
Fix missing recipe registry entry spam on server join

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -582,4 +582,9 @@ public class OrePrefix {
     public static Collection<OrePrefix> values() {
         return PREFIXES.values();
     }
+
+    @Override
+    public String toString() {
+        return name + "/" + id;
+    }
 }


### PR DESCRIPTION
**What:**
Fixes spam of this type of error on the client when joining a server
`[Client thread/INFO] [FML]: Registry IRecipe: Found a missing id from the world gregtech:annealed_copper_cable_gregtech.api.unification.ore.oreprefix@36ce903_quadrupling`

**How solved:**
Added a `toString` to `OrePrefix`

**Outcome:**
Recipe names no longer use the default `toString` from `Object`, allowing them to be consistent between client and server and preventing "missing" recipe registry entries

**Additional info:**
Both the name and ID are used, so if there is an ID shift or name change in OrePrefix and the versions on client/server are desynced, the spam may return, which is not a bad thing, since it will signal different client/server versions