### PR TITLE
Fix grid overlay on non pipes

### DIFF
--- a/src/main/java/gregtech/client/renderer/handler/ToolOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/ToolOverlayRenderer.java
@@ -139,7 +139,10 @@ public class ToolOverlayRenderer {
         // MetaTileEntity
         if (tileEntity instanceof MetaTileEntityHolder) {
             MetaTileEntity mte = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
-            return mte != null && mte.canRenderMachineGrid() && itemStack.hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null);
+            if(mte == null || !mte.canRenderMachineGrid())
+                return false;
+            if(itemStack.hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null))
+                return true;
         }
 
         // Pipes


### PR DESCRIPTION
Fixes grid overlay not rendering on anything that isn't a pipe when holding something that isn't wrench.
bug was introduced by me in #361 