### PR TITLE
Introduce new Parallel Logic for trimming recipe outputs

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -25,6 +25,11 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     }
 
     @Override
+    public boolean shouldTrimOutputs() {
+        return true;
+    }
+
+    @Override
     public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
         int currentRecipeEU = builder.getEUt();
         int currentRecipeDuration = builder.getDuration() / getParallelLimit();

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -25,7 +25,7 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     }
 
     @Override
-    public boolean shouldTrimOutputs() {
+    public boolean trimOutputs() {
         return true;
     }
 
@@ -34,6 +34,6 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
         int currentRecipeEU = builder.getEUt();
         int currentRecipeDuration = builder.getDuration() / getParallelLimit();
         builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU) * 1.33))
-           .duration((int) (currentRecipeDuration * 1.5));
+                .duration((int) (currentRecipeDuration * 1.5));
     }
 }

--- a/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
@@ -22,16 +22,6 @@ public interface IParallelableRecipeLogic {
     }
 
     /**
-     * Whether the parallel logic should trim recipe outputs when creating the new parallel recipe.
-     * Useful for Steam Multiblocks, which only output one item even though they could output multiple.
-     *
-     * @return {@code true} if the parallel recipe should be limited to its first recipe output/chanced output
-     */
-    default boolean shouldTrimOutputs() {
-        return false;
-    }
-
-    /**
      * Method which finds a recipe which can be parallelized, works by multiplying the recipe by the parallelization factor,
      * and shrinking the recipe till its outputs can fit
      *
@@ -44,7 +34,7 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage, boolean shouldTrimOutputs) {
+    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage, boolean trimOutputs) {
         return ParallelLogic.doParallelRecipes(
                 currentRecipe,
                 recipeMap,
@@ -54,7 +44,7 @@ public interface IParallelableRecipeLogic {
                 fluidOutputs,
                 parallelLimit,
                 maxVoltage,
-                shouldTrimOutputs);
+                trimOutputs);
     }
 
     /**
@@ -67,23 +57,23 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, boolean shouldTrimOutputs) {
+    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, boolean trimOutputs) {
         return ParallelLogic.appendItemRecipes(
                 recipeMap,
                 inputs,
                 outputs,
                 parallelLimit,
                 maxVoltage,
-                shouldTrimOutputs);
+                trimOutputs);
     }
 
     default Recipe findParallelRecipe(AbstractRecipeLogic logic, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, long maxVoltage, int parallelLimit) {
         if (parallelLimit > 1) {
             RecipeBuilder<?> parallelBuilder = null;
             if (logic.getParallelLogicType() == ParallelLogicType.MULTIPLY) {
-                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage, shouldTrimOutputs());
+                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage, logic.trimOutputs());
             } else if (logic.getParallelLogicType() == ParallelLogicType.APPEND_ITEMS) {
-                parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage, shouldTrimOutputs());
+                parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage, logic.trimOutputs());
             }
             // if the builder returned is null, no recipe was found.
             if (parallelBuilder == null) {

--- a/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
@@ -22,6 +22,16 @@ public interface IParallelableRecipeLogic {
     }
 
     /**
+     * Whether the parallel logic should trim recipe outputs when creating the new parallel recipe.
+     * Useful for Steam Multiblocks, which only output one item even though they could output multiple.
+     *
+     * @return {@code true} if the parallel recipe should be limited to its first recipe output/chanced output
+     */
+    default boolean shouldTrimOutputs() {
+        return false;
+    }
+
+    /**
      * Method which finds a recipe which can be parallelized, works by multiplying the recipe by the parallelization factor,
      * and shrinking the recipe till its outputs can fit
      *
@@ -34,7 +44,7 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage) {
+    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage, boolean shouldTrimOutputs) {
         return ParallelLogic.doParallelRecipes(
                 currentRecipe,
                 recipeMap,
@@ -43,7 +53,8 @@ public interface IParallelableRecipeLogic {
                 outputs,
                 fluidOutputs,
                 parallelLimit,
-                maxVoltage);
+                maxVoltage,
+                shouldTrimOutputs);
     }
 
     /**
@@ -56,22 +67,23 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage) {
+    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, boolean shouldTrimOutputs) {
         return ParallelLogic.appendItemRecipes(
                 recipeMap,
                 inputs,
                 outputs,
                 parallelLimit,
-                maxVoltage);
+                maxVoltage,
+                shouldTrimOutputs);
     }
 
     default Recipe findParallelRecipe(AbstractRecipeLogic logic, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, long maxVoltage, int parallelLimit) {
         if (parallelLimit > 1) {
             RecipeBuilder<?> parallelBuilder = null;
             if (logic.getParallelLogicType() == ParallelLogicType.MULTIPLY) {
-                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage);
+                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage, shouldTrimOutputs());
             } else if (logic.getParallelLogicType() == ParallelLogicType.APPEND_ITEMS) {
-                parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage);
+                parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage, shouldTrimOutputs());
             }
             // if the builder returned is null, no recipe was found.
             if (parallelBuilder == null) {

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -362,12 +362,35 @@ public class ParallelLogic {
         return minMultiplier;
     }
 
-    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage) {
+    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, boolean shouldTrimOutputs) {
         int multiplierByInputs = getMaxRecipeMultiplier(currentRecipe, importInventory, importFluids, parallelAmount);
         if (multiplierByInputs == 0) {
             return null;
         }
         RecipeBuilder<?> recipeBuilder = recipeMap.recipeBuilder();
+
+        //Trim the recipe outputs if required
+        if((currentRecipe.getOutputs().size() > 1 || (currentRecipe.getOutputs().size() + currentRecipe.getChancedOutputs().size()) > 1) && shouldTrimOutputs) {
+            RecipeBuilder<?> builder = recipeMap.recipeBuilder();
+            builder.append(currentRecipe, 1, false);
+            ItemStack output = builder.getOutputs().get(0).copy();
+            builder.clearChancedOutput();
+            builder.clearOutputs();
+            builder.outputs(output);
+
+            currentRecipe = builder.build().getResult();
+        }
+        else if(currentRecipe.getChancedOutputs().size() > 1 && shouldTrimOutputs) {
+            RecipeBuilder<?> builder = recipeMap.recipeBuilder();
+            builder.append(currentRecipe, 1, false);
+            Recipe.ChanceEntry chanced = currentRecipe.getChancedOutputs().get(0).copy();
+            builder.clearChancedOutput();
+            builder.chancedOutput(chanced.getItemStack(), chanced.getChance(), chanced.getBoostPerTier());
+
+            currentRecipe = builder.build().getResult();
+        }
+
+
         // Simulate the merging of the maximum amount of recipes
         // and limit by the amount we can successfully merge
         int limitByOutput = ParallelLogic.limitByOutputMerging(currentRecipe, exportInventory, exportFluids, multiplierByInputs);
@@ -392,7 +415,7 @@ public class ParallelLogic {
      * @param maxVoltage      The maximum voltage of the machine
      * @return A {@link RecipeBuilder} containing the recipes that can be performed in parallel, limited by the ingredients available, and the output space available.
      */
-    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage) {
+    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, boolean shouldTrimOutputs) {
         RecipeBuilder<?> recipeBuilder = null;
 
         OverlayedItemHandler overlayedItemHandler = new OverlayedItemHandler(exportInventory);
@@ -428,6 +451,27 @@ public class ParallelLogic {
 
             //equivalent of getting the max ratio from the inputs from Parallel logic
             int ingredientRatio = Math.min(parallelAmount - engagedItems, currentInputItem.getCount() / Math.max(matchingRecipe.getInputs().get(0).getCount(), 1));
+
+            //Trim the recipe outputs if required
+            if((matchingRecipe.getOutputs().size() > 1 || (matchingRecipe.getOutputs().size() + matchingRecipe.getChancedOutputs().size()) > 1) && shouldTrimOutputs) {
+                RecipeBuilder<?> builder = recipeMap.recipeBuilder();
+                builder.append(matchingRecipe, 1, false);
+                ItemStack output = builder.getOutputs().get(0).copy();
+                builder.clearChancedOutput();
+                builder.clearOutputs();
+                builder.outputs(output);
+
+                matchingRecipe = builder.build().getResult();
+            }
+            else if(matchingRecipe.getChancedOutputs().size() > 1 && shouldTrimOutputs) {
+                RecipeBuilder<?> builder = recipeMap.recipeBuilder();
+                builder.append(matchingRecipe, 1, false);
+                Recipe.ChanceEntry chanced = matchingRecipe.getChancedOutputs().get(0).copy();
+                builder.clearChancedOutput();
+                builder.chancedOutput(chanced.getItemStack(), chanced.getChance(), chanced.getBoostPerTier());
+
+                matchingRecipe = builder.build().getResult();
+            }
 
             //how much we can add to the output inventory
             int limitByOutput = limitParallelByItemsIncremental(recipeBuilder.getOutputs(), matchingRecipe.getOutputs(), overlayedItemHandler, ingredientRatio);

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -362,34 +362,12 @@ public class ParallelLogic {
         return minMultiplier;
     }
 
-    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, boolean shouldTrimOutputs) {
+    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, boolean trimOutputs) {
         int multiplierByInputs = getMaxRecipeMultiplier(currentRecipe, importInventory, importFluids, parallelAmount);
         if (multiplierByInputs == 0) {
             return null;
         }
         RecipeBuilder<?> recipeBuilder = recipeMap.recipeBuilder();
-
-        //Trim the recipe outputs if required
-        if((currentRecipe.getOutputs().size() > 1 || (currentRecipe.getOutputs().size() + currentRecipe.getChancedOutputs().size()) > 1) && shouldTrimOutputs) {
-            RecipeBuilder<?> builder = recipeMap.recipeBuilder();
-            builder.append(currentRecipe, 1, false);
-            ItemStack output = builder.getOutputs().get(0).copy();
-            builder.clearChancedOutput();
-            builder.clearOutputs();
-            builder.outputs(output);
-
-            currentRecipe = builder.build().getResult();
-        }
-        else if(currentRecipe.getChancedOutputs().size() > 1 && shouldTrimOutputs) {
-            RecipeBuilder<?> builder = recipeMap.recipeBuilder();
-            builder.append(currentRecipe, 1, false);
-            Recipe.ChanceEntry chanced = currentRecipe.getChancedOutputs().get(0).copy();
-            builder.clearChancedOutput();
-            builder.chancedOutput(chanced.getItemStack(), chanced.getChance(), chanced.getBoostPerTier());
-
-            currentRecipe = builder.build().getResult();
-        }
-
 
         // Simulate the merging of the maximum amount of recipes
         // and limit by the amount we can successfully merge
@@ -398,7 +376,7 @@ public class ParallelLogic {
         int parallelizable = Math.min(limitByVoltage, Math.min(multiplierByInputs, limitByOutput));
 
         if (parallelizable > 0) {
-            recipeBuilder.append(currentRecipe, parallelizable, false);
+            recipeBuilder.append(currentRecipe, parallelizable, false, trimOutputs);
         }
 
         return recipeBuilder;
@@ -415,7 +393,7 @@ public class ParallelLogic {
      * @param maxVoltage      The maximum voltage of the machine
      * @return A {@link RecipeBuilder} containing the recipes that can be performed in parallel, limited by the ingredients available, and the output space available.
      */
-    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, boolean shouldTrimOutputs) {
+    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, boolean trimOutputs) {
         RecipeBuilder<?> recipeBuilder = null;
 
         OverlayedItemHandler overlayedItemHandler = new OverlayedItemHandler(exportInventory);
@@ -452,27 +430,6 @@ public class ParallelLogic {
             //equivalent of getting the max ratio from the inputs from Parallel logic
             int ingredientRatio = Math.min(parallelAmount - engagedItems, currentInputItem.getCount() / Math.max(matchingRecipe.getInputs().get(0).getCount(), 1));
 
-            //Trim the recipe outputs if required
-            if((matchingRecipe.getOutputs().size() > 1 || (matchingRecipe.getOutputs().size() + matchingRecipe.getChancedOutputs().size()) > 1) && shouldTrimOutputs) {
-                RecipeBuilder<?> builder = recipeMap.recipeBuilder();
-                builder.append(matchingRecipe, 1, false);
-                ItemStack output = builder.getOutputs().get(0).copy();
-                builder.clearChancedOutput();
-                builder.clearOutputs();
-                builder.outputs(output);
-
-                matchingRecipe = builder.build().getResult();
-            }
-            else if(matchingRecipe.getChancedOutputs().size() > 1 && shouldTrimOutputs) {
-                RecipeBuilder<?> builder = recipeMap.recipeBuilder();
-                builder.append(matchingRecipe, 1, false);
-                Recipe.ChanceEntry chanced = matchingRecipe.getChancedOutputs().get(0).copy();
-                builder.clearChancedOutput();
-                builder.chancedOutput(chanced.getItemStack(), chanced.getChance(), chanced.getBoostPerTier());
-
-                matchingRecipe = builder.build().getResult();
-            }
-
             //how much we can add to the output inventory
             int limitByOutput = limitParallelByItemsIncremental(recipeBuilder.getOutputs(), matchingRecipe.getOutputs(), overlayedItemHandler, ingredientRatio);
 
@@ -480,7 +437,7 @@ public class ParallelLogic {
             int multiplierRecipeAmount = Math.min(ingredientRatio, limitByOutput);
 
             if (multiplierRecipeAmount > 0) {
-                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, true);
+                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, true, trimOutputs);
                 engagedItems += multiplierRecipeAmount;
             }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -17,7 +17,6 @@ import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
-import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.sound.GTSounds;
 import gregtech.client.renderer.ICubeRenderer;
@@ -272,14 +271,11 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
-        public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
-
+        public boolean trimOutputs() {
             MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(currentMachineStack);
 
             //Clear the chanced outputs of LV and MV macerators, as they do not have the slots to get byproducts
-            if (mte instanceof MetaTileEntityMacerator && machineTier < GTValues.HV) {
-                builder.clearChancedOutput();
-            }
+            return mte instanceof MetaTileEntityMacerator && machineTier < GTValues.HV;
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
@@ -7,8 +7,6 @@ import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
-import gregtech.api.recipes.Recipe;
-import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -16,12 +14,9 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nonnull;
-
-import java.util.Collections;
 
 import static gregtech.client.renderer.texture.Textures.BRONZE_PLATED_BRICKS;
 import static gregtech.client.renderer.texture.Textures.SOLID_STEEL_CASING;
@@ -30,29 +25,7 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
 
     public MetaTileEntitySteamGrinder(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.MACERATOR_RECIPES, CONVERSION_RATE);
-        this.recipeMapWorkable = new SteamMultiWorkable(this, CONVERSION_RATE) {
-            @Override
-            public void applyParallelBonus(RecipeBuilder<?> builder) {
-                super.applyParallelBonus(builder);
-                if (builder.getOutputs().size() > 0) {
-                    ItemStack output = builder.getOutputs().get(0).copy();
-                    for(int i = 1; i < builder.getOutputs().size(); i++) {
-                        ItemStack tempOutput = builder.getOutputs().get(i).copy();
-                        if(tempOutput.isItemEqual(output)) {
-                            int newSize = output.getCount() + tempOutput.getCount();
-                            output.setCount(newSize);
-                        }
-                    }
-                    builder.clearOutputs();
-                    builder.clearChancedOutput();
-                    builder.outputs(output);
-                } else {
-                    Recipe.ChanceEntry entry = builder.getChancedOutputs().get(0);
-                    builder.clearChancedOutput();
-                    builder.chancedOutputs(Collections.nCopies(builder.getParallel(), entry));
-                }
-            }
-        };
+        this.recipeMapWorkable = new SteamMultiWorkable(this, CONVERSION_RATE);
         this.recipeMapWorkable.setParallelLimit(8);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
@@ -36,6 +36,13 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
                 super.applyParallelBonus(builder);
                 if (builder.getOutputs().size() > 0) {
                     ItemStack output = builder.getOutputs().get(0).copy();
+                    for(int i = 1; i < builder.getOutputs().size(); i++) {
+                        ItemStack tempOutput = builder.getOutputs().get(i).copy();
+                        if(tempOutput.isItemEqual(output)) {
+                            int newSize = output.getCount() + tempOutput.getCount();
+                            output.setCount(newSize);
+                        }
+                    }
                     builder.clearOutputs();
                     builder.clearChancedOutput();
                     builder.outputs(output);

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -216,7 +216,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, false);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
@@ -270,7 +270,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, false);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());
@@ -324,7 +324,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 120);
+                exportItemBus.getExportItems(), parallelLimit, 120, false);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
@@ -375,7 +375,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 120);
+                exportItemBus.getExportItems(), parallelLimit, 120, false);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());


### PR DESCRIPTION
**What:**
Introduces a new parallel logic setting for recipe outputs to be trimmed and only give the first output in the recipe. This is used for both steam multiblocks, and will later be used for the Processing Array for some cases involving low tier macerators.


This new logic fixes the Steam Grinder voiding outputs from the not first output in the list if the output item was the same as the first item output.
EG: 4 iron plates and 4 iron ingots would only return 4 iron dust, even though both recipes output iron dust