### PR TITLE
Allow parts to specify if they can be shared

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/IMultiblockPart.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IMultiblockPart.java
@@ -8,4 +8,8 @@ public interface IMultiblockPart {
 
     void removeFromMultiBlock(MultiblockControllerBase controllerBase);
 
+    default boolean canPartShare() {
+        return true;
+    }
+
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -214,7 +214,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
             parts.sort(Comparator.comparing(it -> multiblockPartSorter().apply(((MetaTileEntity) it).getPos())));
             for (IMultiblockPart part : parts) {
                 if (part.isAttachedToMultiBlock()) {
-                    if (!canShare() || part instanceof MetaTileEntityRotorHolder || part instanceof IMaintenanceHatch) {
+                    if (!canShare() || !part.canPartShare()) {
                         return;
                     }
                 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityAutoMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityAutoMaintenanceHatch.java
@@ -92,4 +92,9 @@ public class MetaTileEntityAutoMaintenanceHatch extends MetaTileEntityMultiblock
     public void registerAbilities(List<IMaintenanceHatch> abilityList) {
         abilityList.add(this);
     }
+
+    @Override
+    public boolean canPartShare() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -431,4 +431,9 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     public void registerAbilities(List<IMaintenanceHatch> abilityList) {
         abilityList.add(this);
     }
+
+    @Override
+    public boolean canPartShare() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -319,6 +319,11 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         abilityList.add(this);
     }
 
+    @Override
+    public boolean canPartShare() {
+        return false;
+    }
+
     private class InventoryRotorHolder extends ItemStackHandler {
 
         public InventoryRotorHolder() {


### PR DESCRIPTION
**What:**

Allows for specific Multiblock parts to specify if they can be shared or not. This is done because the special case list was getting a little long, especially since the PA PR adds another entry.