### PR TITLE
EU to FE compat for Items

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechCapabilities.java
+++ b/src/main/java/gregtech/api/capability/GregtechCapabilities.java
@@ -1,9 +1,11 @@
 package gregtech.api.capability;
 
 import gregtech.api.GTValues;
-import gregtech.api.capability.impl.EUToFEProvider;
+import gregtech.api.capability.impl.fecompat.EUToFEItemProvider;
+import gregtech.api.capability.impl.fecompat.EUToFEProvider;
 import gregtech.api.capability.tool.*;
 import gregtech.api.terminal.hardware.HardwareProvider;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
@@ -48,8 +50,15 @@ public class GregtechCapabilities {
 
     private static final ResourceLocation CAPABILITY_EU_TO_FE = new ResourceLocation(GTValues.MODID, "fe_capability");
 
+    private static final ResourceLocation CAPABILITY_EU_TO_FE_ITEM = new ResourceLocation(GTValues.MODID, "fe_item_capability");
+
     @SubscribeEvent
     public static void attachTileCapability(AttachCapabilitiesEvent<TileEntity> event) {
         event.addCapability(CAPABILITY_EU_TO_FE, new EUToFEProvider(event.getObject()));
+    }
+
+    @SubscribeEvent
+    public static void attachItemCapability(AttachCapabilitiesEvent<ItemStack> event) {
+        event.addCapability(CAPABILITY_EU_TO_FE_ITEM, new EUToFEItemProvider(event.getObject()));
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/fecompat/EUToFEProvider.java
+++ b/src/main/java/gregtech/api/capability/impl/fecompat/EUToFEProvider.java
@@ -1,0 +1,66 @@
+package gregtech.api.capability.impl.fecompat;
+
+import gregtech.api.capability.GregtechCapabilities;
+import gregtech.common.ConfigHolder;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class EUToFEProvider implements ICapabilityProvider {
+
+    private final TileEntity tileEntity;
+    private GTEnergyWrapper wrapper;
+
+    /**
+     * Lock used for concurrency protection between hasCapability and getCapability.
+     */
+    ReentrantLock lock = new ReentrantLock();
+
+    public EUToFEProvider(TileEntity tileEntity) {
+        this.tileEntity = tileEntity;
+    }
+
+    @Override
+    public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing facing) {
+
+        if (!ConfigHolder.compat.energy.nativeEUToFE)
+            return false;
+
+        if (lock.isLocked() || capability != GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER)
+            return false;
+
+        // Wrap FE Machines with a GTEU EnergyContainer
+        if (wrapper == null) wrapper = new GTEnergyWrapper(tileEntity);
+
+        lock.lock();
+        try {
+            return wrapper.isValid(facing);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
+
+        if (!ConfigHolder.compat.energy.nativeEUToFE)
+            return null;
+
+        if (lock.isLocked() || capability != GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER)
+            return null;
+
+        if (wrapper == null) wrapper = new GTEnergyWrapper(tileEntity);
+
+        lock.lock();
+        try {
+            return wrapper.isValid(facing) ? (T) wrapper : null;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/gregtech/api/capability/impl/fecompat/ForgeEnergyCompat.java
+++ b/src/main/java/gregtech/api/capability/impl/fecompat/ForgeEnergyCompat.java
@@ -1,0 +1,46 @@
+package gregtech.api.capability.impl.fecompat;
+
+import gregtech.common.ConfigHolder;
+
+public class ForgeEnergyCompat {
+
+    /**
+     * @return If native conversion is enabled.
+     */
+    public static boolean nativeEUtoFE() {
+        return ConfigHolder.compat.energy.nativeEUToFE;
+    }
+
+    /**
+     * @return how many FE are equal to 1 EU when converting from EU to FE.
+     */
+    public static double ratioEUToFE() {
+        return ConfigHolder.compat.energy.ratioEUToFE;
+    }
+
+    /**
+     * @return How many FE are equal to 1 EU when converting from FE to EU.
+     *
+     * Currently is equal to {@link ForgeEnergyCompat#ratioEUToFE()}.
+     */
+    public static double ratioFEToEU() {
+        return ConfigHolder.compat.energy.ratioEUToFE;
+    }
+
+    /**
+     * Converts EU to FE.
+     * @return FE
+     */
+    public static int convertToFE(long EU) {
+        return (int) (EU * ConfigHolder.compat.energy.ratioEUToFE);
+    }
+
+    /**
+     * Converts FE to EU.
+     *
+     * @return EU
+     */
+    public static long convertToEU(long FE) {
+        return (long) (FE * ConfigHolder.compat.energy.ratioEUToFE);
+    }
+}

--- a/src/main/java/gregtech/api/capability/impl/fecompat/GTEnergyItemWrapper.java
+++ b/src/main/java/gregtech/api/capability/impl/fecompat/GTEnergyItemWrapper.java
@@ -1,0 +1,104 @@
+package gregtech.api.capability.impl.fecompat;
+
+import gregtech.api.capability.IElectricItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+
+import java.util.function.BiConsumer;
+
+public class GTEnergyItemWrapper implements IElectricItem {
+
+    /**
+     * Capability Provider of the FE TileEntity for the EU-capability.
+     */
+    private final ICapabilityProvider upvalue;
+
+    /**
+     * Capability holder for the FE-capability.
+     */
+    private IEnergyStorage energyStorage;
+
+    protected GTEnergyItemWrapper(ICapabilityProvider upvalue) {
+        this.upvalue = upvalue;
+    }
+
+    /**
+     * Test this EnergyContainer for sided Capabilities.
+     *
+     * @param side The side of the TileEntity to test for the Capability
+     * @return True if side has Capability, false otherwise
+     */
+    protected boolean isValid(EnumFacing side) {
+        return upvalue.hasCapability(CapabilityEnergy.ENERGY, side);
+    }
+
+    private IEnergyStorage getEnergyStorage() {
+        if(energyStorage == null) {
+            energyStorage = upvalue.getCapability(CapabilityEnergy.ENERGY, null);
+        }
+        return energyStorage;
+    }
+
+    @Override
+    public boolean canProvideChargeExternally() {
+        return true;
+    }
+
+    @Override
+    public boolean chargeable() {
+        IEnergyStorage storage = getEnergyStorage();
+        if(storage != null)
+            return storage.canReceive();
+        return false;
+    }
+
+    @Override
+    public void addChargeListener(BiConsumer<ItemStack, Long> chargeListener) {
+    }
+
+    @Override
+    public long charge(long amount, int chargerTier, boolean ignoreTransferLimit, boolean simulate) {
+        IEnergyStorage storage = getEnergyStorage();
+        if(storage == null) return 0;
+        int max = Math.min(ForgeEnergyCompat.convertToFE(amount), storage.getMaxEnergyStored() - storage.getEnergyStored());
+        return ForgeEnergyCompat.convertToEU(storage.receiveEnergy(max, simulate));
+    }
+
+    @Override
+    public long discharge(long amount, int dischargerTier, boolean ignoreTransferLimit, boolean externally, boolean simulate) {
+        return 0;
+        //IEnergyStorage storage = getEnergyStorage();
+        //if(storage == null) return 0;
+        //int max = (int) Math.min(amount * EU_TO_FE, storage.getEnergyStored());
+        //return (long) (storage.extractEnergy(max, simulate) * FE_TO_EU);
+    }
+
+    @Override
+    public long getTransferLimit() {
+        return getMaxCharge();
+    }
+
+    @Override
+    public long getMaxCharge() {
+        IEnergyStorage storage = getEnergyStorage();
+        if(storage != null)
+            return ForgeEnergyCompat.convertToEU(storage.getMaxEnergyStored());
+        return 0;
+    }
+
+    @Override
+    public long getCharge() {
+        IEnergyStorage storage = getEnergyStorage();
+        if(storage != null)
+            return ForgeEnergyCompat.convertToEU(storage.getEnergyStored());
+        return 0;
+    }
+
+    @Override
+    public int getTier() {
+        return 0;
+    }
+}

--- a/src/main/java/gregtech/api/capability/impl/fecompat/GTEnergyWrapper.java
+++ b/src/main/java/gregtech/api/capability/impl/fecompat/GTEnergyWrapper.java
@@ -1,9 +1,8 @@
-package gregtech.api.capability.impl;
+package gregtech.api.capability.impl.fecompat;
 
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.util.GTUtility;
-import gregtech.common.ConfigHolder;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.energy.CapabilityEnergy;
@@ -136,7 +135,7 @@ public class GTEnergyWrapper implements IEnergyContainer {
             }
         }
 
-        long maxPacket = (long) (voltage * ConfigHolder.compat.energy.rfRatio);
+        long maxPacket = ForgeEnergyCompat.convertToFE(voltage);
         long maximalValue = maxPacket * amperage;
 
         // Try to consume our remainder buffer plus a fresh packet
@@ -209,7 +208,7 @@ public class GTEnergyWrapper implements IEnergyContainer {
         if (container == null || delta == 0)
             return 0;
 
-        long energyValue = (long) (delta * ConfigHolder.compat.energy.rfRatio);
+        long energyValue = (long) (delta * ForgeEnergyCompat.ratioEUToFE());
         if (energyValue > Integer.MAX_VALUE)
             energyValue = Integer.MAX_VALUE;
 
@@ -217,19 +216,19 @@ public class GTEnergyWrapper implements IEnergyContainer {
 
             int extract = container.extractEnergy(safeCastLongToInt(energyValue), true);
 
-            if (extract != ConfigHolder.compat.energy.rfRatio)
-                extract -= extract % ConfigHolder.compat.energy.rfRatio;
+            if (extract != ForgeEnergyCompat.ratioEUToFE())
+                extract -= extract % ForgeEnergyCompat.ratioEUToFE();
 
-            return (long) (container.extractEnergy(extract, false) / ConfigHolder.compat.energy.rfRatio);
+            return ForgeEnergyCompat.convertToEU(container.extractEnergy(extract, false));
 
         } else {
 
             int receive = container.receiveEnergy((int) energyValue, true);
 
-            if (receive != ConfigHolder.compat.energy.rfRatio)
-                receive -= receive % ConfigHolder.compat.energy.rfRatio;
+            if (receive != ForgeEnergyCompat.ratioEUToFE())
+                receive -= receive % ForgeEnergyCompat.ratioEUToFE();
 
-            return (long) (container.receiveEnergy(receive, false) / ConfigHolder.compat.energy.rfRatio);
+            return ForgeEnergyCompat.convertToEU(container.receiveEnergy(receive, false));
         }
     }
 
@@ -249,7 +248,7 @@ public class GTEnergyWrapper implements IEnergyContainer {
         if (cap == null)
             return 0L;
 
-        return (long) (cap.getMaxEnergyStored() / ConfigHolder.compat.energy.rfRatio);
+        return ForgeEnergyCompat.convertToEU(cap.getMaxEnergyStored());
     }
 
     @Override
@@ -259,7 +258,7 @@ public class GTEnergyWrapper implements IEnergyContainer {
         if (cap == null)
             return 0L;
 
-        return (long) (cap.getEnergyStored() / ConfigHolder.compat.energy.rfRatio);
+        return ForgeEnergyCompat.convertToEU(cap.getEnergyStored());
     }
 
     @Override
@@ -294,7 +293,7 @@ public class GTEnergyWrapper implements IEnergyContainer {
         if (maxInput == 0)
             return 0;
 
-        maxInput = (long) (maxInput / ConfigHolder.compat.energy.rfRatio);
+        maxInput = ForgeEnergyCompat.convertToEU(maxInput);
         return GTValues.V[GTUtility.getTierByVoltage(maxInput)];
     }
 

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -212,9 +212,14 @@ public class ConfigHolder {
             @Config.Comment({"Enable Native GTEU to Forge Energy (RF and alike) on GT Cables and Wires.", "Default: true"})
             public boolean nativeEUToFE = true;
 
-            @Config.Comment({"GTEU to Forge Energy (RF and alike) ratio.", "Default: 4 FE to 1 EU"})
+            // TODO Energy Converters
+            //@Config.Comment({"Forge Energy to GTEU ratio for converting FE to EU.", "Default: 4 FE == 1 EU"})
+            //@Config.RangeDouble() // to ensure positive number
+            //public double ratioFEToEU = 4;
+
+            @Config.Comment({"GTEU to Forge Energy ratio for converting EU to FE. Affects Native Conversion.", "Default: 4 FE == 1 EU"})
             @Config.RangeDouble() // to ensure positive number
-            public double rfRatio = 4;
+            public double ratioEUToFE = 4;
         }
     }
 

--- a/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
@@ -8,6 +8,7 @@ import codechicken.lib.vec.Matrix4;
 import codechicken.lib.vec.Rotation;
 import gregtech.api.capability.*;
 import gregtech.api.capability.impl.*;
+import gregtech.api.capability.impl.fecompat.ForgeEnergyCompat;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.CoverWithUI;
 import gregtech.api.cover.ICoverable;
@@ -22,7 +23,6 @@ import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.Position;
 import gregtech.client.utils.RenderUtil;
-import gregtech.common.ConfigHolder;
 import gregtech.common.terminal.app.prospector.widget.WidgetOreList;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -743,10 +743,10 @@ public class CoverDigitalInterface extends CoverBehavior implements IFastRenderM
                         return 0;
                     }
                     public long getEnergyStored() {
-                        return (long) (fe.getEnergyStored() / ConfigHolder.compat.energy.rfRatio);
+                        return ForgeEnergyCompat.convertToEU(fe.getEnergyStored());
                     }
                     public long getEnergyCapacity() {
-                        return (long) (fe.getMaxEnergyStored() / ConfigHolder.compat.energy.rfRatio);
+                        return ForgeEnergyCompat.convertToEU(fe.getMaxEnergyStored());
                     }
                     public long getInputAmperage() {
                         return 0;


### PR DESCRIPTION
Cherrypicks the code from #86 for allowing RF items to be charged by GT energy slots.

Also brings over some slight code improvements, and a new reorganization