### PR TITLE
Prevent loot entry failures for colliding entry names

### DIFF
--- a/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
+++ b/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
@@ -72,7 +72,7 @@ public class ChestGenHooks {
                         return stack;
                     }
                 }
-        }, NO_CONDITIONS, "#gregtech:loot_" + item.toString());
+        }, NO_CONDITIONS, "#gregtech:loot_" + item.hashCode());
         if (lootEntryItems.containsKey(lootTable)) {
             lootEntryItems.get(lootTable).add(itemEntry);
         } else {


### PR DESCRIPTION
**What:**

Prevents failure of items being added to loot tables when `item.toString()` produced the same loot entry name. Loot Entries with the same name cannot be added to the same Loot Table