### PR TITLE
Make StoneTypes not drop custom items

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/StoneType.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneType.java
@@ -36,10 +36,11 @@ public class StoneType implements Comparable<StoneType> {
     private final com.google.common.base.Predicate<IBlockState> predicate;
     public final boolean unbreakable;
     public final boolean affectedByGravity;
+    public final boolean shouldBeDroppedAsItem;
 
     public static final GTControlledRegistry<String, StoneType> STONE_TYPE_REGISTRY = new GTControlledRegistry<>(128);
 
-    public StoneType(int id, String name, ResourceLocation backgroundSideTexture, ResourceLocation backgroundTopTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, int flags, Supplier<IBlockState> stone, Predicate<IBlockState> predicate) {
+    public StoneType(int id, String name, ResourceLocation backgroundSideTexture, ResourceLocation backgroundTopTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, int flags, Supplier<IBlockState> stone, Predicate<IBlockState> predicate, boolean shouldBeDroppedAsItem) {
         Preconditions.checkArgument(
                 stoneMaterial.hasProperty(PropertyKey.DUST),
                 "Stone type must be made with a Material with the Dust Property!"
@@ -55,11 +56,12 @@ public class StoneType implements Comparable<StoneType> {
         this.affectedByGravity = (flags & AFFECTED_BY_GRAVITY) > 0;
         this.stone = stone;
         this.predicate = predicate::test;
+        this.shouldBeDroppedAsItem = shouldBeDroppedAsItem;
         STONE_TYPE_REGISTRY.register(id, name, this);
     }
 
-    public StoneType(int id, String name, ResourceLocation backgroundTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, int flags, Supplier<IBlockState> stone, Predicate<IBlockState> predicate) {
-        this(id, name, backgroundTexture, backgroundTexture, soundType, processingPrefix, stoneMaterial, harvestTool, flags, stone, predicate);
+    public StoneType(int id, String name, ResourceLocation backgroundTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, int flags, Supplier<IBlockState> stone, Predicate<IBlockState> predicate, boolean shouldBeDroppedAsItem) {
+        this(id, name, backgroundTexture, backgroundTexture, soundType, processingPrefix, stoneMaterial, harvestTool, flags, stone, predicate, shouldBeDroppedAsItem);
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/ore/StoneType.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneType.java
@@ -19,9 +19,6 @@ import java.util.function.Supplier;
  */
 public class StoneType implements Comparable<StoneType> {
 
-    public static final int AFFECTED_BY_GRAVITY = 1;
-    public static final int UNBREAKABLE = 1 << 1;
-
     public final String name;
     public final String harvestTool;
     public final ResourceLocation backgroundSideTexture;
@@ -34,13 +31,11 @@ public class StoneType implements Comparable<StoneType> {
     //we are using guava predicate because isReplaceableOreGen uses it
     @SuppressWarnings("Guava")
     private final com.google.common.base.Predicate<IBlockState> predicate;
-    public final boolean unbreakable;
-    public final boolean affectedByGravity;
     public final boolean shouldBeDroppedAsItem;
 
     public static final GTControlledRegistry<String, StoneType> STONE_TYPE_REGISTRY = new GTControlledRegistry<>(128);
 
-    public StoneType(int id, String name, ResourceLocation backgroundSideTexture, ResourceLocation backgroundTopTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, int flags, Supplier<IBlockState> stone, Predicate<IBlockState> predicate, boolean shouldBeDroppedAsItem) {
+    public StoneType(int id, String name, ResourceLocation backgroundSideTexture, ResourceLocation backgroundTopTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, Supplier<IBlockState> stone, Predicate<IBlockState> predicate, boolean shouldBeDroppedAsItem) {
         Preconditions.checkArgument(
                 stoneMaterial.hasProperty(PropertyKey.DUST),
                 "Stone type must be made with a Material with the Dust Property!"
@@ -52,16 +47,14 @@ public class StoneType implements Comparable<StoneType> {
         this.processingPrefix = processingPrefix;
         this.stoneMaterial = stoneMaterial;
         this.harvestTool = harvestTool;
-        this.unbreakable = (flags & UNBREAKABLE) > 0;
-        this.affectedByGravity = (flags & AFFECTED_BY_GRAVITY) > 0;
         this.stone = stone;
         this.predicate = predicate::test;
         this.shouldBeDroppedAsItem = shouldBeDroppedAsItem;
         STONE_TYPE_REGISTRY.register(id, name, this);
     }
 
-    public StoneType(int id, String name, ResourceLocation backgroundTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, int flags, Supplier<IBlockState> stone, Predicate<IBlockState> predicate, boolean shouldBeDroppedAsItem) {
-        this(id, name, backgroundTexture, backgroundTexture, soundType, processingPrefix, stoneMaterial, harvestTool, flags, stone, predicate, shouldBeDroppedAsItem);
+    public StoneType(int id, String name, ResourceLocation backgroundTexture, SoundType soundType, OrePrefix processingPrefix, Material stoneMaterial, String harvestTool, Supplier<IBlockState> stone, Predicate<IBlockState> predicate, boolean shouldBeDroppedAsItem) {
+        this(id, name, backgroundTexture, backgroundTexture, soundType, processingPrefix, stoneMaterial, harvestTool, stone, predicate, shouldBeDroppedAsItem);
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/ore/StoneTypes.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneTypes.java
@@ -17,37 +17,42 @@ import static gregtech.api.unification.ore.StoneType.AFFECTED_BY_GRAVITY;
 
 public class StoneTypes {
 
+    // Real Types that drop custom Ores
+
     public static final StoneType STONE = new StoneType(0, "stone", new ResourceLocation("blocks/stone"), SoundType.STONE, OrePrefix.ore, Materials.Stone, "pickaxe", 0,
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.STONE),
             state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == BlockStone.EnumType.STONE, true);
 
-    public static StoneType GRANITE = new StoneType(1, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.oreGranite, Materials.Granite, "pickaxe", 0,
-            () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.GRANITE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.GRANITE, false);
-
-    public static StoneType DIORITE = new StoneType(2, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.oreDiorite, Materials.Diorite, "pickaxe", 0,
-            () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.DIORITE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.DIORITE, false);
-
-    public static StoneType ANDESITE = new StoneType(3, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.oreAndesite, Materials.Andesite, "pickaxe", 0,
-            () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.ANDESITE, false);
-
-    public static StoneType NETHERRACK = new StoneType(4, "netherrack", new ResourceLocation("blocks/netherrack"), SoundType.STONE, OrePrefix.oreNetherrack, Materials.Netherrack, "pickaxe", 0,
+    public static StoneType NETHERRACK = new StoneType(1, "netherrack", new ResourceLocation("blocks/netherrack"), SoundType.STONE, OrePrefix.oreNetherrack, Materials.Netherrack, "pickaxe", 0,
             Blocks.NETHERRACK::getDefaultState,
             state -> state.getBlock() == Blocks.NETHERRACK, true);
 
-    public static StoneType ENDSTONE = new StoneType(5, "endstone", new ResourceLocation("blocks/end_stone"), SoundType.STONE, OrePrefix.oreEndstone, Materials.Endstone, "pickaxe", 0,
+    public static StoneType ENDSTONE = new StoneType(2, "endstone", new ResourceLocation("blocks/end_stone"), SoundType.STONE, OrePrefix.oreEndstone, Materials.Endstone, "pickaxe", 0,
             Blocks.END_STONE::getDefaultState,
             state -> state.getBlock() == Blocks.END_STONE, true);
 
-    public static StoneType SANDSTONE = new StoneType(6, "sandstone", new ResourceLocation("blocks/sandstone_normal"), new ResourceLocation("blocks/sandstone_top"), SoundType.STONE, OrePrefix.oreSand, Materials.SiliconDioxide, "pickaxe", 0,
+
+    // Dummy Types used for better world generation
+
+    public static StoneType SANDSTONE = new StoneType(3, "sandstone", new ResourceLocation("blocks/sandstone_normal"), new ResourceLocation("blocks/sandstone_top"), SoundType.STONE, OrePrefix.oreSand, Materials.SiliconDioxide, "pickaxe", 0,
             () -> Blocks.SANDSTONE.getDefaultState().withProperty(BlockSandStone.TYPE, BlockSandStone.EnumType.DEFAULT),
             state -> state.getBlock() instanceof BlockSandStone && state.getValue(BlockSandStone.TYPE) == BlockSandStone.EnumType.DEFAULT, false);
 
-    public static StoneType RED_SANDSTONE = new StoneType(7, "red_sandstone", new ResourceLocation("blocks/red_sandstone_normal"), new ResourceLocation("blocks/red_sandstone_top"), SoundType.STONE, OrePrefix.oreRedSand, Materials.SiliconDioxide, "pickaxe", 0,
+    public static StoneType RED_SANDSTONE = new StoneType(4, "red_sandstone", new ResourceLocation("blocks/red_sandstone_normal"), new ResourceLocation("blocks/red_sandstone_top"), SoundType.STONE, OrePrefix.oreRedSand, Materials.SiliconDioxide, "pickaxe", 0,
             () -> Blocks.RED_SANDSTONE.getDefaultState().withProperty(BlockRedSandstone.TYPE, BlockRedSandstone.EnumType.DEFAULT),
             state -> state.getBlock() instanceof BlockRedSandstone && state.getValue(BlockRedSandstone.TYPE) == BlockRedSandstone.EnumType.DEFAULT, false);
+
+    public static StoneType GRANITE = new StoneType(5, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.oreGranite, Materials.Granite, "pickaxe", 0,
+            () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.GRANITE),
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.GRANITE, false);
+
+    public static StoneType DIORITE = new StoneType(6, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.oreDiorite, Materials.Diorite, "pickaxe", 0,
+            () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.DIORITE),
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.DIORITE, false);
+
+    public static StoneType ANDESITE = new StoneType(7, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.oreAndesite, Materials.Andesite, "pickaxe", 0,
+            () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE),
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.ANDESITE, false);
 
     public static StoneType BLACK_GRANITE = new StoneType(8, "black_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_black_stone"), SoundType.STONE, OrePrefix.oreBlackgranite, Materials.GraniteBlack, "pickaxe", 0,
             () -> MetaBlocks.GRANITE.withVariant(GraniteVariant.BLACK_GRANITE, ChiselingVariant.NORMAL),
@@ -61,7 +66,7 @@ public class StoneTypes {
             () -> MetaBlocks.MINERAL.withVariant(MineralVariant.MARBLE, ChiselingVariant.NORMAL),
             state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.MARBLE, false);
 
-    public static StoneType BASALT = new StoneType(12, "basalt", new ResourceLocation(GTValues.MODID, "blocks/stones/basalt/basalt_stone"), SoundType.STONE, OrePrefix.oreBasalt, Materials.Basalt, "pickaxe", 0,
+    public static StoneType BASALT = new StoneType(11, "basalt", new ResourceLocation(GTValues.MODID, "blocks/stones/basalt/basalt_stone"), SoundType.STONE, OrePrefix.oreBasalt, Materials.Basalt, "pickaxe", 0,
             () -> MetaBlocks.MINERAL.withVariant(MineralVariant.BASALT, ChiselingVariant.NORMAL),
             state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.BASALT, false);
 }

--- a/src/main/java/gregtech/api/unification/ore/StoneTypes.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneTypes.java
@@ -13,60 +13,58 @@ import net.minecraft.block.BlockStone.EnumType;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 
-import static gregtech.api.unification.ore.StoneType.AFFECTED_BY_GRAVITY;
-
 public class StoneTypes {
 
     // Real Types that drop custom Ores
 
-    public static final StoneType STONE = new StoneType(0, "stone", new ResourceLocation("blocks/stone"), SoundType.STONE, OrePrefix.ore, Materials.Stone, "pickaxe", 0,
+    public static final StoneType STONE = new StoneType(0, "stone", new ResourceLocation("blocks/stone"), SoundType.STONE, OrePrefix.ore, Materials.Stone, "pickaxe",
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.STONE),
             state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == BlockStone.EnumType.STONE, true);
 
-    public static StoneType NETHERRACK = new StoneType(1, "netherrack", new ResourceLocation("blocks/netherrack"), SoundType.STONE, OrePrefix.oreNetherrack, Materials.Netherrack, "pickaxe", 0,
+    public static StoneType NETHERRACK = new StoneType(1, "netherrack", new ResourceLocation("blocks/netherrack"), SoundType.STONE, OrePrefix.oreNetherrack, Materials.Netherrack, "pickaxe",
             Blocks.NETHERRACK::getDefaultState,
             state -> state.getBlock() == Blocks.NETHERRACK, true);
 
-    public static StoneType ENDSTONE = new StoneType(2, "endstone", new ResourceLocation("blocks/end_stone"), SoundType.STONE, OrePrefix.oreEndstone, Materials.Endstone, "pickaxe", 0,
+    public static StoneType ENDSTONE = new StoneType(2, "endstone", new ResourceLocation("blocks/end_stone"), SoundType.STONE, OrePrefix.oreEndstone, Materials.Endstone, "pickaxe",
             Blocks.END_STONE::getDefaultState,
             state -> state.getBlock() == Blocks.END_STONE, true);
 
 
     // Dummy Types used for better world generation
 
-    public static StoneType SANDSTONE = new StoneType(3, "sandstone", new ResourceLocation("blocks/sandstone_normal"), new ResourceLocation("blocks/sandstone_top"), SoundType.STONE, OrePrefix.oreSand, Materials.SiliconDioxide, "pickaxe", 0,
+    public static StoneType SANDSTONE = new StoneType(3, "sandstone", new ResourceLocation("blocks/sandstone_normal"), new ResourceLocation("blocks/sandstone_top"), SoundType.STONE, OrePrefix.oreSand, Materials.SiliconDioxide, "pickaxe",
             () -> Blocks.SANDSTONE.getDefaultState().withProperty(BlockSandStone.TYPE, BlockSandStone.EnumType.DEFAULT),
             state -> state.getBlock() instanceof BlockSandStone && state.getValue(BlockSandStone.TYPE) == BlockSandStone.EnumType.DEFAULT, false);
 
-    public static StoneType RED_SANDSTONE = new StoneType(4, "red_sandstone", new ResourceLocation("blocks/red_sandstone_normal"), new ResourceLocation("blocks/red_sandstone_top"), SoundType.STONE, OrePrefix.oreRedSand, Materials.SiliconDioxide, "pickaxe", 0,
+    public static StoneType RED_SANDSTONE = new StoneType(4, "red_sandstone", new ResourceLocation("blocks/red_sandstone_normal"), new ResourceLocation("blocks/red_sandstone_top"), SoundType.STONE, OrePrefix.oreRedSand, Materials.SiliconDioxide, "pickaxe",
             () -> Blocks.RED_SANDSTONE.getDefaultState().withProperty(BlockRedSandstone.TYPE, BlockRedSandstone.EnumType.DEFAULT),
             state -> state.getBlock() instanceof BlockRedSandstone && state.getValue(BlockRedSandstone.TYPE) == BlockRedSandstone.EnumType.DEFAULT, false);
 
-    public static StoneType GRANITE = new StoneType(5, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.oreGranite, Materials.Granite, "pickaxe", 0,
+    public static StoneType GRANITE = new StoneType(5, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.oreGranite, Materials.Granite, "pickaxe",
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.GRANITE),
             state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.GRANITE, false);
 
-    public static StoneType DIORITE = new StoneType(6, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.oreDiorite, Materials.Diorite, "pickaxe", 0,
+    public static StoneType DIORITE = new StoneType(6, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.oreDiorite, Materials.Diorite, "pickaxe",
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.DIORITE),
             state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.DIORITE, false);
 
-    public static StoneType ANDESITE = new StoneType(7, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.oreAndesite, Materials.Andesite, "pickaxe", 0,
+    public static StoneType ANDESITE = new StoneType(7, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.oreAndesite, Materials.Andesite, "pickaxe",
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE),
             state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.ANDESITE, false);
 
-    public static StoneType BLACK_GRANITE = new StoneType(8, "black_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_black_stone"), SoundType.STONE, OrePrefix.oreBlackgranite, Materials.GraniteBlack, "pickaxe", 0,
+    public static StoneType BLACK_GRANITE = new StoneType(8, "black_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_black_stone"), SoundType.STONE, OrePrefix.oreBlackgranite, Materials.GraniteBlack, "pickaxe",
             () -> MetaBlocks.GRANITE.withVariant(GraniteVariant.BLACK_GRANITE, ChiselingVariant.NORMAL),
             state -> state.getBlock() instanceof BlockGranite && ((BlockGranite) state.getBlock()).getVariant(state) == GraniteVariant.BLACK_GRANITE, false);
 
-    public static StoneType RED_GRANITE = new StoneType(9, "red_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_red_stone"), SoundType.STONE, OrePrefix.oreRedgranite, Materials.GraniteRed, "pickaxe", 0,
+    public static StoneType RED_GRANITE = new StoneType(9, "red_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_red_stone"), SoundType.STONE, OrePrefix.oreRedgranite, Materials.GraniteRed, "pickaxe",
             () -> MetaBlocks.GRANITE.withVariant(GraniteVariant.RED_GRANITE, ChiselingVariant.NORMAL),
             state -> state.getBlock() instanceof BlockGranite && ((BlockGranite) state.getBlock()).getVariant(state) == GraniteVariant.RED_GRANITE, false);
 
-    public static StoneType MARBLE = new StoneType(10, "marble", new ResourceLocation(GTValues.MODID, "blocks/stones/marble/marble_stone"), SoundType.STONE, OrePrefix.oreMarble, Materials.Marble, "pickaxe", 0,
+    public static StoneType MARBLE = new StoneType(10, "marble", new ResourceLocation(GTValues.MODID, "blocks/stones/marble/marble_stone"), SoundType.STONE, OrePrefix.oreMarble, Materials.Marble, "pickaxe",
             () -> MetaBlocks.MINERAL.withVariant(MineralVariant.MARBLE, ChiselingVariant.NORMAL),
             state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.MARBLE, false);
 
-    public static StoneType BASALT = new StoneType(11, "basalt", new ResourceLocation(GTValues.MODID, "blocks/stones/basalt/basalt_stone"), SoundType.STONE, OrePrefix.oreBasalt, Materials.Basalt, "pickaxe", 0,
+    public static StoneType BASALT = new StoneType(11, "basalt", new ResourceLocation(GTValues.MODID, "blocks/stones/basalt/basalt_stone"), SoundType.STONE, OrePrefix.oreBasalt, Materials.Basalt, "pickaxe",
             () -> MetaBlocks.MINERAL.withVariant(MineralVariant.BASALT, ChiselingVariant.NORMAL),
             state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.BASALT, false);
 }

--- a/src/main/java/gregtech/api/unification/ore/StoneTypes.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneTypes.java
@@ -19,53 +19,49 @@ public class StoneTypes {
 
     public static final StoneType STONE = new StoneType(0, "stone", new ResourceLocation("blocks/stone"), SoundType.STONE, OrePrefix.ore, Materials.Stone, "pickaxe", 0,
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.STONE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == BlockStone.EnumType.STONE);
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == BlockStone.EnumType.STONE, true);
 
     public static StoneType GRANITE = new StoneType(1, "granite", new ResourceLocation("blocks/stone_granite"), SoundType.STONE, OrePrefix.oreGranite, Materials.Granite, "pickaxe", 0,
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.GRANITE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.GRANITE);
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.GRANITE, false);
 
     public static StoneType DIORITE = new StoneType(2, "diorite", new ResourceLocation("blocks/stone_diorite"), SoundType.STONE, OrePrefix.oreDiorite, Materials.Diorite, "pickaxe", 0,
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, EnumType.DIORITE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.DIORITE);
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.DIORITE, false);
 
     public static StoneType ANDESITE = new StoneType(3, "andesite", new ResourceLocation("blocks/stone_andesite"), SoundType.STONE, OrePrefix.oreAndesite, Materials.Andesite, "pickaxe", 0,
             () -> Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE),
-            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.ANDESITE);
+            state -> state.getBlock() instanceof BlockStone && state.getValue(BlockStone.VARIANT) == EnumType.ANDESITE, false);
 
-    public static StoneType GRAVEL = new StoneType(4, "gravel", new ResourceLocation("blocks/gravel"), SoundType.SAND, OrePrefix.oreGravel, Materials.Flint, "shovel", AFFECTED_BY_GRAVITY,
-            Blocks.GRAVEL::getDefaultState,
-            state -> state.getBlock() instanceof BlockGravel);
-
-    public static StoneType NETHERRACK = new StoneType(5, "netherrack", new ResourceLocation("blocks/netherrack"), SoundType.STONE, OrePrefix.oreNetherrack, Materials.Netherrack, "pickaxe", 0,
+    public static StoneType NETHERRACK = new StoneType(4, "netherrack", new ResourceLocation("blocks/netherrack"), SoundType.STONE, OrePrefix.oreNetherrack, Materials.Netherrack, "pickaxe", 0,
             Blocks.NETHERRACK::getDefaultState,
-            state -> state.getBlock() == Blocks.NETHERRACK);
+            state -> state.getBlock() == Blocks.NETHERRACK, true);
 
-    public static StoneType ENDSTONE = new StoneType(6, "endstone", new ResourceLocation("blocks/end_stone"), SoundType.STONE, OrePrefix.oreEndstone, Materials.Endstone, "pickaxe", 0,
+    public static StoneType ENDSTONE = new StoneType(5, "endstone", new ResourceLocation("blocks/end_stone"), SoundType.STONE, OrePrefix.oreEndstone, Materials.Endstone, "pickaxe", 0,
             Blocks.END_STONE::getDefaultState,
-            state -> state.getBlock() == Blocks.END_STONE);
+            state -> state.getBlock() == Blocks.END_STONE, true);
 
-    public static StoneType SANDSTONE = new StoneType(7, "sandstone", new ResourceLocation("blocks/sandstone_normal"), new ResourceLocation("blocks/sandstone_top"), SoundType.STONE, OrePrefix.oreSand, Materials.SiliconDioxide, "pickaxe", 0,
+    public static StoneType SANDSTONE = new StoneType(6, "sandstone", new ResourceLocation("blocks/sandstone_normal"), new ResourceLocation("blocks/sandstone_top"), SoundType.STONE, OrePrefix.oreSand, Materials.SiliconDioxide, "pickaxe", 0,
             () -> Blocks.SANDSTONE.getDefaultState().withProperty(BlockSandStone.TYPE, BlockSandStone.EnumType.DEFAULT),
-            state -> state.getBlock() instanceof BlockSandStone && state.getValue(BlockSandStone.TYPE) == BlockSandStone.EnumType.DEFAULT);
+            state -> state.getBlock() instanceof BlockSandStone && state.getValue(BlockSandStone.TYPE) == BlockSandStone.EnumType.DEFAULT, false);
 
-    public static StoneType RED_SANDSTONE = new StoneType(8, "red_sandstone", new ResourceLocation("blocks/red_sandstone_normal"), new ResourceLocation("blocks/red_sandstone_top"), SoundType.STONE, OrePrefix.oreRedSand, Materials.SiliconDioxide, "pickaxe", 0,
+    public static StoneType RED_SANDSTONE = new StoneType(7, "red_sandstone", new ResourceLocation("blocks/red_sandstone_normal"), new ResourceLocation("blocks/red_sandstone_top"), SoundType.STONE, OrePrefix.oreRedSand, Materials.SiliconDioxide, "pickaxe", 0,
             () -> Blocks.RED_SANDSTONE.getDefaultState().withProperty(BlockRedSandstone.TYPE, BlockRedSandstone.EnumType.DEFAULT),
-            state -> state.getBlock() instanceof BlockRedSandstone && state.getValue(BlockRedSandstone.TYPE) == BlockRedSandstone.EnumType.DEFAULT);
+            state -> state.getBlock() instanceof BlockRedSandstone && state.getValue(BlockRedSandstone.TYPE) == BlockRedSandstone.EnumType.DEFAULT, false);
 
-    public static StoneType BLACK_GRANITE = new StoneType(9, "black_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_black_stone"), SoundType.STONE, OrePrefix.oreBlackgranite, Materials.GraniteBlack, "pickaxe", 0,
+    public static StoneType BLACK_GRANITE = new StoneType(8, "black_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_black_stone"), SoundType.STONE, OrePrefix.oreBlackgranite, Materials.GraniteBlack, "pickaxe", 0,
             () -> MetaBlocks.GRANITE.withVariant(GraniteVariant.BLACK_GRANITE, ChiselingVariant.NORMAL),
-            state -> state.getBlock() instanceof BlockGranite && ((BlockGranite) state.getBlock()).getVariant(state) == GraniteVariant.BLACK_GRANITE);
+            state -> state.getBlock() instanceof BlockGranite && ((BlockGranite) state.getBlock()).getVariant(state) == GraniteVariant.BLACK_GRANITE, false);
 
-    public static StoneType RED_GRANITE = new StoneType(10, "red_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_red_stone"), SoundType.STONE, OrePrefix.oreRedgranite, Materials.GraniteRed, "pickaxe", 0,
+    public static StoneType RED_GRANITE = new StoneType(9, "red_granite", new ResourceLocation(GTValues.MODID, "blocks/stones/granite/granite_red_stone"), SoundType.STONE, OrePrefix.oreRedgranite, Materials.GraniteRed, "pickaxe", 0,
             () -> MetaBlocks.GRANITE.withVariant(GraniteVariant.RED_GRANITE, ChiselingVariant.NORMAL),
-            state -> state.getBlock() instanceof BlockGranite && ((BlockGranite) state.getBlock()).getVariant(state) == GraniteVariant.RED_GRANITE);
+            state -> state.getBlock() instanceof BlockGranite && ((BlockGranite) state.getBlock()).getVariant(state) == GraniteVariant.RED_GRANITE, false);
 
-    public static StoneType MARBLE = new StoneType(11, "marble", new ResourceLocation(GTValues.MODID, "blocks/stones/marble/marble_stone"), SoundType.STONE, OrePrefix.oreMarble, Materials.Marble, "pickaxe", 0,
+    public static StoneType MARBLE = new StoneType(10, "marble", new ResourceLocation(GTValues.MODID, "blocks/stones/marble/marble_stone"), SoundType.STONE, OrePrefix.oreMarble, Materials.Marble, "pickaxe", 0,
             () -> MetaBlocks.MINERAL.withVariant(MineralVariant.MARBLE, ChiselingVariant.NORMAL),
-            state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.MARBLE);
+            state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.MARBLE, false);
 
     public static StoneType BASALT = new StoneType(12, "basalt", new ResourceLocation(GTValues.MODID, "blocks/stones/basalt/basalt_stone"), SoundType.STONE, OrePrefix.oreBasalt, Materials.Basalt, "pickaxe", 0,
             () -> MetaBlocks.MINERAL.withVariant(MineralVariant.BASALT, ChiselingVariant.NORMAL),
-            state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.BASALT);
+            state -> state.getBlock() instanceof BlockMineral && ((BlockMineral) state.getBlock()).getVariant(state) == MineralVariant.BASALT, false);
 }

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -2,7 +2,6 @@ package gregtech.common.blocks;
 
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
-import gregtech.api.unification.ore.StoneTypes;
 import gregtech.client.model.IModelSupplier;
 import gregtech.client.model.SimpleStateMapper;
 import gregtech.api.unification.material.Material;
@@ -33,7 +32,6 @@ import net.minecraftforge.client.model.ModelLoader;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Random;
 
 public class BlockOre extends Block implements IBlockOre, IModelSupplier {
 
@@ -144,6 +142,16 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
             return super.getItem(worldIn, pos, state);
         }
         return new ItemStack(this, 1, 0);
+    }
+
+    @Override
+    @Nonnull
+    protected ItemStack getSilkTouchDrop(IBlockState state) {
+        StoneType stoneType = state.getValue(STONE_TYPE);
+        if (stoneType.shouldBeDroppedAsItem) {
+            return super.getSilkTouchDrop(state);
+        }
+        return super.getSilkTouchDrop(this.getDefaultState());
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -497,7 +497,7 @@ public class MetaBlocks {
         for (BlockOre blockOre : ORES) {
             Material material = blockOre.material;
             for (StoneType stoneType : blockOre.STONE_TYPE.getAllowedValues()) {
-                if (stoneType == null) continue;
+                if (stoneType == null || !stoneType.shouldBeDroppedAsItem) continue;
                 ItemStack normalStack = blockOre.getItem(blockOre.getDefaultState()
                         .withProperty(blockOre.STONE_TYPE, stoneType));
                 OreDictUnifier.registerOre(normalStack, stoneType.processingPrefix, material);

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -9,6 +9,7 @@ import gregtech.api.worldgen.populator.FluidSpringPopulator;
 import gregtech.api.worldgen.populator.IVeinPopulator;
 import gregtech.api.worldgen.populator.SurfaceBlockPopulator;
 import gregtech.api.worldgen.populator.SurfaceRockPopulator;
+import gregtech.common.blocks.BlockOre;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
@@ -105,7 +106,15 @@ public class GTOreInfo implements IRecipeWrapper {
         //Needed because one generation option returns all possible blockStates
         List<FillerEntry> possibleStates = blockFiller.getAllPossibleStates();
         for (FillerEntry entry : possibleStates) {
-            containedStates.addAll(entry.getPossibleResults());
+            Collection<IBlockState> possibleResults = entry.getPossibleResults();
+            for (IBlockState state : possibleResults) {
+                if (state.getBlock() instanceof BlockOre) {
+                    if (!state.getValue(((BlockOre) state.getBlock()).STONE_TYPE).shouldBeDroppedAsItem) {
+                        continue;
+                    }
+                }
+                containedStates.add(state);
+            }
         }
 
         //Check to see if we are dealing with a fluid generation case, before transforming states

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -18,20 +18,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class OreByProduct implements IRecipeWrapper {
+
     private final static ImmutableList<OrePrefix> ORES = ImmutableList.of(
             OrePrefix.ore,
-            OrePrefix.oreGranite,
-            OrePrefix.oreDiorite,
-            OrePrefix.oreAndesite,
-            OrePrefix.oreBasalt,
-            OrePrefix.oreBlackgranite,
             OrePrefix.oreEndstone,
-            OrePrefix.oreGravel,
-            OrePrefix.oreMarble,
-            OrePrefix.oreNetherrack,
-            OrePrefix.oreRedgranite,
-            OrePrefix.oreSand,
-            OrePrefix.oreRedSand);
+            OrePrefix.oreNetherrack
+            /* OrePrefix.oreSand, */
+            /* OrePrefix.oreRedSand */);
 
     private final List<List<ItemStack>> matchingInputs = new ArrayList<>();
     private final List<ItemStack> oreProcessingSteps = new ArrayList<>();

--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -27,18 +27,10 @@ public class OreRecipeHandler {
 
     public static void register() {
         OrePrefix.ore.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreGranite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreDiorite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreAndesite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreBasalt.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreBlackgranite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
         OrePrefix.oreEndstone.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreGravel.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
         OrePrefix.oreNetherrack.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreMarble.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreRedgranite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreSand.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreRedSand.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
+        //OrePrefix.oreSand.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
+        //OrePrefix.oreRedSand.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
 
         OrePrefix.crushed.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCrushedOre);
         OrePrefix.crushedPurified.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCrushedPurified);


### PR DESCRIPTION
- Makes StoneTypes other than Stone, Netherrack, and Endstone drop just Stone when broken
- Removes Gravel StoneType entirely (no more Shovel needed)

With this PR, StoneTypes other than Stone, Netherrack, and Endstone should be impossible to obtain. As a result, they have been hidden from CreativeTabs and JEI, have no OreDictionary entries, and have no recipes. If it is ever possible to obtain one of these ores, that issue should be addressed instead of readding any of this.