### PR TITLE
Allow toolProperty to not make crafting tools

### DIFF
--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialExpansion.java
@@ -197,7 +197,7 @@ public class MaterialExpansion {
     }
 
     @ZenMethod
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability, @Optional int enchantability) {
+    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability, @Optional int enchantability, @Optional boolean shouldIngoreCraftingTools) {
         if (checkFrozen("set tool stats")) return;
         ToolProperty prop = m.getProperty(PropertyKey.TOOL);
         if (prop != null) {
@@ -205,6 +205,7 @@ public class MaterialExpansion {
             prop.setToolAttackDamage(toolAttackDamage);
             prop.setToolDurability(toolDurability);
             prop.setToolEnchantability(enchantability == 0 ? 10 : enchantability);
+            prop.setShouldIgnoreCraftingTools(shouldIngoreCraftingTools);
         } else logError(m, "change tool stats", "Tool");
     }
 

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
@@ -151,7 +151,7 @@ public class MaterialPropertyExpansion {
             m.getProperty(PropertyKey.TOOL).setToolDurability(toolDurability);
             m.getProperty(PropertyKey.TOOL).setToolEnchantability(toolEnchantability);
             m.getProperty(PropertyKey.TOOL).setShouldIgnoreCraftingTools(shouldIgnoreCraftingTools);
-        } else m.setProperty(PropertyKey.TOOL, new ToolProperty(toolSpeed, toolAttackDamage, toolDurability, toolEnchantability));
+        } else m.setProperty(PropertyKey.TOOL, new ToolProperty(toolSpeed, toolAttackDamage, toolDurability, toolEnchantability, shouldIgnoreCraftingTools));
     }
 
     @ZenMethod

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
@@ -142,7 +142,7 @@ public class MaterialPropertyExpansion {
     }
 
     @ZenMethod
-    public static void addTools(Material m, float toolSpeed, float toolAttackDamage, int toolDurability, @Optional int toolEnchantability) {
+    public static void addTools(Material m, float toolSpeed, float toolAttackDamage, int toolDurability, @Optional int toolEnchantability, @Optional boolean shouldIgnoreCraftingTools) {
         if (checkFrozen("add Tools to a material")) return;
         if (toolEnchantability == 0) toolEnchantability = 10;
         if (m.hasProperty(PropertyKey.TOOL)) {
@@ -150,6 +150,7 @@ public class MaterialPropertyExpansion {
             m.getProperty(PropertyKey.TOOL).setToolAttackDamage(toolAttackDamage);
             m.getProperty(PropertyKey.TOOL).setToolDurability(toolDurability);
             m.getProperty(PropertyKey.TOOL).setToolEnchantability(toolEnchantability);
+            m.getProperty(PropertyKey.TOOL).setShouldIgnoreCraftingTools(shouldIgnoreCraftingTools);
         } else m.setProperty(PropertyKey.TOOL, new ToolProperty(toolSpeed, toolAttackDamage, toolDurability, toolEnchantability));
     }
 

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -720,6 +720,11 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        public Builder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {
+            properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability, ignoreCraftingTools));
+            return this;
+        }
+
         public Builder blastTemp(int temp) {
             properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp));
             return this;

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -716,8 +716,7 @@ public class Material implements Comparable<Material> {
         }
 
         public Builder toolStats(float speed, float damage, int durability, int enchantability) {
-            properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability));
-            return this;
+            return toolStats(speed, damage, durability, enchantability, false);
         }
 
         public Builder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -369,7 +369,7 @@ public class SecondDegreeMaterials {
                 .gem(1)
                 .color(0x002040).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
-                .toolStats(6, 4, 80, 10)
+                .toolStats(6, 4, 80, 10, true)
                 .build();
 
         Air = new Material.Builder(2050, "air")

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -37,6 +37,11 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     private int toolEnchantability;
 
     /**
+     * If crafting tools should not be made from this material
+     */
+    private boolean ignoreCraftingTools;
+
+    /**
      * Enchantment to be applied to tools made from this Material.
      * <p>
      * Default: none.
@@ -48,6 +53,14 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
         this.toolAttackDamage = toolAttackDamage;
         this.toolDurability = toolDurability;
         this.toolEnchantability = toolEnchantability;
+    }
+
+    public ToolProperty(float toolSpeed, float toolAttackDamage, int toolDurability, int toolEnchantability, boolean ignoreCraftingTools) {
+        this.toolSpeed = toolSpeed;
+        this.toolAttackDamage = toolAttackDamage;
+        this.toolDurability = toolDurability;
+        this.toolEnchantability = toolEnchantability;
+        this.ignoreCraftingTools = ignoreCraftingTools;
     }
 
     /**
@@ -91,6 +104,14 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     public void setToolEnchantability(int toolEnchantability) {
         if (toolEnchantability <= 0) throw new IllegalArgumentException("Tool Enchantability must be greater than zero!");
         this.toolEnchantability = toolEnchantability;
+    }
+
+    public boolean getShouldIgnoreCraftingTools() {
+        return ignoreCraftingTools;
+    }
+
+    public void setShouldIgnoreCraftingTools(boolean ignore) {
+        this.ignoreCraftingTools = ignore;
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -48,13 +48,6 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
      */
     public final List<EnchantmentData> toolEnchantments = new ArrayList<>();
 
-    public ToolProperty(float toolSpeed, float toolAttackDamage, int toolDurability, int toolEnchantability) {
-        this.toolSpeed = toolSpeed;
-        this.toolAttackDamage = toolAttackDamage;
-        this.toolDurability = toolDurability;
-        this.toolEnchantability = toolEnchantability;
-    }
-
     public ToolProperty(float toolSpeed, float toolAttackDamage, int toolDurability, int toolEnchantability, boolean ignoreCraftingTools) {
         this.toolSpeed = toolSpeed;
         this.toolAttackDamage = toolAttackDamage;
@@ -67,7 +60,7 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
      * Default values constructor.
      */
     public ToolProperty() {
-        this(1.0f, 1.0f, 100, 10);
+        this(1.0f, 1.0f, 100, 10, false);
     }
 
     public float getToolSpeed() {

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -148,21 +148,21 @@ public class OrePrefix {
     // made of 3 Ingots.
     public static final OrePrefix toolHeadSense = new OrePrefix("toolHeadSense", M * 3, null, MaterialIconType.toolHeadSense, ENABLE_UNIFICATION, hasToolProperty);
     // made of 2 Ingots.
-    public static final OrePrefix toolHeadFile = new OrePrefix("toolHeadFile", M * 2, null, MaterialIconType.toolHeadFile, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadFile = new OrePrefix("toolHeadFile", M * 2, null, MaterialIconType.toolHeadFile, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 6 Ingots.
-    public static final OrePrefix toolHeadHammer = new OrePrefix("toolHeadHammer", M * 6, null, MaterialIconType.toolHeadHammer, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadHammer = new OrePrefix("toolHeadHammer", M * 6, null, MaterialIconType.toolHeadHammer, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 2 Ingots.
-    public static final OrePrefix toolHeadSaw = new OrePrefix("toolHeadSaw", M * 2, null, MaterialIconType.toolHeadSaw, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadSaw = new OrePrefix("toolHeadSaw", M * 2, null, MaterialIconType.toolHeadSaw, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 4 Ingots.
-    public static final OrePrefix toolHeadBuzzSaw = new OrePrefix("toolHeadBuzzSaw", M * 4, null, MaterialIconType.toolHeadBuzzSaw, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadBuzzSaw = new OrePrefix("toolHeadBuzzSaw", M * 4, null, MaterialIconType.toolHeadBuzzSaw, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 1 Ingots.
-    public static final OrePrefix toolHeadScrewdriver = new OrePrefix("toolHeadScrewdriver", M, null, MaterialIconType.toolHeadScrewdriver, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadScrewdriver = new OrePrefix("toolHeadScrewdriver", M, null, MaterialIconType.toolHeadScrewdriver, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 4 Ingots.
     public static final OrePrefix toolHeadDrill = new OrePrefix("toolHeadDrill", M * 4, null, MaterialIconType.toolHeadDrill, ENABLE_UNIFICATION, hasToolProperty);
     // made of 2 Ingots.
-    public static final OrePrefix toolHeadChainsaw = new OrePrefix("toolHeadChainsaw", M * 2, null, MaterialIconType.toolHeadChainsaw, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadChainsaw = new OrePrefix("toolHeadChainsaw", M * 2, null, MaterialIconType.toolHeadChainsaw, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 4 Ingots.
-    public static final OrePrefix toolHeadWrench = new OrePrefix("toolHeadWrench", M * 4, null, MaterialIconType.toolHeadWrench, ENABLE_UNIFICATION, hasToolProperty);
+    public static final OrePrefix toolHeadWrench = new OrePrefix("toolHeadWrench", M * 4, null, MaterialIconType.toolHeadWrench, ENABLE_UNIFICATION, hasNoCraftingToolProperty);
     // made of 5 Ingots.
     public static final OrePrefix turbineBlade = new OrePrefix("turbineBlade", M * 10, null, MaterialIconType.turbineBlade, ENABLE_UNIFICATION, hasToolProperty.and(m -> m.hasFlags(GENERATE_BOLT_SCREW, GENERATE_PLATE)));
 
@@ -241,6 +241,7 @@ public class OrePrefix {
 
     public static class Conditions {
         public static final Predicate<Material> hasToolProperty = mat -> mat.hasProperty(PropertyKey.TOOL);
+        public static final Predicate<Material> hasNoCraftingToolProperty = mat -> mat.hasProperty(PropertyKey.TOOL) && !mat.getProperty(PropertyKey.TOOL).getShouldIgnoreCraftingTools();
         public static final Predicate<Material> hasOreProperty = mat -> mat.hasProperty(PropertyKey.ORE);
         public static final Predicate<Material> hasGemProperty = mat -> mat.hasProperty(PropertyKey.GEM);
         public static final Predicate<Material> hasDustProperty = mat -> mat.hasProperty(PropertyKey.DUST);


### PR DESCRIPTION
**What:**
Allows for materials that have a declared ToolProperty to not make crafting tools, and applies this change to flint, so you cannot make flint crafting tools like wrenches, hammers, files, etc