### PR TITLE
Use GTValues.VA for recipe EU/t

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -55,7 +55,7 @@ public class GTValues {
     /**
      * The Voltage Tiers adjusted for cable loss.
      */
-    public static final long[] VA = new long[]{7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320, 31457280, 125829120, 503316480, 2013265920};
+    public static final int[] VA = new int[]{7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320, 31457280, 125829120, 503316480, 2013265920};
 
     public static final int ULV = 0;
     public static final int LV = 1;

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -53,7 +53,7 @@ public class GTValues {
 
 
     /**
-     * The Voltage Tiers adjusted for cable loss.
+     * The Voltage Tiers adjusted for cable loss. Use this for recipe EU/t to avoid full-amp recipes
      */
     public static final int[] VA = new int[]{7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320, 31457280, 125829120, 503316480, 2013265920};
 

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -14,6 +14,8 @@ import net.minecraft.init.SoundEvents;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenProperty;
 
+import static gregtech.api.GTValues.*;
+
 @ZenClass("mods.gregtech.recipe.RecipeMaps")
 @ZenRegister
 public class RecipeMaps {
@@ -33,7 +35,7 @@ public class RecipeMaps {
 
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> MACERATOR_RECIPES = new RecipeMap<>("macerator", 1, 1, 1, 3, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(150).EUt(8), false)
+    public static final RecipeMap<SimpleRecipeBuilder> MACERATOR_RECIPES = new RecipeMap<>("macerator", 1, 1, 1, 3, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(150).EUt(VA[ULV]), false)
             .setSlotOverlay(false, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MACERATE, MoveType.HORIZONTAL)
@@ -221,7 +223,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Water.getFluid(100))
      * 				.outputs(new ItemStack(Items.paper, 1, 0))
      * 				.duration(100)
-     * 				.EUt(8)
+     * 				.EUt(VA[ULV])
      * 				.buildAndRegister();
      * </pre>
      */
@@ -256,7 +258,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Water.getFluid(6))
      * 				.fluidOutputs(Materials.Water.getGas(960))
      * 				.duration(30)
-     * 				.EUt(32)
+     * 				.EUt(30)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -313,7 +315,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Steel.getFluid(72))
      * 				.outputs(ItemList.IC2_Item_Casing_Steel.get(1))
      * 				.duration(16)
-     * 				.EUt(8)
+     * 				.EUt(VA[ULV])
      * 				.buildAndRegister();
      * </pre>
      */
@@ -429,7 +431,7 @@ public class RecipeMaps {
      */
 
     @ZenProperty
-    public static final RecipeMap<ImplosionRecipeBuilder> IMPLOSION_RECIPES = new RecipeMap<>("implosion_compressor", 2, 3, 1, 2, 0, 0, 0, 0, new ImplosionRecipeBuilder().duration(20).EUt(30), false)
+    public static final RecipeMap<ImplosionRecipeBuilder> IMPLOSION_RECIPES = new RecipeMap<>("implosion_compressor", 2, 3, 1, 2, 0, 0, 0, 0, new ImplosionRecipeBuilder().duration(20).EUt(VA[LV]), false)
             .setSlotOverlay(false, false, true, GuiTextures.IMPLOSION_OVERLAY_1)
             .setSlotOverlay(false, false, false, GuiTextures.IMPLOSION_OVERLAY_2)
             .setSlotOverlay(true, false, true, GuiTextures.DUST_OVERLAY)
@@ -447,7 +449,7 @@ public class RecipeMaps {
      */
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> VACUUM_RECIPES = new RecipeMap<>("vacuum_freezer", 0, 1, 0, 1, 0, 1, 0, 1, new SimpleRecipeBuilder().EUt(120), false)
+    public static final RecipeMap<SimpleRecipeBuilder> VACUUM_RECIPES = new RecipeMap<>("vacuum_freezer", 0, 1, 0, 1, 0, 1, 0, 1, new SimpleRecipeBuilder().EUt(VA[MV]), false)
             .setSound(GTSounds.COOLING);
 
     /**
@@ -465,7 +467,7 @@ public class RecipeMaps {
      */
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CHEMICAL_RECIPES = new RecipeMap<>("chemical_reactor", 0, 2, 0, 2, 0, 3, 0, 2, new SimpleRecipeBuilder().EUt(30), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CHEMICAL_RECIPES = new RecipeMap<>("chemical_reactor", 0, 2, 0, 2, 0, 3, 0, 2, new SimpleRecipeBuilder().EUt(VA[LV]), false)
             .setSlotOverlay(false, false, false, GuiTextures.MOLECULAR_OVERLAY_1)
             .setSlotOverlay(false, false, true, GuiTextures.MOLECULAR_OVERLAY_2)
             .setSlotOverlay(false, true, false, GuiTextures.MOLECULAR_OVERLAY_3)
@@ -500,7 +502,7 @@ public class RecipeMaps {
      */
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> LARGE_CHEMICAL_RECIPES = new RecipeMap<>("large_chemical_reactor", 0, 3, 0, 3, 0, 5, 0, 4, new SimpleRecipeBuilder().EUt(30), false)
+    public static final RecipeMap<SimpleRecipeBuilder> LARGE_CHEMICAL_RECIPES = new RecipeMap<>("large_chemical_reactor", 0, 3, 0, 3, 0, 5, 0, 4, new SimpleRecipeBuilder().EUt(VA[LV]), false)
             .setSlotOverlay(false, false, false, GuiTextures.MOLECULAR_OVERLAY_1)
             .setSlotOverlay(false, false, true, GuiTextures.MOLECULAR_OVERLAY_2)
             .setSlotOverlay(false, true, false, GuiTextures.MOLECULAR_OVERLAY_3)
@@ -592,7 +594,7 @@ public class RecipeMaps {
      * 				.inputs(OreDictUnifier.get(OrePrefix.plate, Materials.Tin, 12L))
      * 				.outputs(ItemList.Cell_Empty.get(6))
      * 				.duration(1200)
-     * 				.EUt(8)
+     * 				.EUt(7)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -661,7 +663,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Lubricant.getFluid(1))
      * 				.outputs(new ItemStack(Blocks.PLANKS), OreDictUnifier.get(OrePrefix.dust, Materials.Wood, 1L))
      * 				.duration(200)
-     * 				.EUt(8)
+     * 				.EUt(7)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -699,7 +701,7 @@ public class RecipeMaps {
      * 				.notConsumable(ItemList.Shape_Extruder_Rod)
      * 				.outputs(OreDictUnifier.get(OrePrefix.stick, Materials.Iron.smeltInto, 2))
      * 				.duration(64)
-     * 				.EUt(8)
+     * 				.EUt(7)
      * 				.buildAndRegister();
      * </pre>
      */

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -35,7 +35,7 @@ public class RecipeMaps {
 
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> MACERATOR_RECIPES = new RecipeMap<>("macerator", 1, 1, 1, 3, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(150).EUt(VA[ULV]), false)
+    public static final RecipeMap<SimpleRecipeBuilder> MACERATOR_RECIPES = new RecipeMap<>("macerator", 1, 1, 1, 3, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(150).EUt(2), false)
             .setSlotOverlay(false, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MACERATE, MoveType.HORIZONTAL)
@@ -223,7 +223,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Water.getFluid(100))
      * 				.outputs(new ItemStack(Items.paper, 1, 0))
      * 				.duration(100)
-     * 				.EUt(VA[ULV])
+     * 				.EUt(8)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -258,7 +258,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Water.getFluid(6))
      * 				.fluidOutputs(Materials.Water.getGas(960))
      * 				.duration(30)
-     * 				.EUt(30)
+     * 				.EUt(32)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -315,7 +315,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Steel.getFluid(72))
      * 				.outputs(ItemList.IC2_Item_Casing_Steel.get(1))
      * 				.duration(16)
-     * 				.EUt(VA[ULV])
+     * 				.EUt(8)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -594,7 +594,7 @@ public class RecipeMaps {
      * 				.inputs(OreDictUnifier.get(OrePrefix.plate, Materials.Tin, 12L))
      * 				.outputs(ItemList.Cell_Empty.get(6))
      * 				.duration(1200)
-     * 				.EUt(7)
+     * 				.EUt(8)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -663,7 +663,7 @@ public class RecipeMaps {
      * 				.fluidInputs(Materials.Lubricant.getFluid(1))
      * 				.outputs(new ItemStack(Blocks.PLANKS), OreDictUnifier.get(OrePrefix.dust, Materials.Wood, 1L))
      * 				.duration(200)
-     * 				.EUt(7)
+     * 				.EUt(8)
      * 				.buildAndRegister();
      * </pre>
      */
@@ -701,7 +701,7 @@ public class RecipeMaps {
      * 				.notConsumable(ItemList.Shape_Extruder_Rod)
      * 				.outputs(OreDictUnifier.get(OrePrefix.stick, Materials.Iron.smeltInto, 2))
      * 				.duration(64)
-     * 				.EUt(7)
+     * 				.EUt(8)
      * 				.buildAndRegister();
      * </pre>
      */

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -6,6 +6,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Material.FluidType;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -256,7 +257,7 @@ public class ElementMaterials {
                 .element(Elements.Eu)
                 .cableProperties(GTValues.V[GTValues.UHV], 2, 32)
                 .fluidPipeProperties(7780, 1200, true)
-                .blastTemp(6000, GasTier.MID, 7680, 180)
+                .blastTemp(6000, GasTier.MID, VA[IV], 180)
                 .build();
 
         Fermium = new Material.Builder(34, "fermium")
@@ -377,7 +378,7 @@ public class ElementMaterials {
                 .element(Elements.Ir)
                 .toolStats(7.0f, 3.0f, 2560, 21)
                 .fluidPipeProperties(3398, 140, true)
-                .blastTemp(4500, GasTier.HIGH, 7680, 1100)
+                .blastTemp(4500, GasTier.HIGH, VA[IV], 1100)
                 .build();
 
         Iron = new Material.Builder(51, "iron")
@@ -534,7 +535,7 @@ public class ElementMaterials {
                 .color(0xBEB4C8).iconSet(METALLIC)
                 .flags(STD_METAL)
                 .element(Elements.Nb)
-                .blastTemp(2750, GasTier.MID, 480, 900)
+                .blastTemp(2750, GasTier.MID, VA[HV], 900)
                 .build();
 
         Nitrogen = new Material.Builder(72, "nitrogen")
@@ -566,7 +567,7 @@ public class ElementMaterials {
                 .toolStats(16.0f, 4.0f, 1280, 21)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .itemPipeProperties(256, 8.0f)
-                .blastTemp(4500, GasTier.HIGH, 30720, 1000)
+                .blastTemp(4500, GasTier.HIGH, VA[LuV], 1000)
                 .build();
 
         Oxygen = new Material.Builder(76, "oxygen")
@@ -581,7 +582,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL)
                 .element(Elements.Pd)
                 .toolStats(8.0f, 2.0f, 512, 33)
-                .blastTemp(1828, GasTier.LOW, 480, 900)
+                .blastTemp(1828, GasTier.LOW, VA[HV], 900)
                 .build();
 
         Phosphorus = new Material.Builder(78, "phosphorus")
@@ -679,7 +680,7 @@ public class ElementMaterials {
                 .color(0xDC0C58).iconSet(BRIGHT)
                 .flags(EXT2_METAL)
                 .element(Elements.Rh)
-                .blastTemp(2237, GasTier.MID, 1920, 1200)
+                .blastTemp(2237, GasTier.MID, VA[EV], 1200)
                 .build();
 
         Roentgenium = new Material.Builder(91, "roentgenium")
@@ -702,7 +703,7 @@ public class ElementMaterials {
                 .color(0x50ACCD).iconSet(SHINY)
                 .flags(EXT2_METAL)
                 .element(Elements.Ru)
-                .blastTemp(2607, GasTier.MID, 1920, 900)
+                .blastTemp(2607, GasTier.MID, VA[EV], 900)
                 .build();
 
         Rutherfordium = new Material.Builder(94, "rutherfordium")
@@ -718,7 +719,7 @@ public class ElementMaterials {
                 .color(0xFFFFCC).iconSet(METALLIC)
                 .flags(STD_METAL)
                 .element(Elements.Sm)
-                .blastTemp(5400, GasTier.HIGH, 1920, 1500)
+                .blastTemp(5400, GasTier.HIGH, VA[EV], 1500)
                 .build();
 
         Scandium = new Material.Builder(96, "scandium")
@@ -860,7 +861,7 @@ public class ElementMaterials {
                 .element(Elements.Ti)
                 .toolStats(7.0f, 3.0f, 1600, 21)
                 .fluidPipeProperties(2426, 80, true)
-                .blastTemp(1941, GasTier.MID, 480, 1500)
+                .blastTemp(1941, GasTier.MID, VA[HV], 1500)
                 .build();
 
         Tritium = new Material.Builder(114, "tritium")
@@ -877,7 +878,7 @@ public class ElementMaterials {
                 .toolStats(7.0f, 3.0f, 2560, 21)
                 .cableProperties(GTValues.V[5], 2, 2)
                 .fluidPipeProperties(4618, 90, true)
-                .blastTemp(3600, GasTier.MID, 1920, 1800)
+                .blastTemp(3600, GasTier.MID, VA[EV], 1800)
                 .build();
 
         Uranium238 = new Material.Builder(116, "uranium")
@@ -950,7 +951,7 @@ public class ElementMaterials {
                 .toolStats(6.0f, 4.0f, 1280, 21)
                 .cableProperties(GTValues.V[7], 2, 2)
                 .fluidPipeProperties(19200, 1500, true)
-                .blastTemp(5000, GasTier.HIGH, 7680, 600)
+                .blastTemp(5000, GasTier.HIGH, VA[IV], 600)
                 .build();
 
         NaquadahEnriched = new Material.Builder(125, "naquadah_enriched")
@@ -959,7 +960,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .element(Elements.Nq1)
                 .toolStats(6.0f, 4.0f, 1280, 21)
-                .blastTemp(7000, GasTier.HIGH, 7680, 1000)
+                .blastTemp(7000, GasTier.HIGH, VA[IV], 1000)
                 .build();
 
         Naquadria = new Material.Builder(126, "naquadria")
@@ -967,7 +968,7 @@ public class ElementMaterials {
                 .color(0x1E1E1E, false).iconSet(SHINY)
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_GEAR, GENERATE_DENSE, GENERATE_FINE_WIRE)
                 .element(Elements.Nq2)
-                .blastTemp(9000, GasTier.HIGH, 122880, 1200)
+                .blastTemp(9000, GasTier.HIGH, VA[ZPM], 1200)
                 .build();
 
         Neutronium = new Material.Builder(127, "neutronium")
@@ -1002,7 +1003,7 @@ public class ElementMaterials {
                 .color(0x9973BD).iconSet(SHINY)
                 .flags(GENERATE_FOIL)
                 .element(Elements.Ke)
-                .blastTemp(8600, GasTier.HIGH, 30720, 1500)
+                .blastTemp(8600, GasTier.HIGH, VA[LuV], 1500)
                 .build();
 
         Adamantium = new Material.Builder(131, "adamantium")

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -6,6 +6,7 @@ import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import gregtech.api.unification.material.properties.PropertyKey;
 import net.minecraft.init.Enchantments;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -285,7 +286,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Iron, 1, Aluminium, 1, Chrome, 1)
                 .cableProperties(GTValues.V[3], 4, 3)
-                .blastTemp(1800, GasTier.LOW, 120, 1000)
+                .blastTemp(1800, GasTier.LOW, VA[MV], 1000)
                 .build();
 
         Lazurite = new Material.Builder(289, "lazurite")
@@ -328,7 +329,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Nickel, 4, Chrome, 1)
                 .cableProperties(GTValues.V[4], 4, 4)
-                .blastTemp(2700, GasTier.LOW, 480, 1300)
+                .blastTemp(2700, GasTier.LOW, VA[HV], 1300)
                 .build();
 
         NiobiumNitride = new Material.Builder(295, "niobium_nitride")
@@ -347,7 +348,7 @@ public class FirstDegreeMaterials {
                 .components(Niobium, 1, Titanium, 1)
                 .fluidPipeProperties(2900, 150, true)
                 .cableProperties(GTValues.V[6], 4, 2)
-                .blastTemp(4500, GasTier.HIGH, 480, 1500)
+                .blastTemp(4500, GasTier.HIGH, VA[HV], 1500)
                 .build();
 
         Obsidian = new Material.Builder(297, "obsidian")
@@ -378,7 +379,7 @@ public class FirstDegreeMaterials {
                 .components(Copper, 1, Silver, 4)
                 .toolStats(13.0f, 2.0f, 196, 33)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(1700, GasTier.LOW, 120, 1000)
+                .blastTemp(1700, GasTier.LOW, VA[MV], 1000)
                 .build();
 
         RoseGold = new Material.Builder(301, "rose_gold")
@@ -389,7 +390,7 @@ public class FirstDegreeMaterials {
                 .toolStats(14.0f, 2.0f, 152, 33)
                 .addDefaultEnchant(Enchantments.SMITE, 4)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(1600, GasTier.LOW, 120, 1000)
+                .blastTemp(1600, GasTier.LOW, VA[MV], 1000)
                 .build();
 
         BlackBronze = new Material.Builder(302, "black_bronze")
@@ -400,7 +401,7 @@ public class FirstDegreeMaterials {
                 .toolStats(12.0f, 2.0f, 256, 21)
                 .addDefaultEnchant(Enchantments.SMITE, 2)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(2000, GasTier.LOW, 120, 1000)
+                .blastTemp(2000, GasTier.LOW, VA[MV], 1000)
                 .build();
 
         BismuthBronze = new Material.Builder(303, "bismuth_bronze")
@@ -410,7 +411,7 @@ public class FirstDegreeMaterials {
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
                 .toolStats(8.0f, 3.0f, 256, 21)
                 .addDefaultEnchant(Enchantments.BANE_OF_ARTHROPODS, 5)
-                .blastTemp(1100, GasTier.LOW, 120, 1000)
+                .blastTemp(1100, GasTier.LOW, VA[MV], 1000)
                 .build();
 
         Biotite = new Material.Builder(304, "biotite")
@@ -456,7 +457,7 @@ public class FirstDegreeMaterials {
                 .colorAverage().iconSet(BRIGHT)
                 .flags(GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Ruthenium, 2, Iridium, 1)
-                .blastTemp(4500, GasTier.HIGH, 1920, 1600)
+                .blastTemp(4500, GasTier.HIGH, VA[EV], 1600)
                 .build();
 
         Ruby = new Material.Builder(311, "ruby")
@@ -511,7 +512,7 @@ public class FirstDegreeMaterials {
                 .toolStats(6.0f, 6.0f, 2200, 21)
                 .itemPipeProperties(32, 128)
                 .cableProperties(GTValues.V[10], 8, 16)
-                .blastTemp(10400, GasTier.HIGHER, 491520, 1600)
+                .blastTemp(10400, GasTier.HIGHER, VA[UV], 1600)
                 .build();
 
         Tantalite = new Material.Builder(318, "tantalite")
@@ -554,7 +555,7 @@ public class FirstDegreeMaterials {
                 .components(Iron, 6, Chrome, 1, Manganese, 1, Nickel, 1)
                 .toolStats(7.0f, 4.0f, 480, 33)
                 .fluidPipeProperties(2428, 60, true)
-                .blastTemp(1700, GasTier.LOW, 480, 1100)
+                .blastTemp(1700, GasTier.LOW, VA[HV], 1100)
                 .build();
 
         Steel = new Material.Builder(324, "steel")
@@ -566,7 +567,7 @@ public class FirstDegreeMaterials {
                 .toolStats(6.0f, 3.0f, 512, 21)
                 .fluidPipeProperties(2557, 40, true)
                 .cableProperties(GTValues.V[4], 2, 2)
-                .blastTemp(1000, null, 120, 800) // no gas tier for steel
+                .blastTemp(1000, null, VA[MV], 800) // no gas tier for steel
                 .build();
 
         Stibnite = new Material.Builder(325, "stibnite")
@@ -620,7 +621,7 @@ public class FirstDegreeMaterials {
                 .components(Cobalt, 5, Chrome, 2, Nickel, 1, Molybdenum, 1)
                 .toolStats(9.0f, 4.0f, 2048, 33)
                 .itemPipeProperties(128, 16)
-                .blastTemp(2700, GasTier.MID, 480, 1300)
+                .blastTemp(2700, GasTier.MID, VA[HV], 1300)
                 .build();
 
         Uraninite = new Material.Builder(332, "uraninite")
@@ -643,7 +644,7 @@ public class FirstDegreeMaterials {
                 .flags(STD_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_SPRING_SMALL)
                 .components(Vanadium, 3, Gallium, 1)
                 .cableProperties(GTValues.V[7], 4, 2)
-                .blastTemp(4500, GasTier.HIGH, 1920, 1200)
+                .blastTemp(4500, GasTier.HIGH, VA[EV], 1200)
                 .build();
 
         WroughtIron = new Material.Builder(335, "wrought_iron")
@@ -728,7 +729,7 @@ public class FirstDegreeMaterials {
                 .components(Iridium, 3, Osmium, 1)
                 .toolStats(9.0f, 3.0f, 3152, 21)
                 .itemPipeProperties(64, 32)
-                .blastTemp(4500, GasTier.HIGH, 30720, 900)
+                .blastTemp(4500, GasTier.HIGH, VA[LuV], 900)
                 .build();
 
         Tenorite = new Material.Builder(345, "tenorite")
@@ -772,7 +773,7 @@ public class FirstDegreeMaterials {
                 .color(0xA0A0A0)
                 .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Arsenic, 1, Gallium, 1)
-                .blastTemp(1200, GasTier.LOW, 120, 1200)
+                .blastTemp(1200, GasTier.LOW, VA[MV], 1200)
                 .build();
 
         Potash = new Material.Builder(352, "potash")
@@ -1057,7 +1058,7 @@ public class FirstDegreeMaterials {
                 .components(Tungsten, 1, Carbon, 1)
                 .toolStats(12.0f, 4.0f, 1280, 21)
                 .fluidPipeProperties(7568, 125, true)
-                .blastTemp(3143, GasTier.MID, 480, 1500)
+                .blastTemp(3143, GasTier.MID, VA[HV], 1500)
                 .build();
 
         CarbonDioxide = new Material.Builder(397, "carbon_dioxide")
@@ -1259,7 +1260,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Magnesium, 1, Boron, 2)
                 .cableProperties(GTValues.V[GTValues.MV], 4, 0, true)
-                .blastTemp(2500, GasTier.LOW, 480, 1000)
+                .blastTemp(2500, GasTier.LOW, VA[HV], 1000)
                 .build();
 
         MercuryBariumCalciumCuprate = new Material.Builder(426, "mercury_barium_calcium_cuprate")
@@ -1268,7 +1269,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Mercury, 1, Barium, 2, Calcium, 2, Copper, 3, Oxygen, 8)
                 .cableProperties(GTValues.V[GTValues.HV], 4, 0, true)
-                .blastTemp(3300, GasTier.LOW, 480, 1500)
+                .blastTemp(3300, GasTier.LOW, VA[HV], 1500)
                 .build();
 
         UraniumTriplatinum = new Material.Builder(427, "uranium_triplatinum")
@@ -1277,7 +1278,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Uranium238, 1, Platinum, 3)
                 .cableProperties(GTValues.V[GTValues.EV], 6, 0, true)
-                .blastTemp(4400, GasTier.MID, 1920, 1000)
+                .blastTemp(4400, GasTier.MID, VA[EV], 1000)
                 .build()
                 .setFormula("UPt3", true);
 
@@ -1287,7 +1288,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Samarium, 1, Iron, 1, Arsenic, 1, Oxygen, 1)
                 .cableProperties(GTValues.V[GTValues.IV], 6, 0, true)
-                .blastTemp(5200, GasTier.MID, 1920, 1500)
+                .blastTemp(5200, GasTier.MID, VA[EV], 1500)
                 .build();
 
         IndiumTinBariumTitaniumCuprate = new Material.Builder(429, "indium_tin_barium_titanium_cuprate")
@@ -1296,7 +1297,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING, GENERATE_FINE_WIRE)
                 .components(Indium, 4, Tin, 2, Barium, 2, Titanium, 1, Copper, 7, Oxygen, 14)
                 .cableProperties(GTValues.V[GTValues.LuV], 8, 0, true)
-                .blastTemp(6000, GasTier.HIGH, 7680, 1000)
+                .blastTemp(6000, GasTier.HIGH, VA[IV], 1000)
                 .build();
 
         UraniumRhodiumDinaquadide = new Material.Builder(430, "uranium_rhodium_dinaquadide")
@@ -1305,7 +1306,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FINE_WIRE)
                 .components(Uranium238, 1, Rhodium, 1, Naquadah, 2)
                 .cableProperties(GTValues.V[GTValues.ZPM], 8, 0, true)
-                .blastTemp(9000, GasTier.HIGH, 7680, 1500)
+                .blastTemp(9000, GasTier.HIGH, VA[IV], 1500)
                 .build()
                 .setFormula("URhNq2", true);
 
@@ -1315,7 +1316,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FINE_WIRE)
                 .components(NaquadahEnriched, 4, Trinium, 3, Europium, 2, Duranium, 1)
                 .cableProperties(GTValues.V[GTValues.UV], 16, 0, true)
-                .blastTemp(9900, GasTier.HIGH, 30720, 1000)
+                .blastTemp(9900, GasTier.HIGH, VA[LuV], 1000)
                 .build();
 
         RutheniumTriniumAmericiumNeutronate = new Material.Builder(432, "ruthenium_trinium_americium_neutronate")

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -37,7 +38,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_GEAR)
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(7.0f, 4.5f, 896, 21)
-                .blastTemp(1300, GasTier.LOW, 480, 1000)
+                .blastTemp(1300, GasTier.LOW, VA[HV], 1000)
                 .build();
 
         BlueSteel = new Material.Builder(2511, "blue_steel")
@@ -46,7 +47,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FRAME, GENERATE_GEAR)
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(7.5f, 5.0f, 1024, 21)
-                .blastTemp(1400, GasTier.LOW, 480, 1000)
+                .blastTemp(1400, GasTier.LOW, VA[HV], 1000)
                 .build();
 
         Basalt = new Material.Builder(2512, "basalt")
@@ -84,7 +85,7 @@ public class HigherDegreeMaterials {
                 .components(TungstenSteel, 5, Chrome, 1, Molybdenum, 2, Vanadium, 1)
                 .toolStats(10.0f, 5.5f, 4000, 21)
                 .cableProperties(GTValues.V[6], 4, 2)
-                .blastTemp(4200, GasTier.MID, 1920, 1300)
+                .blastTemp(4200, GasTier.MID, VA[EV], 1300)
                 .build();
 
         RedAlloy = new Material.Builder(2517, "red_alloy")
@@ -108,7 +109,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING)
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
                 .toolStats(10.0f, 8.0f, 5120, 21)
-                .blastTemp(5000, GasTier.HIGH, 1920, 1400)
+                .blastTemp(5000, GasTier.HIGH, VA[EV], 1400)
                 .build();
 
         HSSS = new Material.Builder(2520, "hsss")
@@ -117,7 +118,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_SPRING, GENERATE_ROTOR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
                 .toolStats(15.0f, 7.0f, 3000, 21)
-                .blastTemp(5000, GasTier.HIGH, 1920, 1500)
+                .blastTemp(5000, GasTier.HIGH, VA[EV], 1500)
                 .build();
 
         FluxedElectrum = new Material.Builder(2521, "fluxed_electrum")
@@ -128,7 +129,7 @@ public class HigherDegreeMaterials {
                 .toolStats(11.0f, 6.0f, 2100, 21)
                 .cableProperties(GTValues.V[8], 3, 2)
                 .itemPipeProperties(128, 16)
-                .blastTemp(9000, GasTier.HIGHER, 122880, 1000)
+                .blastTemp(9000, GasTier.HIGHER, VA[ZPM], 1000)
                 .build();
 
         IridiumMetalResidue = new Material.Builder(2522, "iridium_metal_residue")

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -5,6 +5,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import gregtech.api.unification.material.properties.PropertyKey;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.material.info.MaterialIconSet.*;
@@ -321,7 +322,7 @@ public class SecondDegreeMaterials {
                 .components(Naquadah, 2, Osmiridium, 1, Trinium, 1)
                 .toolStats(8.0f, 5.0f, 5120, 21)
                 .cableProperties(GTValues.V[8], 2, 4)
-                .blastTemp(7200, GasTier.HIGH, 30720, 1000)
+                .blastTemp(7200, GasTier.HIGH, VA[LuV], 1000)
                 .build();
 
         SulfuricNickelSolution = new Material.Builder(2043, "sulfuric_nickel_solution")
@@ -460,7 +461,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE)
                 .components(Palladium, 3, Rhodium, 1)
                 .toolStats(12.0f, 3.0f, 1024, 33)
-                .blastTemp(4500, GasTier.HIGH, 7680, 1200)
+                .blastTemp(4500, GasTier.HIGH, VA[IV], 1200)
                 .build();
 
         Clay = new Material.Builder(2063, "clay")

--- a/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 
 public class DecompositionRecipeHandler {
@@ -100,7 +101,7 @@ public class DecompositionRecipeHandler {
         } else {
             builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder()
                     .duration((int) Math.ceil(material.getAverageMass() * totalInputAmount * 1.5))
-                    .EUt(30);
+                    .EUt(VA[LV]);
         }
         builder.outputs(outputs);
         builder.fluidOutputs(fluidOutputs);

--- a/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
@@ -136,12 +136,12 @@ public class DecompositionRecipeHandler {
     private static int getElectrolyzingVoltage(List<Material> components) {
         //tungsten-containing materials electrolyzing requires 1920
         if (components.contains(Materials.Tungsten))
-            return 1920; //EV voltage (tungstate and scheelite electrolyzing)
+            return VA[EV]; //EV voltage (tungstate and scheelite electrolyzing)
         //Binary compound materials require 30 EU/t
         if (components.size() <= 2) {
-            return 30;
+            return VA[LV];
         }
-        return 2 * 30;
+        return 2 * VA[LV];
     }
 
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -461,6 +461,6 @@ public class MaterialRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() >= 2800 ? 32 : 8;
+        return material.getBlastTemperature() >= 2800 ? VA[LV] : VA[ULV];
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -21,8 +21,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import java.util.*;
 
-import static gregtech.api.GTValues.L;
-import static gregtech.api.GTValues.M;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ALLOY_SMELTER_RECIPES;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -234,7 +233,7 @@ public class MaterialRecipeHandler {
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT)
                     .fluidInputs(material.getFluid(L))
                     .outputs(OreDictUnifier.get(ingotPrefix, material))
-                    .duration(20).EUt(8)
+                    .duration(20).EUt(VA[ULV])
                     .buildAndRegister();
         }
 
@@ -248,14 +247,14 @@ public class MaterialRecipeHandler {
                     .buildAndRegister();
         }
 
-        ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(8).duration((int) material.getAverageMass())
+        ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getAverageMass())
                 .input(ingot, material)
                 .notConsumable(MetaItems.SHAPE_MOLD_NUGGET.getStackForm())
                 .output(nugget, material, 9)
                 .buildAndRegister();
 
         if (!OreDictUnifier.get(block, material).isEmpty()) {
-            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(8).duration((int) material.getAverageMass() * 9)
+            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getAverageMass() * 9)
                     .input(block, material)
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT.getStackForm())
                     .output(ingot, material, 9)
@@ -351,7 +350,7 @@ public class MaterialRecipeHandler {
                     .outputs(ingotStack)
                     .buildAndRegister();
 
-            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(8).duration((int) material.getAverageMass())
+            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getAverageMass())
                     .input(nugget, material, 9)
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT.getStackForm())
                     .output(ingot, material)
@@ -363,7 +362,7 @@ public class MaterialRecipeHandler {
                         .fluidInputs(material.getFluid(L))
                         .outputs(OreDictUnifier.get(orePrefix, material, 9))
                         .duration((int) material.getAverageMass())
-                        .EUt(8)
+                        .EUt(VA[ULV])
                         .buildAndRegister();
             }
         } else if (material.hasProperty(PropertyKey.GEM)) {
@@ -388,7 +387,7 @@ public class MaterialRecipeHandler {
                     .input(OrePrefix.stick, material, 4)
                     .circuitMeta(4)
                     .outputs(OreDictUnifier.get(framePrefix, material, 1))
-                    .EUt(8).duration(64)
+                    .EUt(VA[ULV]).duration(64)
                     .buildAndRegister();
         }
     }
@@ -401,7 +400,7 @@ public class MaterialRecipeHandler {
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
                     .fluidInputs(material.getFluid((int) (materialAmount * L / M)))
                     .outputs(blockStack)
-                    .duration((int) material.getAverageMass()).EUt(8)
+                    .duration((int) material.getAverageMass()).EUt(VA[ULV])
                     .buildAndRegister();
         }
 
@@ -411,7 +410,7 @@ public class MaterialRecipeHandler {
                 RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                         .input(blockPrefix, material)
                         .outputs(GTUtility.copyAmount((int) (materialAmount / M), plateStack))
-                        .duration((int) (material.getAverageMass() * 8L)).EUt(30)
+                        .duration((int) (material.getAverageMass() * 8L)).EUt(VA[LV])
                         .buildAndRegister();
             }
         }

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -115,7 +115,7 @@ public class MaterialRecipeHandler {
             duration = Math.max(1, (int) (material.getAverageMass() * blastTemp / 50L));
         }
         int EUt = property.getEUtOverride();
-        if (EUt <= 0) EUt = 120;
+        if (EUt <= 0) EUt = VA[MV];
 
         BlastRecipeBuilder blastBuilder = RecipeMaps.BLAST_RECIPES.recipeBuilder()
                 .input(dust, material)

--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.info.MaterialFlags.HIGH_SIFTER_OUTPUT;
 
 public class OreRecipeHandler {
@@ -121,7 +122,7 @@ public class OreRecipeHandler {
         RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
                 .input(crushedPrefix, material)
                 .outputs(impureDustStack)
-                .duration(60).EUt(8)
+                .duration(60).EUt(VA[ULV])
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
@@ -178,7 +179,7 @@ public class OreRecipeHandler {
                     .outputs(crushedPurifiedOre)
                     .chancedOutput(OreDictUnifier.get(OrePrefix.dust, washingByproduct, property.getByProductMultiplier()), 7000, 580)
                     .chancedOutput(OreDictUnifier.get(OrePrefix.dust, Materials.Stone), 4000, 650)
-                    .duration(800).EUt(8)
+                    .duration(800).EUt(VA[ULV])
                     .buildAndRegister();
         }
 
@@ -196,7 +197,7 @@ public class OreRecipeHandler {
         RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
                 .input(centrifugedPrefix, material)
                 .outputs(dustStack)
-                .duration(60).EUt(8)
+                .duration(60).EUt(VA[ULV])
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
@@ -223,7 +224,7 @@ public class OreRecipeHandler {
                 .input(purifiedPrefix, material)
                 .outputs(dustStack)
                 .duration(60)
-                .EUt(8)
+                .EUt(VA[ULV])
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -89,7 +89,7 @@ public class OreRecipeHandler {
                     .input(orePrefix, material)
                     .outputs(GTUtility.copyAmount((int) Math.round(amountOfCrushedOre) * 2 * oreTypeMultiplier, crushedStack))
                     .chancedOutput(byproductStack, 1400, 850)
-                    .duration(400).EUt(12);
+                    .duration(400);
             for (MaterialStack secondaryMaterial : orePrefix.secondaryMaterials) {
                 if (secondaryMaterial.material.hasProperty(PropertyKey.DUST)) {
                     ItemStack dustStack = OreDictUnifier.getDust(secondaryMaterial);
@@ -128,7 +128,7 @@ public class OreRecipeHandler {
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .input(crushedPrefix, material)
                 .outputs(impureDustStack)
-                .duration(200).EUt(12)
+                .duration(200)
                 .chancedOutput(OreDictUnifier.get(OrePrefix.dust, byproductMaterial, property.getByProductMultiplier()), 1400, 850)
                 .buildAndRegister();
 
@@ -204,7 +204,7 @@ public class OreRecipeHandler {
                 .input(centrifugedPrefix, material)
                 .outputs(dustStack)
                 .chancedOutput(byproductStack, 1400, 850)
-                .duration(200).EUt(12)
+                .duration(200)
                 .buildAndRegister();
 
         ModHandler.addShapelessRecipe(String.format("centrifuged_ore_to_dust_%s", material), dustStack,
@@ -232,7 +232,6 @@ public class OreRecipeHandler {
                 .outputs(dustStack)
                 .chancedOutput(byproductStack, 1400, 850)
                 .duration(200)
-                .EUt(12)
                 .buildAndRegister();
 
         RecipeMaps.SIMPLE_WASHER_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
@@ -21,7 +21,7 @@ import gregtech.common.items.behaviors.TurbineRotorBehavior;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.BENDER_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.LATHE_RECIPES;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
@@ -77,7 +77,7 @@ public class PartsRecipeHandler {
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_BOLT)
                     .outputs(GTUtility.copyAmount(8, boltStack))
                     .duration(15)
-                    .EUt(120)
+                    .EUt(VA[MV])
                     .buildAndRegister();
         }
     }
@@ -133,14 +133,14 @@ public class PartsRecipeHandler {
                     .input(OrePrefix.wireGtSingle, material)
                     .outputs(OreDictUnifier.get(OrePrefix.wireFine, material, 4))
                     .duration(200)
-                    .EUt(8)
+                    .EUt(VA[ULV])
                     .buildAndRegister();
         } else {
             RecipeMaps.WIREMILL_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material)
                     .outputs(OreDictUnifier.get(OrePrefix.wireFine, material, 8))
                     .duration(400)
-                    .EUt(8)
+                    .EUt(VA[ULV])
                     .buildAndRegister();
         }
     }
@@ -173,7 +173,7 @@ public class PartsRecipeHandler {
                     .fluidInputs(material.getFluid(L * (isSmall ? 1 : 4)))
                     .outputs(stack)
                     .duration(isSmall ? 20 : 100)
-                    .EUt(8)
+                    .EUt(VA[ULV])
                     .buildAndRegister();
         }
 
@@ -190,7 +190,7 @@ public class PartsRecipeHandler {
                         .EUt(material.getBlastTemperature() >= 2800 ? 256 : 64)
                         .buildAndRegister();
 
-                RecipeMaps.ALLOY_SMELTER_RECIPES.recipeBuilder().duration((int) material.getAverageMass()).EUt(30)
+                RecipeMaps.ALLOY_SMELTER_RECIPES.recipeBuilder().duration((int) material.getAverageMass()).EUt(VA[LV])
                         .input(ingot, material, 2)
                         .notConsumable(MetaItems.SHAPE_MOLD_GEAR_SMALL.getStackForm())
                         .output(gearSmall, material)
@@ -239,7 +239,7 @@ public class PartsRecipeHandler {
                     .fluidInputs(material.getFluid(L))
                     .outputs(OreDictUnifier.get(platePrefix, material))
                     .duration(40)
-                    .EUt(8)
+                    .EUt(VA[ULV])
                     .buildAndRegister();
         }
 
@@ -259,7 +259,7 @@ public class PartsRecipeHandler {
                         "h", "P", "P", 'P', new UnificationEntry(plate, material));
             }
 
-            BENDER_RECIPES.recipeBuilder().EUt(30).duration((int) material.getAverageMass() * 2)
+            BENDER_RECIPES.recipeBuilder().EUt(VA[LV]).duration((int) material.getAverageMass() * 2)
                     .input(plate, material, 2)
                     .output(doublePrefix, material)
                     .circuitMeta(2)
@@ -307,7 +307,7 @@ public class PartsRecipeHandler {
                 OreDictUnifier.get(springSmall, material),
                 " s ", "fRx", 'R', new UnificationEntry(stick, material));
 
-        BENDER_RECIPES.recipeBuilder().duration((int) (material.getAverageMass() / 2)).EUt(8)
+        BENDER_RECIPES.recipeBuilder().duration((int) (material.getAverageMass() / 2)).EUt(VA[ULV])
                 .input(stick, material)
                 .output(springSmall, material, 2)
                 .circuitMeta(1)
@@ -473,7 +473,7 @@ public class PartsRecipeHandler {
                     "fIh", 'I', new UnificationEntry(ingot, material));
         }
 
-        LATHE_RECIPES.recipeBuilder().EUt(8).duration(100)
+        LATHE_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(100)
                 .input(nugget, material)
                 .output(round, material)
                 .buildAndRegister();

--- a/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PartsRecipeHandler.java
@@ -480,6 +480,6 @@ public class PartsRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() > 2800 ? 32 : 8;
+        return material.getBlastTemperature() > 2800 ? VA[LV] : VA[ULV];
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PipeRecipeHandler.java
@@ -16,6 +16,8 @@ import gregtech.api.util.GTUtility;
 import gregtech.common.items.MetaItems;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.GTValues.*;
+
 public class PipeRecipeHandler {
 
     public static void register() {
@@ -51,7 +53,7 @@ public class PipeRecipeHandler {
                 .input(OrePrefix.ring, Materials.Iron, 2)
                 .output(pipePrefix, material)
                 .duration(20)
-                .EUt(8)
+                .EUt(VA[ULV])
                 .buildAndRegister();
 
         ModHandler.addShapedRecipe(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, pipePrefix.toString()) + "_" + material.toCamelCaseString(),
@@ -146,7 +148,7 @@ public class PipeRecipeHandler {
                 .circuitMeta(1)
                 .outputs(quadPipe)
                 .duration(30)
-                .EUt(8)
+                .EUt(VA[ULV])
                 .buildAndRegister();
     }
 
@@ -162,7 +164,7 @@ public class PipeRecipeHandler {
                 .circuitMeta(2)
                 .outputs(nonuplePipe)
                 .duration(40)
-                .EUt(8)
+                .EUt(VA[ULV])
                 .buildAndRegister();
     }
 

--- a/src/main/java/gregtech/loaders/oreprocessing/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PipeRecipeHandler.java
@@ -169,6 +169,6 @@ public class PipeRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() >= 2800 ? 32 : 8;
+        return material.getBlastTemperature() >= 2800 ? VA[LV] : VA[ULV];
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/PolarizingRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PolarizingRecipeHandler.java
@@ -43,7 +43,7 @@ public class PolarizingRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() >= 1200 ? VA[LV] : VA[ULV];
+        return material.getBlastTemperature() >= 1200 ? VA[LV] : 2;
     }
 
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/PolarizingRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/PolarizingRecipeHandler.java
@@ -11,6 +11,8 @@ import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.GTValues.*;
+
 public class PolarizingRecipeHandler {
 
     private static final OrePrefix[] POLARIZING_PREFIXES = new OrePrefix[]{
@@ -41,7 +43,7 @@ public class PolarizingRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() >= 1200 ? 32 : 2;
+        return material.getBlastTemperature() >= 1200 ? VA[LV] : VA[ULV];
     }
 
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/ToolRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ToolRecipeHandler.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import java.util.ArrayList;
 import java.util.function.Function;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.common.items.MetaItems.*;
 
@@ -397,7 +398,7 @@ public class ToolRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() > 2800 ? 32 : 8;
+        return material.getBlastTemperature() > 2800 ? VA[LV] : VA[ULV];
     }
 
     public static void registerManualToolRecipes() {

--- a/src/main/java/gregtech/loaders/oreprocessing/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/WireRecipeHandler.java
@@ -193,6 +193,6 @@ public class WireRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
-        return material.getBlastTemperature() >= 2800 ? 32 : 8;
+        return material.getBlastTemperature() >= 2800 ? VA[LV] : VA[ULV];
     }
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/WireRecipeHandler.java
@@ -14,6 +14,7 @@ import gregtech.api.util.GTUtility;
 
 import java.util.Map;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.NO_WORKING;
@@ -102,7 +103,7 @@ public class WireRecipeHandler {
 
         // Rubber Recipe (ULV-EV cables)
         if (voltageTier <= GTValues.EV) {
-            IntCircuitRecipeBuilder builder = ASSEMBLER_RECIPES.recipeBuilder().EUt(7).duration(100)
+            IntCircuitRecipeBuilder builder = ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(100)
                     .input(wirePrefix, material)
                     .output(cablePrefix, material);
 
@@ -120,7 +121,7 @@ public class WireRecipeHandler {
         }
 
         // Silicone Rubber Recipe (all cables)
-        IntCircuitRecipeBuilder builder = ASSEMBLER_RECIPES.recipeBuilder().EUt(7).duration(100)
+        IntCircuitRecipeBuilder builder = ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(100)
                 .input(wirePrefix, material)
                 .output(cablePrefix, material);
 
@@ -148,7 +149,7 @@ public class WireRecipeHandler {
                 .buildAndRegister();
 
         // Styrene Butadiene Rubber Recipe (all cables)
-        builder = ASSEMBLER_RECIPES.recipeBuilder().EUt(7).duration(100)
+        builder = ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(100)
                 .input(wirePrefix, material)
                 .output(cablePrefix, material);
 
@@ -187,7 +188,7 @@ public class WireRecipeHandler {
                 .input(wirePrefix, material)
                 .input(plate, Rubber, insulationAmount)
                 .output(cablePrefix, material)
-                .duration(100).EUt(8)
+                .duration(100).EUt(VA[ULV])
                 .buildAndRegister();
     }
 

--- a/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
@@ -11,35 +11,37 @@ import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.items.MetaItems;
 import gregtech.common.metatileentities.MetaTileEntities;
 
+import static gregtech.api.GTValues.*;
+
 public class AssemblyLineLoader {
     public static void init() {
 
         // TODO Relocate
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Deuterium.getFluid(125), Materials.Tritium.getFluid(125)).fluidOutputs(Materials.Helium.getPlasma(125)).duration(16).EUt(4096).EUToStart(40000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Deuterium.getFluid(125), Materials.Helium3.getFluid(125)).fluidOutputs(Materials.Helium.getPlasma(125)).duration(16).EUt(2048).EUToStart(60000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Deuterium.getFluid(125), Materials.Helium3.getFluid(125)).fluidOutputs(Materials.Helium.getPlasma(125)).duration(16).EUt(VA[EV]).EUToStart(60000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Carbon.getFluid(125), Materials.Helium3.getFluid(125)).fluidOutputs(Materials.Oxygen.getPlasma(125)).duration(32).EUt(4096).EUToStart(80000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Beryllium.getFluid(16), Materials.Deuterium.getFluid(375)).fluidOutputs(Materials.Nitrogen.getPlasma(175)).duration(16).EUt(16384).EUToStart(180000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Silicon.getFluid(16), Materials.Magnesium.getFluid(16)).fluidOutputs(Materials.Iron.getPlasma(125)).duration(32).EUt(8192).EUToStart(360000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Potassium.getFluid(16), Materials.Fluorine.getFluid(125)).fluidOutputs(Materials.Nickel.getPlasma(125)).duration(16).EUt(32768).EUToStart(480000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Beryllium.getFluid(16), Materials.Tungsten.getFluid(16)).fluidOutputs(Materials.Platinum.getFluid(16)).duration(32).EUt(32768).EUToStart(150000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Silicon.getFluid(16), Materials.Magnesium.getFluid(16)).fluidOutputs(Materials.Iron.getPlasma(125)).duration(32).EUt(VA[IV]).EUToStart(360000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Potassium.getFluid(16), Materials.Fluorine.getFluid(125)).fluidOutputs(Materials.Nickel.getPlasma(125)).duration(16).EUt(VA[LuV]).EUToStart(480000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Beryllium.getFluid(16), Materials.Tungsten.getFluid(16)).fluidOutputs(Materials.Platinum.getFluid(16)).duration(32).EUt(VA[LuV]).EUToStart(150000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Neodymium.getFluid(16), Materials.Hydrogen.getFluid(48)).fluidOutputs(Materials.Europium.getFluid(16)).duration(64).EUt(24576).EUToStart(150000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Lutetium.getFluid(16), Materials.Chrome.getFluid(16)).fluidOutputs(Materials.Americium.getFluid(16)).duration(96).EUt(49152).EUToStart(200000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Plutonium239.getFluid(16), Materials.Thorium.getFluid(16)).fluidOutputs(Materials.Naquadah.getFluid(16)).duration(64).EUt(32768).EUToStart(300000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Plutonium239.getFluid(16), Materials.Thorium.getFluid(16)).fluidOutputs(Materials.Naquadah.getFluid(16)).duration(64).EUt(VA[LuV]).EUToStart(300000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Americium.getFluid(16), Materials.Naquadria.getFluid(16)).fluidOutputs(Materials.Neutronium.getFluid(2)).duration(200).EUt(98304).EUToStart(600000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Tungsten.getFluid(16), Materials.Helium.getFluid(16)).fluidOutputs(Materials.Osmium.getFluid(16)).duration(64).EUt(24578).EUToStart(150000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Manganese.getFluid(16), Materials.Hydrogen.getFluid(16)).fluidOutputs(Materials.Iron.getFluid(16)).duration(64).EUt(8192).EUToStart(120000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Manganese.getFluid(16), Materials.Hydrogen.getFluid(16)).fluidOutputs(Materials.Iron.getFluid(16)).duration(64).EUt(VA[IV]).EUToStart(120000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Mercury.getFluid(16), Materials.Magnesium.getFluid(16)).fluidOutputs(Materials.Uranium238.getFluid(16)).duration(64).EUt(49152).EUToStart(240000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Gold.getFluid(16), Materials.Aluminium.getFluid(16)).fluidOutputs(Materials.Uranium238.getFluid(16)).duration(64).EUt(49152).EUToStart(240000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Uranium238.getFluid(16), Materials.Helium.getFluid(16)).fluidOutputs(Materials.Plutonium239.getFluid(16)).duration(128).EUt(49152).EUToStart(480000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Vanadium.getFluid(16), Materials.Hydrogen.getFluid(125)).fluidOutputs(Materials.Chrome.getFluid(16)).duration(64).EUt(24576).EUToStart(140000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Gallium.getFluid(16), Materials.Radon.getFluid(125)).fluidOutputs(Materials.Duranium.getFluid(16)).duration(64).EUt(16384).EUToStart(140000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Titanium.getFluid(48), Materials.Duranium.getFluid(32)).fluidOutputs(Materials.Tritanium.getFluid(16)).duration(64).EUt(32768).EUToStart(200000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Gold.getFluid(16), Materials.Mercury.getFluid(16)).fluidOutputs(Materials.Radon.getFluid(125)).duration(64).EUt(32768).EUToStart(200000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Titanium.getFluid(48), Materials.Duranium.getFluid(32)).fluidOutputs(Materials.Tritanium.getFluid(16)).duration(64).EUt(VA[LuV]).EUToStart(200000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Gold.getFluid(16), Materials.Mercury.getFluid(16)).fluidOutputs(Materials.Radon.getFluid(125)).duration(64).EUt(VA[LuV]).EUToStart(200000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Tantalum.getFluid(16), Materials.Tritium.getFluid(16)).fluidOutputs(Materials.Tungsten.getFluid(16)).duration(16).EUt(24576).EUToStart(200000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Silver.getFluid(16), Materials.Lithium.getFluid(16)).fluidOutputs(Materials.Indium.getFluid(16)).duration(32).EUt(24576).EUToStart(380000000).buildAndRegister();
         RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.NaquadahEnriched.getFluid(15), Materials.Radon.getFluid(125)).fluidOutputs(Materials.Naquadria.getFluid(3)).duration(64).EUt(49152).EUToStart(400000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Lanthanum.getFluid(16), Materials.Silicon.getFluid(16)).fluidOutputs(Materials.Lutetium.getFluid(16)).duration(16).EUt(8192).EUToStart(80000000).buildAndRegister();
-        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Plutonium241.getFluid(16), Materials.Titanium.getFluid(16)).fluidOutputs(Materials.Livermorium.getFluid(16)).duration(32).EUt(32768).EUToStart(200000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Lanthanum.getFluid(16), Materials.Silicon.getFluid(16)).fluidOutputs(Materials.Lutetium.getFluid(16)).duration(16).EUt(VA[IV]).EUToStart(80000000).buildAndRegister();
+        RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Plutonium241.getFluid(16), Materials.Titanium.getFluid(16)).fluidOutputs(Materials.Livermorium.getFluid(16)).duration(32).EUt(VA[LuV]).EUToStart(200000000).buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder().inputs(OreDictUnifier.get(OrePrefix.plate, Materials.Europium, 16), MetaItems.WETWARE_SUPER_COMPUTER_UV.getStackForm(4), MetaItems.ENERGY_LAPOTRONIC_ORB_CLUSTER.getStackForm(8), MetaItems.FIELD_GENERATOR_LUV.getStackForm(2), MetaItems.NANO_CENTRAL_PROCESSING_UNIT.getStackForm(64), MetaItems.NANO_CENTRAL_PROCESSING_UNIT.getStackForm(64), MetaItems.SMD_DIODE.getStackForm(8), OreDictUnifier.get(OrePrefix.cableGtSingle, Materials.Naquadah, 32)).fluidInputs(Materials.SolderingAlloy.getFluid(2880), Materials.Polybenzimidazole.getFluid(288)).outputs(MetaItems.ENERGY_LAPOTRONIC_MODULE.getStackForm()).duration(2000).EUt(100000).buildAndRegister();
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder().inputs(OreDictUnifier.get(OrePrefix.plate, Materials.Americium, 16), MetaItems.WETWARE_SUPER_COMPUTER_UV.getStackForm(4), MetaItems.ENERGY_LAPOTRONIC_MODULE.getStackForm(8), MetaItems.FIELD_GENERATOR_ZPM.getStackForm(2), MetaItems.HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(64), MetaItems.HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(64), MetaItems.SMD_DIODE.getStackForm(16), OreDictUnifier.get(OrePrefix.cableGtSingle, Materials.NaquadahAlloy, 32)).fluidInputs(Materials.SolderingAlloy.getFluid(2880), Materials.Polybenzimidazole.getFluid(576)).outputs(MetaItems.ENERGY_LAPOTRONIC_CLUSTER.getStackForm()).duration(2000).EUt(200000).buildAndRegister();
@@ -60,7 +62,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(Materials.NiobiumTitanium.getFluid(GTValues.L * 8))
                 .outputs(MetaTileEntities.FUSION_REACTOR[0].getStackForm())
                 .duration(800)
-                .EUt(30720)
+                .EUt(VA[LuV])
                 .buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -96,7 +98,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(Materials.YttriumBariumCuprate.getFluid(GTValues.L * 8))
                 .outputs(MetaTileEntities.FUSION_REACTOR[2].getStackForm())
                 .duration(1000)
-                .EUt(122880)
+                .EUt(VA[ZPM])
                 .buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
@@ -3,6 +3,7 @@ package gregtech.loaders.recipe;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.stack.UnificationEntry;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -64,7 +65,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // EV
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[HV])
                 .input(cableGtSingle, Aluminium, 2)
                 .input(plate, BlueSteel, 2)
                 .fluidInputs(Polytetrafluoroethylene.getFluid(144))
@@ -72,7 +73,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // IV
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(1920)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV])
                 .input(cableGtSingle, Platinum, 2)
                 .input(plate, RoseGold, 6)
                 .fluidInputs(Polytetrafluoroethylene.getFluid(288))
@@ -80,7 +81,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // LuV
-        ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(7680)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(VA[IV])
                 .input(cableGtSingle, NiobiumTitanium, 2)
                 .input(plate, RedSteel, 18)
                 .fluidInputs(Polybenzimidazole.getFluid(144))
@@ -88,7 +89,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // ZPM
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(30720)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LuV])
                 .input(cableGtSingle, Naquadah, 2)
                 .input(plate, Europium, 6)
                 .fluidInputs(Polybenzimidazole.getFluid(288))
@@ -96,7 +97,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // UV
-        ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(122880)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(VA[ZPM])
                 .input(cableGtSingle, NaquadahAlloy, 2)
                 .input(plate, Americium, 18)
                 .fluidInputs(Polybenzimidazole.getFluid(576))
@@ -163,7 +164,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // EV
-        CANNER_RECIPES.recipeBuilder().duration(100).EUt(480)
+        CANNER_RECIPES.recipeBuilder().duration(100).EUt(VA[HV])
                 .input(BATTERY_HULL_SMALL_VANADIUM)
                 .input(dust, Vanadium, 2)
                 .output(BATTERY_EV_VANADIUM)
@@ -177,7 +178,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // LuV
-        CANNER_RECIPES.recipeBuilder().duration(200).EUt(1920)
+        CANNER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV])
                 .input(BATTERY_HULL_LARGE_VANADIUM)
                 .input(dust, Vanadium, 16)
                 .output(BATTERY_LUV_VANADIUM)
@@ -191,7 +192,7 @@ public class BatteryRecipes {
                 .buildAndRegister();
 
         // UV
-        CANNER_RECIPES.recipeBuilder().duration(300).EUt(7680)
+        CANNER_RECIPES.recipeBuilder().duration(300).EUt(VA[IV])
                 .input(BATTERY_HULL_LARGE_NAQUADRIA)
                 .input(dust, Naquadria, 16)
                 .output(BATTERY_UV_NAQUADRIA)

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -8,7 +8,7 @@ import gregtech.api.unification.stack.UnificationEntry;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -29,14 +29,14 @@ public class CircuitRecipes {
     private static void waferRecipes() {
 
         // Boules
-        BLAST_RECIPES.recipeBuilder().duration(9000).EUt(120)
+        BLAST_RECIPES.recipeBuilder().duration(9000).EUt(VA[MV])
                 .input(dust, Silicon, 32)
                 .input(dustSmall, GalliumArsenide)
                 .output(SILICON_BOULE)
                 .blastFurnaceTemp(1784)
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(12000).EUt(480)
+        BLAST_RECIPES.recipeBuilder().duration(12000).EUt(VA[HV])
                 .input(dust, Silicon, 64)
                 .input(dust, Glowstone, 8)
                 .fluidInputs(Nitrogen.getFluid(8000))
@@ -44,7 +44,7 @@ public class CircuitRecipes {
                 .blastFurnaceTemp(2484)
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(15000).EUt(1920)
+        BLAST_RECIPES.recipeBuilder().duration(15000).EUt(VA[EV])
                 .input(block, Silicon, 16)
                 .input(ingot, Naquadah)
                 .fluidInputs(Argon.getFluid(8000))
@@ -52,7 +52,7 @@ public class CircuitRecipes {
                 .blastFurnaceTemp(5400)
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(18000).EUt(7680)
+        BLAST_RECIPES.recipeBuilder().duration(18000).EUt(VA[IV])
                 .input(block, Silicon, 32)
                 .input(ingot, Neutronium, 4)
                 .fluidInputs(Xenon.getFluid(8000))
@@ -62,86 +62,86 @@ public class CircuitRecipes {
 
         // Boule cutting
         CUTTER_RECIPES.recipeBuilder().duration(400).EUt(16).input(SILICON_BOULE).output(SILICON_WAFER, 16).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(800).EUt(120).input(GLOWSTONE_BOULE).output(GLOWSTONE_WAFER, 32).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(1600).EUt(480).input(NAQUADAH_BOULE).output(NAQUADAH_WAFER, 64).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(2400).EUt(1920).input(NEUTRONIUM_BOULE).output(NEUTRONIUM_WAFER, 64).output(NEUTRONIUM_WAFER, 32).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(800).EUt(VA[MV]).input(GLOWSTONE_BOULE).output(GLOWSTONE_WAFER, 32).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(1600).EUt(VA[HV]).input(NAQUADAH_BOULE).output(NAQUADAH_WAFER, 64).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(2400).EUt(VA[EV]).input(NEUTRONIUM_BOULE).output(NEUTRONIUM_WAFER, 64).output(NEUTRONIUM_WAFER, 32).buildAndRegister();
 
         // Wafer engraving
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(120).input(SILICON_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 8).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 16).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 16).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(120).input(SILICON_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 8).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 16).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 16).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(120).input(SILICON_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 8).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 16).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 16).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(120).input(SILICON_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 8).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 16).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Magenta).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 16).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(120).input(SILICON_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 8).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 16).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 16).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(120).input(SILICON_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 8).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 16).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 16).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER, 8).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER, 8).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER, 8).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(480).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER, 4).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER, 8).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER, 4).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER, 8).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(1920).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Purple).output(ADVANCED_SYSTEM_ON_CHIP_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Purple).output(ADVANCED_SYSTEM_ON_CHIP_WAFER, 2).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Purple).output(ADVANCED_SYSTEM_ON_CHIP_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Purple).output(ADVANCED_SYSTEM_ON_CHIP_WAFER, 2).buildAndRegister();
 
         // Can replace this with a Quantum Star/Eye Lens if desired
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(7680).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Black).output(HIGHLY_ADVANCED_SOC_WAFER).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Black).output(HIGHLY_ADVANCED_SOC_WAFER).buildAndRegister();
 
         // Wafer chemical refining recipes
-        CHEMICAL_RECIPES.recipeBuilder().duration(1200).EUt(7680)
+        CHEMICAL_RECIPES.recipeBuilder().duration(1200).EUt(VA[IV])
                 .input(POWER_INTEGRATED_CIRCUIT_WAFER)
                 .input(dust, IndiumGalliumPhosphide, 2)
                 .fluidInputs(RedAlloy.getFluid(L * 2))
                 .output(HIGH_POWER_INTEGRATED_CIRCUIT_WAFER)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(1200).EUt(1920)
+        CHEMICAL_RECIPES.recipeBuilder().duration(1200).EUt(VA[EV])
                 .input(CENTRAL_PROCESSING_UNIT_WAFER)
                 .input(CARBON_FIBERS, 16)
                 .fluidInputs(Glowstone.getFluid(L * 4))
                 .output(NANO_CENTRAL_PROCESSING_UNIT_WAFER)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(900).EUt(1920)
+        CHEMICAL_RECIPES.recipeBuilder().duration(900).EUt(VA[EV])
                 .input(NANO_CENTRAL_PROCESSING_UNIT_WAFER)
                 .input(QUANTUM_EYE, 2)
                 .fluidInputs(GalliumArsenide.getFluid(L * 2))
                 .output(QUBIT_CENTRAL_PROCESSING_UNIT_WAFER)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(1200).EUt(1920)
+        CHEMICAL_RECIPES.recipeBuilder().duration(1200).EUt(VA[EV])
                 .input(NANO_CENTRAL_PROCESSING_UNIT_WAFER)
                 .input(dust, IndiumGalliumPhosphide)
                 .fluidInputs(Radon.getFluid(50))
@@ -149,21 +149,21 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Wafer cutting
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(7680).input(HIGHLY_ADVANCED_SOC_WAFER).output(HIGHLY_ADVANCED_SOC, 6).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(1920).input(ADVANCED_SYSTEM_ON_CHIP_WAFER).output(ADVANCED_SYSTEM_ON_CHIP, 6).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(480).input(SYSTEM_ON_CHIP_WAFER).output(SYSTEM_ON_CHIP, 6).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[IV]).input(HIGHLY_ADVANCED_SOC_WAFER).output(HIGHLY_ADVANCED_SOC, 6).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[EV]).input(ADVANCED_SYSTEM_ON_CHIP_WAFER).output(ADVANCED_SYSTEM_ON_CHIP, 6).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(SYSTEM_ON_CHIP_WAFER).output(SYSTEM_ON_CHIP, 6).buildAndRegister();
         CUTTER_RECIPES.recipeBuilder().duration(900).EUt(64).input(SIMPLE_SYSTEM_ON_CHIP_WAFER).output(SIMPLE_SYSTEM_ON_CHIP, 6).buildAndRegister();
         CUTTER_RECIPES.recipeBuilder().duration(900).EUt(96).input(RANDOM_ACCESS_MEMORY_WAFER).output(RANDOM_ACCESS_MEMORY, 32).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(1920).input(QUBIT_CENTRAL_PROCESSING_UNIT_WAFER).output(QUBIT_CENTRAL_PROCESSING_UNIT, 4).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(120).input(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT, 6).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(480).input(LOW_POWER_INTEGRATED_CIRCUIT_WAFER).output(LOW_POWER_INTEGRATED_CIRCUIT, 4).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(1920).input(POWER_INTEGRATED_CIRCUIT_WAFER).output(POWER_INTEGRATED_CIRCUIT, 4).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(7680).input(HIGH_POWER_INTEGRATED_CIRCUIT_WAFER).output(HIGH_POWER_INTEGRATED_CIRCUIT, 2).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[EV]).input(QUBIT_CENTRAL_PROCESSING_UNIT_WAFER).output(QUBIT_CENTRAL_PROCESSING_UNIT, 4).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT, 6).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(LOW_POWER_INTEGRATED_CIRCUIT_WAFER).output(LOW_POWER_INTEGRATED_CIRCUIT, 4).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[EV]).input(POWER_INTEGRATED_CIRCUIT_WAFER).output(POWER_INTEGRATED_CIRCUIT, 4).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[IV]).input(HIGH_POWER_INTEGRATED_CIRCUIT_WAFER).output(HIGH_POWER_INTEGRATED_CIRCUIT, 2).buildAndRegister();
         CUTTER_RECIPES.recipeBuilder().duration(900).EUt(192).input(NOR_MEMORY_CHIP_WAFER).output(NOR_MEMORY_CHIP, 16).buildAndRegister();
         CUTTER_RECIPES.recipeBuilder().duration(900).EUt(192).input(NAND_MEMORY_CHIP_WAFER).output(NAND_MEMORY_CHIP, 32).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(120).input(CENTRAL_PROCESSING_UNIT_WAFER).output(CENTRAL_PROCESSING_UNIT, 8).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(CENTRAL_PROCESSING_UNIT_WAFER).output(CENTRAL_PROCESSING_UNIT, 8).buildAndRegister();
         CUTTER_RECIPES.recipeBuilder().duration(900).EUt(64).input(INTEGRATED_LOGIC_CIRCUIT_WAFER).output(INTEGRATED_LOGIC_CIRCUIT, 8).buildAndRegister();
-        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(480).input(NANO_CENTRAL_PROCESSING_UNIT_WAFER).output(NANO_CENTRAL_PROCESSING_UNIT, 8).buildAndRegister();
+        CUTTER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(NANO_CENTRAL_PROCESSING_UNIT_WAFER).output(NANO_CENTRAL_PROCESSING_UNIT, 8).buildAndRegister();
     }
 
     private static void componentRecipes() {
@@ -175,14 +175,14 @@ public class CircuitRecipes {
                 'T', GLASS_TUBE.getStackForm(),
                 'W', new UnificationEntry(wireGtSingle, Copper));
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(8).circuitMeta(1)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(VA[ULV]).circuitMeta(1)
                 .input(GLASS_TUBE)
                 .input(bolt, Steel, 2)
                 .input(wireGtSingle, Copper, 2)
                 .output(VACUUM_TUBE, 2)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(40).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(40).EUt(VA[ULV])
                 .input(GLASS_TUBE)
                 .input(bolt, Steel)
                 .input(wireGtSingle, Copper, 2)
@@ -190,14 +190,14 @@ public class CircuitRecipes {
                 .output(VACUUM_TUBE, 4)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(8).circuitMeta(1)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(VA[ULV]).circuitMeta(1)
                 .input(GLASS_TUBE)
                 .input(bolt, Steel, 2)
                 .input(wireGtSingle, AnnealedCopper, 2)
                 .output(VACUUM_TUBE, 4)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(40).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(40).EUt(VA[ULV])
                 .input(GLASS_TUBE)
                 .input(bolt, Steel)
                 .input(wireGtSingle, AnnealedCopper, 2)
@@ -211,7 +211,7 @@ public class CircuitRecipes {
                 .output(GLASS_TUBE)
                 .buildAndRegister();
 
-        FORMING_PRESS_RECIPES.recipeBuilder().duration(80).EUt(8)
+        FORMING_PRESS_RECIPES.recipeBuilder().duration(80).EUt(VA[ULV])
                 .input(dust, Glass)
                 .notConsumable(SHAPE_MOLD_BALL)
                 .output(GLASS_TUBE)
@@ -303,7 +303,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Capacitor
-        ASSEMBLER_RECIPES.recipeBuilder().duration(320).EUt(120)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(320).EUt(VA[MV])
                 .input(foil, Polyethylene)
                 .input(foil, Aluminium, 2)
                 .fluidInputs(Polyethylene.getFluid(L))
@@ -319,35 +319,35 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Diode
-        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(VA[LV])
                 .input(wireFine, Copper, 4)
                 .input(dustSmall, GalliumArsenide)
                 .fluidInputs(Glass.getFluid(L))
                 .output(DIODE)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(VA[LV])
                 .input(wireFine, Copper, 4)
                 .input(dustSmall, GalliumArsenide)
                 .fluidInputs(Polyethylene.getFluid(L))
                 .output(DIODE, 2)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(VA[LV])
                 .input(wireFine, Copper, 4)
                 .input(SILICON_WAFER)
                 .fluidInputs(Polyethylene.getFluid(L))
                 .output(DIODE, 4)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(VA[LV])
                 .input(wireFine, AnnealedCopper, 4)
                 .input(dustSmall, GalliumArsenide)
                 .fluidInputs(Polyethylene.getFluid(L))
                 .output(DIODE, 6)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(VA[LV])
                 .input(wireFine, AnnealedCopper, 4)
                 .input(SILICON_WAFER)
                 .fluidInputs(Polyethylene.getFluid(L))
@@ -370,7 +370,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // SMD Resistor
-        ASSEMBLER_RECIPES.recipeBuilder().duration(160).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(160).EUt(VA[HV])
                 .input(dust, Carbon)
                 .input(wireFine, Electrum, 4)
                 .fluidInputs(Polyethylene.getFluid(L * 2))
@@ -378,7 +378,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // SMD Diode
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[HV])
                 .input(dust, GalliumArsenide)
                 .input(wireFine, Platinum, 8)
                 .fluidInputs(Polyethylene.getFluid(L * 2))
@@ -386,7 +386,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // SMD Transistor
-        ASSEMBLER_RECIPES.recipeBuilder().duration(160).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(160).EUt(VA[HV])
                 .input(foil, Gallium)
                 .input(wireFine, AnnealedCopper, 8)
                 .fluidInputs(Polyethylene.getFluid(L))
@@ -394,28 +394,28 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // SMD Capacitor
-        ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(VA[HV])
                 .input(foil, SiliconeRubber)
                 .input(foil, Aluminium)
                 .fluidInputs(Polyethylene.getFluid(72))
                 .output(SMD_CAPACITOR, 8)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(VA[HV])
                 .input(foil, PolyvinylChloride, 2)
                 .input(foil, Aluminium)
                 .fluidInputs(Polyethylene.getFluid(72))
                 .output(SMD_CAPACITOR, 12)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(VA[HV])
                 .input(foil, SiliconeRubber)
                 .input(foil, Tantalum)
                 .fluidInputs(Polyethylene.getFluid(72))
                 .output(SMD_CAPACITOR, 16)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(120).EUt(VA[HV])
                 .input(foil, PolyvinylChloride, 2)
                 .input(foil, Tantalum)
                 .fluidInputs(Polyethylene.getFluid(72))
@@ -431,7 +431,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Advanced SMD Diode
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(480).duration(150)
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(150)
                 .input(dustSmall, IndiumGalliumPhosphide)
                 .input(wireFine, NiobiumTitanium, 4)
                 .fluidInputs(Polybenzimidazole.getFluid(L / 2))
@@ -439,7 +439,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Advanced SMD Transistor
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(480).duration(160)
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(160)
                 .input(foil, VanadiumGallium)
                 .input(wireFine, HSSG, 8)
                 .fluidInputs(Polybenzimidazole.getFluid(L))
@@ -447,7 +447,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Advanced SMD Capacitor
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(480).duration(80)
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(80)
                 .input(foil, Polybenzimidazole, 2)
                 .input(foil, HSSS)
                 .fluidInputs(Polybenzimidazole.getFluid(L / 4))
@@ -455,32 +455,32 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Carbon Fibers
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(30)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(VA[LV])
                 .input(dust, Carbon, 4)
                 .fluidInputs(Polyethylene.getFluid(36))
                 .output(CARBON_FIBERS)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(120)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(VA[MV])
                 .input(dust, Carbon, 4)
                 .fluidInputs(Polytetrafluoroethylene.getFluid(18))
                 .output(CARBON_FIBERS, 2)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(480)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(VA[HV])
                 .input(dust, Carbon, 4)
                 .fluidInputs(Epoxy.getFluid(9))
                 .output(CARBON_FIBERS, 4)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(1920)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(37).EUt(VA[EV])
                 .input(dust, Carbon, 8)
                 .fluidInputs(Polybenzimidazole.getFluid(9))
                 .output(CARBON_FIBERS, 16)
                 .buildAndRegister();
 
         // Crystal Circuit Components
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(256).EUt(480)
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(256).EUt(VA[HV])
                 .input(LAPOTRON_CRYSTAL)
                 .notConsumable(craftingLens, Color.Blue)
                 .output(ENGRAVED_LAPOTRON_CHIP, 3)
@@ -510,37 +510,37 @@ public class CircuitRecipes {
                 .chancedOutput(RAW_CRYSTAL_CHIP, 1000, 2000)
                 .buildAndRegister();
 
-        FORGE_HAMMER_RECIPES.recipeBuilder().EUt(480).duration(100)
+        FORGE_HAMMER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .input(RAW_CRYSTAL_CHIP)
                 .output(RAW_CRYSTAL_CHIP_PART, 9)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(12000).EUt(480)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(12000).EUt(VA[HV])
                 .input(RAW_CRYSTAL_CHIP_PART)
                 .fluidInputs(Europium.getFluid(L / 9))
                 .chancedOutput(RAW_CRYSTAL_CHIP, 8000, 250)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(12000).EUt(480)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(12000).EUt(VA[HV])
                 .input(RAW_CRYSTAL_CHIP_PART)
                 .fluidInputs(Mutagen.getFluid(250))
                 .chancedOutput(RAW_CRYSTAL_CHIP, 8000, 250)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(12000).EUt(480)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(12000).EUt(VA[HV])
                 .input(RAW_CRYSTAL_CHIP_PART)
                 .fluidInputs(BacterialSludge.getFluid(250))
                 .chancedOutput(RAW_CRYSTAL_CHIP, 8000, 250)
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(900).EUt(480).blastFurnaceTemp(5000)
+        BLAST_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).blastFurnaceTemp(5000)
                 .input(plate, Emerald)
                 .input(RAW_CRYSTAL_CHIP)
                 .fluidInputs(Helium.getFluid(1000))
                 .output(ENGRAVED_CRYSTAL_CHIP)
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(900).EUt(480).blastFurnaceTemp(5000)
+        BLAST_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).blastFurnaceTemp(5000)
                 .input(plate, Olivine)
                 .input(RAW_CRYSTAL_CHIP)
                 .fluidInputs(Helium.getFluid(1000))
@@ -560,7 +560,7 @@ public class CircuitRecipes {
                 .output(QUANTUM_STAR)
                 .buildAndRegister();
 
-        AUTOCLAVE_RECIPES.recipeBuilder().duration(480).EUt(7680)
+        AUTOCLAVE_RECIPES.recipeBuilder().duration(480).EUt(VA[IV])
                 .input(gem, NetherStar)
                 .fluidInputs(Neutronium.getFluid(L * 2))
                 .output(GRAVI_STAR)
@@ -587,35 +587,35 @@ public class CircuitRecipes {
                 'B', COATED_BOARD.getStackForm());
 
         // Basic Circuit Board
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(foil, Copper, 4)
                 .input(plate, Wood)
                 .fluidInputs(Glue.getFluid(100))
                 .output(BASIC_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(foil, Copper, 4)
                 .input(plate, Wood)
                 .fluidInputs(Polyethylene.getFluid(36))
                 .output(BASIC_CIRCUIT_BOARD, 2)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(foil, Copper, 4)
                 .input(plate, Wood)
                 .fluidInputs(Polytetrafluoroethylene.getFluid(18))
                 .output(BASIC_CIRCUIT_BOARD, 2)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(foil, Copper, 4)
                 .input(plate, Wood)
                 .fluidInputs(Epoxy.getFluid(18))
                 .output(BASIC_CIRCUIT_BOARD, 3)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(foil, Copper, 4)
                 .input(plate, Wood)
                 .fluidInputs(Polybenzimidazole.getFluid(9))
@@ -623,21 +623,21 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Phenolic Board
-        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV])
                 .input(dust, Wood)
                 .notConsumable(SHAPE_MOLD_PLATE)
                 .fluidInputs(Glue.getFluid(50))
                 .output(PHENOLIC_BOARD)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV])
                 .input(dust, Wood)
                 .notConsumable(SHAPE_MOLD_PLATE)
                 .fluidInputs(BisphenolA.getFluid(18))
                 .output(PHENOLIC_BOARD, 2)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(8)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV])
                 .input(dust, Wood)
                 .notConsumable(SHAPE_MOLD_PLATE)
                 .fluidInputs(Epoxy.getFluid(18))
@@ -650,14 +650,14 @@ public class CircuitRecipes {
                 'W', new UnificationEntry(wireGtSingle, Gold),
                 'B', PHENOLIC_BOARD.getStackForm());
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(30).duration(300)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(300)
                 .input(foil, Gold, 4)
                 .input(PHENOLIC_BOARD)
                 .fluidInputs(SodiumPersulfate.getFluid(250))
                 .output(GOOD_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(75)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(75)
                 .input(foil, Gold, 4)
                 .input(PHENOLIC_BOARD)
                 .fluidInputs(Iron3Chloride.getFluid(125))
@@ -694,14 +694,14 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Plastic Circuit Board
-        CHEMICAL_RECIPES.recipeBuilder().duration(600).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(600).EUt(VA[LV])
                 .input(PLASTIC_BOARD)
                 .input(foil, Copper, 6)
                 .fluidInputs(SodiumPersulfate.getFluid(500))
                 .output(PLASTIC_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(480)
+        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(VA[HV])
                 .input(PLASTIC_BOARD)
                 .input(foil, Copper, 6)
                 .fluidInputs(Iron3Chloride.getFluid(250))
@@ -709,7 +709,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Epoxy Board
-        CHEMICAL_RECIPES.recipeBuilder().duration(600).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(600).EUt(VA[LV])
                 .input(plate, Epoxy)
                 .input(foil, Gold, 8)
                 .fluidInputs(SulfuricAcid.getFluid(500))
@@ -717,14 +717,14 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Advanced Circuit Board
-        CHEMICAL_RECIPES.recipeBuilder().duration(900).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(900).EUt(VA[LV])
                 .input(EPOXY_BOARD)
                 .input(foil, Electrum, 8)
                 .fluidInputs(SodiumPersulfate.getFluid(1000))
                 .output(ADVANCED_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(225).EUt(480)
+        CHEMICAL_RECIPES.recipeBuilder().duration(225).EUt(VA[HV])
                 .input(EPOXY_BOARD)
                 .input(foil, Electrum, 8)
                 .fluidInputs(Iron3Chloride.getFluid(500))
@@ -759,14 +759,14 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Extreme Circuit Board
-        CHEMICAL_RECIPES.recipeBuilder().duration(300).EUt(480)
+        CHEMICAL_RECIPES.recipeBuilder().duration(300).EUt(VA[HV])
                 .input(FIBER_BOARD)
                 .input(foil, AnnealedCopper, 12)
                 .fluidInputs(SodiumPersulfate.getFluid(2000))
                 .output(EXTREME_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(1920)
+        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(VA[EV])
                 .input(FIBER_BOARD)
                 .input(foil, AnnealedCopper, 12)
                 .fluidInputs(Iron3Chloride.getFluid(1000))
@@ -774,7 +774,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Multi-Layer Fiber Reinforced Epoxy Board
-        CHEMICAL_RECIPES.recipeBuilder().duration(500).EUt(480)
+        CHEMICAL_RECIPES.recipeBuilder().duration(500).EUt(VA[HV])
                 .input(FIBER_BOARD, 2)
                 .input(foil, Platinum, 8)
                 .fluidInputs(SulfuricAcid.getFluid(500))
@@ -782,14 +782,14 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // Elite Circuit Board
-        CHEMICAL_RECIPES.recipeBuilder().duration(300).EUt(1920)
+        CHEMICAL_RECIPES.recipeBuilder().duration(300).EUt(VA[EV])
                 .input(MULTILAYER_FIBER_BOARD)
                 .input(foil, Platinum, 8)
                 .fluidInputs(SodiumPersulfate.getFluid(4000))
                 .output(ELITE_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(7680)
+        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(VA[IV])
                 .input(MULTILAYER_FIBER_BOARD)
                 .input(foil, Platinum, 8)
                 .fluidInputs(Iron3Chloride.getFluid(2000))
@@ -804,13 +804,13 @@ public class CircuitRecipes {
                 .output(PETRI_DISH)
                 .buildAndRegister();
 
-        FLUID_SOLIDFICATION_RECIPES.recipeBuilder().duration(40).EUt(480)
+        FLUID_SOLIDFICATION_RECIPES.recipeBuilder().duration(40).EUt(VA[HV])
                 .notConsumable(SHAPE_MOLD_CYLINDER)
                 .fluidInputs(Polybenzimidazole.getFluid(L / 8))
                 .output(PETRI_DISH, 2)
                 .buildAndRegister();
 
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(30720)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(VA[LuV])
                 .input(MULTILAYER_FIBER_BOARD, 16)
                 .input(PETRI_DISH)
                 .input(ELECTRIC_PUMP_LUV)
@@ -821,14 +821,14 @@ public class CircuitRecipes {
                 .output(WETWARE_BOARD, 16)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(300).EUt(7680)
+        CHEMICAL_RECIPES.recipeBuilder().duration(300).EUt(VA[IV])
                 .input(WETWARE_BOARD)
                 .input(foil, NiobiumTitanium, 32)
                 .fluidInputs(SodiumPersulfate.getFluid(8000))
                 .output(WETWARE_CIRCUIT_BOARD)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(30720)
+        CHEMICAL_RECIPES.recipeBuilder().duration(150).EUt(VA[LuV])
                 .input(WETWARE_BOARD)
                 .input(foil, NiobiumTitanium, 32)
                 .fluidInputs(Iron3Chloride.getFluid(4000))
@@ -866,7 +866,7 @@ public class CircuitRecipes {
                 'B', GOOD_CIRCUIT_BOARD.getStackForm(),
                 'D', DIODE.getStackForm());
 
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(300)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).duration(300)
                 .input(GOOD_CIRCUIT_BOARD)
                 .input(circuit, Tier.Basic, 2)
                 .input(component, Component.Diode, 2)
@@ -899,7 +899,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // HV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(800)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).duration(800)
                 .input(INTEGRATED_CIRCUIT_MV)
                 .input(INTEGRATED_LOGIC_CIRCUIT, 2)
                 .input(RANDOM_ACCESS_MEMORY, 2)
@@ -912,7 +912,7 @@ public class CircuitRecipes {
         // T2.5: Misc ==================================================================================================
 
         // NAND Chip ULV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(30).duration(300)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).duration(300)
                 .input(GOOD_CIRCUIT_BOARD)
                 .input(SIMPLE_SYSTEM_ON_CHIP)
                 .input(bolt, RedAlloy, 2)
@@ -963,7 +963,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // HV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(120).duration(400)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[MV]).duration(400)
                 .input(PLASTIC_CIRCUIT_BOARD)
                 .input(PROCESSOR_MV, 2)
                 .input(SMALL_COIL, 4)
@@ -975,7 +975,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // EV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(120).duration(400)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[MV]).duration(400)
                 .input(PLASTIC_CIRCUIT_BOARD)
                 .input(PROCESSOR_ASSEMBLY_HV, 2)
                 .input(component, Component.Diode, 4)
@@ -987,7 +987,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // IV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(480).duration(800)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(800)
                 .input(frameGt, Aluminium, 2)
                 .input(WORKSTATION_EV, 2)
                 .input(SMALL_COIL, 12)
@@ -998,7 +998,7 @@ public class CircuitRecipes {
                 .solderMultiplier(4)
                 .buildAndRegister();
 
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(480).duration(400)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(400)
                 .input(frameGt, Aluminium, 2)
                 .input(WORKSTATION_EV, 2)
                 .input(SMALL_COIL, 12)
@@ -1088,7 +1088,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // LuV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(1920).duration(800)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[EV]).duration(800)
                 .input(frameGt, Aluminium, 2)
                 .input(NANO_COMPUTER_IV, 2)
                 .input(SMALL_COIL, 16)
@@ -1099,7 +1099,7 @@ public class CircuitRecipes {
                 .solderMultiplier(4)
                 .buildAndRegister();
 
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(1920).duration(400)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[EV]).duration(400)
                 .input(frameGt, Aluminium, 2)
                 .input(NANO_COMPUTER_IV, 2)
                 .input(SMALL_COIL, 16)
@@ -1189,7 +1189,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // ZPM
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(7680).duration(800)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[IV]).duration(800)
                 .input(frameGt, HSSG, 2)
                 .input(QUANTUM_COMPUTER_LUV, 2)
                 .input(SMALL_COIL, 24)
@@ -1200,7 +1200,7 @@ public class CircuitRecipes {
                 .output(QUANTUM_MAINFRAME_ZPM)
                 .buildAndRegister();
 
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(7680).duration(400)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[IV]).duration(400)
                 .input(frameGt, HSSG, 2)
                 .input(QUANTUM_COMPUTER_LUV, 2)
                 .input(SMALL_COIL, 24)
@@ -1258,7 +1258,7 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // UV
-        ASSEMBLY_LINE_RECIPES.recipeBuilder().EUt(30720).duration(800)
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().EUt(VA[LuV]).duration(800)
                 .input(frameGt, HSSE, 2)
                 .input(CRYSTAL_COMPUTER_ZPM, 2)
                 .input(RANDOM_ACCESS_MEMORY, 32)

--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -778,7 +778,7 @@ public class ComponentRecipes {
                     .inputs(PUMPS[i].getStackForm())
                     .input(OrePrefix.circuit, circuitTiers[i], 2)
                     .outputs(FLUID_REGULATORS[i].getStackForm())
-                    .EUt((int) (GTValues.V[i + 1] * 30 / 32))
+                    .EUt(GTValues.VA[i + 1])
                     .duration(400 - 50 * i)
                     .buildAndRegister();
         }

--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -13,7 +13,7 @@ import gregtech.common.items.MetaItems;
 import java.util.HashMap;
 import java.util.Map;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.common.items.MetaItems.FLUID_REGULATORS;
 import static gregtech.common.items.MetaItems.PUMPS;
 
@@ -34,7 +34,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic, 2)
                 .input(OrePrefix.wireGtQuadruple, Materials.ManganesePhosphide, 4)
                 .outputs(MetaItems.FIELD_GENERATOR_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.gem, Materials.EnderPearl)
@@ -42,7 +42,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Good, 2)
                 .input(OrePrefix.wireGtQuadruple, Materials.MagnesiumDiboride, 4)
                 .outputs(MetaItems.FIELD_GENERATOR_MV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.gem, Materials.EnderEye)
@@ -50,7 +50,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced, 2)
                 .input(OrePrefix.wireGtQuadruple, Materials.MercuryBariumCalciumCuprate, 4)
                 .outputs(MetaItems.FIELD_GENERATOR_HV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(MetaItems.QUANTUM_EYE.getStackForm())
@@ -58,7 +58,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme, 2)
                 .input(OrePrefix.wireGtQuadruple, Materials.UraniumTriplatinum, 4)
                 .outputs(MetaItems.FIELD_GENERATOR_EV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(MetaItems.QUANTUM_STAR.getStackForm())
@@ -66,7 +66,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite, 2)
                 .input(OrePrefix.wireGtQuadruple, Materials.SamariumIronArsenicOxide, 4)
                 .outputs(MetaItems.FIELD_GENERATOR_IV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                 .input(OrePrefix.frameGt, Materials.HSSG)
@@ -125,7 +125,7 @@ public class ComponentRecipes {
                 .inputs(MetaItems.ELECTRIC_PISTON_LV.getStackForm())
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic)
                 .outputs(MetaItems.ROBOT_ARM_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Copper, 3)
@@ -134,7 +134,7 @@ public class ComponentRecipes {
                 .inputs(MetaItems.ELECTRIC_PISTON_MV.getStackForm())
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Good)
                 .outputs(MetaItems.ROBOT_ARM_MV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Gold, 3)
@@ -143,7 +143,7 @@ public class ComponentRecipes {
                 .inputs(MetaItems.ELECTRIC_PISTON_HV.getStackForm())
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced)
                 .outputs(MetaItems.ROBOT_ARM_HV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Aluminium, 3)
@@ -152,7 +152,7 @@ public class ComponentRecipes {
                 .inputs(MetaItems.ELECTRIC_PISTON_EV.getStackForm())
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme)
                 .outputs(MetaItems.ROBOT_ARM_EV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Tungsten, 3)
@@ -161,7 +161,7 @@ public class ComponentRecipes {
                 .inputs(MetaItems.ELECTRIC_PISTON_IV.getStackForm())
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite)
                 .outputs(MetaItems.ROBOT_ARM_IV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                 .input(OrePrefix.stickLong, Materials.HSSG, 2)
@@ -217,7 +217,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.stick, Materials.IronMagnetic)
                 .input(OrePrefix.wireGtSingle, Materials.Copper, 4)
                 .outputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Tin, 2)
@@ -225,7 +225,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.stick, Materials.SteelMagnetic)
                 .input(OrePrefix.wireGtSingle, Materials.Copper, 4)
                 .outputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtSingle, Materials.Copper, 2)
@@ -233,7 +233,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.stick, Materials.SteelMagnetic)
                 .input(OrePrefix.wireGtDouble, Materials.Cupronickel, 4)
                 .outputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtDouble, Materials.Silver, 2)
@@ -241,7 +241,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.stick, Materials.SteelMagnetic)
                 .input(OrePrefix.wireGtDouble, Materials.Electrum, 4)
                 .outputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtDouble, Materials.Aluminium, 2)
@@ -249,7 +249,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.stick, Materials.NeodymiumMagnetic)
                 .input(OrePrefix.wireGtDouble, Materials.Kanthal, 4)
                 .outputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.cableGtDouble, Materials.Tungsten, 2)
@@ -257,7 +257,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.stick, Materials.NeodymiumMagnetic)
                 .input(OrePrefix.wireGtDouble, Materials.Graphene, 4)
                 .outputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                 .input(OrePrefix.stickLong, Materials.SamariumMagnetic)
@@ -318,7 +318,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Basic)
                 .input(OrePrefix.gem, Materials.Quartzite)
                 .outputs(MetaItems.SENSOR_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Electrum)
@@ -326,7 +326,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Good)
                 .input(OrePrefix.gem, Materials.NetherQuartz)
                 .outputs(MetaItems.SENSOR_MV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Chrome)
@@ -334,7 +334,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Advanced)
                 .input(OrePrefix.gem, Materials.Emerald)
                 .outputs(MetaItems.SENSOR_HV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Platinum)
@@ -342,7 +342,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Extreme)
                 .input(OrePrefix.gem, Materials.EnderPearl)
                 .outputs(MetaItems.SENSOR_EV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Iridium)
@@ -350,7 +350,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.circuit, MarkerMaterials.Tier.Elite)
                 .input(OrePrefix.gem, Materials.EnderEye)
                 .outputs(MetaItems.SENSOR_IV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                 .input(OrePrefix.frameGt, Materials.HSSG)
@@ -409,7 +409,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gem, Materials.Quartzite)
                 .circuitMeta(1)
                 .outputs(MetaItems.EMITTER_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Electrum, 4)
@@ -418,7 +418,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gem, Materials.NetherQuartz)
                 .circuitMeta(1)
                 .outputs(MetaItems.EMITTER_MV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Chrome, 4)
@@ -427,7 +427,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gem, Materials.Emerald)
                 .circuitMeta(1)
                 .outputs(MetaItems.EMITTER_HV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Platinum, 4)
@@ -436,7 +436,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gem, Materials.EnderPearl)
                 .circuitMeta(1)
                 .outputs(MetaItems.EMITTER_EV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Iridium, 4)
@@ -445,7 +445,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gem, Materials.EnderEye)
                 .circuitMeta(1)
                 .outputs(MetaItems.EMITTER_IV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                 .input(OrePrefix.frameGt, Materials.HSSG)
@@ -504,7 +504,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gearSmall, Materials.Steel)
                 .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
                 .outputs(MetaItems.ELECTRIC_PISTON_LV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Aluminium, 2)
@@ -513,7 +513,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gearSmall, Materials.Aluminium)
                 .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm())
                 .outputs(MetaItems.ELECTRIC_PISTON_MV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.StainlessSteel, 2)
@@ -522,7 +522,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gearSmall, Materials.StainlessSteel)
                 .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm())
                 .outputs(MetaItems.ELECTRIC_PISTON_HV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Titanium, 2)
@@ -531,7 +531,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gearSmall, Materials.Titanium)
                 .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm())
                 .outputs(MetaItems.ELECTRIC_PISTON_EV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.TungstenSteel, 2)
@@ -540,7 +540,7 @@ public class ComponentRecipes {
                 .input(OrePrefix.gearSmall, Materials.TungstenSteel)
                 .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
                 .outputs(MetaItems.ELECTRIC_PISTON_IV.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -601,7 +601,7 @@ public class ComponentRecipes {
                     .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm(2))
                     .circuitMeta(1)
                     .outputs(MetaItems.CONVEYOR_MODULE_LV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .input(OrePrefix.cableGtSingle, Materials.Copper)
@@ -609,7 +609,7 @@ public class ComponentRecipes {
                     .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm(2))
                     .circuitMeta(1)
                     .outputs(MetaItems.CONVEYOR_MODULE_MV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .input(OrePrefix.cableGtSingle, Materials.Gold)
@@ -617,7 +617,7 @@ public class ComponentRecipes {
                     .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm(2))
                     .circuitMeta(1)
                     .outputs(MetaItems.CONVEYOR_MODULE_HV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .input(OrePrefix.cableGtSingle, Materials.Aluminium)
@@ -625,7 +625,7 @@ public class ComponentRecipes {
                     .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm(2))
                     .circuitMeta(1)
                     .outputs(MetaItems.CONVEYOR_MODULE_EV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             if (!materialEntry.getValue().equals(Materials.Rubber))
                 RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -634,7 +634,7 @@ public class ComponentRecipes {
                         .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm(2))
                         .circuitMeta(1)
                         .outputs(MetaItems.CONVEYOR_MODULE_IV.getStackForm())
-                        .duration(100).EUt(30).buildAndRegister();
+                        .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .input(OrePrefix.gearSmall, Materials.HSSG, 2)
@@ -689,7 +689,7 @@ public class ComponentRecipes {
                     .input(OrePrefix.ring, materialEntry.getValue(), 2)
                     .inputs(MetaItems.ELECTRIC_MOTOR_LV.getStackForm())
                     .outputs(MetaItems.ELECTRIC_PUMP_LV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .input(OrePrefix.cableGtSingle, Materials.Copper)
@@ -699,7 +699,7 @@ public class ComponentRecipes {
                     .input(OrePrefix.ring, materialEntry.getValue(), 2)
                     .inputs(MetaItems.ELECTRIC_MOTOR_MV.getStackForm())
                     .outputs(MetaItems.ELECTRIC_PUMP_MV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .input(OrePrefix.cableGtSingle, Materials.Copper)
@@ -709,7 +709,7 @@ public class ComponentRecipes {
                     .input(OrePrefix.ring, materialEntry.getValue(), 2)
                     .inputs(MetaItems.ELECTRIC_MOTOR_HV.getStackForm())
                     .outputs(MetaItems.ELECTRIC_PUMP_HV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .input(OrePrefix.cableGtSingle, Materials.Aluminium)
@@ -719,7 +719,7 @@ public class ComponentRecipes {
                     .input(OrePrefix.ring, materialEntry.getValue(), 2)
                     .inputs(MetaItems.ELECTRIC_MOTOR_EV.getStackForm())
                     .outputs(MetaItems.ELECTRIC_PUMP_EV.getStackForm())
-                    .duration(100).EUt(30).buildAndRegister();
+                    .duration(100).EUt(VA[LV]).buildAndRegister();
 
             if (!materialEntry.getValue().equals(Materials.Rubber))
                 RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -730,7 +730,7 @@ public class ComponentRecipes {
                         .input(OrePrefix.ring, materialEntry.getValue(), 2)
                         .inputs(MetaItems.ELECTRIC_MOTOR_IV.getStackForm())
                         .outputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
-                        .duration(100).EUt(30).buildAndRegister();
+                        .duration(100).EUt(VA[LV]).buildAndRegister();
         }
 
         RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -39,7 +39,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.fluids.FluidStack;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -128,87 +128,87 @@ public class MachineRecipeLoader {
                 .circuitMeta(12)
                 .input(OrePrefix.plate, Materials.Tin, 2)
                 .outputs(MetaItems.FLUID_CELL.getStackForm())
-                .duration(200).EUt(8)
+                .duration(200).EUt(VA[ULV])
                 .buildAndRegister();
 
         BENDER_RECIPES.recipeBuilder()
                 .circuitMeta(12)
                 .input(OrePrefix.plate, Materials.Steel)
                 .outputs(MetaItems.FLUID_CELL.getStackForm())
-                .duration(100).EUt(8)
+                .duration(100).EUt(VA[ULV])
                 .buildAndRegister();
 
         BENDER_RECIPES.recipeBuilder()
                 .circuitMeta(12)
                 .input(OrePrefix.plate, Polytetrafluoroethylene)
                 .outputs(MetaItems.FLUID_CELL.getStackForm(4))
-                .duration(100).EUt(8)
+                .duration(100).EUt(VA[ULV])
                 .buildAndRegister();
 
         BENDER_RECIPES.recipeBuilder()
                 .circuitMeta(12)
                 .input(OrePrefix.plate, Polybenzimidazole)
                 .outputs(MetaItems.FLUID_CELL.getStackForm(16))
-                .duration(100).EUt(8)
+                .duration(100).EUt(VA[ULV])
                 .buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Materials.Tin, 2)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .outputs(MetaItems.FLUID_CELL.getStackForm())
-                .duration(128).EUt(30)
+                .duration(128).EUt(VA[LV])
                 .buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Materials.Steel)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .outputs(MetaItems.FLUID_CELL.getStackForm())
-                .duration(128).EUt(30)
+                .duration(128).EUt(VA[LV])
                 .buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Polytetrafluoroethylene)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .outputs(MetaItems.FLUID_CELL.getStackForm(4))
-                .duration(128).EUt(30)
+                .duration(128).EUt(VA[LV])
                 .buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Polybenzimidazole)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .outputs(MetaItems.FLUID_CELL.getStackForm(16))
-                .duration(128).EUt(30)
+                .duration(128).EUt(VA[LV])
                 .buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Steel, 4)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .output(FLUID_CELL_LARGE_STEEL)
-                .duration(256).EUt(30).buildAndRegister();
+                .duration(256).EUt(VA[LV]).buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Aluminium, 4)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .output(FLUID_CELL_LARGE_ALUMINIUM)
-                .duration(256).EUt(120).buildAndRegister();
+                .duration(256).EUt(VA[MV]).buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, StainlessSteel, 6)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .output(FLUID_CELL_LARGE_STAINLESS_STEEL)
-                .duration(512).EUt(120).buildAndRegister();
+                .duration(512).EUt(VA[MV]).buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, Titanium, 6)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .output(FLUID_CELL_LARGE_TITANIUM)
-                .duration(512).EUt(480).buildAndRegister();
+                .duration(512).EUt(VA[HV]).buildAndRegister();
 
         EXTRUDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.ingot, TungstenSteel, 8)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_CELL)
                 .output(FLUID_CELL_LARGE_TUNGSTEN_STEEL)
-                .duration(1024).EUt(480).buildAndRegister();
+                .duration(1024).EUt(VA[HV]).buildAndRegister();
 
         COMPRESSOR_RECIPES.recipeBuilder()
                 .input(OrePrefix.dust, Materials.NetherQuartz)
@@ -316,7 +316,7 @@ public class MachineRecipeLoader {
                 .buildAndRegister();
 
         RecipeMaps.MIXER_RECIPES.recipeBuilder()
-                .duration(600).EUt(120)
+                .duration(600).EUt(VA[MV])
                 .input(OrePrefix.dust, Materials.Ruby, 4)
                 .input(OrePrefix.dust, Materials.Redstone, 5)
                 .outputs(MetaItems.ENERGIUM_DUST.getStackForm(9))
@@ -325,14 +325,14 @@ public class MachineRecipeLoader {
         RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder().inputs(MetaItems.ENERGIUM_DUST.getStackForm(9))
                 .fluidInputs(Materials.Water.getFluid(1800))
                 .outputs(MetaItems.ENERGIUM_CRYSTAL.getStackForm())
-                .duration(2000).EUt(120)
+                .duration(2000).EUt(VA[MV])
                 .buildAndRegister();
 
         RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
                 .inputs(MetaItems.ENERGIUM_DUST.getStackForm(9))
                 .fluidInputs(Materials.DistilledWater.getFluid(1800))
                 .outputs(MetaItems.ENERGIUM_CRYSTAL.getStackForm())
-                .duration(1500).EUt(120)
+                .duration(1500).EUt(VA[MV])
                 .buildAndRegister();
 
         RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
@@ -346,7 +346,7 @@ public class MachineRecipeLoader {
 //            .input(OrePrefix.dust, Materials.NetherStar)
 //            .fluidInputs(Materials.UUMatter.getFluid(576))
 //            .chancedOutput(new ItemStack(Items.NETHER_STAR), 3333, 3333)
-//            .duration(72000).EUt(480).buildAndRegister();
+//            .duration(72000).EUt(VA[HV]).buildAndRegister();
 
         RecipeMaps.MIXER_RECIPES.recipeBuilder()
                 .input(OrePrefix.crushedPurified, Materials.Sphalerite)
@@ -359,7 +359,7 @@ public class MachineRecipeLoader {
                 .input(OrePrefix.dust, Materials.Sodium)
                 .input(OrePrefix.dust, Materials.Potassium)
                 .fluidOutputs(Materials.SodiumPotassium.getFluid(1000))
-                .duration(400).EUt(30).buildAndRegister();
+                .duration(400).EUt(VA[LV]).buildAndRegister();
 
     }
 
@@ -424,10 +424,10 @@ public class MachineRecipeLoader {
         COMPRESSOR_RECIPES.recipeBuilder().inputs(MetaItems.CARBON_FIBERS.getStackForm(2)).outputs(MetaItems.CARBON_MESH.getStackForm()).duration(100).buildAndRegister();
         COMPRESSOR_RECIPES.recipeBuilder().inputs(MetaItems.CARBON_MESH.getStackForm()).outputs(MetaItems.CARBON_PLATE.getStackForm()).buildAndRegister();
 
-        ALLOY_SMELTER_RECIPES.recipeBuilder().duration(10).EUt(7).input(OrePrefix.ingot, Materials.Rubber, 2).notConsumable(MetaItems.SHAPE_MOLD_PLATE).output(OrePrefix.plate, Materials.Rubber).buildAndRegister();
-        ALLOY_SMELTER_RECIPES.recipeBuilder().duration(100).EUt(7).input(OrePrefix.dust, Materials.Sulfur).input(OrePrefix.dust, Materials.RawRubber, 3).output(OrePrefix.ingot, Materials.Rubber).buildAndRegister();
+        ALLOY_SMELTER_RECIPES.recipeBuilder().duration(10).EUt(VA[ULV]).input(OrePrefix.ingot, Materials.Rubber, 2).notConsumable(MetaItems.SHAPE_MOLD_PLATE).output(OrePrefix.plate, Materials.Rubber).buildAndRegister();
+        ALLOY_SMELTER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).input(OrePrefix.dust, Materials.Sulfur).input(OrePrefix.dust, Materials.RawRubber, 3).output(OrePrefix.ingot, Materials.Rubber).buildAndRegister();
 
-        ALLOY_SMELTER_RECIPES.recipeBuilder().duration(150).EUt(7).inputs(OreDictUnifier.get("sand")).inputs(new ItemStack(Items.CLAY_BALL)).outputs(COKE_OVEN_BRICK.getStackForm(2)).buildAndRegister();
+        ALLOY_SMELTER_RECIPES.recipeBuilder().duration(150).EUt(VA[ULV]).inputs(OreDictUnifier.get("sand")).inputs(new ItemStack(Items.CLAY_BALL)).outputs(COKE_OVEN_BRICK.getStackForm(2)).buildAndRegister();
     }
 
     private static void registerAssemblerRecipes() {
@@ -436,7 +436,7 @@ public class MachineRecipeLoader {
                     .inputs(MetaItems.SPRAY_EMPTY.getStackForm())
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L * 4))
                     .outputs(MetaItems.SPRAY_CAN_DYES[i].getStackForm())
-                    .EUt(8).duration(200)
+                    .EUt(VA[ULV]).duration(200)
                     .buildAndRegister();
         }
 
@@ -507,7 +507,7 @@ public class MachineRecipeLoader {
                 .inputs(new ItemStack(Items.CAULDRON))
                 .input(circuit, MarkerMaterials.Tier.Advanced)
                 .output(COVER_INFINITE_WATER)
-                .EUt(480).duration(200)
+                .EUt(VA[HV]).duration(200)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -518,7 +518,7 @@ public class MachineRecipeLoader {
                 .input(ELECTRIC_PUMP_HV)
                 .fluidInputs(Polyethylene.getFluid(L * 2))
                 .output(COVER_ENDER_FLUID_LINK)
-                .EUt(480).duration(320)
+                .EUt(VA[HV]).duration(320)
                 .buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(OrePrefix.plate, WroughtIron, 8).outputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.ULV)).circuitMeta(8).duration(25).buildAndRegister();
@@ -533,13 +533,13 @@ public class MachineRecipeLoader {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(OrePrefix.plate, Neutronium, 8).outputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.MAX)).circuitMeta(8).duration(50).buildAndRegister();
 
         if (ConfigHolder.recipes.harderHeatingCoils) {
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(30).input(OrePrefix.wireGtDouble, Materials.Cupronickel, 8).input(OrePrefix.foil, Materials.Bronze, 8).fluidInputs(Materials.TinAlloy.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.CUPRONICKEL)).duration(200).buildAndRegister();
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(120).input(OrePrefix.wireGtDouble, Materials.Kanthal, 8).input(OrePrefix.foil, Materials.Aluminium, 8).fluidInputs(Materials.Copper.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.KANTHAL)).duration(300).buildAndRegister();
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(480).input(OrePrefix.wireGtDouble, Materials.Nichrome, 8).input(OrePrefix.foil, Materials.StainlessSteel, 8).fluidInputs(Materials.Aluminium.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NICHROME)).duration(400).buildAndRegister();
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(1920).input(OrePrefix.wireGtDouble, Materials.TungstenSteel, 8).input(OrePrefix.foil, Materials.VanadiumSteel, 8).fluidInputs(Materials.Nichrome.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TUNGSTENSTEEL)).duration(500).buildAndRegister();
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(7680).input(OrePrefix.wireGtDouble, Materials.HSSG, 8).input(OrePrefix.foil, Materials.TungstenCarbide, 8).fluidInputs(Materials.Tungsten.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.HSS_G)).duration(600).buildAndRegister();
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(30720).input(OrePrefix.wireGtDouble, Materials.Naquadah, 8).input(OrePrefix.foil, Materials.Osmium, 8).fluidInputs(Materials.TungstenSteel.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH)).duration(700).buildAndRegister();
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(122880).input(OrePrefix.wireGtDouble, Materials.NaquadahAlloy, 8).input(OrePrefix.foil, Materials.Osmiridium, 8).fluidInputs(Materials.Naquadah.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH_ALLOY)).duration(800).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(OrePrefix.wireGtDouble, Materials.Cupronickel, 8).input(OrePrefix.foil, Materials.Bronze, 8).fluidInputs(Materials.TinAlloy.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.CUPRONICKEL)).duration(200).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[MV]).input(OrePrefix.wireGtDouble, Materials.Kanthal, 8).input(OrePrefix.foil, Materials.Aluminium, 8).fluidInputs(Materials.Copper.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.KANTHAL)).duration(300).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[HV]).input(OrePrefix.wireGtDouble, Materials.Nichrome, 8).input(OrePrefix.foil, Materials.StainlessSteel, 8).fluidInputs(Materials.Aluminium.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NICHROME)).duration(400).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[EV]).input(OrePrefix.wireGtDouble, Materials.TungstenSteel, 8).input(OrePrefix.foil, Materials.VanadiumSteel, 8).fluidInputs(Materials.Nichrome.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TUNGSTENSTEEL)).duration(500).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[IV]).input(OrePrefix.wireGtDouble, Materials.HSSG, 8).input(OrePrefix.foil, Materials.TungstenCarbide, 8).fluidInputs(Materials.Tungsten.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.HSS_G)).duration(600).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LuV]).input(OrePrefix.wireGtDouble, Materials.Naquadah, 8).input(OrePrefix.foil, Materials.Osmium, 8).fluidInputs(Materials.TungstenSteel.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH)).duration(700).buildAndRegister();
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ZPM]).input(OrePrefix.wireGtDouble, Materials.NaquadahAlloy, 8).input(OrePrefix.foil, Materials.Osmiridium, 8).fluidInputs(Materials.Naquadah.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH_ALLOY)).duration(800).buildAndRegister();
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(500000).input(OrePrefix.wireGtDouble, Materials.FluxedElectrum, 8).input(OrePrefix.foil, Materials.Naquadria, 8).fluidInputs(Materials.NaquadahAlloy.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.FLUXED_ELECTRUM)).duration(900).buildAndRegister();
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(2000000).input(OrePrefix.wireGtDouble, Materials.DiamericiumTitanium, 8).input(OrePrefix.foil, Materials.Trinium, 8).fluidInputs(Materials.Neutronium.getFluid(GTValues.L)).outputs(MetaBlocks.WIRE_COIL2.getItemVariant(CoilType2.DIAMERICIUM_TITANIUM)).duration(1000).buildAndRegister();
 
@@ -575,19 +575,19 @@ public class MachineRecipeLoader {
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.METAL_CASING.getItemVariant(MetalCasingType.STEEL_SOLID)).fluidInputs(Materials.Polytetrafluoroethylene.getFluid(216)).notConsumable(new IntCircuitIngredient(6)).outputs(MetaBlocks.METAL_CASING.getItemVariant(MetalCasingType.PTFE_INERT_CASING)).duration(50).buildAndRegister();
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(30720).input(OrePrefix.wireGtDouble, Materials.IndiumTinBariumTitaniumCuprate, 32).input(OrePrefix.foil, Materials.NiobiumTitanium, 32).fluidInputs(Materials.Ruthenium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).duration(100).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(122880).input(OrePrefix.wireGtDouble, Materials.UraniumRhodiumDinaquadide, 16).input(OrePrefix.foil, Materials.NiobiumTitanium, 16).fluidInputs(Materials.Ruthenium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).duration(100).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(491520).input(OrePrefix.wireGtDouble, Materials.EnrichedNaquadahTriniumEuropiumDuranide, 8).input(OrePrefix.foil, Materials.NiobiumTitanium, 8).fluidInputs(Materials.Ruthenium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LuV]).input(OrePrefix.wireGtDouble, Materials.IndiumTinBariumTitaniumCuprate, 32).input(OrePrefix.foil, Materials.NiobiumTitanium, 32).fluidInputs(Materials.Ruthenium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ZPM]).input(OrePrefix.wireGtDouble, Materials.UraniumRhodiumDinaquadide, 16).input(OrePrefix.foil, Materials.NiobiumTitanium, 16).fluidInputs(Materials.Ruthenium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[UV]).input(OrePrefix.wireGtDouble, Materials.EnrichedNaquadahTriniumEuropiumDuranide, 8).input(OrePrefix.foil, Materials.NiobiumTitanium, 8).fluidInputs(Materials.Ruthenium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).duration(100).buildAndRegister();
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(122880).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).inputs(MetaItems.FIELD_GENERATOR_HV.getStackForm(2)).inputs(MetaItems.NEUTRON_REFLECTOR.getStackForm(2)).input(OrePrefix.circuit, MarkerMaterials.Tier.Master, 4).fluidInputs(Materials.Osmium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_COIL)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ZPM]).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).inputs(MetaItems.FIELD_GENERATOR_HV.getStackForm(2)).inputs(MetaItems.NEUTRON_REFLECTOR.getStackForm(2)).input(OrePrefix.circuit, MarkerMaterials.Tier.Master, 4).fluidInputs(Materials.Osmium.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_COIL)).duration(100).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(OrePrefix.frameGt, Materials.HSSE).inputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                 BlockGlassCasing.CasingType.TEMPERED_GLASS, 2)).input(OrePrefix.plate, Materials.NiobiumNitride, 2).inputs(MetaItems.NEUTRON_REFLECTOR.getStackForm(2)).outputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                 BlockGlassCasing.CasingType.FUSION_GLASS, 2)).duration(50).buildAndRegister();
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(30720).inputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.LuV)).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).inputs(MetaItems.NEUTRON_REFLECTOR.getStackForm()).input(OrePrefix.plate, Materials.TungstenSteel, 6).fluidInputs(Materials.Polybenzimidazole.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_CASING, 2)).duration(100).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(122880).inputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.ZPM)).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_COIL)).inputs(MetaItems.VOLTAGE_COIL_ZPM.getStackForm(2)).input(OrePrefix.plate, Materials.Europium, 6).fluidInputs(Materials.Polybenzimidazole.getFluid(GTValues.L * 2)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_CASING_MK2, 2)).duration(100).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(491520).inputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.UV)).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_COIL)).inputs(MetaItems.VOLTAGE_COIL_UV.getStackForm(2)).input(OrePrefix.plate, Materials.Americium, 6).fluidInputs(Materials.Polybenzimidazole.getFluid(GTValues.L * 4)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_CASING_MK3, 2)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LuV]).inputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.LuV)).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.SUPERCONDUCTOR_COIL)).inputs(MetaItems.NEUTRON_REFLECTOR.getStackForm()).input(OrePrefix.plate, Materials.TungstenSteel, 6).fluidInputs(Materials.Polybenzimidazole.getFluid(GTValues.L)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_CASING, 2)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[ZPM]).inputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.ZPM)).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_COIL)).inputs(MetaItems.VOLTAGE_COIL_ZPM.getStackForm(2)).input(OrePrefix.plate, Materials.Europium, 6).fluidInputs(Materials.Polybenzimidazole.getFluid(GTValues.L * 2)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_CASING_MK2, 2)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[UV]).inputs(MetaBlocks.MACHINE_CASING.getItemVariant(MachineCasingType.UV)).inputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_COIL)).inputs(MetaItems.VOLTAGE_COIL_UV.getStackForm(2)).input(OrePrefix.plate, Materials.Americium, 6).fluidInputs(Materials.Polybenzimidazole.getFluid(GTValues.L * 4)).outputs(MetaBlocks.FUSION_CASING.getItemVariant(BlockFusionCasing.CasingType.FUSION_CASING_MK3, 2)).duration(100).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(OrePrefix.plate, Materials.Magnalium, 6).input(OrePrefix.frameGt, Materials.BlueSteel, 1).outputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.STEEL_TURBINE_CASING, 2)).duration(50).buildAndRegister();
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.STEEL_TURBINE_CASING)).input(OrePrefix.plate, Materials.StainlessSteel, 6).outputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.STAINLESS_TURBINE_CASING, 2)).duration(50).buildAndRegister();
@@ -610,10 +610,10 @@ public class MachineRecipeLoader {
         ASSEMBLER_RECIPES.recipeBuilder().EUt(2).inputs(new ItemStack(Blocks.CHEST, 1, GTValues.W)).input(plate, Iron, 5).outputs(new ItemStack(Blocks.HOPPER)).duration(800).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(2).inputs(new ItemStack(Blocks.TRAPPED_CHEST, 1, GTValues.W)).input(plate, WroughtIron, 5).outputs(new ItemStack(Blocks.HOPPER)).duration(800).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).input(foil, Polycaprolactam, 4).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE).duration(100).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).input(foil, SiliconeRubber, 4).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE, 2).duration(100).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).input(foil, StyreneButadieneRubber, 2).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(144)).output(DUCT_TAPE, 4).duration(100).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(30).input(foil, Polybenzimidazole).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(72)).output(DUCT_TAPE, 8).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, Polycaprolactam, 4).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, SiliconeRubber, 4).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE, 2).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, StyreneButadieneRubber, 2).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(144)).output(DUCT_TAPE, 4).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, Polybenzimidazole).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(72)).output(DUCT_TAPE, 8).duration(100).buildAndRegister();
 
     }
 
@@ -624,12 +624,12 @@ public class MachineRecipeLoader {
         BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(800).EUt(480).input(dust, Ilmenite, 5).outputs(OreDictUnifier.get(ingot, WroughtIron), OreDictUnifier.get(dust, Rutile)).blastFurnaceTemp(1700).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(800).EUt(480).input(dust, Magnesium, 2).fluidInputs(TitaniumTetrachloride.getFluid(1000)).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.Titanium), OreDictUnifier.get(OrePrefix.dust, Materials.MagnesiumChloride, 6)).blastFurnaceTemp(Materials.Titanium.getBlastTemperature() + 200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).input(ingot, Iron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(100).EUt(120).input(ingot, WroughtIron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(200).EUt(120).input(dust, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).input(ingot, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(800).EUt(VA[HV]).input(dust, Ilmenite, 5).outputs(OreDictUnifier.get(ingot, WroughtIron), OreDictUnifier.get(dust, Rutile)).blastFurnaceTemp(1700).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(800).EUt(VA[HV]).input(dust, Magnesium, 2).fluidInputs(TitaniumTetrachloride.getFluid(1000)).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.Titanium), OreDictUnifier.get(OrePrefix.dust, Materials.MagnesiumChloride, 6)).blastFurnaceTemp(Materials.Titanium.getBlastTemperature() + 200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(500).EUt(VA[MV]).input(ingot, Iron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(100).EUt(VA[MV]).input(ingot, WroughtIron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(200).EUt(VA[MV]).input(dust, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(500).EUt(VA[MV]).input(ingot, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
         //Tempered Glass
         BLAST_RECIPES.recipeBuilder()
                 .input(block, Glass)
@@ -637,7 +637,7 @@ public class MachineRecipeLoader {
                 .outputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                         BlockGlassCasing.CasingType.TEMPERED_GLASS))
                 .blastFurnaceTemp(1000)
-                .duration(200).EUt(120).buildAndRegister();
+                .duration(200).EUt(VA[MV]).buildAndRegister();
 
         registerBlastFurnaceMetallurgyRecipes();
     }
@@ -648,7 +648,7 @@ public class MachineRecipeLoader {
         createSulfurDioxideRecipe(Pyrite, BandedIron, 2000);
         createSulfurDioxideRecipe(Pentlandite, Garnierite, 1000);
 
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
                 .input(dust, Tetrahedrite)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, CupricOxide)
@@ -656,7 +656,7 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(2000))
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
                 .input(dust, Cobaltite)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, CobaltOxide)
@@ -664,7 +664,7 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(1000))
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
                 .input(dust, Galena)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, Massicot)
@@ -672,7 +672,7 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(1000))
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
                 .input(dust, Chalcopyrite)
                 .input(dust, SiliconDioxide)
                 .fluidInputs(Oxygen.getFluid(3000))
@@ -681,7 +681,7 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(2000))
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(240).EUt(120).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(240).EUt(VA[MV]).blastFurnaceTemp(1200)
                 .input(dust, SiliconDioxide)
                 .input(dust, Carbon, 2)
                 .output(ingot, Silicon)
@@ -691,7 +691,7 @@ public class MachineRecipeLoader {
     }
 
     private static void createSulfurDioxideRecipe(Material inputMaterial, Material outputMaterial, int sulfurDioxideAmount) {
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
                 .input(dust, inputMaterial)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, outputMaterial)
@@ -877,10 +877,10 @@ public class MachineRecipeLoader {
                 .fluidInputs(Concrete.getFluid(GTValues.L))
                 .notConsumable(MetaItems.SHAPE_MOLD_BLOCK.getStackForm())
                 .output(stone, Concrete)
-                .duration(98).EUt(8).buildAndRegister();
+                .duration(98).EUt(VA[ULV]).buildAndRegister();
 
-        FLUID_HEATER_RECIPES.recipeBuilder().duration(30).EUt(32).fluidInputs(Water.getFluid(6)).circuitMeta(1).fluidOutputs(Steam.getFluid(960)).buildAndRegister();
-        FLUID_HEATER_RECIPES.recipeBuilder().duration(30).EUt(32).fluidInputs(DistilledWater.getFluid(6)).circuitMeta(1).fluidOutputs(Steam.getFluid(960)).buildAndRegister();
+        FLUID_HEATER_RECIPES.recipeBuilder().duration(30).EUt(VA[LV]).fluidInputs(Water.getFluid(6)).circuitMeta(1).fluidOutputs(Steam.getFluid(960)).buildAndRegister();
+        FLUID_HEATER_RECIPES.recipeBuilder().duration(30).EUt(VA[LV]).fluidInputs(DistilledWater.getFluid(6)).circuitMeta(1).fluidOutputs(Steam.getFluid(960)).buildAndRegister();
     }
 
     private static <T extends Enum<T> & IStringSerializable> void registerBrickRecipe(StoneBlock<T> stoneBlock, T normalVariant, T brickVariant) {

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -817,37 +817,37 @@ public class MachineRecipeLoader {
                 .inputs(new ItemStack(Items.PORKCHOP))
                 .output(dustSmall, Meat, 6)
                 .output(dustTiny, Bone)
-                .duration(102).EUt(4).buildAndRegister();
+                .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.FISH, 1, GTValues.W))
                 .output(dustSmall, Meat, 6)
                 .output(dustTiny, Bone)
-                .duration(102).EUt(4).buildAndRegister();
+                .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.CHICKEN))
                 .output(dust, Meat)
                 .output(dustTiny, Bone)
-                .duration(102).EUt(4).buildAndRegister();
+                .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.BEEF))
                 .output(dustSmall, Meat, 6)
                 .output(dustTiny, Bone)
-                .duration(102).EUt(4).buildAndRegister();
+                .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.RABBIT))
                 .output(dustSmall, Meat, 6)
                 .output(dustTiny, Bone)
-                .duration(102).EUt(4).buildAndRegister();
+                .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.MUTTON))
                 .output(dust, Meat)
                 .output(dustTiny, Bone)
-                .duration(102).EUt(4).buildAndRegister();
+                .duration(102).buildAndRegister();
 
 
     }

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -9,6 +9,7 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.items.MetaItems;
 import gregtech.common.metatileentities.MetaTileEntities;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.common.metatileentities.MetaTileEntities.*;
 
 public class MetaTileEntityMachineRecipeLoader {
@@ -26,7 +27,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .input(OrePrefix.rotor, Materials.Lead)
                     .fluidInputs(Materials.Lubricant.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.ULV].getStackForm())
-                    .duration(200).EUt(7).buildAndRegister();
+                    .duration(200).EUt(VA[ULV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.LV].getStackForm())
@@ -36,7 +37,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_LV.getStackForm())
                     .fluidInputs(Materials.Lubricant.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.LV].getStackForm())
-                    .duration(200).EUt(30).buildAndRegister();
+                    .duration(200).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.MV].getStackForm())
@@ -46,7 +47,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_MV.getStackForm())
                     .fluidInputs(Materials.Lubricant.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.MV].getStackForm())
-                    .duration(200).EUt(120).buildAndRegister();
+                    .duration(200).EUt(VA[MV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.HV].getStackForm())
@@ -56,7 +57,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_HV.getStackForm())
                     .fluidInputs(Materials.Helium.getFluid(1000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.HV].getStackForm())
-                    .duration(200).EUt(480).buildAndRegister();
+                    .duration(200).EUt(VA[HV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.HV].getStackForm())
@@ -66,7 +67,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_HV.getStackForm())
                     .fluidInputs(Materials.SodiumPotassium.getFluid(1000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.HV].getStackForm())
-                    .duration(200).EUt(480).buildAndRegister();
+                    .duration(200).EUt(VA[HV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.EV].getStackForm())
@@ -76,7 +77,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_EV.getStackForm())
                     .fluidInputs(Materials.Helium.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.EV].getStackForm())
-                    .duration(200).EUt(1920).buildAndRegister();
+                    .duration(200).EUt(VA[EV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.EV].getStackForm())
@@ -86,7 +87,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_EV.getStackForm())
                     .fluidInputs(Materials.SodiumPotassium.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.EV].getStackForm())
-                    .duration(200).EUt(1920).buildAndRegister();
+                    .duration(200).EUt(VA[EV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.IV].getStackForm())
@@ -96,7 +97,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
                     .fluidInputs(Materials.Helium.getFluid(3000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.IV].getStackForm())
-                    .duration(200).EUt(7680).buildAndRegister();
+                    .duration(200).EUt(VA[IV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.IV].getStackForm())
@@ -106,7 +107,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
                     .fluidInputs(Materials.SodiumPotassium.getFluid(3000))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.IV].getStackForm())
-                    .duration(200).EUt(7680).buildAndRegister();
+                    .duration(200).EUt(VA[IV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.LuV].getStackForm())
@@ -118,7 +119,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.Helium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(720))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.LuV].getStackForm())
-                    .duration(400).EUt(30720).buildAndRegister();
+                    .duration(400).EUt(VA[LuV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.LuV].getStackForm())
@@ -130,7 +131,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.SodiumPotassium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(720))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.LuV].getStackForm())
-                    .duration(400).EUt(30720).buildAndRegister();
+                    .duration(400).EUt(VA[LuV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.ZPM].getStackForm())
@@ -142,7 +143,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.Helium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(1440))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.ZPM].getStackForm())
-                    .duration(600).EUt(122880).buildAndRegister();
+                    .duration(600).EUt(VA[ZPM]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.ZPM].getStackForm())
@@ -154,7 +155,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.SodiumPotassium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(1440))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.ZPM].getStackForm())
-                    .duration(600).EUt(122880).buildAndRegister();
+                    .duration(600).EUt(VA[ZPM]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.UV].getStackForm())
@@ -166,7 +167,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.Helium.getFluid(12000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(2880))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.UV].getStackForm())
-                    .duration(800).EUt(491520).buildAndRegister();
+                    .duration(800).EUt(VA[UV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.UV].getStackForm())
@@ -178,7 +179,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.SodiumPotassium.getFluid(12000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(2880))
                     .outputs(MetaTileEntities.ENERGY_OUTPUT_HATCH[GTValues.UV].getStackForm())
-                    .duration(800).EUt(491520).buildAndRegister();
+                    .duration(800).EUt(VA[UV]).buildAndRegister();
 
             // Energy Input Hatches
 
@@ -190,7 +191,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .input(OrePrefix.rotor, Materials.Lead)
                     .fluidInputs(Materials.Lubricant.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.ULV].getStackForm())
-                    .duration(200).EUt(7).buildAndRegister();
+                    .duration(200).EUt(VA[ULV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.LV].getStackForm())
@@ -200,7 +201,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_LV.getStackForm())
                     .fluidInputs(Materials.Lubricant.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.LV].getStackForm())
-                    .duration(200).EUt(30).buildAndRegister();
+                    .duration(200).EUt(VA[LV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.MV].getStackForm())
@@ -210,7 +211,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_MV.getStackForm())
                     .fluidInputs(Materials.Lubricant.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.MV].getStackForm())
-                    .duration(200).EUt(120).buildAndRegister();
+                    .duration(200).EUt(VA[MV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.HV].getStackForm())
@@ -220,7 +221,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_HV.getStackForm())
                     .fluidInputs(Materials.Helium.getFluid(1000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.HV].getStackForm())
-                    .duration(200).EUt(480).buildAndRegister();
+                    .duration(200).EUt(VA[HV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.HV].getStackForm())
@@ -230,7 +231,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_HV.getStackForm())
                     .fluidInputs(Materials.SodiumPotassium.getFluid(1000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.HV].getStackForm())
-                    .duration(200).EUt(480).buildAndRegister();
+                    .duration(200).EUt(VA[HV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.EV].getStackForm())
@@ -240,7 +241,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_EV.getStackForm())
                     .fluidInputs(Materials.Helium.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.EV].getStackForm())
-                    .duration(200).EUt(1920).buildAndRegister();
+                    .duration(200).EUt(VA[EV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.EV].getStackForm())
@@ -250,7 +251,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_EV.getStackForm())
                     .fluidInputs(Materials.SodiumPotassium.getFluid(2000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.EV].getStackForm())
-                    .duration(200).EUt(1920).buildAndRegister();
+                    .duration(200).EUt(VA[EV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.IV].getStackForm())
@@ -260,7 +261,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
                     .fluidInputs(Materials.Helium.getFluid(3000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.IV].getStackForm())
-                    .duration(200).EUt(7680).buildAndRegister();
+                    .duration(200).EUt(VA[IV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.IV].getStackForm())
@@ -270,7 +271,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .inputs(MetaItems.ELECTRIC_PUMP_IV.getStackForm())
                     .fluidInputs(Materials.SodiumPotassium.getFluid(3000))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.IV].getStackForm())
-                    .duration(200).EUt(7680).buildAndRegister();
+                    .duration(200).EUt(VA[IV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.LuV].getStackForm())
@@ -282,7 +283,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.Helium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(720))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.LuV].getStackForm())
-                    .duration(400).EUt(30720).buildAndRegister();
+                    .duration(400).EUt(VA[LuV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.LuV].getStackForm())
@@ -294,7 +295,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.SodiumPotassium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(720))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.LuV].getStackForm())
-                    .duration(400).EUt(30720).buildAndRegister();
+                    .duration(400).EUt(VA[LuV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.ZPM].getStackForm())
@@ -306,7 +307,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.Helium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(1440))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.ZPM].getStackForm())
-                    .duration(600).EUt(122880).buildAndRegister();
+                    .duration(600).EUt(VA[ZPM]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.ZPM].getStackForm())
@@ -318,7 +319,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.SodiumPotassium.getFluid(6000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(1440))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.ZPM].getStackForm())
-                    .duration(600).EUt(122880).buildAndRegister();
+                    .duration(600).EUt(VA[ZPM]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.UV].getStackForm())
@@ -330,7 +331,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.Helium.getFluid(12000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(2880))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.UV].getStackForm())
-                    .duration(800).EUt(491520).buildAndRegister();
+                    .duration(800).EUt(VA[UV]).buildAndRegister();
 
             RecipeMaps.ASSEMBLY_LINE_RECIPES.recipeBuilder()
                     .inputs(HULL[GTValues.UV].getStackForm())
@@ -342,7 +343,7 @@ public class MetaTileEntityMachineRecipeLoader {
                     .fluidInputs(Materials.SodiumPotassium.getFluid(12000))
                     .fluidInputs(Materials.SolderingAlloy.getFluid(2880))
                     .outputs(MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.UV].getStackForm())
-                    .duration(800).EUt(491520).buildAndRegister();
+                    .duration(800).EUt(VA[UV]).buildAndRegister();
 
         }
 
@@ -357,7 +358,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.Tin)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.ULV].getStackForm())
-                .duration(200).EUt(7).buildAndRegister();
+                .duration(200).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.LV].getStackForm())
@@ -368,7 +369,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.Copper)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.LV].getStackForm())
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.MV].getStackForm())
@@ -379,7 +380,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.Gold)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.MV].getStackForm())
-                .duration(200).EUt(120).buildAndRegister();
+                .duration(200).EUt(VA[MV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.HV].getStackForm())
@@ -390,7 +391,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.Aluminium)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.HV].getStackForm())
-                .duration(200).EUt(480).buildAndRegister();
+                .duration(200).EUt(VA[HV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.EV].getStackForm())
@@ -401,7 +402,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.Tungsten)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.EV].getStackForm())
-                .duration(200).EUt(1920).buildAndRegister();
+                .duration(200).EUt(VA[EV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.IV].getStackForm())
@@ -412,7 +413,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.NiobiumTitanium)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.IV].getStackForm())
-                .duration(200).EUt(7680).buildAndRegister();
+                .duration(200).EUt(VA[IV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.LuV].getStackForm())
@@ -423,7 +424,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.VanadiumGallium)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.LuV].getStackForm())
-                .duration(200).EUt(32768).buildAndRegister();
+                .duration(200).EUt(VA[LuV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.ZPM].getStackForm())
@@ -434,7 +435,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.YttriumBariumCuprate)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.ZPM].getStackForm())
-                .duration(200).EUt(131072).buildAndRegister();
+                .duration(200).EUt(VA[ZPM]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(TRANSFORMER[GTValues.UV].getStackForm())
@@ -445,7 +446,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.spring, Materials.Europium)
                 .fluidInputs(Materials.Lubricant.getFluid(2000))
                 .outputs(ADJUSTABLE_TRANSFORMER[GTValues.UV].getStackForm())
-                .duration(200).EUt(524288).buildAndRegister();
+                .duration(200).EUt(VA[UV]).buildAndRegister();
 
         // Adjustable Input Hatches
 
@@ -457,7 +458,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.RedAlloy, 4)
                 .input(OrePrefix.plateDouble, Materials.WroughtIron)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.ULV].getStackForm())
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.LV].getStackForm())
@@ -467,7 +468,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Copper, 4)
                 .input(OrePrefix.plateDouble, Materials.Steel)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.LV].getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.MV].getStackForm())
@@ -477,7 +478,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Cupronickel, 4)
                 .input(OrePrefix.plateDouble, Materials.Aluminium)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.MV].getStackForm())
-                .duration(100).EUt(120).buildAndRegister();
+                .duration(100).EUt(VA[MV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.HV].getStackForm())
@@ -487,7 +488,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Kanthal, 4)
                 .input(OrePrefix.plateDouble, Materials.StainlessSteel)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.HV].getStackForm())
-                .duration(100).EUt(480).buildAndRegister();
+                .duration(100).EUt(VA[HV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.EV].getStackForm())
@@ -497,7 +498,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Nichrome, 4)
                 .input(OrePrefix.plateDouble, Materials.Titanium)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.EV].getStackForm())
-                .duration(100).EUt(1920).buildAndRegister();
+                .duration(100).EUt(VA[EV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.IV].getStackForm())
@@ -507,7 +508,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.TungstenSteel, 4)
                 .input(OrePrefix.plateDouble, Materials.TungstenSteel)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.IV].getStackForm())
-                .duration(100).EUt(7680).buildAndRegister();
+                .duration(100).EUt(VA[IV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.LuV].getStackForm())
@@ -517,7 +518,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.HSSG, 4)
                 .input(OrePrefix.plateDouble, Materials.RhodiumPlatedPalladium)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.LuV].getStackForm())
-                .duration(100).EUt(32768).buildAndRegister();
+                .duration(100).EUt(VA[LuV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.ZPM].getStackForm())
@@ -527,7 +528,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Naquadah, 4)
                 .input(OrePrefix.plateDouble, Materials.Iridium)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.ZPM].getStackForm())
-                .duration(100).EUt(131072).buildAndRegister();
+                .duration(100).EUt(VA[ZPM]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.UV].getStackForm())
@@ -537,7 +538,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.NaquadahAlloy, 4)
                 .input(OrePrefix.plateDouble, Materials.Osmium)
                 .outputs(ENERGY_INPUT_HATCH_ADJUSTABLE[GTValues.UV].getStackForm())
-                .duration(100).EUt(524288).buildAndRegister();
+                .duration(100).EUt(VA[UV]).buildAndRegister();
 
         // Adjustable Output Hatches
 
@@ -549,7 +550,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.RedAlloy, 4)
                 .input(OrePrefix.plateDouble, Materials.WroughtIron)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.ULV].getStackForm())
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.LV].getStackForm())
@@ -559,7 +560,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Copper, 4)
                 .input(OrePrefix.plateDouble, Materials.Steel)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.LV].getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.MV].getStackForm())
@@ -569,7 +570,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Cupronickel, 4)
                 .input(OrePrefix.plateDouble, Materials.Aluminium)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.MV].getStackForm())
-                .duration(100).EUt(120).buildAndRegister();
+                .duration(100).EUt(VA[MV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.HV].getStackForm())
@@ -579,7 +580,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Kanthal, 4)
                 .input(OrePrefix.plateDouble, Materials.StainlessSteel)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.HV].getStackForm())
-                .duration(100).EUt(480).buildAndRegister();
+                .duration(100).EUt(VA[HV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.EV].getStackForm())
@@ -589,7 +590,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Nichrome, 4)
                 .input(OrePrefix.plateDouble, Materials.Titanium)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.EV].getStackForm())
-                .duration(100).EUt(1920).buildAndRegister();
+                .duration(100).EUt(VA[EV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.IV].getStackForm())
@@ -599,7 +600,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.TungstenSteel, 4)
                 .input(OrePrefix.plateDouble, Materials.TungstenSteel)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.IV].getStackForm())
-                .duration(100).EUt(7680).buildAndRegister();
+                .duration(100).EUt(VA[IV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.LuV].getStackForm())
@@ -609,7 +610,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.HSSG, 4)
                 .input(OrePrefix.plateDouble, Materials.RhodiumPlatedPalladium)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.LuV].getStackForm())
-                .duration(100).EUt(32768).buildAndRegister();
+                .duration(100).EUt(VA[LuV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.ZPM].getStackForm())
@@ -619,7 +620,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.Naquadah, 4)
                 .input(OrePrefix.plateDouble, Materials.Iridium)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.ZPM].getStackForm())
-                .duration(100).EUt(131072).buildAndRegister();
+                .duration(100).EUt(VA[ZPM]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(ADJUSTABLE_TRANSFORMER[GTValues.UV].getStackForm())
@@ -629,7 +630,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .input(OrePrefix.wireGtQuadruple, Materials.NaquadahAlloy, 4)
                 .input(OrePrefix.plateDouble, Materials.Osmium)
                 .outputs(ENERGY_OUTPUT_HATCH_ADJUSTABLE[GTValues.UV].getStackForm())
-                .duration(100).EUt(524288).buildAndRegister();
+                .duration(100).EUt(VA[UV]).buildAndRegister();
 
         // Maintenance Hatch
 
@@ -637,7 +638,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .inputs(HULL[GTValues.LV].getStackForm())
                 .circuitMeta(1)
                 .outputs(MAINTENANCE_HATCH.getStackForm())
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         // Multiblock Miners
 
@@ -650,7 +651,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .inputs(MetaItems.CONVEYOR_MODULE_EV.getStackForm(4))
                 .input(OrePrefix.gear, Materials.Tungsten, 2)
                 .outputs(MetaTileEntities.BASIC_LARGE_MINER.getStackForm())
-                .duration(400).EUt(1920).buildAndRegister();
+                .duration(400).EUt(VA[EV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(HULL[GTValues.IV].getStackForm())
@@ -661,7 +662,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .inputs(MetaItems.CONVEYOR_MODULE_IV.getStackForm(4))
                 .input(OrePrefix.gear, Materials.Ultimet, 2)
                 .outputs(MetaTileEntities.LARGE_MINER.getStackForm())
-                .duration(400).EUt(7680).buildAndRegister();
+                .duration(400).EUt(VA[IV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(HULL[GTValues.LuV].getStackForm())
@@ -672,6 +673,6 @@ public class MetaTileEntityMachineRecipeLoader {
                 .inputs(MetaItems.CONVEYOR_MODULE_LUV.getStackForm(4))
                 .input(OrePrefix.gear, Materials.Ruridit, 2)
                 .outputs(MetaTileEntities.ADVANCED_LARGE_MINER.getStackForm())
-                .duration(400).EUt(30720).buildAndRegister();
+                .duration(400).EUt(VA[LuV]).buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -452,7 +452,7 @@ public class MiscRecipeLoader {
                     .fluidOutputs(Glass.getFluid(108))
                     .buildAndRegister();
 
-            MACERATOR_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(22)
+            MACERATOR_RECIPES.recipeBuilder().duration(22)
                     .input(item)
                     .output(dustSmall, Glass, 3)
                     .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -17,7 +17,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.MarkerMaterials.Tier.*;
 import static gregtech.api.unification.material.Materials.*;
@@ -36,14 +36,14 @@ public class MiscRecipeLoader {
                 new UnificationEntry(dust, Bronze),
                 new UnificationEntry(dust, Tin));
 
-        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(100).EUt(8)
+        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV])
                 .input(dust, Sugar)
                 .inputs(new ItemStack(Blocks.BROWN_MUSHROOM))
                 .inputs(new ItemStack(Items.SPIDER_EYE))
                 .outputs(new ItemStack(Items.FERMENTED_SPIDER_EYE))
                 .buildAndRegister();
 
-        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(100).EUt(8)
+        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV])
                 .input(dust, Sugar)
                 .inputs(new ItemStack(Blocks.RED_MUSHROOM))
                 .inputs(new ItemStack(Items.SPIDER_EYE))
@@ -67,75 +67,75 @@ public class MiscRecipeLoader {
                 .notConsumable(new ItemStack(Blocks.COBBLESTONE))
                 .outputs(new ItemStack(Blocks.COBBLESTONE))
                 .duration(16)
-                .EUt(30)
+                .EUt(VA[LV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(new ItemStack(Blocks.STONE, 1, 0))
                 .outputs(new ItemStack(Blocks.STONE, 1, 0))
                 .duration(16)
-                .EUt(30)
+                .EUt(VA[LV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, Andesite)
                 .output(stone, Andesite)
                 .duration(16)
-                .EUt(120)
+                .EUt(VA[MV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, Granite)
                 .output(stone, Granite)
                 .duration(16)
-                .EUt(120)
+                .EUt(VA[MV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, Diorite)
                 .output(stone, Diorite)
                 .duration(16)
-                .EUt(120)
+                .EUt(VA[MV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(dust, Redstone)
                 .outputs(new ItemStack(Blocks.OBSIDIAN, 1))
                 .duration(16)
-                .EUt(480)
+                .EUt(VA[HV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, Marble)
                 .output(stone, Marble)
                 .duration(16)
-                .EUt(480)
+                .EUt(VA[HV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, Basalt)
                 .output(stone, Basalt)
                 .duration(16)
-                .EUt(480)
+                .EUt(VA[HV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, GraniteRed)
                 .output(stone, GraniteRed)
                 .duration(16)
-                .EUt(1920)
+                .EUt(VA[EV])
                 .buildAndRegister();
 
         RecipeMaps.ROCK_BREAKER_RECIPES.recipeBuilder()
                 .notConsumable(stone, GraniteBlack)
                 .output(stone, GraniteBlack)
                 .duration(16)
-                .EUt(1920)
+                .EUt(VA[EV])
                 .buildAndRegister();
 
         //armor
         // Nightvision Goggles
-        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(128)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(400).EUt(VA[MV])
                 .inputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                         BlockGlassCasing.CasingType.TEMPERED_GLASS))
                 .inputs(EMITTER_MV.getStackForm(2))
@@ -146,7 +146,7 @@ public class MiscRecipeLoader {
                 .buildAndRegister();
 
         // NanoMuscle Suite
-        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(512)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(VA[HV])
                 .input(circuit, Advanced)
                 .inputs(CARBON_PLATE.getStackForm(7))
                 .inputs(BATTERY_HV_LITHIUM.getStackForm())
@@ -154,7 +154,7 @@ public class MiscRecipeLoader {
                 .outputs(NANO_MUSCLE_SUITE_CHESTPLATE.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(512)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(VA[HV])
                 .input(circuit, Advanced)
                 .inputs(CARBON_PLATE.getStackForm(6))
                 .inputs(BATTERY_HV_LITHIUM.getStackForm())
@@ -162,7 +162,7 @@ public class MiscRecipeLoader {
                 .outputs(NANO_MUSCLE_SUITE_LEGGINGS.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(512)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(VA[HV])
                 .input(circuit, Advanced)
                 .inputs(CARBON_PLATE.getStackForm(4))
                 .inputs(BATTERY_HV_LITHIUM.getStackForm())
@@ -170,7 +170,7 @@ public class MiscRecipeLoader {
                 .outputs(NANO_MUSCLE_SUITE_BOOTS.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(512)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(1200).EUt(VA[HV])
                 .input(circuit, Advanced, 2)
                 .inputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                         BlockGlassCasing.CasingType.TEMPERED_GLASS))
@@ -313,7 +313,7 @@ public class MiscRecipeLoader {
                 .outputs(GRAVITATION_ENGINE.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(3600).EUt(8192)
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(3600).EUt(VA[IV])
                 .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(16))
                 .input(wireGtSingle, SamariumIronArsenicOxide, 8)
                 .inputs(GRAVITATION_ENGINE.getStackForm(2))
@@ -324,7 +324,7 @@ public class MiscRecipeLoader {
                 .outputs(ADVANCED_QUARK_TECH_SUITE_CHESTPLATE.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(3600).EUt(8192)
+        ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(3600).EUt(VA[IV])
                 .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(8))
                 .input(wireGtSingle, SamariumIronArsenicOxide, 8)
                 .inputs(GRAVITATION_ENGINE.getStackForm(2))
@@ -362,7 +362,7 @@ public class MiscRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(144))
                 .outputs(DISPLAY.getStackForm())
                 .buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(VA[HV])
                 .inputs(DISPLAY.getStackForm())
                 .inputs((ItemStack) CraftingComponent.HULL.getIngredient(3))
                 .input(wireFine, AnnealedCopper, 8)
@@ -376,7 +376,7 @@ public class MiscRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(432))
                 .outputs(MetaTileEntities.CENTRAL_MONITOR.getStackForm())
                 .buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(120)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
                 .inputs(DISPLAY.getStackForm())
                 .input(plate, Aluminium)
                 .input(circuit, MarkerMaterials.Tier.Good)
@@ -420,7 +420,7 @@ public class MiscRecipeLoader {
                 .buildAndRegister();
 
         // terminal
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(120)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
                 .input(circuit, Good, 4)
                 .input(ELECTRIC_MOTOR_MV, 2)
                 .input(ELECTRIC_PISTON_MV, 2)
@@ -428,7 +428,7 @@ public class MiscRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(144))
                 .outputs(WIRELESS.getStackForm())
                 .buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                 .input(ELECTRIC_PISTON_MV, 2)
                 .input(ELECTRIC_PISTON_MV)
                 .input(lens, Glass)
@@ -439,7 +439,7 @@ public class MiscRecipeLoader {
                 .buildAndRegister();
 
         // Tempered Glass in Arc Furnace
-        ARC_FURNACE_RECIPES.recipeBuilder().duration(60).EUt(30)
+        ARC_FURNACE_RECIPES.recipeBuilder().duration(60).EUt(VA[LV])
                 .input(block, Glass)
                 .outputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                         BlockGlassCasing.CasingType.TEMPERED_GLASS))
@@ -447,19 +447,19 @@ public class MiscRecipeLoader {
 
         // Dyed Lens Decomposition
         for (MetaValueItem item : GLASS_LENSES.values()) {
-            EXTRACTOR_RECIPES.recipeBuilder().EUt(32).duration(60)
+            EXTRACTOR_RECIPES.recipeBuilder().EUt(VA[LV]).duration(60)
                     .input(item)
                     .fluidOutputs(Glass.getFluid(108))
                     .buildAndRegister();
 
-            MACERATOR_RECIPES.recipeBuilder().EUt(8).duration(22)
+            MACERATOR_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(22)
                     .input(item)
                     .output(dustSmall, Glass, 3)
                     .buildAndRegister();
         }
 
         // Dyed Lens Recipes
-        RecipeBuilder<?> builder = CHEMICAL_BATH_RECIPES.recipeBuilder().EUt(480).duration(200).input(craftingLens, Glass);
+        RecipeBuilder<?> builder = CHEMICAL_BATH_RECIPES.recipeBuilder().EUt(VA[HV]).duration(200).input(craftingLens, Glass);
         final int dyeAmount = 288;
 
         builder.copy().fluidInputs(DyeWhite.getFluid(dyeAmount))    .output(lens, Glass)                      .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -19,6 +19,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
 
 public class VanillaOverrideRecipes {
@@ -201,7 +202,7 @@ public class VanillaOverrideRecipes {
                 'G', new UnificationEntry(OrePrefix.gearSmall, Materials.Iron),
                 'A', new UnificationEntry(OrePrefix.stick, Materials.RedAlloy));
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30)
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.COBBLESTONE, 2))
                 .input(OrePrefix.ring, Materials.Iron)
                 .input(OrePrefix.spring, Materials.Iron, 2)
@@ -234,7 +235,7 @@ public class VanillaOverrideRecipes {
                 .input("cobblestone", 1)
                 .fluidInputs(Materials.RedAlloy.getFluid(GTValues.L))
                 .outputs(new ItemStack(Blocks.PISTON))
-                .duration(240).EUt(8).buildAndRegister();
+                .duration(240).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Steel)
@@ -252,7 +253,7 @@ public class VanillaOverrideRecipes {
                 .input("cobblestone", 4)
                 .fluidInputs(Materials.RedAlloy.getFluid(GTValues.L * 3))
                 .outputs(new ItemStack(Blocks.PISTON, 4))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.StainlessSteel)
@@ -261,7 +262,7 @@ public class VanillaOverrideRecipes {
                 .input("cobblestone", 8)
                 .fluidInputs(Materials.RedAlloy.getFluid(GTValues.L * 4))
                 .outputs(new ItemStack(Blocks.PISTON, 8))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Titanium)
@@ -270,7 +271,7 @@ public class VanillaOverrideRecipes {
                 .input("cobblestone", 16)
                 .fluidInputs(Materials.RedAlloy.getFluid(GTValues.L * 8))
                 .outputs(new ItemStack(Blocks.PISTON, 16))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:stone_pressure_plate"));
@@ -306,13 +307,13 @@ public class VanillaOverrideRecipes {
                 .input(OrePrefix.spring, Materials.Iron)
                 .inputs(new ItemStack(Blocks.STONE_SLAB, 2))
                 .outputs(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 2))
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.spring, Materials.Iron)
                 .input(OrePrefix.plank, Materials.Wood, 2)
                 .outputs(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 2))
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.spring, Materials.Steel)
@@ -337,12 +338,12 @@ public class VanillaOverrideRecipes {
         RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.STONE_PRESSURE_PLATE))
                 .outputs(new ItemStack(Blocks.STONE_BUTTON, 12))
-                .duration(25).EUt(7).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE))
                 .outputs(new ItemStack(Blocks.WOODEN_BUTTON, 12))
-                .duration(25).EUt(7).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:lever"));
         ModHandler.addShapedRecipe("lever", new ItemStack(Blocks.LEVER), "B", "S",
@@ -467,7 +468,7 @@ public class VanillaOverrideRecipes {
                 .input(OrePrefix.screw, Materials.Steel)
                 .input(OrePrefix.stick, Materials.Wood)
                 .outputs(new ItemStack(Blocks.GOLDEN_RAIL, 8))
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:detector_rail"));
         ModHandler.addShapedRecipe("detector_rail", new ItemStack(Blocks.DETECTOR_RAIL), "SPS", "IWI", "IdI",
@@ -483,7 +484,7 @@ public class VanillaOverrideRecipes {
                 .input(OrePrefix.screw, Materials.Iron)
                 .input(OrePrefix.stick, Materials.Wood)
                 .outputs(new ItemStack(Blocks.DETECTOR_RAIL, 2))
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:rail"));
         ModHandler.addShapedRecipe("rail", new ItemStack(Blocks.RAIL, 8), "ShS", "IWI", "IdI",
@@ -506,7 +507,7 @@ public class VanillaOverrideRecipes {
                 .input(OrePrefix.screw, Materials.Iron)
                 .input(OrePrefix.stick, Materials.Wood)
                 .outputs(new ItemStack(Blocks.ACTIVATOR_RAIL, 2))
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
     }
 
     /**
@@ -526,7 +527,7 @@ public class VanillaOverrideRecipes {
                 .input(OrePrefix.plate, Materials.Iron, 4)
                 .fluidInputs(Materials.Steel.getFluid(GTValues.L / 9))
                 .outputs(new ItemStack(Items.IRON_DOOR))
-                .duration(400).EUt(7).buildAndRegister();
+                .duration(400).EUt(VA[ULV]).buildAndRegister();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:cauldron"));
         ModHandler.addShapedRecipe("cauldron", new ItemStack(Items.CAULDRON), "X X", "XhX", "XXX",
@@ -699,7 +700,7 @@ public class VanillaOverrideRecipes {
                 .input(OrePrefix.stoneCobble, Materials.Stone, 8)
                 .inputs(new ItemStack(Items.FLINT))
                 .outputs(new ItemStack(Blocks.FURNACE))
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:crafting_table"));
         ModHandler.addShapedRecipe("crafting_table", new ItemStack(Blocks.CRAFTING_TABLE), "FF", "WW", 'F', new ItemStack(Items.FLINT), 'W', new UnificationEntry(OrePrefix.log, Materials.Wood));

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -178,7 +178,7 @@ public class VanillaOverrideRecipes {
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.SAND))
                 .output(OrePrefix.dust, Materials.QuartzSand)
-                .duration(30).EUt(4).buildAndRegister();
+                .duration(30).buildAndRegister();
 
         ModHandler.addShapelessRecipe("glass_dust_flint", OreDictUnifier.get(OrePrefix.dust, Materials.Glass),
                 new UnificationEntry(OrePrefix.dust, Materials.QuartzSand),

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -18,7 +18,7 @@ import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -111,24 +111,24 @@ public class VanillaStandardRecipes {
 
         ModHandler.addShapelessRecipe("glass_dust_handcrafting", OreDictUnifier.get(dust, Glass), "dustSand", "dustFlint");
 
-        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(160).EUt(7)
+        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(160).EUt(VA[ULV])
                 .input(dustSmall, Materials.Flint)
                 .input(dust, Materials.Quartzite, 4)
                 .output(dust, Materials.Glass, 5)
                 .buildAndRegister();
 
-        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(200).EUt(7)
+        RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(dustSmall, Materials.Flint)
                 .input(dust, Materials.QuartzSand, 4)
                 .output(dust, Materials.Glass, 4)
                 .buildAndRegister();
 
-        RecipeMaps.ARC_FURNACE_RECIPES.recipeBuilder().duration(20).EUt(30)
+        RecipeMaps.ARC_FURNACE_RECIPES.recipeBuilder().duration(20).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.SAND, 1))
                 .outputs(new ItemStack(Blocks.GLASS, 2))
                 .buildAndRegister();
 
-        RecipeMaps.FORMING_PRESS_RECIPES.recipeBuilder().duration(80).EUt(30)
+        RecipeMaps.FORMING_PRESS_RECIPES.recipeBuilder().duration(80).EUt(VA[LV])
                 .input(dust, Materials.Glass)
                 .notConsumable(SHAPE_MOLD_BLOCK.getStackForm())
                 .outputs(new ItemStack(Blocks.GLASS, 1))
@@ -172,7 +172,7 @@ public class VanillaStandardRecipes {
 
             ModHandler.addShapedRecipe("stained_glass_pane_" + i, new ItemStack(Blocks.STAINED_GLASS_PANE, 2, i), "sG", 'G', new ItemStack(Blocks.STAINED_GLASS, 1, i));
 
-            CUTTER_RECIPES.recipeBuilder().duration(50).EUt(8)
+            CUTTER_RECIPES.recipeBuilder().duration(50).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.STAINED_GLASS, 3, i))
                     .outputs(new ItemStack(Blocks.STAINED_GLASS_PANE, 8, i))
                     .buildAndRegister();
@@ -183,7 +183,7 @@ public class VanillaStandardRecipes {
 
         ModHandler.addShapedRecipe("glass_pane", new ItemStack(Blocks.GLASS_PANE, 2), "sG", 'G', new ItemStack(Blocks.GLASS));
 
-        CUTTER_RECIPES.recipeBuilder().duration(50).EUt(8)
+        CUTTER_RECIPES.recipeBuilder().duration(50).EUt(VA[ULV])
                 .inputs(new ItemStack(Blocks.GLASS, 3))
                 .outputs(new ItemStack(Blocks.GLASS_PANE, 8))
                 .buildAndRegister();
@@ -345,28 +345,28 @@ public class VanillaStandardRecipes {
         LATHE_RECIPES.recipeBuilder()
                 .input(plank, Wood)
                 .output(stick, Wood, 2)
-                .duration(10).EUt(8)
+                .duration(10).EUt(VA[ULV])
                 .buildAndRegister();
 
         LATHE_RECIPES.recipeBuilder()
                 .input(log, Wood)
                 .output(stickLong, Wood, 4)
                 .output(dust, Wood, 2)
-                .duration(160).EUt(8)
+                .duration(160).EUt(VA[ULV])
                 .buildAndRegister();
 
         LATHE_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.SAPLING, 1, GTValues.W))
                 .outputs(new ItemStack(Items.STICK))
                 .output(dustTiny, Wood)
-                .duration(16).EUt(8)
+                .duration(16).EUt(VA[ULV])
                 .buildAndRegister();
 
         LATHE_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.WOODEN_SLAB, 1, GTValues.W))
                 .outputs(new ItemStack(Items.BOWL))
                 .output(dustSmall, Wood)
-                .duration(50).EUt(8)
+                .duration(50).EUt(VA[ULV])
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -457,52 +457,52 @@ public class VanillaStandardRecipes {
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.STONE))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.SANDSTONE))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2, 1))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.COBBLESTONE))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2, 3))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.BRICK_BLOCK))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2, 4))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.STONEBRICK))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2, 5))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.NETHER_BRICK))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2, 6))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 1))
                 .outputs(new ItemStack(Blocks.STONE_SLAB, 2, 7))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.RED_SANDSTONE, 1, 0))
                 .outputs(new ItemStack(Blocks.STONE_SLAB2, 2, 0))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PURPUR_BLOCK, 1, 0))
                 .outputs(new ItemStack(Blocks.PURPUR_SLAB, 2, 0))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.SNOW, 1))
                 .outputs(new ItemStack(Blocks.SNOW_LAYER, 16))
-                .duration(25).EUt(8).buildAndRegister();
+                .duration(25).EUt(VA[ULV]).buildAndRegister();
     }
 
     /**
@@ -510,55 +510,55 @@ public class VanillaStandardRecipes {
      */
     private static void dyingCleaningRecipes() {
         for (int i = 0; i < 16; i++) {
-            MIXER_RECIPES.recipeBuilder().duration(200).EUt(7)
+            MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.SAND, 4))
                     .inputs(new ItemStack(Blocks.GRAVEL, 4))
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L))
                     .outputs(new ItemStack(Blocks.CONCRETE_POWDER, 8, i))
                     .buildAndRegister();
 
-            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.CONCRETE_POWDER, 1, i))
                     .fluidInputs(Water.getFluid(1000))
                     .outputs(new ItemStack(Blocks.CONCRETE, 1, i))
                     .buildAndRegister();
 
-            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.CONCRETE))
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L / 8))
                     .outputs(new ItemStack(Blocks.CONCRETE, 1, i))
                     .buildAndRegister();
 
-            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.HARDENED_CLAY))
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L / 8))
                     .outputs(new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, i))
                     .buildAndRegister();
 
-            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.GLASS))
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L / 8))
                     .outputs(new ItemStack(Blocks.STAINED_GLASS, 1, i))
                     .buildAndRegister();
 
-            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.GLASS_PANE))
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L / 8))
                     .outputs(new ItemStack(Blocks.STAINED_GLASS_PANE, 1, i))
                     .buildAndRegister();
 
-            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CHEMICAL_BATH_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.WOOL))
                     .fluidInputs(Materials.CHEMICAL_DYES[i].getFluid(GTValues.L))
                     .outputs(new ItemStack(Blocks.WOOL, 1, i))
                     .buildAndRegister();
 
-            CUTTER_RECIPES.recipeBuilder().duration(20).EUt(7)
+            CUTTER_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .inputs(new ItemStack(Blocks.WOOL, 2, i))
                     .outputs(new ItemStack(Blocks.CARPET, 3, i))
                     .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder().duration(20).EUt(7)
+            ASSEMBLER_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
                     .circuitMeta(6)
                     .inputs(new ItemStack(Items.STICK))
                     .inputs(new ItemStack(Blocks.WOOL, 6, i))
@@ -606,7 +606,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Blocks.STICKY_PISTON))
                 .fluidInputs(Chlorine.getFluid(10))
                 .outputs(new ItemStack(Blocks.PISTON))
-                .duration(30).EUt(30).buildAndRegister();
+                .duration(30).EUt(VA[LV]).buildAndRegister();
     }
 
     /**
@@ -836,7 +836,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.LEATHER))
                 .fluidInputs(Materials.Glue.getFluid(20))
                 .outputs(new ItemStack(Items.BOOK))
-                .duration(32).EUt(7).buildAndRegister();
+                .duration(32).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.PAPER, 3))
@@ -849,7 +849,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.PAPER, 8))
                 .inputs(new ItemStack(Items.COMPASS))
                 .outputs(new ItemStack(Items.MAP))
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(dust, Materials.Netherrack)
@@ -874,7 +874,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.LEAD))
                 .fluidInputs(Materials.Glue.getFluid(100))
                 .outputs(new ItemStack(Items.NAME_TAG))
-                .duration(100).EUt(7).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.STRING, 3, GTValues.W))
@@ -947,25 +947,25 @@ public class VanillaStandardRecipes {
 
         if (!ConfigHolder.recipes.hardMiscRecipes) {
             ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(8).input(OrePrefix.stoneCobble, Materials.Stone, 8).outputs(new ItemStack(Blocks.FURNACE)).duration(100).EUt(7).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().inputs(new ItemStack(Blocks.OBSIDIAN, 4)).input(gem, Diamond, 2).inputs(new ItemStack(Items.BOOK)).outputs(new ItemStack(Blocks.ENCHANTING_TABLE)).duration(100).EUt(7).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30).circuitMeta(2).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).input(dust, Redstone).outputs(new ItemStack(Blocks.DROPPER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(8).input(OrePrefix.stoneCobble, Materials.Stone, 8).outputs(new ItemStack(Blocks.FURNACE)).duration(100).EUt(VA[ULV]).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().inputs(new ItemStack(Blocks.OBSIDIAN, 4)).input(gem, Diamond, 2).inputs(new ItemStack(Items.BOOK)).outputs(new ItemStack(Blocks.ENCHANTING_TABLE)).duration(100).EUt(VA[ULV]).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(2).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).input(dust, Redstone).outputs(new ItemStack(Blocks.DROPPER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
         }
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(4).circuitMeta(3).inputs(new ItemStack(Blocks.NETHER_BRICK)).outputs(new ItemStack(Blocks.NETHER_BRICK_FENCE)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(8).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(8).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Items.CHORUS_FRUIT_POPPED)).inputs(new ItemStack(Items.BLAZE_ROD)).outputs(new ItemStack(Blocks.END_ROD, 4)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(8).input("chestWood", 1).inputs(new ItemStack(Items.SHULKER_SHELL, 2)).outputs(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).input("chestWood", 1).inputs(new ItemStack(Items.SHULKER_SHELL, 2)).outputs(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).circuitMeta(1).input("wool", 1).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.PAINTING)).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Items.LEATHER)).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.ITEM_FRAME)).buildAndRegister();
@@ -973,7 +973,7 @@ public class VanillaStandardRecipes {
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(10).EUt(2).inputs(new ItemStack(Items.BRICK, 3)).outputs(new ItemStack(Items.FLOWER_POT)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(8).inputs(new ItemStack(Blocks.STONE_SLAB, 1, 0)).inputs(new ItemStack(Items.STICK, 6)).outputs(new ItemStack(Items.ARMOR_STAND)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV]).inputs(new ItemStack(Blocks.STONE_SLAB, 1, 0)).inputs(new ItemStack(Items.STICK, 6)).outputs(new ItemStack(Items.ARMOR_STAND)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(16).inputs(new ItemStack(Items.GHAST_TEAR)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Items.END_CRYSTAL)).fluidInputs(Glass.getFluid(GTValues.L * 7)).buildAndRegister();
 
@@ -982,7 +982,7 @@ public class VanillaStandardRecipes {
                 .input(OrePrefix.stick, Materials.Wood)
                 .circuitMeta(1)
                 .outputs(new ItemStack(Blocks.RAIL, 32))
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         if (!ConfigHolder.recipes.hardRedstoneRecipes) {
             RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -991,7 +991,7 @@ public class VanillaStandardRecipes {
                     .input(dust, Redstone)
                     .circuitMeta(1)
                     .outputs(new ItemStack(Blocks.GOLDEN_RAIL, 32))
-                    .duration(200).EUt(30).buildAndRegister();
+                    .duration(200).EUt(VA[LV]).buildAndRegister();
         }
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -1012,19 +1012,19 @@ public class VanillaStandardRecipes {
                     .inputs(new ItemStack(Blocks.STONE, 1, 1))
                     .fluidInputs(fluidStack)
                     .outputs(new ItemStack(Blocks.STONE, 1, 2))
-                    .duration(100).EUt(8).buildAndRegister();
+                    .duration(100).EUt(VA[ULV]).buildAndRegister();
 
             AUTOCLAVE_RECIPES.recipeBuilder()
                     .inputs(new ItemStack(Blocks.STONE, 1, 3))
                     .fluidInputs(fluidStack)
                     .outputs(new ItemStack(Blocks.STONE, 1, 4))
-                    .duration(100).EUt(8).buildAndRegister();
+                    .duration(100).EUt(VA[ULV]).buildAndRegister();
 
             AUTOCLAVE_RECIPES.recipeBuilder()
                     .inputs(new ItemStack(Blocks.STONE, 1, 5))
                     .fluidInputs(fluidStack)
                     .outputs(new ItemStack(Blocks.STONE, 1, 6))
-                    .duration(100).EUt(8).buildAndRegister();
+                    .duration(100).EUt(VA[ULV]).buildAndRegister();
         }
 
         AUTOCLAVE_RECIPES.recipeBuilder()
@@ -1043,7 +1043,7 @@ public class VanillaStandardRecipes {
                 .input(dust, Materials.Gunpowder)
                 .input(dust, Materials.Blaze)
                 .outputs(new ItemStack(Items.FIRE_CHARGE, 3))
-                .duration(400).EUt(30).buildAndRegister();
+                .duration(400).EUt(VA[LV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.GRAVEL))

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -217,7 +217,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Blocks.GRAVEL, 1))
                 .output(dust, Stone)
                 .chancedOutput(new ItemStack(Items.FLINT), 1000, 1000)
-                .EUt(2).duration(400)
+                .duration(400)
                 .buildAndRegister();
 
         FORGE_HAMMER_RECIPES.recipeBuilder()
@@ -249,21 +249,18 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.WHEAT))
                 .output(OrePrefix.dust, Materials.Wheat)
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.DYE, 1, EnumDyeColor.BROWN.getDyeDamage()))
                 .outputs(OreDictUnifier.get(OrePrefix.dust, Materials.Cocoa, 1))
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.REEDS, 1))
                 .outputs(new ItemStack(Items.SUGAR, 1))
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
@@ -271,21 +268,18 @@ public class VanillaStandardRecipes {
                 .outputs(new ItemStack(Items.MELON, 8, 0))
                 .chancedOutput(new ItemStack(Items.MELON_SEEDS, 1), 8000, 500)
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PUMPKIN, 1, 0))
                 .outputs(new ItemStack(Items.PUMPKIN_SEEDS, 4, 0))
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.MELON, 1, 0))
                 .outputs(new ItemStack(Items.MELON_SEEDS, 1, 0))
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
@@ -293,7 +287,6 @@ public class VanillaStandardRecipes {
                 .outputs(new ItemStack(Items.STRING, 3))
                 .chancedOutput(new ItemStack(Items.STRING, 1), 2000, 800)
                 .duration(400)
-                .EUt(2)
                 .buildAndRegister();
     }
 

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -64,7 +65,7 @@ public class WoodMachineRecipes {
             CUTTER_RECIPES.recipeBuilder().inputs(stack)
                     .fluidInputs(Lubricant.getFluid(1))
                     .outputs(GTUtility.copyAmount((int) (originalOutput * 1.5), plankStack), OreDictUnifier.get(dust, Wood, 2))
-                    .duration(200).EUt(8)
+                    .duration(200).EUt(VA[ULV])
                     .buildAndRegister();
 
             ItemStack doorStack = ModHandler.getRecipeOutput(DummyWorld.INSTANCE,
@@ -86,7 +87,7 @@ public class WoodMachineRecipes {
                 CUTTER_RECIPES.recipeBuilder()
                         .inputs(GTUtility.copyAmount(1, plankStack))
                         .outputs(GTUtility.copyAmount(2, slabStack))
-                        .duration(200).EUt(8)
+                        .duration(200).EUt(VA[ULV])
                         .buildAndRegister();
 
                 ModHandler.addShapedRecipe(slabStack.getDisplayName() + "_saw", GTUtility.copyAmount(2, slabStack), "sS", 'S', GTUtility.copyAmount(1, plankStack));

--- a/src/main/java/gregtech/loaders/recipe/chemistry/AssemblerRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/AssemblerRecipeLoader.java
@@ -4,7 +4,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -25,21 +25,21 @@ public class AssemblerRecipeLoader {
                 .input(gear, Bronze, 2)
                 .input(frameGt, Bronze)
                 .outputs(TURBINE_CASING.getItemVariant(BRONZE_GEARBOX, 2))
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plate, Steel, 4)
                 .input(gear, Steel, 2)
                 .input(frameGt, Steel)
                 .outputs(TURBINE_CASING.getItemVariant(STEEL_GEARBOX, 2))
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plate, Titanium, 4)
                 .input(gear, Titanium, 2)
                 .input(frameGt, Titanium)
                 .outputs(TURBINE_CASING.getItemVariant(TITANIUM_GEARBOX, 2))
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         // Other
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -47,13 +47,13 @@ public class AssemblerRecipeLoader {
                 .input(pipeNormalFluid, Titanium, 4)
                 .inputs(METAL_CASING.getItemVariant(TITANIUM_STABLE))
                 .outputs(MULTIBLOCK_CASING.getItemVariant(ENGINE_INTAKE_CASING, 2))
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plate, Bronze, 6)
                 .inputs(new ItemStack(Blocks.BRICK_BLOCK, 1))
                 .outputs(METAL_CASING.getItemVariant(BRONZE_BRICKS, 2))
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plate, Invar, 2)
@@ -71,14 +71,14 @@ public class AssemblerRecipeLoader {
                 .input(dust, Redstone)
                 .input(FLUID_CELL)
                 .output(SPRAY_EMPTY)
-                .duration(200).EUt(8).buildAndRegister();
+                .duration(200).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plate, Tin, 6)
                 .input(SPRAY_EMPTY)
                 .input(paneGlass.name(), 1)
                 .output(FOAM_SPRAYER)
-                .duration(200).EUt(8).buildAndRegister();
+                .duration(200).EUt(VA[ULV]).buildAndRegister();
 
         // Matches/lighters recipes
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -106,21 +106,21 @@ public class AssemblerRecipeLoader {
                 .duration(64).EUt(16).buildAndRegister();
 
         // Wood Pipes
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                 .input(plate, Wood)
                 .circuitMeta(12)
                 .fluidInputs(Glue.getFluid(50))
                 .output(pipeSmallFluid, Wood)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                 .input(plate, Wood, 3)
                 .circuitMeta(4)
                 .fluidInputs(Glue.getFluid(20))
                 .output(pipeNormalFluid, Wood)
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                 .input(plate, Wood, 6)
                 .circuitMeta(2)
                 .fluidInputs(Glue.getFluid(10))
@@ -128,63 +128,63 @@ public class AssemblerRecipeLoader {
                 .buildAndRegister();
 
         // Voltage Coils
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(7)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(stick, IronMagnetic)
                 .input(wireFine, Lead, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_ULV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(30)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                 .input(stick, IronMagnetic)
                 .input(wireFine, Steel, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_LV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(120)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[MV])
                 .input(stick, SteelMagnetic)
                 .input(wireFine, Aluminium, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_MV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(480)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[HV])
                 .input(stick, SteelMagnetic)
                 .input(wireFine, BlackSteel, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_HV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(1920)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV])
                 .input(stick, NeodymiumMagnetic)
                 .input(wireFine, TungstenSteel, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_EV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(1920)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV])
                 .input(stick, NeodymiumMagnetic)
                 .input(wireFine, Iridium, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_IV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(30720)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LuV])
                 .input(stick, SamariumMagnetic)
                 .input(wireFine, Osmiridium, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_LUV.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(122880)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ZPM])
                 .input(stick, SamariumMagnetic)
                 .input(wireFine, Europium, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_ZPM.getStackForm())
                 .buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(491520)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[UV])
                 .input(stick, SamariumMagnetic)
                 .input(wireFine, FluxedElectrum, 16)
                 .circuitMeta(1)
@@ -192,7 +192,7 @@ public class AssemblerRecipeLoader {
                 .buildAndRegister();
 
         // Neutron Reflector
-        ASSEMBLER_RECIPES.recipeBuilder().duration(4000).EUt(120)
+        ASSEMBLER_RECIPES.recipeBuilder().duration(4000).EUt(VA[MV])
                 .input(plate, Ruridit)
                 .input(plateDouble, Beryllium, 4)
                 .input(plateDouble, TungstenCarbide, 2)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ChemicalBathRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ChemicalBathRecipes.java
@@ -3,6 +3,7 @@ package gregtech.loaders.recipe.chemistry;
 import gregtech.api.unification.OreDictUnifier;
 import net.minecraft.init.Items;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CHEMICAL_BATH_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -27,7 +28,7 @@ public class ChemicalBathRecipes {
                 .input(Items.REEDS, 1, true)
                 .fluidInputs(Water.getFluid(100))
                 .output(Items.PAPER)
-                .duration(100).EUt(8).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_BATH_RECIPES.recipeBuilder()
                 .input(dust, Wood)
@@ -45,7 +46,7 @@ public class ChemicalBathRecipes {
                 .input(Items.REEDS, 1, true)
                 .fluidInputs(DistilledWater.getFluid(100))
                 .output(Items.PAPER)
-                .duration(100).EUt(8).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         //todo add these to ore byproducts
         CHEMICAL_BATH_RECIPES.recipeBuilder()
@@ -54,7 +55,7 @@ public class ChemicalBathRecipes {
                 .output(crushedPurified, Gold)
                 .chancedOutput(OreDictUnifier.get(dust, Copper), 7000, 580)
                 .chancedOutput(OreDictUnifier.get(dust, Stone), 4000, 650)
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_BATH_RECIPES.recipeBuilder()
                 .input(crushed, Nickel)
@@ -62,7 +63,7 @@ public class ChemicalBathRecipes {
                 .output(crushedPurified, Nickel)
                 .chancedOutput(OreDictUnifier.get(dust, Nickel), 7000, 580)
                 .chancedOutput(OreDictUnifier.get(dust, Stone), 4000, 650)
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_BATH_RECIPES.recipeBuilder()
                 .input(crushed, Cooperite)
@@ -70,7 +71,7 @@ public class ChemicalBathRecipes {
                 .output(crushedPurified, Cooperite)
                 .chancedOutput(OreDictUnifier.get(dust, Nickel), 7000, 580)
                 .chancedOutput(OreDictUnifier.get(dust, Stone), 4000, 650)
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_BATH_RECIPES.recipeBuilder()
                 .input(crushed, Copper)
@@ -78,7 +79,7 @@ public class ChemicalBathRecipes {
                 .output(crushedPurified, Copper)
                 .chancedOutput(OreDictUnifier.get(dust, Copper), 7000, 580)
                 .chancedOutput(OreDictUnifier.get(dust, Stone), 4000, 650)
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_BATH_RECIPES.recipeBuilder()
                 .input(crushed, Platinum)
@@ -86,7 +87,7 @@ public class ChemicalBathRecipes {
                 .output(crushedPurified, Platinum)
                 .chancedOutput(OreDictUnifier.get(dust, Nickel), 7000, 580)
                 .chancedOutput(OreDictUnifier.get(dust, Stone), 4000, 650)
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_BATH_RECIPES.recipeBuilder()
                 .input(crushed, Chalcopyrite)
@@ -94,6 +95,6 @@ public class ChemicalBathRecipes {
                 .output(crushedPurified, Chalcopyrite)
                 .chancedOutput(OreDictUnifier.get(dust, Cobalt), 7000, 580)
                 .chancedOutput(OreDictUnifier.get(dust, Stone), 4000, 650)
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ChemistryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ChemistryRecipes.java
@@ -3,6 +3,7 @@ package gregtech.loaders.recipe.chemistry;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import net.minecraft.init.Items;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.dust;
@@ -34,40 +35,40 @@ public class ChemistryRecipes {
                 .circuitMeta(1)
                 .fluidInputs(Acetone.getFluid(100))
                 .fluidOutputs(Ethenone.getFluid(100))
-                .duration(16).EUt(30).buildAndRegister();
+                .duration(16).EUt(VA[LV]).buildAndRegister();
 
         FLUID_HEATER_RECIPES.recipeBuilder()
                 .circuitMeta(1)
                 .fluidInputs(DissolvedCalciumAcetate.getFluid(200))
                 .fluidOutputs(Acetone.getFluid(200))
-                .duration(16).EUt(30).buildAndRegister();
+                .duration(16).EUt(VA[LV]).buildAndRegister();
 
         VACUUM_RECIPES.recipeBuilder()
                 .fluidInputs(Water.getFluid(1000))
                 .fluidOutputs(Ice.getFluid(1000))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         VACUUM_RECIPES.recipeBuilder()
                 .fluidInputs(Air.getFluid(4000))
                 .fluidOutputs(LiquidAir.getFluid(4000))
-                .duration(80).EUt(480).buildAndRegister();
+                .duration(80).EUt(VA[HV]).buildAndRegister();
 
         VACUUM_RECIPES.recipeBuilder()
                 .fluidInputs(NetherAir.getFluid(4000))
                 .fluidOutputs(LiquidNetherAir.getFluid(4000))
-                .duration(80).EUt(1920).buildAndRegister();
+                .duration(80).EUt(VA[EV]).buildAndRegister();
 
         VACUUM_RECIPES.recipeBuilder()
                 .fluidInputs(EnderAir.getFluid(4000))
                 .fluidOutputs(LiquidEnderAir.getFluid(4000))
-                .duration(80).EUt(7680).buildAndRegister();
+                .duration(80).EUt(VA[IV]).buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder()
                 .input(dust, FerriteMixture)
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(ingot, NickelZincFerrite)
                 .blastFurnaceTemp(1500)
-                .duration(400).EUt(120).buildAndRegister();
+                .duration(400).EUt(VA[MV]).buildAndRegister();
 
         FERMENTING_RECIPES.recipeBuilder()
                 .fluidInputs(Biomass.getFluid(100))
@@ -84,14 +85,14 @@ public class ChemistryRecipes {
                 .input(ingot, Copper)
                 .output(ingot, RedAlloy, 2)
                 .blastFurnaceTemp(1200)
-                .duration(884).EUt(120).buildAndRegister();
+                .duration(884).EUt(VA[MV]).buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder()
                 .input(Items.REDSTONE)
                 .input(dust, Copper)
                 .output(ingot, RedAlloy, 2)
                 .blastFurnaceTemp(1200)
-                .duration(884).EUt(120).buildAndRegister();
+                .duration(884).EUt(VA[MV]).buildAndRegister();
 
         GAS_COLLECTOR_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/CrackingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/CrackingRecipes.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CRACKING_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 
@@ -10,132 +11,132 @@ public class CrackingRecipes {
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Ethane.getFluid(1000))
                 .fluidOutputs(HydroCrackedEthane.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidOutputs(HydroCrackedEthylene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidOutputs(HydroCrackedPropene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Propane.getFluid(1000))
                 .fluidOutputs(HydroCrackedPropane.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(LightFuel.getFluid(1000))
                 .fluidOutputs(HydroCrackedLightFuel.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Butane.getFluid(1000))
                 .fluidOutputs(HydroCrackedButane.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Naphtha.getFluid(1000))
                 .fluidOutputs(HydroCrackedNaphtha.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(HeavyFuel.getFluid(1000))
                 .fluidOutputs(HydroCrackedHeavyFuel.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(RefineryGas.getFluid(1000))
                 .fluidOutputs(HydroCrackedGas.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Butene.getFluid(1000))
                 .fluidOutputs(HydroCrackedButene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidInputs(Butadiene.getFluid(1000))
                 .fluidOutputs(HydroCrackedButadiene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Ethane.getFluid(1000))
                 .fluidOutputs(SteamCrackedEthane.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidOutputs(SteamCrackedEthylene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidOutputs(SteamCrackedPropene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Propane.getFluid(1000))
                 .fluidOutputs(SteamCrackedPropane.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(LightFuel.getFluid(1000))
                 .fluidOutputs(SteamCrackedLightFuel.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Butane.getFluid(1000))
                 .fluidOutputs(SteamCrackedButane.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Naphtha.getFluid(1000))
                 .fluidOutputs(SteamCrackedNaphtha.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(HeavyFuel.getFluid(1000))
                 .fluidOutputs(SteamCrackedHeavyFuel.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(RefineryGas.getFluid(1000))
                 .fluidOutputs(SteamCrackedGas.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Butene.getFluid(1000))
                 .fluidOutputs(SteamCrackedButene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
 
         CRACKING_RECIPES.recipeBuilder()
                 .fluidInputs(Steam.getFluid(2000))
                 .fluidInputs(Butadiene.getFluid(1000))
                 .fluidOutputs(SteamCrackedButadiene.getFluid(1000))
-                .duration(40).EUt(120).buildAndRegister();
+                .duration(40).EUt(VA[MV]).buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
@@ -4,6 +4,7 @@ import gregtech.api.unification.material.Materials;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.DISTILLATION_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.DISTILLERY_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
@@ -20,50 +21,50 @@ public class DistillationRecipes {
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedEthane.getFluid(1000))
                 .fluidOutputs(Methane.getFluid(2000))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedEthane.getFluid(1000))
                 .output(dustSmall, Carbon, 2)
                 .fluidOutputs(Methane.getFluid(1500))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedEthylene.getFluid(1000))
                 .fluidOutputs(Ethane.getFluid(1000))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedEthylene.getFluid(1000))
                 .output(dust, Carbon)
                 .fluidOutputs(Methane.getFluid(1000))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedPropene.getFluid(1000))
                 .fluidOutputs(Propane.getFluid(500))
                 .fluidOutputs(Ethylene.getFluid(500))
                 .fluidOutputs(Methane.getFluid(500))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedPropene.getFluid(1000))
                 .output(dustSmall, Carbon, 6)
                 .fluidOutputs(Methane.getFluid(1500))
-                .duration(180).EUt(120).buildAndRegister();
+                .duration(180).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedPropane.getFluid(1000))
                 .fluidOutputs(Ethane.getFluid(1000))
                 .fluidOutputs(Methane.getFluid(1000))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedPropane.getFluid(1000))
                 .output(dustSmall, Carbon, 2)
                 .fluidOutputs(Ethylene.getFluid(750))
                 .fluidOutputs(Methane.getFluid(1250))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedLightFuel.getFluid(1000))
@@ -73,7 +74,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Propane.getFluid(200))
                 .fluidOutputs(Ethane.getFluid(125))
                 .fluidOutputs(Methane.getFluid(125))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedLightFuel.getFluid(1000))
@@ -89,14 +90,14 @@ public class DistillationRecipes {
                 .fluidOutputs(Ethane.getFluid(50))
                 .fluidOutputs(Ethylene.getFluid(250))
                 .fluidOutputs(Methane.getFluid(250))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedButane.getFluid(750))
                 .fluidOutputs(Propane.getFluid(500))
                 .fluidOutputs(Ethane.getFluid(500))
                 .fluidOutputs(Methane.getFluid(500))
-                .duration(90).EUt(120).buildAndRegister();
+                .duration(90).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedButane.getFluid(1000))
@@ -105,7 +106,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Ethane.getFluid(125))
                 .fluidOutputs(Ethylene.getFluid(125))
                 .fluidOutputs(Methane.getFluid(2000))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedNaphtha.getFluid(1000))
@@ -113,7 +114,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Propane.getFluid(300))
                 .fluidOutputs(Ethane.getFluid(250))
                 .fluidOutputs(Methane.getFluid(250))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedNaphtha.getFluid(1000))
@@ -129,7 +130,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Ethane.getFluid(65))
                 .fluidOutputs(Ethylene.getFluid(500))
                 .fluidOutputs(Methane.getFluid(500))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedHeavyFuel.getFluid(1000))
@@ -139,7 +140,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Propane.getFluid(100))
                 .fluidOutputs(Ethane.getFluid(75))
                 .fluidOutputs(Methane.getFluid(75))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedHeavyFuel.getFluid(1000))
@@ -155,14 +156,14 @@ public class DistillationRecipes {
                 .fluidOutputs(Ethane.getFluid(15))
                 .fluidOutputs(Ethylene.getFluid(150))
                 .fluidOutputs(Methane.getFluid(150))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedGas.getFluid(1000))
                 .fluidOutputs(Methane.getFluid(1400))
                 .fluidOutputs(Hydrogen.getFluid(1340))
                 .fluidOutputs(Helium.getFluid(20))
-                .duration(120).EUt(120).buildAndRegister();
+                .duration(120).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedGas.getFluid(800))
@@ -172,7 +173,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Ethylene.getFluid(20))
                 .fluidOutputs(Methane.getFluid(914))
                 .fluidOutputs(Helium.getFluid(16))
-                .duration(96).EUt(120).buildAndRegister();
+                .duration(96).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedButene.getFluid(750))
@@ -180,7 +181,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Propene.getFluid(250))
                 .fluidOutputs(Ethane.getFluid(250))
                 .fluidOutputs(Methane.getFluid(250))
-                .duration(90).EUt(120).buildAndRegister();
+                .duration(90).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedButene.getFluid(2000))
@@ -188,13 +189,13 @@ public class DistillationRecipes {
                 .fluidOutputs(Propene.getFluid(250))
                 .fluidOutputs(Ethylene.getFluid(625))
                 .fluidOutputs(Methane.getFluid(3000))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(HydroCrackedButadiene.getFluid(750))
                 .fluidOutputs(Butene.getFluid(500))
                 .fluidOutputs(Ethylene.getFluid(500))
-                .duration(90).EUt(120).buildAndRegister();
+                .duration(90).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedButadiene.getFluid(2000))
@@ -202,7 +203,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Propene.getFluid(250))
                 .fluidOutputs(Ethylene.getFluid(375))
                 .fluidOutputs(Methane.getFluid(2250))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(OilLight.getFluid(150))
@@ -246,7 +247,7 @@ public class DistillationRecipes {
                 .fluidInputs(DilutedSulfuricAcid.getFluid(3000))
                 .fluidOutputs(SulfuricAcid.getFluid(2000))
                 .fluidOutputs(Water.getFluid(1000))
-                .duration(600).EUt(120).buildAndRegister();
+                .duration(600).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(CharcoalByproducts.getFluid(1000))
@@ -288,7 +289,7 @@ public class DistillationRecipes {
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(Water.getFluid(576))
                 .fluidOutputs(DistilledWater.getFluid(520))
-                .duration(160).EUt(120).buildAndRegister();
+                .duration(160).EUt(VA[MV]).buildAndRegister();
 
         DISTILLERY_RECIPES.recipeBuilder()
                 .fluidInputs(Water.getFluid(5))
@@ -308,7 +309,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Acetone.getFluid(1000))
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
-                .duration(80).EUt(120).buildAndRegister();
+                .duration(80).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeedOil.getFluid(24))
@@ -339,7 +340,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Ethane.getFluid(100))
                 .fluidOutputs(Methane.getFluid(750))
                 .fluidOutputs(Helium.getFluid(20))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(Biomass.getFluid(600))
@@ -355,7 +356,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Ammonia.getFluid(300))
                 .fluidOutputs(Ethylbenzene.getFluid(250))
                 .fluidOutputs(CarbonDioxide.getFluid(250))
-                .duration(80).EUt(120)
+                .duration(80).EUt(VA[MV])
                 .buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
@@ -365,7 +366,7 @@ public class DistillationRecipes {
                 .fluidOutputs(HydrogenSulfide.getFluid(300))
                 .fluidOutputs(Creosote.getFluid(200))
                 .fluidOutputs(Phenol.getFluid(100))
-                .duration(80).EUt(120)
+                .duration(80).EUt(VA[MV])
                 .buildAndRegister();
 
         DISTILLERY_RECIPES.recipeBuilder()
@@ -419,7 +420,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Argon.getFluid(500))
                 .chancedOutput(dust, Ice, 9000, 0)
                 .disableDistilleryRecipes()
-                .duration(2000).EUt(480).buildAndRegister();
+                .duration(2000).EUt(VA[HV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LiquidNetherAir.getFluid(100000))
@@ -431,7 +432,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Neon.getFluid(500))
                 .chancedOutput(dustSmall, Ash, 9000, 0)
                 .disableDistilleryRecipes()
-                .duration(2000).EUt(1920).buildAndRegister();
+                .duration(2000).EUt(VA[EV]).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LiquidEnderAir.getFluid(200000))
@@ -444,6 +445,6 @@ public class DistillationRecipes {
                 .fluidOutputs(Radon.getFluid(1000))
                 .chancedOutput(dustTiny, EnderPearl, 9000, 0)
                 .disableDistilleryRecipes()
-                .duration(2000).EUt(7680).buildAndRegister();
+                .duration(2000).EUt(VA[IV]).buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/FuelRecipeChains.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/FuelRecipeChains.java
@@ -2,6 +2,7 @@ package gregtech.loaders.recipe.chemistry;
 
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CHEMICAL_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.LARGE_CHEMICAL_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
@@ -11,7 +12,7 @@ public class FuelRecipeChains {
     public static void init() {
 
         // High Octane Gasoline
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(100)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .fluidInputs(Naphtha.getFluid(16000))
                 .fluidInputs(RefineryGas.getFluid(2000))
                 .fluidInputs(Methanol.getFluid(1000))
@@ -20,14 +21,14 @@ public class FuelRecipeChains {
                 .fluidOutputs(RawGasoline.getFluid(20000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(10)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(10)
                 .fluidInputs(RawGasoline.getFluid(10000))
                 .fluidInputs(Toluene.getFluid(1000))
                 .fluidOutputs(Gasoline.getFluid(11000))
                 .buildAndRegister();
 
         // Nitrous Oxide
-        CHEMICAL_RECIPES.recipeBuilder().EUt(30).duration(100)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(100)
                 .fluidInputs(Nitrogen.getFluid(2000))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .notConsumable(new IntCircuitIngredient(4))
@@ -35,13 +36,13 @@ public class FuelRecipeChains {
                 .buildAndRegister();
 
         // Ethyl Tert-Butyl Ether
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(400)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(400)
                 .fluidInputs(Butene.getFluid(1000))
                 .fluidInputs(Ethanol.getFluid(1000))
                 .fluidOutputs(EthylTertButylEther.getFluid(1000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(1920).duration(50)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(50)
                 .fluidInputs(Gasoline.getFluid(20000))
                 .fluidInputs(Octane.getFluid(2000))
                 .fluidInputs(NitrousOxide.getFluid(2000))
@@ -52,7 +53,7 @@ public class FuelRecipeChains {
                 .buildAndRegister();
 
         // Nitrobenzene
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(160)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(160)
                 .fluidInputs(Benzene.getFluid(5000))
                 .fluidInputs(NitrationMixture.getFluid(2000))
                 .fluidInputs(DistilledWater.getFluid(2000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/GemSlurryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/GemSlurryRecipes.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CENTRIFUGE_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.MIXER_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
@@ -11,13 +12,13 @@ public class GemSlurryRecipes {
     public static void init() {
 
         // Ruby
-        MIXER_RECIPES.recipeBuilder().duration(280).EUt(1920)
+        MIXER_RECIPES.recipeBuilder().duration(280).EUt(VA[EV])
                 .input(dust, Ruby, 6)
                 .fluidInputs(AquaRegia.getFluid(2000))
                 .fluidOutputs(RubySlurry.getFluid(2000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(480)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(VA[HV])
                 .fluidInputs(RubySlurry.getFluid(2000))
                 .output(dust, Aluminium, 2)
                 .output(dust, Chrome)
@@ -30,13 +31,13 @@ public class GemSlurryRecipes {
                 .buildAndRegister();
 
         // Sapphire
-        MIXER_RECIPES.recipeBuilder().duration(280).EUt(1920)
+        MIXER_RECIPES.recipeBuilder().duration(280).EUt(VA[EV])
                 .input(dust, Sapphire, 5)
                 .fluidInputs(AquaRegia.getFluid(2000))
                 .fluidOutputs(SapphireSlurry.getFluid(2000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(480)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(VA[HV])
                 .fluidInputs(SapphireSlurry.getFluid(2000))
                 .output(dust, Aluminium, 2)
                 .chancedOutput(dustTiny, Titanium, 2000, 0)
@@ -48,13 +49,13 @@ public class GemSlurryRecipes {
                 .buildAndRegister();
 
         // Green Sapphire
-        MIXER_RECIPES.recipeBuilder().duration(280).EUt(1920)
+        MIXER_RECIPES.recipeBuilder().duration(280).EUt(VA[EV])
                 .input(dust, GreenSapphire, 5)
                 .fluidInputs(AquaRegia.getFluid(2000))
                 .fluidOutputs(GreenSapphireSlurry.getFluid(2000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(480)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(VA[HV])
                 .fluidInputs(GreenSapphireSlurry.getFluid(2000))
                 .output(dust, Aluminium, 2)
                 .chancedOutput(dustTiny, Beryllium, 2000, 0)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
@@ -5,6 +5,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.dust;
@@ -16,7 +17,7 @@ public class GrowthMediumRecipes {
     public static void init() {
 
         // Bio Chaff
-        MACERATOR_RECIPES.recipeBuilder().EUt(30).duration(200)
+        MACERATOR_RECIPES.recipeBuilder().EUt(VA[LV]).duration(200)
                 .input(PLANT_BALL, 2)
                 .output(BIO_CHAFF)
                 .output(BIO_CHAFF)
@@ -36,14 +37,14 @@ public class GrowthMediumRecipes {
                 .buildAndRegister();
 
         // Bacteria
-        BREWING_RECIPES.recipeBuilder().EUt(480).duration(300)
+        BREWING_RECIPES.recipeBuilder().EUt(VA[HV]).duration(300)
                 .input(BIO_CHAFF, 4)
                 .fluidInputs(DistilledWater.getFluid(1000))
                 .fluidOutputs(Bacteria.getFluid(1000))
                 .buildAndRegister();
 
         // Bacterial Sludge
-        CHEMICAL_RECIPES.recipeBuilder().EUt(1920).duration(600)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(600)
                 .fluidInputs(Biomass.getFluid(1000))
                 .fluidInputs(Bacteria.getFluid(1000))
                 .fluidOutputs(BacterialSludge.getFluid(1000))
@@ -69,20 +70,20 @@ public class GrowthMediumRecipes {
                 .buildAndRegister();
 
         // Mutagen
-        DISTILLERY_RECIPES.recipeBuilder().EUt(1920).duration(40)
+        DISTILLERY_RECIPES.recipeBuilder().EUt(VA[EV]).duration(40)
                 .fluidInputs(EnrichedBacterialSludge.getFluid(10))
                 .circuitMeta(1)
                 .fluidOutputs(Mutagen.getFluid(1))
                 .buildAndRegister();
 
-        DISTILLERY_RECIPES.recipeBuilder().EUt(7680).duration(100)
+        DISTILLERY_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
                 .fluidInputs(EnrichedBacterialSludge.getFluid(1000))
                 .circuitMeta(2)
                 .fluidOutputs(Mutagen.getFluid(100))
                 .buildAndRegister();
 
         // Collagen
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(800)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(800)
                 .input(dust, Meat)
                 .inputs(new ItemStack(Items.DYE, 1, 15))
                 .fluidInputs(SulfuricAcid.getFluid(500))
@@ -90,7 +91,7 @@ public class GrowthMediumRecipes {
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(500))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(1600)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(1600)
                 .input(dust, Meat, 2)
                 .inputs(new ItemStack(Items.BONE))
                 .fluidInputs(SulfuricAcid.getFluid(1000))
@@ -99,28 +100,28 @@ public class GrowthMediumRecipes {
                 .buildAndRegister();
 
         // Gelatin
-        MIXER_RECIPES.recipeBuilder().EUt(480).duration(1600)
+        MIXER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(1600)
                 .input(dust, Collagen, 4)
                 .fluidInputs(PhosphoricAcid.getFluid(1000))
                 .fluidInputs(Water.getFluid(3000))
                 .fluidOutputs(GelatinMixture.getFluid(4000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().EUt(480).duration(2400)
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(VA[HV]).duration(2400)
                 .fluidInputs(GelatinMixture.getFluid(6000))
                 .output(dust, Phosphorus)
                 .output(dust, Gelatin, 4)
                 .buildAndRegister();
 
         // Agar
-        AUTOCLAVE_RECIPES.recipeBuilder().EUt(480).duration(600)
+        AUTOCLAVE_RECIPES.recipeBuilder().EUt(VA[HV]).duration(600)
                 .input(dust, Gelatin)
                 .fluidInputs(DistilledWater.getFluid(1000))
                 .output(dust, Agar)
                 .buildAndRegister();
 
         // Raw Growth Medium
-        MIXER_RECIPES.recipeBuilder().EUt(7680).duration(1200)
+        MIXER_RECIPES.recipeBuilder().EUt(VA[IV]).duration(1200)
                 .input(dust, Meat, 4)
                 .input(dust, Salt, 4)
                 .input(dust, Calcium, 4)
@@ -130,14 +131,14 @@ public class GrowthMediumRecipes {
                 .buildAndRegister();
 
         // Sterile Growth Medium
-        FLUID_HEATER_RECIPES.recipeBuilder().EUt(7680).duration(20)
+        FLUID_HEATER_RECIPES.recipeBuilder().EUt(VA[IV]).duration(20)
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(RawGrowthMedium.getFluid(100))
                 .fluidOutputs(SterileGrowthMedium.getFluid(100))
                 .buildAndRegister();
 
         // Stem Cells
-        CHEMICAL_RECIPES.recipeBuilder().EUt(30720).duration(300)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LuV]).duration(300)
                 .input(dust, Osmiridium)
                 .fluidInputs(Bacteria.getFluid(500))
                 .fluidInputs(SterileGrowthMedium.getFluid(500))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
@@ -17,7 +17,7 @@ public class GrowthMediumRecipes {
     public static void init() {
 
         // Bio Chaff
-        MACERATOR_RECIPES.recipeBuilder().EUt(VA[LV]).duration(200)
+        MACERATOR_RECIPES.recipeBuilder().duration(200)
                 .input(PLANT_BALL, 2)
                 .output(BIO_CHAFF)
                 .output(BIO_CHAFF)
@@ -25,7 +25,7 @@ public class GrowthMediumRecipes {
                 //.chancedOutput(BIO_CHAFF, 2500, 0) TODO Enable once macerator gets 4th slot
                 .buildAndRegister();
 
-        MACERATOR_RECIPES.recipeBuilder().EUt(2).duration(300)
+        MACERATOR_RECIPES.recipeBuilder().duration(300)
                 .input(BIO_CHAFF)
                 .outputs(new ItemStack(Blocks.DIRT))
                 .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/chemistry/LCRCombined.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/LCRCombined.java
@@ -2,6 +2,7 @@ package gregtech.loaders.recipe.chemistry;
 
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.LARGE_CHEMICAL_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.dust;
@@ -19,7 +20,7 @@ public class LCRCombined {
                 .fluidOutputs(Epoxy.getFluid(1000))
                 .fluidOutputs(SaltWater.getFluid(1000))
                 .fluidOutputs(DilutedHydrochloricAcid.getFluid(1000))
-                .EUt(30)
+                .EUt(VA[LV])
                 .duration(24 * 20)
                 .buildAndRegister();
 
@@ -32,7 +33,7 @@ public class LCRCombined {
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(Epichlorohydrin.getFluid(1000))
                 .fluidOutputs(SaltWater.getFluid(1000))
-                .EUt(30)
+                .EUt(VA[LV])
                 .duration(24 * 20)
                 .buildAndRegister();
 
@@ -43,7 +44,7 @@ public class LCRCombined {
                 .fluidInputs(Oxygen.getFluid(3000))
                 .fluidOutputs(Ammonia.getFluid(4000))
                 .fluidOutputs(CarbonMonoxide.getFluid(3000))
-                .EUt(480)
+                .EUt(VA[HV])
                 .duration(320)
                 .buildAndRegister();
 
@@ -53,7 +54,7 @@ public class LCRCombined {
                 .fluidInputs(CarbonDioxide.getFluid(1000))
                 .fluidOutputs(Methane.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
-                .EUt(30)
+                .EUt(VA[LV])
                 .duration(160)
                 .buildAndRegister();
 
@@ -62,7 +63,7 @@ public class LCRCombined {
                 .input(dust, Sulfur)
                 .fluidInputs(Water.getFluid(4000))
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
-                .EUt(480)
+                .EUt(VA[HV])
                 .duration(320)
                 .buildAndRegister();
     }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
@@ -2,6 +2,7 @@ package gregtech.loaders.recipe.chemistry;
 
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.MIXER_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.dust;
@@ -19,37 +20,37 @@ public class MixerRecipes {
                 .fluidInputs(PolyvinylAcetate.getFluid(1000))
                 .fluidInputs(Acetone.getFluid(1500))
                 .fluidOutputs(Glue.getFluid(2500))
-                .duration(50).EUt(8).buildAndRegister();
+                .duration(50).EUt(VA[ULV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .fluidInputs(PolyvinylAcetate.getFluid(1000))
                 .fluidInputs(MethylAcetate.getFluid(1500))
                 .fluidOutputs(Glue.getFluid(2500))
-                .duration(50).EUt(8).buildAndRegister();
+                .duration(50).EUt(VA[ULV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .input(dust, Gallium)
                 .input(dust, Arsenic)
                 .output(dust, GalliumArsenide, 2)
-                .duration(300).EUt(30).buildAndRegister();
+                .duration(300).EUt(VA[LV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .input(dust, Salt, 2)
                 .fluidInputs(Water.getFluid(1000))
                 .fluidOutputs(SaltWater.getFluid(1000))
-                .duration(40).EUt(8).buildAndRegister();
+                .duration(40).EUt(VA[ULV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .fluidInputs(BioDiesel.getFluid(1000))
                 .fluidInputs(Tetranitromethane.getFluid(40))
                 .fluidOutputs(NitroDiesel.getFluid(750))
-                .duration(20).EUt(480).buildAndRegister();
+                .duration(20).EUt(VA[HV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .fluidInputs(Diesel.getFluid(1000))
                 .fluidInputs(Tetranitromethane.getFluid(20))
                 .fluidOutputs(NitroDiesel.getFluid(1000))
-                .duration(20).EUt(480).buildAndRegister();
+                .duration(20).EUt(VA[HV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .fluidInputs(Oxygen.getFluid(1000))
@@ -67,10 +68,10 @@ public class MixerRecipes {
                 .fluidInputs(LightFuel.getFluid(5000))
                 .fluidInputs(HeavyFuel.getFluid(1000))
                 .fluidOutputs(Diesel.getFluid(6000))
-                .duration(16).EUt(120).buildAndRegister();
+                .duration(16).EUt(VA[MV]).buildAndRegister();
 
         // Alloys
-        MIXER_RECIPES.recipeBuilder().duration(600).EUt(1920)
+        MIXER_RECIPES.recipeBuilder().duration(600).EUt(VA[EV])
                 .input(dust, Yttrium)
                 .input(dust, Barium, 2)
                 .input(dust, Copper, 3)
@@ -79,14 +80,14 @@ public class MixerRecipes {
                 .output(dust, YttriumBariumCuprate, 13)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(dust, Boron)
                 .input(dust, Glass, 7)
                 .notConsumable(new IntCircuitIngredient(2))
                 .output(dust, BorosilicateGlass, 8)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(dust, Indium)
                 .input(dust, Gallium)
                 .input(dust, Phosphorus)
@@ -94,7 +95,7 @@ public class MixerRecipes {
                 .output(dust, IndiumGalliumPhosphide, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(8)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(dust, Nickel)
                 .input(dust, Zinc)
                 .input(dust, Iron, 4)
@@ -109,21 +110,21 @@ public class MixerRecipes {
                 .output(dust, EnderEye)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(dust, Gold)
                 .input(dust, Silver)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, Electrum, 2)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(300).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(300).EUt(VA[ULV])
                 .input(dust, Iron, 2)
                 .input(dust, Nickel)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, Invar, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(600).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(600).EUt(VA[MV])
                 .input(dust, Iron, 4)
                 .input(dust, Invar, 3)
                 .input(dust, Manganese)
@@ -132,7 +133,7 @@ public class MixerRecipes {
                 .output(dust, StainlessSteel, 9)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(600).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(600).EUt(VA[MV])
                 .input(dust, Iron, 6)
                 .input(dust, Nickel)
                 .input(dust, Manganese)
@@ -141,7 +142,7 @@ public class MixerRecipes {
                 .output(dust, StainlessSteel, 9)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(300).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(300).EUt(VA[MV])
                 .input(dust, Iron)
                 .input(dust, Aluminium)
                 .input(dust, Chrome)
@@ -149,28 +150,28 @@ public class MixerRecipes {
                 .output(dust, Kanthal, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(500).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(500).EUt(VA[MV])
                 .input(dust, Chrome, 4)
                 .input(dust, Nickel)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, Nichrome, 5)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[ULV])
                 .input(dust, Copper, 3)
                 .input(dust, Zinc)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, Brass, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[ULV])
                 .input(dust, Copper, 3)
                 .input(dust, Tin)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, Bronze, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(8)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[ULV])
                 .input(dust, Lead, 2)
                 .input(dust, Bronze, 2)
                 .input(dust, Tin, 1)
@@ -185,35 +186,35 @@ public class MixerRecipes {
                 .output(dust, Cupronickel, 2)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[MV])
                 .input(dust, Copper)
                 .input(dust, Gold, 4)
                 .notConsumable(new IntCircuitIngredient(2))
                 .output(dust, RoseGold, 5)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(500).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(500).EUt(VA[MV])
                 .input(dust, Copper)
                 .input(dust, Silver, 4)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, SterlingSilver, 5)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(500).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(500).EUt(VA[ULV])
                 .input(dust, Copper, 3)
                 .input(dust, Electrum, 2)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, BlackBronze, 5)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(500).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(500).EUt(VA[ULV])
                 .input(dust, Bismuth)
                 .input(dust, Brass, 4)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, BismuthBronze, 5)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(500).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(500).EUt(VA[ULV])
                 .input(dust, BlackBronze)
                 .input(dust, Nickel)
                 .input(dust, Steel, 3)
@@ -221,7 +222,7 @@ public class MixerRecipes {
                 .output(dust, BlackSteel, 5)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(800).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(800).EUt(VA[ULV])
                 .input(dust, SterlingSilver)
                 .input(dust, BismuthBronze)
                 .input(dust, BlackSteel, 4)
@@ -230,7 +231,7 @@ public class MixerRecipes {
                 .output(dust, RedSteel, 8)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(800).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(800).EUt(VA[ULV])
                 .input(dust, RoseGold)
                 .input(dust, Brass)
                 .input(dust, BlackSteel, 4)
@@ -239,7 +240,7 @@ public class MixerRecipes {
                 .output(dust, BlueSteel, 8)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(900).EUt(480)
+        MIXER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV])
                 .input(dust, Cobalt, 5)
                 .input(dust, Chrome, 2)
                 .input(dust, Nickel)
@@ -248,7 +249,7 @@ public class MixerRecipes {
                 .output(dust, Ultimet, 9)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(900).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(900).EUt(VA[ULV])
                 .input(dust, Brass, 7)
                 .input(dust, Aluminium)
                 .input(dust, Cobalt)
@@ -256,7 +257,7 @@ public class MixerRecipes {
                 .output(dust, CobaltBrass, 9)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[ULV])
                 .input(dust, Saltpeter, 2)
                 .input(dust, Sulfur)
                 .input(dust, Coal, 3)
@@ -264,7 +265,7 @@ public class MixerRecipes {
                 .output(dust, Gunpowder, 6)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[ULV])
                 .input(dust, Saltpeter, 2)
                 .input(dust, Sulfur)
                 .input(dust, Charcoal, 3)
@@ -272,7 +273,7 @@ public class MixerRecipes {
                 .output(dust, Gunpowder, 6)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(300).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(300).EUt(VA[ULV])
                 .input(dust, Saltpeter, 2)
                 .input(dust, Sulfur)
                 .input(dust, Carbon, 3)
@@ -296,21 +297,21 @@ public class MixerRecipes {
                 .output(dust, DiamericiumTitanium, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(100).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV])
                 .input(dust, Tin)
                 .input(dust, Iron)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, TinAlloy, 2)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(100).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV])
                 .input(dust, Tin, 9)
                 .input(dust, Antimony)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, SolderingAlloy, 10)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(100).EUt(7)
+        MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV])
                 .input(dust, Lead, 4)
                 .input(dust, Antimony)
                 .notConsumable(new IntCircuitIngredient(1))
@@ -324,7 +325,7 @@ public class MixerRecipes {
                 .output(dust, Magnalium, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(100).EUt(30)
+        MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                 .input(dust, Vanadium)
                 .input(dust, Chrome)
                 .input(dust, Steel, 7)
@@ -332,7 +333,7 @@ public class MixerRecipes {
                 .output(dust, VanadiumSteel, 9)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(480)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[HV])
                 .input(dust, Tungsten)
                 .input(dust, Steel)
                 .notConsumable(new IntCircuitIngredient(1))
@@ -372,21 +373,21 @@ public class MixerRecipes {
                 .output(dust, Ruridit, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(300).EUt(1920)
+        MIXER_RECIPES.recipeBuilder().duration(300).EUt(VA[EV])
                 .input(dust, Osmium)
                 .input(dust, Iridium, 3)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, Osmiridium, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(7680)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[IV])
                 .input(dust, Palladium, 3)
                 .input(dust, Rhodium)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, RhodiumPlatedPalladium, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(7680)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[IV])
                 .input(dust, Naquadah, 2)
                 .input(dust, Osmiridium)
                 .input(dust, Trinium)
@@ -394,7 +395,7 @@ public class MixerRecipes {
                 .output(dust, NaquadahAlloy, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(100).EUt(480)
+        MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[HV])
                 .input(dust, Graphite)
                 .input(dust, Silicon)
                 .notConsumable(new IntCircuitIngredient(1))
@@ -408,14 +409,14 @@ public class MixerRecipes {
                 .output(dust, ManganesePhosphide, 2)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(600).EUt(120)
+        MIXER_RECIPES.recipeBuilder().duration(600).EUt(VA[MV])
                 .input(dust, Magnesium)
                 .input(dust, Boron, 2)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, MagnesiumDiboride, 3)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(480)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[HV])
                 .input(dust, Barium, 2)
                 .input(dust, Calcium, 2)
                 .input(dust, Copper, 3)
@@ -425,14 +426,14 @@ public class MixerRecipes {
                 .output(dust, MercuryBariumCalciumCuprate, 16)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(200).EUt(1920)
+        MIXER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV])
                 .input(dust, Uranium238)
                 .input(dust, Platinum, 3)
                 .notConsumable(new IntCircuitIngredient(1))
                 .output(dust, UraniumTriplatinum, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(100).EUt(7680)
+        MIXER_RECIPES.recipeBuilder().duration(100).EUt(VA[IV])
                 .input(dust, Samarium)
                 .input(dust, Iron)
                 .input(dust, Arsenic)
@@ -441,7 +442,7 @@ public class MixerRecipes {
                 .output(dust, SamariumIronArsenicOxide, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(600).EUt(30720)
+        MIXER_RECIPES.recipeBuilder().duration(600).EUt(VA[LuV])
                 .input(dust, Indium, 4)
                 .input(dust, Tin, 2)
                 .input(dust, Barium, 2)
@@ -452,7 +453,7 @@ public class MixerRecipes {
                 .output(dust, IndiumTinBariumTitaniumCuprate, 16)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(150).EUt(122880)
+        MIXER_RECIPES.recipeBuilder().duration(150).EUt(VA[ZPM])
                 .input(dust, Uranium238)
                 .input(dust, Rhodium)
                 .input(dust, Naquadah, 2)
@@ -460,7 +461,7 @@ public class MixerRecipes {
                 .output(dust, UraniumRhodiumDinaquadide, 4)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(175).EUt(491520)
+        MIXER_RECIPES.recipeBuilder().duration(175).EUt(VA[UV])
                 .input(dust, NaquadahEnriched, 4)
                 .input(dust, Trinium, 3)
                 .input(dust, Europium, 2)
@@ -469,7 +470,7 @@ public class MixerRecipes {
                 .output(dust, EnrichedNaquadahTriniumEuropiumDuranide, 10)
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().duration(400).EUt(491520)
+        MIXER_RECIPES.recipeBuilder().duration(400).EUt(VA[UV])
                 .input(dust, Ruthenium)
                 .input(dust, Trinium, 2)
                 .input(dust, Americium)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/NaquadahRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/NaquadahRecipes.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -23,20 +24,20 @@ public class NaquadahRecipes {
 
         // FLUOROANTIMONIC ACID
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(8).duration(60)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[ULV]).duration(60)
                 .input(dust, Antimony, 2)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, AntimonyTrioxide, 5)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(30).duration(60)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(60)
                 .input(dust, AntimonyTrioxide, 5)
                 .fluidInputs(HydrofluoricAcid.getFluid(6000))
                 .output(dust, AntimonyTrifluoride, 8)
                 .fluidOutputs(Water.getFluid(3000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(300)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(300)
                 .input(dust, AntimonyTrifluoride, 4)
                 .fluidInputs(HydrofluoricAcid.getFluid(4000))
                 .fluidOutputs(FluoroantimonicAcid.getFluid(1000))
@@ -46,7 +47,7 @@ public class NaquadahRecipes {
 
         // STARTING POINT
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(30720).duration(600)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LuV]).duration(600)
                 .fluidInputs(FluoroantimonicAcid.getFluid(1000))
                 .input(dust, Naquadah, 6)
                 .fluidOutputs(ImpureEnrichedNaquadahSolution.getFluid(2000))
@@ -57,34 +58,34 @@ public class NaquadahRecipes {
 
         // ENRICHED NAQUADAH PROCESS
 
-        CENTRIFUGE_RECIPES.recipeBuilder().EUt(1920).duration(400)
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(VA[EV]).duration(400)
                 .fluidInputs(ImpureEnrichedNaquadahSolution.getFluid(2000))
                 .output(dust, IndiumPhosphide)
                 .output(dust, AntimonyTrifluoride, 2)
                 .fluidOutputs(EnrichedNaquadahSolution.getFluid(1000))
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().EUt(480).duration(100)
+        MIXER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .fluidInputs(EnrichedNaquadahSolution.getFluid(1000))
                 .fluidInputs(SulfuricAcid.getFluid(2000))
                 .fluidOutputs(AcidicEnrichedNaquadahSolution.getFluid(3000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().EUt(480).duration(100)
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .fluidInputs(AcidicEnrichedNaquadahSolution.getFluid(3000))
                 .fluidOutputs(EnrichedNaquadahWaste.getFluid(2000))
                 .fluidOutputs(Fluorine.getFluid(500))
                 .output(dust, EnrichedNaquadahSulfate, 6) // Nq+SO4
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().EUt(7680).duration(500).blastFurnaceTemp(7000)
+        BLAST_RECIPES.recipeBuilder().EUt(VA[IV]).duration(500).blastFurnaceTemp(7000)
                 .input(dust, EnrichedNaquadahSulfate, 6)
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .output(ingotHot, NaquadahEnriched)
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
                 .buildAndRegister();
 
-        DISTILLATION_RECIPES.recipeBuilder().EUt(480).duration(300)
+        DISTILLATION_RECIPES.recipeBuilder().EUt(VA[HV]).duration(300)
                 .fluidInputs(EnrichedNaquadahWaste.getFluid(2000))
                 .output(dustSmall, BariumSulfide, 2)
                 .fluidOutputs(SulfuricAcid.getFluid(500))
@@ -95,34 +96,34 @@ public class NaquadahRecipes {
 
         // NAQUADRIA PROCESS
 
-        CENTRIFUGE_RECIPES.recipeBuilder().EUt(1920).duration(400)
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(VA[EV]).duration(400)
                 .fluidInputs(ImpureNaquadriaSolution.getFluid(2000))
                 .output(dust, TriniumSulfide)
                 .output(dust, AntimonyTrifluoride, 2)
                 .fluidOutputs(NaquadriaSolution.getFluid(1000))
                 .buildAndRegister();
 
-        MIXER_RECIPES.recipeBuilder().EUt(480).duration(100)
+        MIXER_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .fluidInputs(NaquadriaSolution.getFluid(1000))
                 .fluidInputs(SulfuricAcid.getFluid(2000))
                 .fluidOutputs(AcidicNaquadriaSolution.getFluid(3000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().EUt(480).duration(100)
+        CENTRIFUGE_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .fluidInputs(AcidicNaquadriaSolution.getFluid(3000))
                 .fluidOutputs(NaquadriaWaste.getFluid(2000))
                 .fluidOutputs(Fluorine.getFluid(500))
                 .output(dust, NaquadriaSulfate, 6)
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().EUt(122880).duration(600).blastFurnaceTemp(9000)
+        BLAST_RECIPES.recipeBuilder().EUt(VA[ZPM]).duration(600).blastFurnaceTemp(9000)
                 .input(dust, NaquadriaSulfate, 6)
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .output(ingotHot, Naquadria)
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
                 .buildAndRegister();
 
-        DISTILLATION_RECIPES.recipeBuilder().EUt(480).duration(300)
+        DISTILLATION_RECIPES.recipeBuilder().EUt(VA[HV]).duration(300)
                 .fluidInputs(NaquadriaWaste.getFluid(2000))
                 .output(dustSmall, GalliumSulfide, 2)
                 .fluidOutputs(SulfuricAcid.getFluid(500))
@@ -133,7 +134,7 @@ public class NaquadahRecipes {
 
         // TRINIUM
 
-        BLAST_RECIPES.recipeBuilder().duration(750).EUt(30720).blastFurnaceTemp(8600)
+        BLAST_RECIPES.recipeBuilder().duration(750).EUt(VA[LuV]).blastFurnaceTemp(8600)
                 .input(dust, TriniumSulfide, 2)
                 .input(dust, Zinc)
                 .output(ingotHot, Trinium)
@@ -144,7 +145,7 @@ public class NaquadahRecipes {
         // BYPRODUCT PROCESSING
 
         // Titanium Trifluoride
-        BLAST_RECIPES.recipeBuilder().EUt(480).duration(900).blastFurnaceTemp(1941)
+        BLAST_RECIPES.recipeBuilder().EUt(VA[HV]).duration(900).blastFurnaceTemp(1941)
                 .input(dust, TitaniumTrifluoride, 4)
                 .fluidInputs(Hydrogen.getFluid(3000))
                 .output(ingotHot, Titanium)
@@ -152,7 +153,7 @@ public class NaquadahRecipes {
                 .buildAndRegister();
 
         // Indium Phosphide
-        CHEMICAL_RECIPES.recipeBuilder().duration(30).EUt(8)
+        CHEMICAL_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV])
                 .input(dust, IndiumPhosphide, 2)
                 .input(dust, Calcium)
                 .output(dust, Indium)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/NuclearRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/NuclearRecipes.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.dust;
@@ -8,7 +9,7 @@ public class NuclearRecipes {
 
     public static void init() {
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                 .input(dust, Uraninite, 3)
                 .fluidInputs(HydrofluoricAcid.getFluid(4000))
                 .fluidInputs(Fluorine.getFluid(2000))
@@ -16,19 +17,19 @@ public class NuclearRecipes {
                 .fluidOutputs(Water.getFluid(2000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(160).EUt(480)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(160).EUt(VA[HV])
                 .fluidInputs(UraniumHexafluoride.getFluid(1000))
                 .fluidOutputs(EnrichedUraniumHexafluoride.getFluid(100))
                 .fluidOutputs(DepletedUraniumHexafluoride.getFluid(900))
                 .buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(120)
+        ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(VA[MV])
                 .fluidInputs(EnrichedUraniumHexafluoride.getFluid(1000))
                 .output(dust, Uranium235)
                 .fluidOutputs(Fluorine.getFluid(6000))
                 .buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(120)
+        ELECTROLYZER_RECIPES.recipeBuilder().duration(160).EUt(VA[MV])
                 .fluidInputs(DepletedUraniumHexafluoride.getFluid(1000))
                 .output(dust, Uranium238)
                 .fluidOutputs(Fluorine.getFluid(6000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PlatGroupMetalsRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PlatGroupMetalsRecipes.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.crushedPurified;
@@ -12,14 +13,14 @@ public class PlatGroupMetalsRecipes {
         // Primary Chain
 
         // Platinum Group Sludge Production
-        CHEMICAL_RECIPES.recipeBuilder().duration(50).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(50).EUt(VA[LV])
                 .input(crushedPurified, Chalcopyrite)
                 .fluidInputs(NitricAcid.getFluid(1000))
                 .output(dust, PlatinumGroupSludge, 2)
                 .fluidOutputs(SulfuricCopperSolution.getFluid(1000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(50).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(50).EUt(VA[LV])
                 .input(crushedPurified, Pentlandite)
                 .fluidInputs(NitricAcid.getFluid(1000))
                 .output(dust, PlatinumGroupSludge, 2)
@@ -28,7 +29,7 @@ public class PlatGroupMetalsRecipes {
 
         // Aqua Regia
         // HNO3 + HCl -> [HNO3 + HCl]
-        MIXER_RECIPES.recipeBuilder().duration(30).EUt(30)
+        MIXER_RECIPES.recipeBuilder().duration(30).EUt(VA[LV])
                 .fluidInputs(NitricAcid.getFluid(1000))
                 .fluidInputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(AquaRegia.getFluid(2000))
@@ -52,7 +53,7 @@ public class PlatGroupMetalsRecipes {
         //
         // Can also modify the PtCl2 electrolyzer recipe to keep a perfect Cl ratio.
         //
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(500).EUt(480)
+        ELECTROLYZER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV])
                 .input(dust, PlatinumGroupSludge, 6)
                 .fluidInputs(AquaRegia.getFluid(1000))
                 .output(dust, PlatinumRaw, 3) // PtCl2
@@ -65,7 +66,7 @@ public class PlatGroupMetalsRecipes {
 
         // PLATINUM
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(120)
+        ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
                 .input(dust, PlatinumRaw, 3)
                 .output(dust, Platinum)
                 .fluidOutputs(Chlorine.getFluid(500))
@@ -74,7 +75,7 @@ public class PlatGroupMetalsRecipes {
 
         // PALLADIUM
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(120)
+        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(VA[MV])
                 .input(dust, PalladiumRaw, 5)
                 .fluidInputs(HydrochloricAcid.getFluid(1000))
                 .output(dust, Palladium)
@@ -84,7 +85,7 @@ public class PlatGroupMetalsRecipes {
 
         // RHODIUM / RUTHENIUM
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(450).EUt(1920)
+        CHEMICAL_RECIPES.recipeBuilder().duration(450).EUt(VA[EV])
                 .input(dust, InertMetalMixture, 6)
                 .fluidInputs(SulfuricAcid.getFluid(1500))
                 .fluidOutputs(RhodiumSulfate.getFluid(500))
@@ -92,14 +93,14 @@ public class PlatGroupMetalsRecipes {
                 .fluidOutputs(Hydrogen.getFluid(3000))
                 .buildAndRegister();
 
-        ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(120)
+        ELECTROLYZER_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
                 .fluidInputs(RhodiumSulfate.getFluid(1000))
                 .output(dust, Rhodium, 2)
                 .fluidOutputs(SulfurTrioxide.getFluid(3000))
                 .fluidOutputs(Oxygen.getFluid(3000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(120)
+        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(VA[MV])
                 .input(dust, RutheniumTetroxide, 5)
                 .input(dust, Carbon, 2)
                 .output(dust, Ruthenium)
@@ -109,7 +110,7 @@ public class PlatGroupMetalsRecipes {
 
         // OSMIUM / IRIDIUM
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().duration(400).EUt(7680)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().duration(400).EUt(VA[IV])
                 .input(dust, RarestMetalMixture, 7)
                 .fluidInputs(HydrochloricAcid.getFluid(4000))
                 .output(dust, IridiumMetalResidue, 5)
@@ -117,27 +118,27 @@ public class PlatGroupMetalsRecipes {
                 .fluidOutputs(Hydrogen.getFluid(3000))
                 .buildAndRegister();
 
-        DISTILLATION_RECIPES.recipeBuilder().duration(400).EUt(120)
+        DISTILLATION_RECIPES.recipeBuilder().duration(400).EUt(VA[MV])
                 .fluidInputs(AcidicOsmiumSolution.getFluid(2000))
                 .output(dust, OsmiumTetroxide, 5)
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                 .input(dust, OsmiumTetroxide, 5)
                 .fluidInputs(Hydrogen.getFluid(8000))
                 .output(dust, Osmium)
                 .fluidOutputs(Water.getFluid(4000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(120)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(VA[MV])
                 .input(dust, IridiumMetalResidue, 5)
                 .output(dust, IridiumChloride, 4)
                 .output(dust, PlatinumSludgeResidue)
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().duration(100).EUt(30)
+        CHEMICAL_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                 .input(dust, IridiumChloride, 4)
                 .fluidInputs(Hydrogen.getFluid(3000))
                 .output(dust, Iridium)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -2,6 +2,7 @@ package gregtech.loaders.recipe.chemistry;
 
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CHEMICAL_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.LARGE_CHEMICAL_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
@@ -15,7 +16,7 @@ public class PolymerRecipes {
     }
 
     private static void polybenzimidazoleProcess() {
-        CHEMICAL_RECIPES.recipeBuilder().EUt(7680).duration(100)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
                 .fluidInputs(Diaminobenzidine.getFluid(1000))
                 .fluidInputs(DiphenylIsophtalate.getFluid(1000))
                 .fluidOutputs(Phenol.getFluid(1000))
@@ -23,7 +24,7 @@ public class PolymerRecipes {
                 .buildAndRegister();
 
         // 3,3-Diaminobenzidine
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(7680).duration(100)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
                 .fluidInputs(Dichlorobenzidine.getFluid(1000))
                 .fluidInputs(Ammonia.getFluid(2000))
                 .notConsumable(dust, Zinc)
@@ -31,21 +32,21 @@ public class PolymerRecipes {
                 .fluidOutputs(HydrochloricAcid.getFluid(2000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(1920).duration(200)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(200)
                 .input(dustTiny, Copper)
                 .fluidInputs(Nitrochlorobenzene.getFluid(1000))
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidOutputs(Dichlorobenzidine.getFluid(1000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(1920).duration(1800)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(1800)
                 .input(dust, Copper)
                 .fluidInputs(Nitrochlorobenzene.getFluid(9000))
                 .notConsumable(new IntCircuitIngredient(9))
                 .fluidOutputs(Dichlorobenzidine.getFluid(9000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(100)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .fluidInputs(NitrationMixture.getFluid(2000))
                 .fluidInputs(Chlorobenzene.getFluid(1000))
                 .notConsumable(new IntCircuitIngredient(1))
@@ -53,7 +54,7 @@ public class PolymerRecipes {
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(1000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(30).duration(240)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(240)
                 .fluidInputs(Chlorine.getFluid(2000))
                 .fluidInputs(Benzene.getFluid(1000))
                 .notConsumable(new IntCircuitIngredient(1))
@@ -62,7 +63,7 @@ public class PolymerRecipes {
                 .buildAndRegister();
 
         // Diphenyl Isophthalate
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(7680).duration(100)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
                 .fluidInputs(Phenol.getFluid(2000))
                 .fluidInputs(SulfuricAcid.getFluid(1000))
                 .fluidInputs(PhthalicAcid.getFluid(1000))
@@ -70,7 +71,7 @@ public class PolymerRecipes {
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(1000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(1920).duration(100)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(100)
                 .input(dustTiny, PotassiumDichromate)
                 .fluidInputs(Dimethylbenzene.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(2000))
@@ -78,7 +79,7 @@ public class PolymerRecipes {
                 .fluidOutputs(Water.getFluid(2000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(1920).duration(900)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(900)
                 .input(dust, PotassiumDichromate)
                 .fluidInputs(Dimethylbenzene.getFluid(9000))
                 .fluidInputs(Oxygen.getFluid(18000))
@@ -86,7 +87,7 @@ public class PolymerRecipes {
                 .fluidOutputs(Water.getFluid(18000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(30).duration(125)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(125)
                 .fluidInputs(Naphthalene.getFluid(2000))
                 .fluidInputs(SulfuricAcid.getFluid(1000))
                 .input(dustTiny, Potassium)
@@ -94,7 +95,7 @@ public class PolymerRecipes {
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(30).duration(1125)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(1125)
                 .fluidInputs(Naphthalene.getFluid(18000))
                 .fluidInputs(SulfuricAcid.getFluid(9000))
                 .input(dust, Potassium)
@@ -102,14 +103,14 @@ public class PolymerRecipes {
                 .fluidOutputs(HydrogenSulfide.getFluid(9000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(120).duration(4000)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[MV]).duration(4000)
                 .fluidInputs(Methane.getFluid(1000))
                 .fluidInputs(Benzene.getFluid(1000))
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidOutputs(Dimethylbenzene.getFluid(1000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(480).duration(100)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)
                 .input(dust, Saltpeter, 10)
                 .input(dust, ChromiumTrioxide, 8)
                 .output(dust, PotassiumDichromate, 11)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -11,6 +11,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CHEMICAL_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -23,13 +24,13 @@ public class ReactorRecipes {
                 .fluidInputs(Isoprene.getFluid(144))
                 .fluidInputs(Air.getFluid(2000))
                 .output(dust, RawRubber)
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Isoprene.getFluid(144))
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(dust, RawRubber, 3)
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Butadiene.getFluid(3000))
@@ -49,34 +50,34 @@ public class ReactorRecipes {
                 .input(dust, RawStyreneButadieneRubber, 9)
                 .input(dust, Sulfur)
                 .fluidOutputs(StyreneButadieneRubber.getFluid(1296))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
                 .fluidInputs(Propene.getFluid(2000))
                 .fluidOutputs(Methane.getFluid(1000))
                 .fluidOutputs(Isoprene.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .input(dust, Carbon)
                 .fluidInputs(Hydrogen.getFluid(4000))
                 .fluidOutputs(Methane.getFluid(1000))
-                .duration(3500).EUt(30).buildAndRegister();
+                .duration(3500).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(Isoprene.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Sodium, 2)
                 .input(dust, Sulfur)
                 .output(dust, SodiumSulfide, 3)
-                .duration(60).EUt(30).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, SodiumSulfide, 3)
@@ -99,14 +100,14 @@ public class ReactorRecipes {
                 .fluidInputs(Air.getFluid(1000))
                 .fluidInputs(Ethylene.getFluid(144))
                 .fluidOutputs(Polyethylene.getFluid(144))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(Ethylene.getFluid(144))
                 .fluidOutputs(Polyethylene.getFluid(216))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -114,7 +115,7 @@ public class ReactorRecipes {
                 .fluidInputs(Ethylene.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(Polyethylene.getFluid(3240))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -122,21 +123,21 @@ public class ReactorRecipes {
                 .fluidInputs(Ethylene.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(Polyethylene.getFluid(4320))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Air.getFluid(1000))
                 .fluidInputs(VinylChloride.getFluid(144))
                 .fluidOutputs(PolyvinylChloride.getFluid(144))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(VinylChloride.getFluid(144))
                 .fluidOutputs(PolyvinylChloride.getFluid(216))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -144,7 +145,7 @@ public class ReactorRecipes {
                 .fluidInputs(VinylChloride.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(PolyvinylChloride.getFluid(3240))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -152,13 +153,13 @@ public class ReactorRecipes {
                 .fluidInputs(VinylChloride.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(PolyvinylChloride.getFluid(4320))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Polydimethylsiloxane, 9)
                 .input(dust, Sulfur)
                 .fluidOutputs(SiliconeRubber.getFluid(1296))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(HydrochloricAcid.getFluid(1000))
@@ -166,27 +167,27 @@ public class ReactorRecipes {
                 .fluidInputs(Phenol.getFluid(2000))
                 .fluidOutputs(BisphenolA.getFluid(1000))
                 .fluidOutputs(DilutedHydrochloricAcid.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfurTrioxide.getFluid(1000))
                 .fluidInputs(Water.getFluid(1000))
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
-                .duration(320).EUt(8).buildAndRegister();
+                .duration(320).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Air.getFluid(1000))
                 .fluidInputs(Tetrafluoroethylene.getFluid(144))
                 .fluidOutputs(Polytetrafluoroethylene.getFluid(144))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(Tetrafluoroethylene.getFluid(144))
                 .fluidOutputs(Polytetrafluoroethylene.getFluid(216))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -194,7 +195,7 @@ public class ReactorRecipes {
                 .fluidInputs(Tetrafluoroethylene.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(Polytetrafluoroethylene.getFluid(3240))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -202,7 +203,7 @@ public class ReactorRecipes {
                 .fluidInputs(Tetrafluoroethylene.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(Polytetrafluoroethylene.getFluid(4320))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, SodiumHydroxide, 3)
@@ -210,7 +211,7 @@ public class ReactorRecipes {
                 .fluidInputs(BisphenolA.getFluid(1000))
                 .fluidOutputs(Epoxy.getFluid(1000))
                 .fluidOutputs(SaltWater.getFluid(1000))
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Carbon, 2)
@@ -218,7 +219,7 @@ public class ReactorRecipes {
                 .fluidInputs(Chlorine.getFluid(4000))
                 .fluidOutputs(CarbonMonoxide.getFluid(2000))
                 .fluidOutputs(TitaniumTetrachloride.getFluid(1000))
-                .duration(400).EUt(480).buildAndRegister();
+                .duration(400).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Dimethyldichlorosilane.getFluid(1000))
@@ -250,7 +251,7 @@ public class ReactorRecipes {
                 .fluidInputs(Chlorine.getFluid(1000))
                 .fluidInputs(Hydrogen.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
-                .duration(60).EUt(8).buildAndRegister();
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         // NaCl + H2SO4 -> NaHSO4 + HCl
         CHEMICAL_RECIPES.recipeBuilder()
@@ -259,14 +260,14 @@ public class ReactorRecipes {
                 .fluidInputs(SulfuricAcid.getFluid(1000))
                 .output(dust, SodiumBisulfate, 7)
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
-                .duration(60).EUt(30).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Iron)
                 .fluidInputs(Chlorine.getFluid(3000))
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidOutputs(Iron3Chloride.getFluid(1000))
-                .duration(400).EUt(30)
+                .duration(400).EUt(VA[LV])
                 .buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
@@ -275,7 +276,7 @@ public class ReactorRecipes {
                 .fluidInputs(Methane.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(3000))
                 .fluidOutputs(Chloroform.getFluid(1000))
-                .duration(80).EUt(30).buildAndRegister();
+                .duration(80).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
@@ -283,7 +284,7 @@ public class ReactorRecipes {
                 .fluidInputs(Methane.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(Chloromethane.getFluid(1000))
-                .duration(80).EUt(30).buildAndRegister();
+                .duration(80).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Chlorine.getFluid(4000))
@@ -291,21 +292,21 @@ public class ReactorRecipes {
                 .notConsumable(new IntCircuitIngredient(2))
                 .fluidOutputs(HydrochloricAcid.getFluid(2000))
                 .fluidOutputs(Dichlorobenzene.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidInputs(Chlorine.getFluid(2000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(AllylChloride.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Chlorine.getFluid(2000))
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidOutputs(VinylChloride.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Apatite, 9)
@@ -314,20 +315,20 @@ public class ReactorRecipes {
                 .output(dust, Gypsum, 40)
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(PhosphoricAcid.getFluid(3000))
-                .duration(320).EUt(30).buildAndRegister();
+                .duration(320).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfurDioxide.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidOutputs(SulfurTrioxide.getFluid(1000))
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
                 .input(dust, Sulfur)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .fluidOutputs(SulfurTrioxide.getFluid(1000))
-                .duration(280).EUt(30).buildAndRegister();
+                .duration(280).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Chloroform.getFluid(2000))
@@ -342,7 +343,7 @@ public class ReactorRecipes {
                 .fluidInputs(Water.getFluid(1000))
                 .output(dust, SodiumHydroxide, 3)
                 .fluidOutputs(Hydrogen.getFluid(1000))
-                .duration(80).EUt(30).buildAndRegister();
+                .duration(80).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
@@ -351,35 +352,35 @@ public class ReactorRecipes {
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .fluidOutputs(VinylChloride.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidInputs(Cumene.getFluid(1000))
                 .fluidOutputs(Phenol.getFluid(1000))
                 .fluidOutputs(Acetone.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(NitrationMixture.getFluid(3000))
                 .fluidInputs(Glycerol.getFluid(1000))
                 .fluidOutputs(GlycerylTrinitrate.getFluid(1000))
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(3000))
-                .duration(180).EUt(30).buildAndRegister();
+                .duration(180).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfuricAcid.getFluid(1000))
                 .fluidInputs(AceticAcid.getFluid(1000))
                 .fluidOutputs(Ethenone.getFluid(1000))
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(1000))
-                .duration(160).EUt(120).buildAndRegister();
+                .duration(160).EUt(VA[MV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Calcite, 5)
                 .fluidInputs(AceticAcid.getFluid(2000))
                 .fluidOutputs(DissolvedCalciumAcetate.getFluid(1000))
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(200).EUt(120).buildAndRegister();
+                .duration(200).EUt(VA[MV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Quicklime, 2)
@@ -399,14 +400,14 @@ public class ReactorRecipes {
                 .fluidInputs(AceticAcid.getFluid(1000))
                 .fluidOutputs(MethylAcetate.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Glycerol.getFluid(1000))
                 .fluidInputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(Water.getFluid(2000))
                 .fluidOutputs(Epichlorohydrin.getFluid(1000))
-                .duration(480).EUt(30).buildAndRegister();
+                .duration(480).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, SodiumHydroxide, 3)
@@ -414,76 +415,76 @@ public class ReactorRecipes {
                 .fluidInputs(HypochlorousAcid.getFluid(1000))
                 .fluidOutputs(SaltWater.getFluid(1000))
                 .fluidOutputs(Epichlorohydrin.getFluid(1000))
-                .duration(480).EUt(30).buildAndRegister();
+                .duration(480).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Sulfur)
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
-                .duration(60).EUt(8).buildAndRegister();
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfuricLightFuel.getFluid(12000))
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .fluidOutputs(LightFuel.getFluid(12000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfuricHeavyFuel.getFluid(8000))
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .fluidOutputs(HeavyFuel.getFluid(8000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfuricNaphtha.getFluid(12000))
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .fluidOutputs(Naphtha.getFluid(12000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfuricGas.getFluid(16000))
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .fluidOutputs(RefineryGas.getFluid(16000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(NaturalGas.getFluid(16000))
                 .fluidInputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .fluidOutputs(RefineryGas.getFluid(16000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Nitrogen.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidOutputs(NitrogenDioxide.getFluid(1000))
-                .duration(1250).EUt(30).buildAndRegister();
+                .duration(1250).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(NitricOxide.getFluid(1000))
                 .fluidOutputs(NitrogenDioxide.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Air.getFluid(1000))
                 .fluidInputs(VinylAcetate.getFluid(144))
                 .fluidOutputs(PolyvinylAcetate.getFluid(144))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(VinylAcetate.getFluid(144))
                 .fluidOutputs(PolyvinylAcetate.getFluid(216))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -491,7 +492,7 @@ public class ReactorRecipes {
                 .fluidInputs(VinylAcetate.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(PolyvinylAcetate.getFluid(3240))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -499,7 +500,7 @@ public class ReactorRecipes {
                 .fluidInputs(VinylAcetate.getFluid(2160))
                 .fluidInputs(TitaniumTetrachloride.getFluid(100))
                 .fluidOutputs(PolyvinylAcetate.getFluid(4320))
-                .duration(800).EUt(30).buildAndRegister();
+                .duration(800).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(6000))
@@ -528,7 +529,7 @@ public class ReactorRecipes {
                 .fluidInputs(Water.getFluid(10000))
                 .fluidInputs(Chlorine.getFluid(10000))
                 .fluidOutputs(HypochlorousAcid.getFluid(10000))
-                .duration(600).EUt(8).buildAndRegister();
+                .duration(600).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -536,14 +537,14 @@ public class ReactorRecipes {
                 .fluidInputs(Chlorine.getFluid(2000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(HypochlorousAcid.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Dimethylamine.getFluid(1000))
                 .fluidInputs(Monochloramine.getFluid(1000))
                 .fluidOutputs(Dimethylhydrazine.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
-                .duration(960).EUt(480).buildAndRegister();
+                .duration(960).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Methanol.getFluid(2000))
@@ -551,14 +552,14 @@ public class ReactorRecipes {
                 .fluidInputs(HypochlorousAcid.getFluid(1000))
                 .fluidOutputs(Dimethylhydrazine.getFluid(1000))
                 .fluidOutputs(DilutedHydrochloricAcid.getFluid(2000))
-                .duration(1040).EUt(480).buildAndRegister();
+                .duration(1040).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
                 .input(dust, Sulfur)
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidOutputs(SulfurDioxide.getFluid(1000))
-                .duration(60).EUt(8).buildAndRegister();
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -566,26 +567,26 @@ public class ReactorRecipes {
                 .fluidInputs(HydrogenSulfide.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .fluidOutputs(SulfurDioxide.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Hydrogen.getFluid(1000))
                 .fluidInputs(Fluorine.getFluid(1000))
                 .fluidOutputs(HydrofluoricAcid.getFluid(1000))
-                .duration(60).EUt(8).buildAndRegister();
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidInputs(Benzene.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(Styrene.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Ethylbenzene.getFluid(1000))
                 .fluidOutputs(Styrene.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
-                .duration(30).EUt(30)
+                .duration(30).EUt(VA[LV])
                 .buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
@@ -593,7 +594,7 @@ public class ReactorRecipes {
                 .fluidInputs(Benzene.getFluid(8000))
                 .fluidInputs(Propene.getFluid(8000))
                 .fluidOutputs(Cumene.getFluid(8000))
-                .duration(1920).EUt(30).buildAndRegister();
+                .duration(1920).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Silicon)
@@ -606,20 +607,20 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidOutputs(AceticAcid.getFluid(1000))
-                .duration(100).EUt(30).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(CarbonMonoxide.getFluid(1000))
                 .fluidInputs(Methanol.getFluid(1000))
                 .fluidOutputs(AceticAcid.getFluid(1000))
-                .duration(300).EUt(30).buildAndRegister();
+                .duration(300).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
                 .fluidInputs(Hydrogen.getFluid(4000))
                 .fluidInputs(CarbonMonoxide.getFluid(2000))
                 .fluidOutputs(AceticAcid.getFluid(1000))
-                .duration(320).EUt(30).buildAndRegister();
+                .duration(320).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(4))
@@ -627,7 +628,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidInputs(Hydrogen.getFluid(4000))
                 .fluidOutputs(AceticAcid.getFluid(1000))
-                .duration(480).EUt(30).buildAndRegister();
+                .duration(480).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Aluminium, 4)
@@ -642,7 +643,7 @@ public class ReactorRecipes {
                 .fluidInputs(Water.getFluid(1000))
                 .fluidOutputs(NitricOxide.getFluid(1000))
                 .fluidOutputs(NitricAcid.getFluid(2000))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -650,7 +651,7 @@ public class ReactorRecipes {
                 .fluidInputs(Ammonia.getFluid(2000))
                 .fluidOutputs(NitricOxide.getFluid(2000))
                 .fluidOutputs(Water.getFluid(3000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
@@ -659,14 +660,14 @@ public class ReactorRecipes {
                 .fluidInputs(Ethylene.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .fluidOutputs(VinylAcetate.getFluid(1000))
-                .duration(180).EUt(30).buildAndRegister();
+                .duration(180).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .input(dust, Carbon)
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
-                .duration(40).EUt(8).buildAndRegister();
+                .duration(40).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -674,7 +675,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(1000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -682,7 +683,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(1000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -690,10 +691,10 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(1000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .duration(80).EUt(8)
+                .duration(80).EUt(VA[ULV])
                 .input(dust, Coal)
                 .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Oxygen.getFluid(1000))
@@ -705,7 +706,7 @@ public class ReactorRecipes {
                 .input(dust, Carbon)
                 .fluidInputs(CarbonDioxide.getFluid(1000))
                 .fluidOutputs(CarbonMonoxide.getFluid(2000))
-                .duration(800).EUt(8).buildAndRegister();
+                .duration(800).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -719,20 +720,20 @@ public class ReactorRecipes {
                 .fluidInputs(Ammonia.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .fluidOutputs(Monochloramine.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Ammonia.getFluid(1000))
                 .fluidInputs(Methanol.getFluid(2000))
                 .fluidOutputs(Water.getFluid(2000))
                 .fluidOutputs(Dimethylamine.getFluid(1000))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, PhosphorusPentoxide, 14)
                 .fluidInputs(Water.getFluid(6000))
                 .fluidOutputs(PhosphoricAcid.getFluid(4000))
-                .duration(40).EUt(30).buildAndRegister();
+                .duration(40).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -740,7 +741,7 @@ public class ReactorRecipes {
                 .fluidInputs(Water.getFluid(3000))
                 .fluidInputs(Oxygen.getFluid(5000))
                 .fluidOutputs(PhosphoricAcid.getFluid(2000))
-                .duration(320).EUt(30).buildAndRegister();
+                .duration(320).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -748,21 +749,21 @@ public class ReactorRecipes {
                 .fluidInputs(Methanol.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .fluidOutputs(Chloromethane.getFluid(1000))
-                .duration(160).EUt(30).buildAndRegister();
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .input(dust, Phosphorus, 4)
                 .fluidInputs(Oxygen.getFluid(10000))
                 .output(dust, PhosphorusPentoxide, 14)
-                .duration(40).EUt(30).buildAndRegister();
+                .duration(40).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
                 .input(dust, Carbon)
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(40).EUt(8).buildAndRegister();
+                .duration(40).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -770,7 +771,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -778,7 +779,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -786,7 +787,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -794,7 +795,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(80).EUt(8).buildAndRegister();
+                .duration(80).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
@@ -802,7 +803,7 @@ public class ReactorRecipes {
                 .fluidInputs(Methane.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(8000))
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(150).EUt(480).buildAndRegister();
+                .duration(150).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(MethylAcetate.getFluid(2000))
@@ -810,14 +811,14 @@ public class ReactorRecipes {
                 .output(dust, Carbon, 5)
                 .fluidOutputs(Tetranitromethane.getFluid(1000))
                 .fluidOutputs(Water.getFluid(8000))
-                .duration(480).EUt(120).buildAndRegister();
+                .duration(480).EUt(VA[MV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(NitricAcid.getFluid(8000))
                 .fluidInputs(Ethenone.getFluid(1000))
                 .fluidOutputs(Tetranitromethane.getFluid(2000))
                 .fluidOutputs(Water.getFluid(5000))
-                .duration(480).EUt(120).buildAndRegister();
+                .duration(480).EUt(VA[MV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
@@ -825,13 +826,13 @@ public class ReactorRecipes {
                 .fluidInputs(Ammonia.getFluid(2000))
                 .fluidOutputs(DinitrogenTetroxide.getFluid(1000))
                 .fluidOutputs(Water.getFluid(3000))
-                .duration(480).EUt(30).buildAndRegister();
+                .duration(480).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
                 .fluidInputs(NitrogenDioxide.getFluid(2000))
                 .fluidOutputs(DinitrogenTetroxide.getFluid(1000))
-                .duration(640).EUt(30).buildAndRegister();
+                .duration(640).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
@@ -840,7 +841,7 @@ public class ReactorRecipes {
                 .fluidInputs(Hydrogen.getFluid(6000))
                 .fluidOutputs(DinitrogenTetroxide.getFluid(1000))
                 .fluidOutputs(Water.getFluid(3000))
-                .duration(1100).EUt(480).buildAndRegister();
+                .duration(1100).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -848,7 +849,7 @@ public class ReactorRecipes {
                 .fluidInputs(Ammonia.getFluid(1000))
                 .fluidOutputs(NitricAcid.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
-                .duration(480).EUt(480).buildAndRegister();
+                .duration(480).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
@@ -856,7 +857,7 @@ public class ReactorRecipes {
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(NitrogenDioxide.getFluid(2000))
                 .fluidOutputs(NitricAcid.getFluid(2000))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(2))
@@ -865,7 +866,7 @@ public class ReactorRecipes {
                 .fluidInputs(Hydrogen.getFluid(3000))
                 .fluidOutputs(NitricAcid.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
-                .duration(720).EUt(480).buildAndRegister();
+                .duration(720).EUt(VA[HV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dustTiny, SodiumHydroxide)
@@ -873,7 +874,7 @@ public class ReactorRecipes {
                 .fluidInputs(Methanol.getFluid(1000))
                 .fluidOutputs(Glycerol.getFluid(1000))
                 .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dustTiny, SodiumHydroxide)
@@ -881,7 +882,7 @@ public class ReactorRecipes {
                 .fluidInputs(Ethanol.getFluid(1000))
                 .fluidOutputs(Glycerol.getFluid(1000))
                 .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dustTiny, SodiumHydroxide)
@@ -889,7 +890,7 @@ public class ReactorRecipes {
                 .fluidInputs(Methanol.getFluid(1000))
                 .fluidOutputs(Glycerol.getFluid(1000))
                 .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dustTiny, SodiumHydroxide)
@@ -897,21 +898,21 @@ public class ReactorRecipes {
                 .fluidInputs(Ethanol.getFluid(1000))
                 .fluidOutputs(Glycerol.getFluid(1000))
                 .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(30).buildAndRegister();
+                .duration(600).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(SulfuricAcid.getFluid(1000))
                 .fluidInputs(Ethanol.getFluid(1000))
                 .fluidOutputs(Ethylene.getFluid(1000))
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(1000))
-                .duration(1200).EUt(120).buildAndRegister();
+                .duration(1200).EUt(VA[MV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, SodiumBisulfate, 7)
                 .fluidInputs(Water.getFluid(1000))
                 .output(dust, SodiumHydroxide, 3)
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
-                .duration(60).EUt(30).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.SUGAR, 9))
@@ -925,53 +926,53 @@ public class ReactorRecipes {
                 .fluidInputs(HydrogenSulfide.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(4000))
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
-                .duration(320).EUt(30).buildAndRegister();
+                .duration(320).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Saltpeter)
                 .fluidInputs(Naphtha.getFluid(576))
                 .output(dustTiny, Potassium)
                 .fluidOutputs(Polycaprolactam.getFluid(1296))
-                .duration(640).EUt(30).buildAndRegister();
+                .duration(640).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Epichlorohydrin.getFluid(144))
                 .fluidInputs(Naphtha.getFluid(3000))
                 .fluidInputs(NitrogenDioxide.getFluid(1000))
                 .fluidOutputs(Epoxy.getFluid(288))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Calcium)
                 .input(dust, Carbon)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, Calcite, 5)
-                .duration(500).EUt(30).buildAndRegister();
+                .duration(500).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Quicklime, 2)
                 .fluidInputs(CarbonDioxide.getFluid(1000))
                 .output(dust, Calcite, 5)
-                .duration(80).EUt(30).buildAndRegister();
+                .duration(80).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Magnesia, 2)
                 .fluidInputs(CarbonDioxide.getFluid(1000))
                 .output(dust, Magnesite, 5)
-                .duration(80).EUt(30).buildAndRegister();
+                .duration(80).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
                 .input(dust, Calcite, 5)
                 .output(dust, Quicklime, 2)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Magnesite, 5)
                 .output(dust, Magnesia, 2)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
-                .duration(240).EUt(30).buildAndRegister();
+                .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, RawRubber, 9)
@@ -983,37 +984,37 @@ public class ReactorRecipes {
                 .inputs(new ItemStack(Items.MELON, 1, OreDictionary.WILDCARD_VALUE))
                 .input(nugget, Gold, 8)
                 .outputs(new ItemStack(Items.SPECKLED_MELON))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.CARROT, 1, OreDictionary.WILDCARD_VALUE))
                 .input(nugget, Gold, 8)
                 .outputs(new ItemStack(Items.GOLDEN_CARROT))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.APPLE, 1, OreDictionary.WILDCARD_VALUE))
                 .input(ingot, Gold, 8)
                 .outputs(new ItemStack(Items.GOLDEN_APPLE))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.APPLE, 1, OreDictionary.WILDCARD_VALUE))
                 .input(block, Gold, 8)
                 .outputs(new ItemStack(Items.GOLDEN_APPLE, 1, 1))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.BLAZE_POWDER))
                 .inputs(new ItemStack(Items.SLIME_BALL))
                 .outputs(new ItemStack(Items.MAGMA_CREAM))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.BLAZE_POWDER))
                 .input(OrePrefix.gem, Materials.EnderPearl)
                 .outputs(new ItemStack(Items.ENDER_EYE))
-                .duration(50).EUt(30).buildAndRegister();
+                .duration(50).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(MetaItems.GELLED_TOLUENE.getStackForm(4))
@@ -1027,7 +1028,7 @@ public class ReactorRecipes {
                 .output(dust, Salt, 4)
                 .fluidOutputs(Phenol.getFluid(1000))
                 .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(120).EUt(30).buildAndRegister();
+                .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(Benzene.getFluid(1000))
@@ -1056,7 +1057,7 @@ public class ReactorRecipes {
                 .fluidInputs(Air.getFluid(10000))
                 .output(dust, Plutonium239, 8)
                 .fluidOutputs(Radon.getFluid(1000))
-                .duration(100000).EUt(8).buildAndRegister();
+                .duration(100000).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(Items.PAPER)
@@ -1069,7 +1070,7 @@ public class ReactorRecipes {
                 .input(dust, Niobium)
                 .fluidInputs(Nitrogen.getFluid(1000))
                 .output(dust, NiobiumNitride, 2)
-                .duration(200).EUt(480).buildAndRegister();
+                .duration(200).EUt(VA[HV]).buildAndRegister();
 
         // Dyes
         for (int i = 0; i < Materials.CHEMICAL_DYES.length; i++) {

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import java.util.Collection;
 import java.util.List;
 
-import static gregtech.api.GTValues.L;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -51,7 +51,7 @@ public class SeparationRecipes {
                 .fluidInputs(NitrationMixture.getFluid(2000))
                 .fluidOutputs(NitricAcid.getFluid(1000))
                 .fluidOutputs(SulfuricAcid.getFluid(1000))
-                .duration(192).EUt(30).buildAndRegister();
+                .duration(192).EUt(VA[LV]).buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder()
                 .input(dust, ReinforcedEpoxyResin)
@@ -120,21 +120,21 @@ public class SeparationRecipes {
                 .fluidOutputs(Methane.getFluid(60))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.DIRT, 1, GTValues.W))
                 .chancedOutput(PLANT_BALL, 1250, 700)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
                 .chancedOutput(dustTiny, Clay, 4000, 900)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.GRASS))
                 .chancedOutput(MetaItems.PLANT_BALL.getStackForm(), 3000, 1200)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
                 .chancedOutput(dustTiny, Clay, 5000, 900)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(650).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(650).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.MYCELIUM))
                 .chancedOutput(new ItemStack(Blocks.RED_MUSHROOM), 2500, 900)
                 .chancedOutput(new ItemStack(Blocks.BROWN_MUSHROOM), 2500, 900)
@@ -142,7 +142,7 @@ public class SeparationRecipes {
                 .chancedOutput(dustTiny, Clay, 5000, 900)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(240).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(240).EUt(VA[LV])
                 .input(dust, Ash)
                 .chancedOutput(dustSmall, Quicklime, 2, 9900, 0)
                 .chancedOutput(dustSmall, Potash, 6400, 0)
@@ -165,7 +165,7 @@ public class SeparationRecipes {
                 .output(dustSmall, Gold, 2)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(36).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(36).EUt(VA[LV])
                 .input(dust, Coal)
                 .output(dust, Carbon, 2)
                 .buildAndRegister();
@@ -238,7 +238,7 @@ public class SeparationRecipes {
                 .chancedOutput(dustSmall, Lanthanum, 2500, 400)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(50).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(50).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.SAND, 1, 1))
                 .chancedOutput(dust, Iron, 5000, 500)
                 .chancedOutput(dustTiny, Diamond, 100, 100)
@@ -260,26 +260,26 @@ public class SeparationRecipes {
                 .fluidOutputs(Helium3.getFluid(5))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(8)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(VA[ULV])
                 .fluidInputs(Air.getFluid(10000))
                 .fluidOutputs(Nitrogen.getFluid(3900))
                 .fluidOutputs(Oxygen.getFluid(1000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(VA[LV])
                 .fluidInputs(NetherAir.getFluid(10000))
                 .fluidOutputs(CarbonMonoxide.getFluid(3900))
                 .fluidOutputs(SulfurDioxide.getFluid(1000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(480)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(VA[HV])
                 .fluidInputs(EnderAir.getFluid(10000))
                 .fluidOutputs(NitrogenDioxide.getFluid(3900))
                 .fluidOutputs(Deuterium.getFluid(1000))
                 .buildAndRegister();
 
         // Stone Dust
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(480).EUt(120)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(480).EUt(VA[MV])
                 .input(dust, Stone)
                 .output(dustSmall, Quartzite)
                 .output(dustSmall, PotassiumFeldspar)
@@ -304,7 +304,7 @@ public class SeparationRecipes {
                 .fluidOutputs(Oil.getFluid(1000))
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(60).EUt(30)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(60).EUt(VA[LV])
                 .input(dust, QuartzSand, 2)
                 .output(dust, Quartzite)
                 .chancedOutput(dust, CertusQuartz, 2000, 200)
@@ -316,33 +316,33 @@ public class SeparationRecipes {
                 .input(dust, SodiumBisulfate, 7)
                 .fluidOutputs(SodiumPersulfate.getFluid(500))
                 .fluidOutputs(Hydrogen.getFluid(1000))
-                .duration(150).EUt(30).buildAndRegister();
+                .duration(150).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .fluidInputs(SaltWater.getFluid(1000))
                 .output(dust, SodiumHydroxide, 3)
                 .fluidOutputs(Chlorine.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(1000))
-                .duration(720).EUt(30).buildAndRegister();
+                .duration(720).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .input(dust, Sphalerite, 2)
                 .output(dust, Zinc)
                 .output(dust, Sulfur)
                 .chancedOutput(dustSmall, Gallium, 2000, 1000)
-                .duration(200).EUt(30).buildAndRegister();
+                .duration(200).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .fluidInputs(Water.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(1500).EUt(30).buildAndRegister();
+                .duration(1500).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .fluidInputs(DistilledWater.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
                 .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(1500).EUt(30).buildAndRegister();
+                .duration(1500).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.DYE, 3))
@@ -383,24 +383,24 @@ public class SeparationRecipes {
                 .fluidInputs(Butane.getFluid(1000))
                 .fluidOutputs(Butene.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .fluidInputs(Butene.getFluid(1000))
                 .fluidOutputs(Butadiene.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
-                .duration(240).EUt(120).buildAndRegister();
+                .duration(240).EUt(VA[MV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .fluidInputs(Propane.getFluid(1000))
                 .fluidOutputs(Propene.getFluid(1000))
                 .fluidOutputs(Hydrogen.getFluid(2000))
-                .duration(640).EUt(120).buildAndRegister();
+                .duration(640).EUt(VA[MV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .input(dust, Diamond)
                 .output(dust, Carbon, 64)
-                .duration(768).EUt(30).buildAndRegister();
+                .duration(768).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .input(dust, Trona, 16)
@@ -497,12 +497,12 @@ public class SeparationRecipes {
                 .outputs(new ItemStack(Items.BOOK, 3))
                 .duration(300).EUt(2).buildAndRegister();
 
-        EXTRACTOR_RECIPES.recipeBuilder().duration(80).EUt(32)
+        EXTRACTOR_RECIPES.recipeBuilder().duration(80).EUt(VA[LV])
                 .input(dust, Redstone)
                 .fluidOutputs(Redstone.getFluid(L))
                 .buildAndRegister();
 
-        EXTRACTOR_RECIPES.recipeBuilder().duration(80).EUt(32)
+        EXTRACTOR_RECIPES.recipeBuilder().duration(80).EUt(VA[LV])
                 .input(dust, Glowstone)
                 .fluidOutputs(Glowstone.getFluid(L))
                 .buildAndRegister();


### PR DESCRIPTION
**What:**
Use `GTValues.VA` for recipe EU/t instead of hardcoding values

**Outcome:**
Cleaner recipe declarations, no more full-amp recipes, and a big git blame
