### PR TITLE
Fluidpipe fixes again

### DIFF
--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -69,6 +69,13 @@ public interface ICoverable {
 
     void scheduleRenderUpdate();
 
+    default boolean hasAnyCover() {
+        for(EnumFacing facing : EnumFacing.VALUES)
+            if(getCoverAtSide(facing) != null)
+                return true;
+        return false;
+    }
+
     @SideOnly(Side.CLIENT)
     default void renderCovers(CCRenderState renderState, Matrix4 translation, GTBlockOperation mteOp) {
         BlockRenderLayer layer = mteOp.layer;

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -15,12 +15,12 @@ import gregtech.api.cover.ICoverable.CoverSideData;
 import gregtech.api.cover.ICoverable.PrimaryBoxData;
 import gregtech.api.cover.IFacadeCover;
 import gregtech.api.items.toolitem.IToolStats;
+import gregtech.api.pipenet.IBlockAppearance;
 import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.WorldPipeNet;
 import gregtech.api.pipenet.tile.AttachmentType;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
-import gregtech.api.pipenet.IBlockAppearance;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.common.advancement.GTTriggers;
@@ -424,12 +424,12 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         if (selfTile.getPipeWorld().getBlockState(selfTile.getPipePos().offset(facing)).getBlock() == Blocks.AIR)
             return false;
         CoverBehavior cover = selfTile.getCoverableImplementation().getCoverAtSide(facing);
-        if(cover != null && !cover.canPipePassThrough())
+        if (cover != null && !cover.canPipePassThrough())
             return false;
         TileEntity other = selfTile.getPipeWorld().getTileEntity(selfTile.getPipePos().offset(facing));
         if (other instanceof IPipeTile) {
             cover = ((IPipeTile<?, ?>) other).getCoverableImplementation().getCoverAtSide(facing.getOpposite());
-            if(cover != null && !cover.canPipePassThrough())
+            if (cover != null && !cover.canPipePassThrough())
                 return false;
             return canPipesConnect(selfTile, facing, (IPipeTile<PipeType, NodeDataType>) other);
         }
@@ -451,11 +451,11 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         int connections = selfTile.getOpenConnections();
         float selfThickness = selfTile.getPipeType().getThickness();
         for (EnumFacing facing : EnumFacing.values()) {
-            if(selfTile.isConnectionOpenAny(facing)) {
+            if (selfTile.isConnectionOpenAny(facing)) {
                 TileEntity neighbourTile = selfTile.getPipeWorld().getTileEntity(selfTile.getPipePos().offset(facing));
                 if (neighbourTile instanceof IPipeTile) {
                     IPipeTile<?, ?> pipeTile = (IPipeTile<?, ?>) neighbourTile;
-                    if(pipeTile.isConnectionOpenAny(facing.getOpposite()) && pipeTile.getPipeType().getThickness() < selfThickness) {
+                    if (pipeTile.isConnectionOpenAny(facing.getOpposite()) && pipeTile.getPipeType().getThickness() < selfThickness) {
                         connections |= 1 << (facing.getIndex() + 6);
                     }
                 }
@@ -500,16 +500,28 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         return result;
     }
 
-    private boolean hasPipeCollisionChangingItem(Entity entity) {
-        if (entity instanceof EntityPlayer) {
-            ItemStack itemStack = ((EntityPlayer) entity).getHeldItemMainhand();
-
-            return itemStack.hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null) ||
-                    itemStack.hasCapability(GregtechCapabilities.CAPABILITY_CUTTER, null) ||
-                    itemStack.hasCapability(GregtechCapabilities.CAPABILITY_SCREWDRIVER, null) ||
-                    GTUtility.isCoverBehaviorItem(itemStack);
+    public boolean hasPipeCollisionChangingItem(IBlockAccess world, BlockPos pos, Entity entity) {
+        if(entity instanceof EntityPlayer) {
+            return hasPipeCollisionChangingItem(world, pos, ((EntityPlayer) entity).getHeldItem(EnumHand.MAIN_HAND)) ||
+                    hasPipeCollisionChangingItem(world, pos, ((EntityPlayer) entity).getHeldItem(EnumHand.OFF_HAND));
         }
         return false;
+    }
+
+    public boolean hasPipeCollisionChangingItem(IBlockAccess world, BlockPos pos, ItemStack stack) {
+        return doDrawGrid(stack) ||
+                stack.hasCapability(GregtechCapabilities.CAPABILITY_SCREWDRIVER, null) ||
+                GTUtility.isCoverBehaviorItem(stack, () -> hasCover(getPipeTileEntity(world, pos)));
+    }
+
+    protected boolean doDrawGrid(ItemStack stack) {
+        return stack.hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null);
+    }
+
+    protected boolean hasCover(IPipeTile<PipeType, NodeDataType> pipeTile) {
+        if (pipeTile == null)
+            return false;
+        return pipeTile.getCoverableImplementation().hasAnyCover();
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -484,7 +484,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         ICoverable coverable = pipeTile.getCoverableImplementation();
 
         // Check if the machine grid is being rendered
-        if (hasPipeCollisionChangingItem(entityIn)) {
+        if (hasPipeCollisionChangingItem(world, pos, entityIn)) {
             result.add(FULL_CUBE_COLLISION);
         }
 

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -59,6 +59,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collector;
@@ -746,13 +747,21 @@ public class GTUtility {
     }
 
     public static boolean isCoverBehaviorItem(ItemStack itemStack) {
+        return isCoverBehaviorItem(itemStack, null);
+    }
+
+    public static boolean isCoverBehaviorItem(ItemStack itemStack, BooleanSupplier hasCoverSupplier) {
         if (itemStack.getItem() instanceof MetaItem) {
             MetaItem<?> metaItem = (MetaItem<?>) itemStack.getItem();
             MetaItem<?>.MetaValueItem valueItem = metaItem.getItem(itemStack);
             if (valueItem != null) {
                 List<IItemBehaviour> behaviourList = valueItem.getBehaviours();
-                return behaviourList.stream().anyMatch(it ->
-                        it instanceof CoverPlaceBehavior || it instanceof CrowbarBehaviour);
+                for(IItemBehaviour behaviour : behaviourList) {
+                    if(behaviour instanceof CoverPlaceBehavior)
+                        return true;
+                    if(behaviour instanceof CrowbarBehaviour)
+                        return hasCoverSupplier == null || hasCoverSupplier.getAsBoolean();
+                }
             }
         }
         return false;

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -156,6 +156,11 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
         }
     }
 
+    @Override
+    protected boolean doDrawGrid(ItemStack stack) {
+        return stack.hasCapability(GregtechCapabilities.CAPABILITY_CUTTER, null);
+    }
+
     @Nonnull
     @Override
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -1,11 +1,9 @@
 package gregtech.common.pipelike.fluidpipe.net;
 
-import gnu.trove.set.TLongSet;
 import gregtech.api.pipenet.Node;
 import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.WorldPipeNet;
 import gregtech.api.unification.material.properties.FluidPipeProperties;
-import gregtech.api.util.GTUtility;
 import gregtech.common.pipelike.fluidpipe.tile.TileEntityFluidPipe;
 import gregtech.common.pipelike.fluidpipe.tile.TileEntityFluidPipeTickable;
 import net.minecraft.nbt.NBTTagCompound;
@@ -168,7 +166,7 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                 fluidsToRemove.clear();
             }
             if (dirtyStacks.size() > 0) {
-                for(Map.Entry<FluidStack, Map<BlockPos, Integer>> entry : dirtyStacks.entrySet()) {
+                for (Map.Entry<FluidStack, Map<BlockPos, Integer>> entry : dirtyStacks.entrySet()) {
                     FluidStack dirtyStack = entry.getKey();
                     if (dirtyStack.amount <= 0) {
                         continue;
@@ -177,7 +175,7 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                     Iterator<Map.Entry<BlockPos, Integer>> iterator = entry.getValue().entrySet().iterator();
                     while (iterator.hasNext()) {
                         Map.Entry<BlockPos, Integer> entry2 = iterator.next();
-                        if(didHandle.contains(entry2.getKey().toLong())) {
+                        if (didHandle.contains(entry2.getKey().toLong())) {
                             iterator.remove();
                             continue;
                         }
@@ -186,7 +184,7 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                         if (pipes.size() == 0) {
                             continue;
                         }
-                        for(TileEntityFluidPipe pipe : pipes) {
+                        for (TileEntityFluidPipe pipe : pipes) {
                             didHandle.add(pipe.getPos().toLong());
                         }
                         long amount = walker.getCount();
@@ -207,12 +205,12 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                                 FluidStack stack = dirtyStack.copy();
                                 stack.amount = count;
                                 int channel = pipe.findChannel(stack);
-                                if(channel < 0) {
+                                if (channel < 0) {
                                     pipeIterator.remove();
                                     continue;
                                 }
                                 FluidStack currentStack = pipe.getContainedFluid(channel);
-                                if(currentStack != null && !currentStack.isFluidEqual(dirtyStack)) {
+                                if (currentStack != null && !currentStack.isFluidEqual(dirtyStack)) {
                                     pipeIterator.remove();
                                     continue;
                                 }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -171,11 +171,11 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                     if (dirtyStack.amount <= 0) {
                         continue;
                     }
-                    Set<Long> didHandle = new HashSet<>();
+                    Set<BlockPos> didHandle = new HashSet<>();
                     Iterator<Map.Entry<BlockPos, Integer>> iterator = entry.getValue().entrySet().iterator();
                     while (iterator.hasNext()) {
                         Map.Entry<BlockPos, Integer> entry2 = iterator.next();
-                        if (didHandle.contains(entry2.getKey().toLong())) {
+                        if (didHandle.contains(entry2.getKey())) {
                             iterator.remove();
                             continue;
                         }
@@ -185,7 +185,7 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                             continue;
                         }
                         for (TileEntityFluidPipe pipe : pipes) {
-                            didHandle.add(pipe.getPos().toLong());
+                            didHandle.add(pipe.getPos());
                         }
                         long amount = walker.getCount();
                         amount += entry2.getValue();

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -171,8 +171,9 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                     if (dirtyStack.amount <= 0) {
                         continue;
                     }
+                    Map<BlockPos, Integer> subMap = entry.getValue();
                     Set<BlockPos> didHandle = new HashSet<>();
-                    Iterator<Map.Entry<BlockPos, Integer>> iterator = entry.getValue().entrySet().iterator();
+                    Iterator<Map.Entry<BlockPos, Integer>> iterator = subMap.entrySet().iterator();
                     while (iterator.hasNext()) {
                         Map.Entry<BlockPos, Integer> entry2 = iterator.next();
                         if (didHandle.contains(entry2.getKey())) {
@@ -184,11 +185,14 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                         if (pipes.size() == 0) {
                             continue;
                         }
+                        long amount = walker.getCount();
                         for (TileEntityFluidPipe pipe : pipes) {
                             didHandle.add(pipe.getPos());
+                            Integer a = subMap.get(pipe.getPos());
+                            if (a != null)
+                                amount += a;
                         }
-                        long amount = walker.getCount();
-                        amount += entry2.getValue();
+
                         int round = 0;
                         while (amount > 0 && pipes.size() > 0) {
                             int c = (int) (amount / pipes.size());

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -1,5 +1,6 @@
 package gregtech.common.pipelike.fluidpipe.net;
 
+import gnu.trove.set.TLongSet;
 import gregtech.api.pipenet.Node;
 import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.WorldPipeNet;
@@ -172,18 +173,21 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                     if (dirtyStack.amount <= 0) {
                         continue;
                     }
-                    Map<BlockPos, Integer> subMap = entry.getValue();
-                    Iterator<Map.Entry<BlockPos, Integer>> iterator = subMap.entrySet().iterator();
+                    Set<Long> didHandle = new HashSet<>();
+                    Iterator<Map.Entry<BlockPos, Integer>> iterator = entry.getValue().entrySet().iterator();
                     while (iterator.hasNext()) {
                         Map.Entry<BlockPos, Integer> entry2 = iterator.next();
+                        if(didHandle.contains(entry2.getKey().toLong())) {
+                            iterator.remove();
+                            continue;
+                        }
                         FluidNetWalker walker = FluidNetWalker.getPipesForFluid(getWorldData(), entry2.getKey(), dirtyStack, true);
                         List<TileEntityFluidPipe> pipes = walker.getPipes();
                         if (pipes.size() == 0) {
                             continue;
                         }
                         for(TileEntityFluidPipe pipe : pipes) {
-                            if(!GTUtility.arePosEqual(pipe.getPos(), entry2.getKey()))
-                                subMap.remove(pipe.getPos());
+                            didHandle.add(pipe.getPos().toLong());
                         }
                         long amount = walker.getCount();
                         amount += entry2.getValue();


### PR DESCRIPTION
- fix random cme crash (didn't know you are not allowed to remove from map with other than `iterator.remove`)