### PR TITLE
Allow Steam Machines to destroy single snow layers when venting

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -7,9 +7,11 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.common.advancement.GTTriggers;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockSnow;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
@@ -121,29 +123,39 @@ public class RecipeLogicSteam extends AbstractRecipeLogic {
         BlockPos ventingBlockPos = machinePos.offset(ventingSide);
         IBlockState blockOnPos = metaTileEntity.getWorld().getBlockState(ventingBlockPos);
         if (blockOnPos.getCollisionBoundingBox(metaTileEntity.getWorld(), ventingBlockPos) == Block.NULL_AABB) {
-            metaTileEntity.getWorld()
-                    .getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(ventingBlockPos), EntitySelectors.CAN_AI_TARGET)
-                    .forEach(entity -> {
-                        entity.attackEntityFrom(DamageSources.getHeatDamage(), this.isHighPressure ? 12.0f : 6.0f);
-                        if (entity instanceof EntityPlayerMP) {
-                            GTTriggers.STEAM_VENT_DEATH.trigger((EntityPlayerMP) entity);
-                        }
-                    });
-            WorldServer world = (WorldServer) metaTileEntity.getWorld();
-            double posX = machinePos.getX() + 0.5 + ventingSide.getXOffset() * 0.6;
-            double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
-            double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
-
-            world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
-                    7 + world.rand.nextInt(3),
-                    ventingSide.getXOffset() / 2.0,
-                    ventingSide.getYOffset() / 2.0,
-                    ventingSide.getZOffset() / 2.0, 0.1);
-            world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1.0f, 1.0f);
-            setNeedsVenting(false);
-        } else if (!ventingStuck) {
+            performVentingAnimation(ventingBlockPos, machinePos);
+        }
+        else if(blockOnPos.getBlock() == Blocks.SNOW_LAYER && blockOnPos.getValue(BlockSnow.LAYERS) == 1) {
+            performVentingAnimation(ventingBlockPos, machinePos);
+            metaTileEntity.getWorld().destroyBlock(ventingBlockPos, false);
+        }
+        else if (!ventingStuck) {
             setVentingStuck(true);
         }
+    }
+
+    private void performVentingAnimation(BlockPos ventingBlockPos, BlockPos machinePos) {
+        metaTileEntity.getWorld()
+                .getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(ventingBlockPos), EntitySelectors.CAN_AI_TARGET)
+                .forEach(entity -> {
+                    entity.attackEntityFrom(DamageSources.getHeatDamage(), this.isHighPressure ? 12.0f : 6.0f);
+                    if (entity instanceof EntityPlayerMP) {
+                        GTTriggers.STEAM_VENT_DEATH.trigger((EntityPlayerMP) entity);
+                    }
+                });
+        WorldServer world = (WorldServer) metaTileEntity.getWorld();
+        double posX = machinePos.getX() + 0.5 + ventingSide.getXOffset() * 0.6;
+        double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
+        double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
+
+        world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
+                7 + world.rand.nextInt(3),
+                ventingSide.getXOffset() / 2.0,
+                ventingSide.getYOffset() / 2.0,
+                ventingSide.getZOffset() / 2.0, 0.1);
+        world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1.0f, 1.0f);
+        setNeedsVenting(false);
+
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
@@ -6,7 +6,9 @@ import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockSnow;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
@@ -132,17 +134,26 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
         BlockPos ventingBlockPos = machinePos.offset(ventingSide);
         IBlockState blockOnPos = metaTileEntity.getWorld().getBlockState(ventingBlockPos);
         if (blockOnPos.getCollisionBoundingBox(metaTileEntity.getWorld(), ventingBlockPos) == Block.NULL_AABB) {
-            WorldServer world = (WorldServer) metaTileEntity.getWorld();
-            double posX = machinePos.getX() + 0.5 + ventingSide.getXOffset() * 0.6;
-            double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
-            double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
-
-            world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
-                    7 + world.rand.nextInt(3),
-                    ventingSide.getXOffset() / 2.0,
-                    ventingSide.getYOffset() / 2.0,
-                    ventingSide.getZOffset() / 2.0, 0.1);
-            world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1.0f, 1.0f);
+            performVentingAnimation(machinePos, ventingSide);
         }
+        else if(blockOnPos.getBlock() == Blocks.SNOW_LAYER && blockOnPos.getValue(BlockSnow.LAYERS) == 1) {
+            performVentingAnimation(machinePos, ventingSide);
+            metaTileEntity.getWorld().destroyBlock(ventingBlockPos, false);
+        }
+    }
+
+    private void performVentingAnimation(BlockPos machinePos, EnumFacing ventingSide) {
+        WorldServer world = (WorldServer) metaTileEntity.getWorld();
+        double posX = machinePos.getX() + 0.5 + ventingSide.getXOffset() * 0.6;
+        double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
+        double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
+
+        world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
+                7 + world.rand.nextInt(3),
+                ventingSide.getXOffset() / 2.0,
+                ventingSide.getYOffset() / 2.0,
+                ventingSide.getZOffset() / 2.0, 0.1);
+        world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1.0f, 1.0f);
+
     }
 }


### PR DESCRIPTION
Allows Steam Machines to destroy single snow layers when venting into the snow layer. This is both a QOL and a logic change, as hot steam being vented into a thin layer of snow would most likely melt the thin layer of snow