### PR TITLE
Fix NullPointerException crash when using mining hammers on blocks supporting gravity-based blocks

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolMiningHammer.java
+++ b/src/main/java/gregtech/common/tools/ToolMiningHammer.java
@@ -161,6 +161,9 @@ public class ToolMiningHammer extends ToolBase {
     }
 
     private static BlockPos rotate(BlockPos origin, int x, int y, EnumFacing sideHit, EnumFacing horizontalFacing) {
+        if (sideHit == null) {
+            return BlockPos.ORIGIN;
+        }
         switch (sideHit.getAxis()) {
             case X:
                 return origin.add(0, y, x);


### PR DESCRIPTION
Fixes a NullPointerException crash according to the title.

**How solved:**
Added a null check for a block face.