### PR TITLE
Fix the Steam Oven not running a recipe if the item was not in first …

### DIFF
--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
@@ -22,7 +22,7 @@ public class RecipeMapFurnace extends RecipeMap<SimpleRecipeBuilder> {
     @Nullable
     public Recipe findRecipe(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, int outputFluidTankCapacity, MatchingMode mode) {
         Recipe normalRecipe = super.findRecipe(voltage, inputs, fluidInputs, outputFluidTankCapacity, mode);
-        if (normalRecipe != null || inputs.size() == 0 || inputs.get(0).isEmpty())
+        if (normalRecipe != null || inputs.size() == 0)
             return normalRecipe;
 
         for (ItemStack input : inputs) {


### PR DESCRIPTION
…input slot

**What:**
Fixes the Steam Oven not being able to run a recipe if the input item was not in the first slot in the input inventory. This issue most likely applied to multismelters as well