### PR TITLE
Add Xs to Machine Grid

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -22,7 +22,6 @@ import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
-import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.recipes.FluidKey;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.*;
@@ -1364,9 +1363,6 @@ public abstract class MetaTileEntity implements ICoverable {
 
     public boolean isSideUsed(EnumFacing face) {
         if (getCoverAtSide(face) != null) return true;
-        if (face == this.getFrontFacing() && this.canRenderFrontFaceX()) return true;
-        TileEntity tileEntity = this.getWorld().getTileEntity(this.getPos().add(face.getOpposite().getDirectionVec()));
-        if (!(tileEntity instanceof TileEntityPipeBase)) return false;
-        return ((TileEntityPipeBase) tileEntity).isConnectionOpenAny(face);
+        return face == this.getFrontFacing() && this.canRenderFrontFaceX();
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -736,14 +736,14 @@ public abstract class MetaTileEntity implements ICoverable {
     public void writeInitialSyncData(PacketBuffer buf) {
         buf.writeByte(this.frontFacing.getIndex());
         boolean isPainted = false;
-        if(this.paintingColor != DEFAULT_PAINTING_COLOR && !(this instanceof MultiblockControllerBase)) {
-            for(EnumDyeColor color : EnumDyeColor.values()) {
-                if(this.paintingColor == color.colorValue) {
+        if (this.paintingColor != DEFAULT_PAINTING_COLOR && !(this instanceof MultiblockControllerBase)) {
+            for (EnumDyeColor color : EnumDyeColor.values()) {
+                if (this.paintingColor == color.colorValue) {
                     isPainted = true;
                     break;
                 }
             }
-            if(!isPainted) {
+            if (!isPainted) {
                 setPaintingColor(DEFAULT_PAINTING_COLOR);
             }
         }
@@ -1355,5 +1355,9 @@ public abstract class MetaTileEntity implements ICoverable {
 
     public boolean isMuffled() {
         return muffled;
+    }
+
+    public boolean canRenderFrontFaceX() {
+        return false;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -22,6 +22,7 @@ import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
+import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.recipes.FluidKey;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.*;
@@ -1359,5 +1360,13 @@ public abstract class MetaTileEntity implements ICoverable {
 
     public boolean canRenderFrontFaceX() {
         return false;
+    }
+
+    public boolean isSideUsed(EnumFacing face) {
+        if (getCoverAtSide(face) != null) return true;
+        if (face == this.getFrontFacing() && this.canRenderFrontFaceX()) return true;
+        TileEntity tileEntity = this.getWorld().getTileEntity(this.getPos().add(face.getOpposite().getDirectionVec()));
+        if (!(tileEntity instanceof TileEntityPipeBase)) return false;
+        return ((TileEntityPipeBase) tileEntity).isConnectionOpenAny(face);
     }
 }

--- a/src/main/java/gregtech/client/renderer/handler/ToolOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/ToolOverlayRenderer.java
@@ -8,6 +8,7 @@ import gregtech.api.cover.ICoverable.PrimaryBoxData;
 import gregtech.api.items.toolitem.IAOEItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.pipenet.tile.AttachmentType;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityMonitorScreen;
@@ -96,6 +97,8 @@ public class ToolOverlayRenderer {
                 AxisAlignedBB box = blockState.getSelectedBoundingBox(world, pos).grow(0.002D).offset(-d3, -d4, -d5);
                 RenderGlobal.drawSelectionBoundingBox(box, 0.0F, 0.0F, 0.0F, 0.4F);
                 drawOverlayLines(facing, box);
+                if (tileEntity instanceof TileEntityPipeBase)
+                    drawPipeOverlayLines(facing, box, (TileEntityPipeBase) tileEntity);
             }
 
             GlStateManager.depthMask(true);
@@ -298,6 +301,149 @@ public class ToolOverlayRenderer {
 
         startLine(buffer, bottomLeft.copy().add(shiftVert));
         endLine(buffer, bottomRight.copy().add(shiftVert));
+
+        tessellator.draw();
+    }
+
+    private static void drawPipeOverlayLines(EnumFacing facing, AxisAlignedBB box, TileEntityPipeBase pipe) {
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder buffer = tessellator.getBuffer();
+        buffer.begin(3, DefaultVertexFormats.POSITION_COLOR);
+
+        Vector3 topRight = new Vector3(box.maxX, box.maxY, box.maxZ);
+        Vector3 bottomRight = new Vector3(box.maxX, box.minY, box.maxZ);
+        Vector3 bottomLeft = new Vector3(box.minX, box.minY, box.maxZ);
+        Vector3 topLeft = new Vector3(box.minX, box.maxY, box.maxZ);
+        Vector3 shift = new Vector3(0.25, 0, 0);
+        Vector3 shiftVert = new Vector3(0, 0.25, 0);
+
+        Vector3 cubeCenter = new Vector3(box.getCenter());
+
+        boolean leftBlocked;
+        boolean topBlocked;
+        boolean rightBlocked;
+        boolean bottomBlocked;
+
+        topRight.subtract(cubeCenter);
+        bottomRight.subtract(cubeCenter);
+        bottomLeft.subtract(cubeCenter);
+        topLeft.subtract(cubeCenter);
+
+        switch (facing) {
+            case WEST: {
+                topRight.rotate(Math.PI / 2, Vector3.down);
+                bottomRight.rotate(Math.PI / 2, Vector3.down);
+                bottomLeft.rotate(Math.PI / 2, Vector3.down);
+                topLeft.rotate(Math.PI / 2, Vector3.down);
+                shift.rotate(Math.PI / 2, Vector3.down);
+                shiftVert.rotate(Math.PI / 2, Vector3.down);
+
+                leftBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.NORTH);
+                topBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.UP);
+                rightBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.SOUTH);
+                bottomBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.DOWN);
+                break;
+            }
+            case EAST: {
+                topRight.rotate(-Math.PI / 2, Vector3.down);
+                bottomRight.rotate(-Math.PI / 2, Vector3.down);
+                bottomLeft.rotate(-Math.PI / 2, Vector3.down);
+                topLeft.rotate(-Math.PI / 2, Vector3.down);
+                shift.rotate(-Math.PI / 2, Vector3.down);
+                shiftVert.rotate(-Math.PI / 2, Vector3.down);
+
+                leftBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.SOUTH);
+                topBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.UP);
+                rightBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.NORTH);
+                bottomBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.DOWN);
+                break;
+            }
+            case NORTH: {
+                topRight.rotate(Math.PI, Vector3.down);
+                bottomRight.rotate(Math.PI, Vector3.down);
+                bottomLeft.rotate(Math.PI, Vector3.down);
+                topLeft.rotate(Math.PI, Vector3.down);
+                shift.rotate(Math.PI, Vector3.down);
+                shiftVert.rotate(Math.PI, Vector3.down);
+
+                leftBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.EAST);
+                topBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.UP);
+                rightBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.WEST);
+                bottomBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.DOWN);
+                break;
+            }
+            case UP: {
+                Vector3 side = new Vector3(1, 0, 0);
+                topRight.rotate(-Math.PI / 2, side);
+                bottomRight.rotate(-Math.PI / 2, side);
+                bottomLeft.rotate(-Math.PI / 2, side);
+                topLeft.rotate(-Math.PI / 2, side);
+                shift.rotate(-Math.PI / 2, side);
+                shiftVert.rotate(-Math.PI / 2, side);
+
+                leftBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.WEST);
+                topBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.NORTH);
+                rightBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.EAST);
+                bottomBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.SOUTH);
+                break;
+            }
+            case DOWN: {
+                Vector3 side = new Vector3(1, 0, 0);
+                topRight.rotate(Math.PI / 2, side);
+                bottomRight.rotate(Math.PI / 2, side);
+                bottomLeft.rotate(Math.PI / 2, side);
+                topLeft.rotate(Math.PI / 2, side);
+                shift.rotate(Math.PI / 2, side);
+                shiftVert.rotate(Math.PI / 2, side);
+
+                leftBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.WEST);
+                topBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.SOUTH);
+                rightBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.EAST);
+                bottomBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.NORTH);
+                break;
+            }
+            default: {
+                leftBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.WEST);
+                topBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.UP);
+                rightBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.EAST);
+                bottomBlocked = pipe.isConnectionOpen(AttachmentType.PIPE, EnumFacing.DOWN);
+            }
+        }
+
+        topRight.add(cubeCenter);
+        bottomRight.add(cubeCenter);
+        bottomLeft.add(cubeCenter);
+        topLeft.add(cubeCenter);
+
+        if (leftBlocked) {
+            startLine(buffer, topLeft.copy().add(shiftVert.copy().negate()));
+            endLine(buffer, bottomLeft.copy().add(shiftVert.copy()).add(shift));
+
+            startLine(buffer, topLeft.copy().add(shiftVert.copy().negate()).add(shift));
+            endLine(buffer, bottomLeft.copy().add(shiftVert));
+        }
+        if (topBlocked) {
+            startLine(buffer, topLeft.copy().add(shift));
+            endLine(buffer, topRight.copy().add(shift.copy().negate()).add(shiftVert.copy().negate()));
+
+            startLine(buffer, topLeft.copy().add(shift).add(shiftVert.copy().negate()));
+            endLine(buffer, topRight.copy().add(shift.copy().negate()));
+        }
+        if (rightBlocked) {
+            startLine(buffer, topRight.copy().add(shiftVert.copy().negate()));
+            endLine(buffer, bottomRight.copy().add(shiftVert.copy()).add(shift.copy().negate()));
+
+            startLine(buffer, topRight.copy().add(shiftVert.copy().negate()).add(shift.copy().negate()));
+            endLine(buffer, bottomRight.copy().add(shiftVert));
+        }
+        if (bottomBlocked) {
+            startLine(buffer, bottomLeft.copy().add(shift));
+            endLine(buffer, bottomRight.copy().add(shift.copy().negate()).add(shiftVert));
+
+            startLine(buffer, bottomLeft.copy().add(shift).add(shiftVert));
+            endLine(buffer, bottomRight.copy().add(shift.copy().negate()));
+        }
+
 
         tessellator.draw();
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityAdjustableEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityAdjustableEnergyHatch.java
@@ -187,4 +187,9 @@ public class MetaTileEntityAdjustableEnergyHatch extends MetaTileEntityMultibloc
         tooltip.add(I18n.format("gregtech.universal.tooltip.energy_storage_capacity", energyContainer.getEnergyCapacity()));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
+
+    @Override
+    public boolean canRenderFrontFaceX() {
+        return isExportHatch;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -89,4 +89,9 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
         tooltip.add(I18n.format("gregtech.universal.tooltip.energy_storage_capacity", energyContainer.getEnergyCapacity()));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
+
+    @Override
+    public boolean canRenderFrontFaceX() {
+        return isExportHatch;
+    }
 }


### PR DESCRIPTION
Adds Xs to the maching grids MTEs and pipes, for displaying sides that are "blocked" in some way.
This also improves the look of the machine grids, producing a GT6-like pulsation.
There is a glitch with pipes not displaying their connections from other MTEs in the grid, but this is out of the scope of the PR.