### PR TITLE
GT5 vein generator

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -1,29 +1,17 @@
 package gregtech.api.worldgen.config;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import crafttweaker.api.world.IBiome;
-import gregtech.api.GTValues;
 import gregtech.api.util.GTLog;
 import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.biome.Biome;
-import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fml.common.Optional;
-import org.apache.commons.lang3.ArrayUtils;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenMethod;
 
 import javax.annotation.Nonnull;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@ZenClass("mods.gregtech.ore.BedrockFluidDepositDefinition")
-@ZenRegister
 public class BedrockFluidDepositDefinition implements IWorldgenDefinition { //todo re-balance depletion rates of default veins
 
     private final String depositName;
@@ -91,57 +79,46 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition { //to
 
     //This is the file name
     @Override
-    @ZenGetter("depositName")
     public String getDepositName() {
         return depositName;
     }
 
-    @ZenGetter("assignedName")
     public String getAssignedName() {
         return assignedName;
     }
 
-    @ZenGetter("description")
     public String getDescription() {
         return description;
     }
 
-    @ZenGetter("weight")
     public int getWeight() {
         return weight;
     }
 
-    @ZenMethod
     public int[] getProductionRates() {
         return productionRates;
     }
 
-    @ZenGetter("minimumProduction")
     public int getMinimumProductionRate() {
         return productionRates[0];
     }
 
-    @ZenGetter("maximumProduction")
     public int getMaximumProductionRate() {
         return productionRates[1];
     }
 
-    @ZenGetter
     public int getDepletionAmount() {
         return depletionAmount;
     }
 
-    @ZenGetter
     public int getDepletionChance() {
         return depletionChance;
     }
 
-    @ZenGetter
     public int getDepletedProductionRate() {
         return depletedProductionRate;
     }
 
-    @ZenGetter
     public Fluid getStoredFluid() {
         return storedFluid;
     }
@@ -152,21 +129,6 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition { //to
 
     public Predicate<WorldProvider> getDimensionFilter() {
         return dimensionFilter;
-    }
-
-    @ZenMethod("getBiomeWeightModifier")
-    @Optional.Method(modid = GTValues.MODID_CT)
-    public int ctGetBiomeWeightModifier(IBiome biome) {
-        int biomeIndex = ArrayUtils.indexOf(CraftTweakerMC.biomes, biome);
-        Biome mcBiome = Biome.REGISTRY.getObjectById(biomeIndex);
-        return mcBiome == null ? 0 : getBiomeWeightModifier().apply(mcBiome);
-    }
-
-    @ZenMethod("checkDimension")
-    @Optional.Method(modid = GTValues.MODID_CT)
-    public boolean ctCheckDimension(int dimensionId) {
-        WorldProvider worldProvider = DimensionManager.getProvider(dimensionId);
-        return worldProvider != null && getDimensionFilter().test(worldProvider);
     }
 
     @Override

--- a/src/main/java/gregtech/api/worldgen/config/FillerConfigUtils.java
+++ b/src/main/java/gregtech/api/worldgen/config/FillerConfigUtils.java
@@ -117,6 +117,28 @@ public class FillerConfigUtils {
         return new WeightRandomMatcherEntry(randomList);
     }
 
+    public static LayeredFillerEntry createLayeredFiller(JsonObject object) {
+        JsonArray values = object.get("values").getAsJsonArray();
+        Preconditions.checkArgument(values.size() == 4, "Invalid number of ores in a Layered vein (should be 4, is actually %d", values.size());
+
+        return new LayeredFillerEntry(
+                readLayerFiller(values.get(0).getAsJsonObject(), "primary"),
+                readLayerFiller(values.get(1).getAsJsonObject(), "secondary"),
+                readLayerFiller(values.get(2).getAsJsonObject(), "between"),
+                createBlockStateFiller(values.get(3).getAsJsonObject().get("sporadic"))
+        );
+    }
+
+    private static Pair<FillerEntry, Integer> readLayerFiller(JsonObject object, String layerType) {
+        FillerEntry filler = createBlockStateFiller(object.get(layerType));
+        JsonElement layerElement = object.get("layers");
+        int layers = -1;
+        if (layerElement != null) {
+            layers = layerElement.getAsInt();
+        }
+        return Pair.of(filler, layers);
+    }
+
     private static class OreFilterEntry implements FillerEntry {
 
         private final Map<StoneType, IBlockState> blockStateMap;
@@ -223,6 +245,98 @@ public class FillerConfigUtils {
         @Override
         public List<Pair<Integer, FillerEntry>> getEntries() {
             return randomList;
+        }
+    }
+
+    public static class LayeredFillerEntry implements FillerEntry {
+
+        private final FillerEntry primary;
+        private final FillerEntry secondary;
+        private final FillerEntry between;
+        private final FillerEntry sporadic;
+
+        private final int betweenLayers;
+
+        // Provided for readability
+        private final int sporadicDivisor;
+        private final int startPrimary;
+        private final int startBetween;
+
+        private final ImmutableList<FillerEntry> subEntries;
+        private final ImmutableList<IBlockState> blockStates;
+
+        public LayeredFillerEntry(Pair<FillerEntry, Integer> primary, Pair<FillerEntry, Integer> secondary, Pair<FillerEntry, Integer> between, FillerEntry sporadic) {
+            this.primary = primary.getLeft();
+            this.secondary = secondary.getLeft();
+            this.between = between.getLeft();
+            this.sporadic = sporadic;
+
+            int primaryLayers = primary.getRight() == -1 ? 4 : primary.getRight();
+            int secondaryLayers = secondary.getRight() == -1 ? 3 : secondary.getRight();
+            this.betweenLayers = between.getRight() == -1 ? 3 : between.getRight();
+
+            // Ensure "between" is not more than the total primary and secondary layers
+            // TODO Comment
+            Preconditions.checkArgument(primaryLayers + secondaryLayers >= betweenLayers, "");
+
+            this.sporadicDivisor = primaryLayers + secondaryLayers - 1;
+            this.startPrimary = secondaryLayers;
+            this.startBetween = secondaryLayers - betweenLayers / 2;
+
+            this.subEntries = ImmutableList.of(this.primary, this.secondary, this.between, this.sporadic);
+            this.blockStates = ImmutableList.<IBlockState>builder()
+                    .addAll(this.primary.getPossibleResults())
+                    .addAll(this.secondary.getPossibleResults())
+                    .addAll(this.between.getPossibleResults())
+                    .addAll(this.sporadic.getPossibleResults())
+                    .build();
+        }
+
+        @Override
+        public IBlockState apply(IBlockState source, IBlockAccess blockAccess, BlockPos blockPos) {
+            // should never be called, but just to be safe...
+            return apply(source, blockAccess, blockPos, 1.0, new Random(), 0);
+        }
+
+        public IBlockState apply(IBlockState source, IBlockAccess blockAccess, BlockPos blockPos, double density, Random random, int layer) {
+            // First try to spawn "between"
+            if (layer >= startBetween && layer - startBetween + 1 <= betweenLayers) {
+                if (random.nextFloat() <= density / 2) {
+                    return between.apply(source, blockAccess, blockPos);
+                }
+            }
+
+            // Then try primary/secondary
+            if (layer >= startPrimary) {
+                if (random.nextFloat() <= density) {
+                    return primary.apply(source, blockAccess, blockPos);
+                }
+            } else {
+                if (random.nextFloat() <= density) {
+                    return secondary.apply(source, blockAccess, blockPos);
+                }
+            }
+
+            // Then lastly, try sporadic
+            if (random.nextFloat() <= density / sporadicDivisor) {
+                return sporadic.apply(source, blockAccess, blockPos);
+            }
+            return source;
+        }
+
+        @Override
+        public List<FillerEntry> getSubEntries() {
+            return subEntries;
+        }
+
+        @Override
+        public Collection<IBlockState> getPossibleResults() {
+            return blockStates;
+        }
+
+        @Override
+        public List<Pair<Integer, FillerEntry>> getEntries() {
+            return Collections.emptyList(); // todo
         }
     }
 }

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -1,33 +1,18 @@
 package gregtech.api.worldgen.config;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import crafttweaker.api.world.IBiome;
-import gregtech.api.GTValues;
 import gregtech.api.unification.ore.StoneType;
 import gregtech.api.util.WorldBlockPredicate;
 import gregtech.api.worldgen.filler.BlockFiller;
 import gregtech.api.worldgen.populator.IVeinPopulator;
 import gregtech.api.worldgen.shape.ShapeGenerator;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.biome.Biome;
-import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.fml.common.Optional.Method;
-import org.apache.commons.lang3.ArrayUtils;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenMethod;
 
 import javax.annotation.Nonnull;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@ZenClass("mods.gregtech.ore.OreDepositDefinition")
-@ZenRegister
 public class OreDepositDefinition implements IWorldgenDefinition {
 
     public static final Function<Biome, Integer> NO_BIOME_INFLUENCE = biome -> 0;
@@ -102,57 +87,46 @@ public class OreDepositDefinition implements IWorldgenDefinition {
 
     //This is the file name
     @Override
-    @ZenGetter("depositName")
     public String getDepositName() {
         return depositName;
     }
 
-    @ZenGetter("assignedName")
     public String getAssignedName() {
         return assignedName;
     }
 
-    @ZenGetter("description")
     public String getDescription() {
         return description;
     }
 
-    @ZenGetter("weight")
     public int getWeight() {
         return weight;
     }
 
-    @ZenGetter("density")
     public float getDensity() {
         return density;
     }
 
-    @ZenGetter("priority")
     public int getPriority() {
         return priority;
     }
 
-    @ZenGetter("isVein")
     public boolean isVein() {
         return countAsVein;
     }
 
-    @ZenMethod
     public boolean checkInHeightLimit(int yLevel) {
         return yLevel >= heightLimit[0] && yLevel <= heightLimit[1];
     }
 
-    @ZenMethod
     public int[] getHeightLimit() {
         return heightLimit;
     }
 
-    @ZenGetter("minimumHeight")
     public int getMinimumHeight() {
         return heightLimit[0];
     }
 
-    @ZenGetter("maximumHeight")
     public int getMaximumHeight() {
         return heightLimit[1];
     }
@@ -173,34 +147,10 @@ public class OreDepositDefinition implements IWorldgenDefinition {
         return veinPopulator;
     }
 
-    @ZenMethod("getBiomeWeightModifier")
-    @Method(modid = GTValues.MODID_CT)
-    public int ctGetBiomeWeightModifier(IBiome biome) {
-        int biomeIndex = ArrayUtils.indexOf(CraftTweakerMC.biomes, biome);
-        Biome mcBiome = Biome.REGISTRY.getObjectById(biomeIndex);
-        return mcBiome == null ? 0 : getBiomeWeightModifier().apply(mcBiome);
-    }
-
-    @ZenMethod("checkDimension")
-    @Method(modid = GTValues.MODID_CT)
-    public boolean ctCheckDimension(int dimensionId) {
-        WorldProvider worldProvider = DimensionManager.getProvider(dimensionId);
-        return worldProvider != null && getDimensionFilter().test(worldProvider);
-    }
-
-    @ZenMethod("canGenerateIn")
-    @Method(modid = GTValues.MODID_CT)
-    public boolean ctCanGenerateIn(crafttweaker.api.block.IBlockState blockState, crafttweaker.api.world.IBlockAccess blockAccess, crafttweaker.api.world.IBlockPos blockPos) {
-        IBlockState mcBlockState = CraftTweakerMC.getBlockState(blockState);
-        return getGenerationPredicate().test(mcBlockState, (IBlockAccess) blockAccess.getInternal(), (BlockPos) blockPos.getInternal());
-    }
-
-    @ZenGetter("filter")
     public BlockFiller getBlockFiller() {
         return blockFiller;
     }
 
-    @ZenGetter("shape")
     public ShapeGenerator getShapeGenerator() {
         return shapeGenerator;
     }

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
 import gregtech.api.GTValues;
 import gregtech.api.util.FileUtility;
 import gregtech.api.util.GTLog;
@@ -25,8 +24,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.io.IOUtils;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -39,8 +36,6 @@ import java.util.Map.Entry;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-@ZenClass("mods.gregtech.ore.WorldGenRegistry")
-@ZenRegister
 public class WorldGenRegistry {
 
     public static final WorldGenRegistry INSTANCE = new WorldGenRegistry();
@@ -526,12 +521,10 @@ public class WorldGenRegistry {
         return veinPopulator;
     }
 
-    @ZenGetter("oreDeposits")
     public static List<OreDepositDefinition> getOreDeposits() {
         return Collections.unmodifiableList(INSTANCE.registeredVeinDefinitions);
     }
 
-    @ZenGetter("bedrockVeinDeposits")
     public static List<BedrockFluidDepositDefinition> getBedrockVeinDeposits() {
         return Collections.unmodifiableList(INSTANCE.registeredBedrockVeinDefinitions);
     }
@@ -539,5 +532,4 @@ public class WorldGenRegistry {
     public static Map<Integer, String> getNamedDimensions() {
         return INSTANCE.namedDimensions;
     }
-
 }

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -10,6 +10,7 @@ import gregtech.api.util.FileUtility;
 import gregtech.api.util.GTLog;
 import gregtech.api.worldgen.filler.BlacklistedBlockFiller;
 import gregtech.api.worldgen.filler.BlockFiller;
+import gregtech.api.worldgen.filler.LayeredBlockFiller;
 import gregtech.api.worldgen.filler.SimpleBlockFiller;
 import gregtech.api.worldgen.generator.WorldGeneratorImpl;
 import gregtech.api.worldgen.populator.FluidSpringPopulator;
@@ -96,7 +97,9 @@ public class WorldGenRegistry {
         registerShapeGenerator("sphere", SphereGenerator::new);
         registerShapeGenerator("plate", PlateGenerator::new);
         registerShapeGenerator("single", SingleBlockGenerator::new);
+        registerShapeGenerator("layered", LayeredGenerator::new);
         registerBlockFiller("simple", SimpleBlockFiller::new);
+        registerBlockFiller("layered", LayeredBlockFiller::new);
         registerBlockFiller("ignore_bedrock", () -> new BlacklistedBlockFiller(Lists.newArrayList(Blocks.BEDROCK.getDefaultState())));
         registerVeinPopulator("surface_rock", SurfaceRockPopulator::new);
         registerVeinPopulator("fluid_spring", FluidSpringPopulator::new);

--- a/src/main/java/gregtech/api/worldgen/filler/BlacklistedBlockFiller.java
+++ b/src/main/java/gregtech/api/worldgen/filler/BlacklistedBlockFiller.java
@@ -1,23 +1,15 @@
 package gregtech.api.worldgen.filler;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import gregtech.api.GTValues;
 import gregtech.api.worldgen.config.FillerConfigUtils;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraftforge.fml.common.Optional.Method;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.filler.BlacklistedBlockFiller")
-@ZenRegister
 public class BlacklistedBlockFiller extends BlockFiller {
 
     private FillerEntry blockStateFiller;
@@ -36,21 +28,13 @@ public class BlacklistedBlockFiller extends BlockFiller {
         return blacklist;
     }
 
-    @ZenGetter("blacklist")
-    @Method(modid = GTValues.MODID_CT)
-    public List<crafttweaker.api.block.IBlockState> ctGetBlacklist() {
-        return blacklist.stream()
-                .map(CraftTweakerMC::getBlockState)
-                .collect(Collectors.toList());
-    }
-
     @Override
     public void loadFromConfig(JsonObject object) {
         this.blockStateFiller = FillerConfigUtils.createBlockStateFiller(object.get("value"));
     }
 
     @Override
-    public IBlockState apply(IBlockState currentState, IBlockAccess blockAccess, BlockPos blockPos, int relativeX, int relativeY, int relativeZ) {
+    public IBlockState apply(IBlockState currentState, IBlockAccess blockAccess, BlockPos blockPos, int relativeX, int relativeY, int relativeZ, double density, Random gridRandom, int layer) {
         for (IBlockState blockState : blacklist) {
             if (blockState == currentState) {
                 return currentState;

--- a/src/main/java/gregtech/api/worldgen/filler/BlockFiller.java
+++ b/src/main/java/gregtech/api/worldgen/filler/BlockFiller.java
@@ -1,13 +1,9 @@
 package gregtech.api.worldgen.filler;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.minecraft.CraftTweakerMC;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenMethod;
 
 import java.util.List;
 import java.util.Random;

--- a/src/main/java/gregtech/api/worldgen/filler/BlockFiller.java
+++ b/src/main/java/gregtech/api/worldgen/filler/BlockFiller.java
@@ -10,21 +10,13 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 import java.util.List;
+import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.filler.BlockFiller")
-@ZenRegister
 public abstract class BlockFiller {
 
     public abstract void loadFromConfig(JsonObject object);
 
-    public abstract IBlockState apply(IBlockState currentState, IBlockAccess blockAccess, BlockPos blockPos, int relativeX, int relativeY, int relativeZ);
+    public abstract IBlockState apply(IBlockState currentState, IBlockAccess blockAccess, BlockPos blockPos, int relativeX, int relativeY, int relativeZ, double density, Random gridRandom, int layer);
 
     public abstract List<FillerEntry> getAllPossibleStates();
-
-    @ZenMethod("apply")
-    public crafttweaker.api.block.IBlockState ctGetStateForGeneration(crafttweaker.api.block.IBlockState currentState, crafttweaker.api.world.IBlockAccess blockAccess, crafttweaker.api.world.IBlockPos blockPos, int relativeX, int relativeY, int relativeZ) {
-        IBlockState mcBlockState = CraftTweakerMC.getBlockState(currentState);
-        return CraftTweakerMC.getBlockState(apply(mcBlockState, (IBlockAccess) blockAccess.getInternal(), (BlockPos) blockPos.getInternal(), relativeX, relativeY, relativeZ));
-    }
-
 }

--- a/src/main/java/gregtech/api/worldgen/filler/FillerEntry.java
+++ b/src/main/java/gregtech/api/worldgen/filler/FillerEntry.java
@@ -5,14 +5,12 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import org.apache.commons.lang3.tuple.Pair;
-import stanhebben.zenscript.annotations.ZenClass;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-@ZenClass("mods.gregtech.ore.filler.")
 public interface FillerEntry {
 
     IBlockState apply(IBlockState source, IBlockAccess blockAccess, BlockPos blockPos);

--- a/src/main/java/gregtech/api/worldgen/filler/LayeredBlockFiller.java
+++ b/src/main/java/gregtech/api/worldgen/filler/LayeredBlockFiller.java
@@ -25,7 +25,7 @@ public class LayeredBlockFiller extends BlockFiller {
 
     @Override
     public IBlockState apply(IBlockState currentState, IBlockAccess blockAccess, BlockPos blockPos, int relativeX, int relativeY, int relativeZ, double density, Random gridRandom, int layer) {
-        return fillerEntry.apply(currentState, blockAccess, blockPos, density, gridRandom, layer); // todo need to pass more through here
+        return fillerEntry.apply(currentState, blockAccess, blockPos, density, gridRandom, layer);
     }
 
     @Override

--- a/src/main/java/gregtech/api/worldgen/filler/LayeredBlockFiller.java
+++ b/src/main/java/gregtech/api/worldgen/filler/LayeredBlockFiller.java
@@ -2,6 +2,7 @@ package gregtech.api.worldgen.filler;
 
 import com.google.gson.JsonObject;
 import gregtech.api.worldgen.config.FillerConfigUtils;
+import gregtech.api.worldgen.config.FillerConfigUtils.LayeredFillerEntry;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -10,25 +11,21 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-public class SimpleBlockFiller extends BlockFiller {
+public class LayeredBlockFiller extends BlockFiller {
 
-    private FillerEntry fillerEntry;
+    private LayeredFillerEntry fillerEntry;
 
-    public SimpleBlockFiller() {
-    }
-
-    public SimpleBlockFiller(FillerEntry blockStateFiller) {
-        this.fillerEntry = blockStateFiller;
+    public LayeredBlockFiller() {
     }
 
     @Override
     public void loadFromConfig(JsonObject object) {
-        this.fillerEntry = FillerConfigUtils.createBlockStateFiller(object.get("value"));
+        this.fillerEntry = FillerConfigUtils.createLayeredFiller(object);
     }
 
     @Override
     public IBlockState apply(IBlockState currentState, IBlockAccess blockAccess, BlockPos blockPos, int relativeX, int relativeY, int relativeZ, double density, Random gridRandom, int layer) {
-        return fillerEntry.apply(currentState, blockAccess, blockPos);
+        return fillerEntry.apply(currentState, blockAccess, blockPos, density, gridRandom, layer); // todo need to pass more through here
     }
 
     @Override

--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -273,7 +273,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
 
         if (withRandom && currentOreVein.getDensity() < randomDensityValue)
             return false; //only place blocks in positions matching density
-        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, 0, !withRandom);
+        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, 0);
         return true;
     }
 
@@ -284,11 +284,11 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
         int globalBlockX = veinCenterX + x;
         int globalBlockY = veinCenterY + y;
         int globalBlockZ = veinCenterZ + z;
-        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, index + 1, false);
+        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, index + 1);
         return true;
     }
 
-    private void setBlock(int worldX, int worldY, int worldZ, OreDepositDefinition definition, int index, boolean withRandom) {
+    private void setBlock(int worldX, int worldY, int worldZ, OreDepositDefinition definition, int index) {
         int chunkX = worldX >> 4;
         int chunkZ = worldZ >> 4;
         int localX = worldX - chunkX * 16;

--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -18,6 +18,7 @@ import gregtech.api.worldgen.populator.IVeinPopulator;
 import gregtech.api.worldgen.populator.VeinBufferPopulator;
 import gregtech.api.worldgen.populator.VeinChunkPopulator;
 import gregtech.api.worldgen.shape.IBlockGeneratorAccess;
+import gregtech.api.worldgen.shape.LayeredGenerator;
 import gregtech.common.ConfigHolder;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -261,7 +262,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
     }
 
     @Override
-    public boolean generateBlock(int x, int y, int z) {
+    public boolean generateBlock(int x, int y, int z, boolean withRandom) {
         if (currentOreVein == null)
             throw new IllegalStateException("Attempted to call generateBlock without current ore vein!");
         int globalBlockX = veinCenterX + x;
@@ -270,9 +271,9 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
         //we should do all random-related things here, otherwise it gets corrupted by current chunk information
         float randomDensityValue = gridRandom.nextFloat();
 
-        if (currentOreVein.getDensity() < randomDensityValue)
+        if (withRandom && currentOreVein.getDensity() < randomDensityValue)
             return false; //only place blocks in positions matching density
-        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, 0);
+        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, 0, !withRandom);
         return true;
     }
 
@@ -283,11 +284,11 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
         int globalBlockX = veinCenterX + x;
         int globalBlockY = veinCenterY + y;
         int globalBlockZ = veinCenterZ + z;
-        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, index + 1);
+        setBlock(globalBlockX, globalBlockY, globalBlockZ, currentOreVein, index + 1, false);
         return true;
     }
 
-    private void setBlock(int worldX, int worldY, int worldZ, OreDepositDefinition definition, int index) {
+    private void setBlock(int worldX, int worldY, int worldZ, OreDepositDefinition definition, int index, boolean withRandom) {
         int chunkX = worldX >> 4;
         int chunkZ = worldZ >> 4;
         int localX = worldX - chunkX * 16;
@@ -296,7 +297,15 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
             long chunkKey = (long) chunkX << 32 | chunkZ & 0xFFFFFFFFL;
             ChunkDataEntry dataEntry = dataByChunkPos.get(chunkKey);
             if (dataEntry == null) {
-                dataEntry = new ChunkDataEntry(chunkX, chunkZ);
+                if (currentOreVein.getShapeGenerator() instanceof LayeredGenerator) {
+                    dataEntry = new ChunkDataEntry(
+                            chunkX, chunkZ,
+                            currentOreVein.getDensity(), gridRandom,
+                            veinCenterY - ((LayeredGenerator) currentOreVein.getShapeGenerator()).getYRadius()
+                    );
+                } else {
+                    dataEntry = new ChunkDataEntry(chunkX, chunkZ, gridRandom);
+                }
                 dataByChunkPos.put(chunkKey, dataEntry);
             }
             dataEntry.setBlock(localX, worldY, localZ, definition, index);
@@ -311,10 +320,21 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
         private final List<OreDepositDefinition> generatedOres = new ArrayList<>();
         private final int chunkX;
         private final int chunkZ;
+        private final double density;
+        private final Random gridRandom;
 
-        public ChunkDataEntry(int chunkX, int chunkZ) {
+        private final int lowestY;
+
+        public ChunkDataEntry(int chunkX, int chunkZ, Random gridRandom) {
+            this(chunkX, chunkZ, 1.0, gridRandom, 0);
+        }
+
+        public ChunkDataEntry(int chunkX, int chunkZ, double density, Random gridRandom, int lowestY) {
             this.chunkX = chunkX;
             this.chunkZ = chunkZ;
+            this.density = density;
+            this.gridRandom = gridRandom;
+            this.lowestY = lowestY;
         }
 
         public void setBlock(int x, int y, int z, OreDepositDefinition definition, int index) {
@@ -349,7 +369,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
                         //it's primary ore block
                         if (!definition.getGenerationPredicate().test(currentState, world, blockPos))
                             continue; //do not generate if predicate didn't match
-                        newState = definition.getBlockFiller().apply(currentState, world, blockPos, blockX, blockY, blockZ);
+                        newState = definition.getBlockFiller().apply(currentState, world, blockPos, blockX, blockY, blockZ, density, gridRandom, blockY - lowestY);
                     } else {
                         //it's populator-generated block with index
                         VeinBufferPopulator populator = (VeinBufferPopulator) definition.getVeinPopulator();

--- a/src/main/java/gregtech/api/worldgen/shape/EllipsoidGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/EllipsoidGenerator.java
@@ -1,15 +1,11 @@
 package gregtech.api.worldgen.shape;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
 import gregtech.api.worldgen.config.OreConfigUtils;
 import net.minecraft.util.math.Vec3i;
-import stanhebben.zenscript.annotations.ZenClass;
 
 import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.generator.EllipsoidGenerator")
-@ZenRegister
 public class EllipsoidGenerator extends ShapeGenerator {
 
     private int radiusMin;
@@ -18,17 +14,15 @@ public class EllipsoidGenerator extends ShapeGenerator {
     public EllipsoidGenerator() {
     }
 
-
-    public EllipsoidGenerator(int radiusMin, int radiusMax) {
-        this.radiusMin = radiusMin;
-        this.radiusMax = radiusMax;
-    }
-
     @Override
     public void loadFromConfig(JsonObject object) {
         int[] data = OreConfigUtils.getIntRange(object.get("radius"));
         this.radiusMin = data[0];
         this.radiusMax = data[1];
+    }
+
+    public int getYRadius() {
+        return Integer.MAX_VALUE;
     }
 
     @Override
@@ -44,19 +38,24 @@ public class EllipsoidGenerator extends ShapeGenerator {
         int ab2 = a * a * b * b, ac2 = a * a * c * c, bc2 = b * b * c * c, abc2 = ab2 * c * c;
 
         int max = Math.max(a, Math.max(b, c));
+        int yMax = Math.min(max, getYRadius());
         for (int x = -max; x <= max; x++) {
             int xr = bc2 * x * x;
             if (xr > abc2) continue;
-            for (int y = -max; y <= max; y++) {
+            for (int y = -yMax; y <= yMax; y++) {
                 int yr = xr + ac2 * y * y + ab2;
                 if (yr > abc2) continue;
                 for (int z = -max; z <= max; z++) {
                     int zr = yr + ab2 * z * z;
                     if (zr > abc2) continue;
-                    blockAccess.generateBlock(x, y, z);
+                    generateBlock(x, y, z, blockAccess);
                 }
             }
         }
     }
 
+    // Used for overriding
+    public void generateBlock(int x, int y, int z, IBlockGeneratorAccess blockAccess) {
+        blockAccess.generateBlock(x, y, z);
+    }
 }

--- a/src/main/java/gregtech/api/worldgen/shape/IBlockGeneratorAccess.java
+++ b/src/main/java/gregtech/api/worldgen/shape/IBlockGeneratorAccess.java
@@ -2,6 +2,9 @@ package gregtech.api.worldgen.shape;
 
 public interface IBlockGeneratorAccess {
 
-    boolean generateBlock(int x, int y, int z);
+    default boolean generateBlock(int x, int y, int z) {
+        return generateBlock(x, y, z, true);
+    };
 
+    boolean generateBlock(int x, int y, int z, boolean withRandom);
 }

--- a/src/main/java/gregtech/api/worldgen/shape/LayeredGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/LayeredGenerator.java
@@ -1,0 +1,33 @@
+package gregtech.api.worldgen.shape;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class LayeredGenerator extends EllipsoidGenerator {
+
+    private int yRadius;
+
+    public LayeredGenerator() {
+    }
+
+    @Override
+    public void loadFromConfig(JsonObject object) {
+        super.loadFromConfig(object);
+        JsonElement element = object.get("layers");
+        if (element != null) {
+            yRadius = element.getAsInt() / 2;
+        } else {
+            yRadius = 3; // default number of layers
+        }
+    }
+
+    @Override
+    public int getYRadius() {
+        return yRadius;
+    }
+
+    @Override
+    public void generateBlock(int x, int y, int z, IBlockGeneratorAccess blockAccess) {
+        blockAccess.generateBlock(x, y, z, false);
+    }
+}

--- a/src/main/java/gregtech/api/worldgen/shape/PlateGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/PlateGenerator.java
@@ -1,16 +1,11 @@
 package gregtech.api.worldgen.shape;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
 import gregtech.api.worldgen.config.OreConfigUtils;
 import net.minecraft.util.math.Vec3i;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
 
 import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.generator.PlateGenerator")
-@ZenRegister
 public class PlateGenerator extends ShapeGenerator {
 
     private int minLength;
@@ -23,46 +18,6 @@ public class PlateGenerator extends ShapeGenerator {
     private float roofSharpness;
 
     public PlateGenerator() {
-    }
-
-    @ZenGetter("minLength")
-    public int getMinLength() {
-        return minLength;
-    }
-
-    @ZenGetter("maxLength")
-    public int getMaxLength() {
-        return maxLength;
-    }
-
-    @ZenGetter("minDepth")
-    public int getMinDepth() {
-        return minDepth;
-    }
-
-    @ZenGetter("maxDepth")
-    public int getMaxDepth() {
-        return maxDepth;
-    }
-
-    @ZenGetter("minHeight")
-    public int getMinHeight() {
-        return minHeight;
-    }
-
-    @ZenGetter("maxHeight")
-    public int getMaxHeight() {
-        return maxHeight;
-    }
-
-    @ZenGetter("floorSharpness")
-    public float getFloorSharpness() {
-        return floorSharpness;
-    }
-
-    @ZenGetter("rootSharpness")
-    public float getRoofSharpness() {
-        return roofSharpness;
     }
 
     @Override
@@ -110,7 +65,5 @@ public class PlateGenerator extends ShapeGenerator {
                 }
             }
         }
-
-
     }
 }

--- a/src/main/java/gregtech/api/worldgen/shape/ShapeGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/ShapeGenerator.java
@@ -1,23 +1,10 @@
 package gregtech.api.worldgen.shape;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.block.IBlockState;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import crafttweaker.api.world.IBlockPos;
-import crafttweaker.api.world.IWorld;
-import gregtech.api.GTValues;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
-import net.minecraft.world.World;
-import net.minecraftforge.fml.common.Optional.Method;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenMethod;
 
 import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.generator.ShapeGenerator")
-@ZenRegister
 public abstract class ShapeGenerator {
 
     /**
@@ -34,13 +21,4 @@ public abstract class ShapeGenerator {
      * @param relativeBlockAccess block access
      */
     public abstract void generate(Random gridRandom, IBlockGeneratorAccess relativeBlockAccess);
-
-    @ZenMethod
-    @Method(modid = GTValues.MODID_CT)
-    public void generate(long randomSeed, IWorld world, IBlockPos centerPos, IBlockState blockState) {
-        World mcWorld = CraftTweakerMC.getWorld(world);
-        net.minecraft.block.state.IBlockState mcBlockState = CraftTweakerMC.getBlockState(blockState);
-        BlockPos blockPos = CraftTweakerMC.getBlockPos(centerPos);
-        generate(new Random(randomSeed), (x, y, z) -> mcWorld.setBlockState(blockPos, mcBlockState));
-    }
 }

--- a/src/main/java/gregtech/api/worldgen/shape/SingleBlockGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/SingleBlockGenerator.java
@@ -1,19 +1,14 @@
 package gregtech.api.worldgen.shape;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
 import gregtech.api.worldgen.config.OreConfigUtils;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos.MutableBlockPos;
 import net.minecraft.util.math.Vec3i;
 import org.apache.commons.lang3.ArrayUtils;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
 
 import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.generator.SingleBlockGenerator")
-@ZenRegister
 public class SingleBlockGenerator extends ShapeGenerator {
 
     private int minBlocksCount;
@@ -22,20 +17,9 @@ public class SingleBlockGenerator extends ShapeGenerator {
     public SingleBlockGenerator() {
     }
 
-
     public SingleBlockGenerator(int minBlocksCount, int maxBlocksCount) {
         this.minBlocksCount = minBlocksCount;
         this.maxBlocksCount = maxBlocksCount;
-    }
-
-    @ZenGetter("minBlocksCount")
-    public int getMinBlocksCount() {
-        return minBlocksCount;
-    }
-
-    @ZenGetter("maxBlocksCount")
-    public int getMaxBlocksCount() {
-        return maxBlocksCount;
     }
 
     @Override

--- a/src/main/java/gregtech/api/worldgen/shape/SphereGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/SphereGenerator.java
@@ -1,16 +1,11 @@
 package gregtech.api.worldgen.shape;
 
 import com.google.gson.JsonObject;
-import crafttweaker.annotations.ZenRegister;
 import gregtech.api.worldgen.config.OreConfigUtils;
 import net.minecraft.util.math.Vec3i;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
 
 import java.util.Random;
 
-@ZenClass("mods.gregtech.ore.generator.SphereGenerator")
-@ZenRegister
 public class SphereGenerator extends ShapeGenerator {
 
     private int radiusMin;
@@ -22,16 +17,6 @@ public class SphereGenerator extends ShapeGenerator {
     public SphereGenerator(int radiusMin, int radiusMax) {
         this.radiusMin = radiusMin;
         this.radiusMax = radiusMax;
-    }
-
-    @ZenGetter("minRadius")
-    public int getRadiusMin() {
-        return radiusMin;
-    }
-
-    @ZenGetter("maxRadius")
-    public int getRadiusMax() {
-        return radiusMax;
     }
 
     @Override
@@ -58,6 +43,5 @@ public class SphereGenerator extends ShapeGenerator {
                 }
             }
         }
-
     }
 }

--- a/src/main/resources/assets/gregtech/worldgen/vein/overworld/apatite_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/vein/overworld/apatite_vein.json
@@ -1,36 +1,33 @@
 {
-  "weight": 70,
-  "density": 0.4,
+  "weight": 300,
+  "density": 0.45,
   "min_height": 45,
   "vein_populator": {
     "type": "surface_rock",
     "material": "apatite"
   },
   "generator": {
-    "type": "ellipsoid",
+    "type": "layered",
     "radius": [
       13,
       16
     ]
   },
   "filler": {
-    "type": "simple",
-    "value": {
-      "type": "weight_random",
-      "values": [
-        {
-          "weight": 60,
-          "value": "ore:apatite"
-        },
-        {
-          "weight": 40,
-          "value": "ore:tricalcium_phosphate"
-        },
-        {
-          "weight": 15,
-          "value": "ore:phosphate"
-        }
-      ]
-    }
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:apatite"
+      },
+      {
+        "secondary": "ore:iron"
+      },
+      {
+        "between": "ore:tricalcium_phosphate"
+      },
+      {
+        "sporadic": "ore:phosphate"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Creates a new vein generator to mimic GT5 ore generation behavior.

Behavior of all other veins are unchanged, unless the vein specifies that it is "layered".

I included a modified Apatite vein in this PR to show off the new generation. It will be removed and reworked in the ore-work branch as soon as this PR is merged.

Said vein:
![image](https://user-images.githubusercontent.com/10861407/146662806-db94b2ce-6537-44d3-a7a6-d6a2c58913f6.png)

The syntax is similar to before, but uses `"layered"` in place of the shape generator (previously `"ellipsoid"`), and in place of the block filler (previously `"simple"`). Both of those options still work, though to use layered, you must use both the layered filler and generator.

An example json:
```json
{
  ...
  "generator": {
    "type": "layered",
    ...
  },
  "filler": {
    "type": "layered",
    "values": [
      {
        "primary": "ore:apatite"
      },
      {
        "secondary": "ore:iron"
      },
      {
        "between": "ore:tricalcium_phosphate"
      },
      {
        "sporadic": "ore:phosphate"
      }
    ]
  }
}
```

Additionally, layers can be sized differently. By default, Primary will be 4 layers, Secondary will be 3 layers, Between will be 3 layers (being the bottom 2 primary, and the top secondary), and Sporadic will appear randomly throughout.

Here is an example generated with different layering:
![image](https://user-images.githubusercontent.com/10861407/146662881-8c5f7948-5939-4a25-9ec8-d9a69d0a04d7.png)

And the layering used:
![image](https://user-images.githubusercontent.com/10861407/146662895-5ba0aa31-0631-4af0-b6f0-ee5edd9b86a8.png)

This also supports the current format of Vein Density. However, a vein with a density of 1 (every block filled) will have no sporadic ores, only being the Primary, Secondary, and Between, as a consequence of how they are prioritized in generation