### PR TITLE
Fix Instances of Tool Sound Spamming

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -158,6 +158,10 @@ public interface IToolStats {
         return true;
     }
 
+    default boolean canPlayBreakingSound(ItemStack stack) {
+        return false;
+    }
+
     default ItemStack getBrokenStack(ItemStack stack) {
         return ItemStack.EMPTY;
     }
@@ -176,7 +180,7 @@ public interface IToolStats {
     }
 
     default void onCraftingUse(ItemStack stack, EntityPlayer player) {
-        if (ConfigHolder.client.toolCraftingSounds && ForgeHooks.getCraftingPlayer() != null && stack.getItem() instanceof ToolMetaItem<?>) {
+        if (ConfigHolder.client.toolCraftingSounds && stack.getItem() instanceof ToolMetaItem<?>) {
             if (((ToolMetaItem<?>) stack.getItem()).canPlaySound(stack)) {
                 ((ToolMetaItem<?>) stack.getItem()).setCraftingSoundTime(stack);
                 player.getEntityWorld().playSound(null, player.getPosition(), ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
@@ -185,14 +189,15 @@ public interface IToolStats {
     }
 
     default void onBreakingUse(ItemStack stack, World world, BlockPos pos) {
-        if (ConfigHolder.client.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?>)
+        if (ConfigHolder.client.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?> && this.canPlayBreakingSound(stack))
             world.playSound(null, pos, ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
     }
 
     static void onOtherUse(@Nonnull ItemStack stack, World world, BlockPos pos) {
         if (stack.getItem() instanceof ToolMetaItem<?>) {
             IToolStats stats = ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getToolStats();
-            stats.onBreakingUse(stack, world, pos);
+            if (ConfigHolder.client.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?>)
+                world.playSound(null, pos, ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
         }
     }
 }

--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -13,7 +13,6 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeHooks;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -158,7 +157,7 @@ public interface IToolStats {
         return true;
     }
 
-    default boolean canPlayBreakingSound(ItemStack stack) {
+    default boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
         return false;
     }
 
@@ -189,7 +188,7 @@ public interface IToolStats {
     }
 
     default void onBreakingUse(ItemStack stack, World world, BlockPos pos) {
-        if (ConfigHolder.client.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?> && this.canPlayBreakingSound(stack))
+        if (ConfigHolder.client.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?> && this.canPlayBreakingSound(stack, world.getBlockState(pos)))
             world.playSound(null, pos, ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -176,8 +176,11 @@ public interface IToolStats {
     }
 
     default void onCraftingUse(ItemStack stack, EntityPlayer player) {
-        if (ConfigHolder.client.toolCraftingSounds && player != null && stack.getItem() instanceof ToolMetaItem<?>) {
-            player.getEntityWorld().playSound(null, player.getPosition(), ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
+        if (ConfigHolder.client.toolCraftingSounds && ForgeHooks.getCraftingPlayer() != null && stack.getItem() instanceof ToolMetaItem<?>) {
+            if (((ToolMetaItem<?>) stack.getItem()).canPlaySound(stack)) {
+                ((ToolMetaItem<?>) stack.getItem()).setCraftingSoundTime(stack);
+                player.getEntityWorld().playSound(null, player.getPosition(), ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -708,7 +708,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
 
     public boolean canPlaySound(ItemStack stack) {
         NBTTagCompound statsTag = getOrCreateToolStatsTag(stack);
-        return (int) System.currentTimeMillis() - statsTag.getInteger("lastCraftingUse") > 16;
+        return Math.abs((int) System.currentTimeMillis() - statsTag.getInteger("lastCraftingUse")) > 16;
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -701,6 +701,16 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
         return false;
     }
 
+    public void setCraftingSoundTime(ItemStack stack) {
+        NBTTagCompound statsTag = getOrCreateToolStatsTag(stack);
+        statsTag.setInteger("lastCraftingUse", (int) System.currentTimeMillis());
+    }
+
+    public boolean canPlaySound(ItemStack stack) {
+        NBTTagCompound statsTag = getOrCreateToolStatsTag(stack);
+        return (int) System.currentTimeMillis() - statsTag.getInteger("lastCraftingUse") > 16;
+    }
+
     @SideOnly(Side.CLIENT)
     public boolean isFull3D() {
         return true;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -13,6 +13,7 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.AdvancedTextWidget;
 import gregtech.api.gui.widgets.ClickButtonWidget;
 import gregtech.api.gui.widgets.SlotWidget;
+import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -259,7 +260,7 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
             for (ItemStack itemStack : entityPlayer.inventory.mainInventory) {
                 if (itemStack.isItemEqualIgnoreDurability(tool.getStackForm())) {
                     ((IMaintenance) this.getController()).setMaintenanceFixed(problemIndex);
-                    tool.getToolStats().onBreakingUse(itemStack, getWorld(), getPos());
+                    IToolStats.onOtherUse(itemStack, getWorld(), getPos());
                     damageTool(itemStack);
                     this.setTaped(false);
                 }

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
@@ -105,13 +105,6 @@ public class CraftingRecipeResolver {
             //if we're not simulated, fire the event, unlock recipe and add crafted items, and play sounds
             FMLCommonHandler.instance().firePlayerCraftingEvent(player, itemStack, inventoryCrafting);
 
-            for (int i = 0; i < inventoryCrafting.getSizeInventory(); i++) {
-                if (inventoryCrafting.getStackInSlot(i).getItem() instanceof ToolMetaItem) {
-                    ToolMetaItem.MetaToolValueItem toolStack = ((ToolMetaItem<?>) inventoryCrafting.getStackInSlot(i).getItem()).getItem(inventoryCrafting.getStackInSlot(i));
-                    toolStack.getToolStats().onCraftingUse(inventoryCrafting.getStackInSlot(i), player);
-                }
-            }
-
             if (cachedRecipe != null && !cachedRecipe.isDynamic()) {
                 player.unlockRecipes(Lists.newArrayList(cachedRecipe));
             }

--- a/src/main/java/gregtech/common/tools/ToolBranchCutter.java
+++ b/src/main/java/gregtech/common/tools/ToolBranchCutter.java
@@ -33,4 +33,9 @@ public class ToolBranchCutter extends ToolBase {
     public boolean canMineBlock(IBlockState block, ItemStack stack) {
         return block.getMaterial() == Material.LEAVES;
     }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolBuzzSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolBuzzSaw.java
@@ -33,9 +33,4 @@ public class ToolBuzzSaw extends ToolSaw {
         IElectricItem electricItem = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         return MetaItems.POWER_UNIT_LV.getChargedStackWithOverride(electricItem);
     }
-
-    @Override
-    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
-        return canMineBlock(state, stack);
-    }
 }

--- a/src/main/java/gregtech/common/tools/ToolBuzzSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolBuzzSaw.java
@@ -3,6 +3,7 @@ package gregtech.common.tools;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.common.items.MetaItems;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 
 public class ToolBuzzSaw extends ToolSaw {
@@ -31,5 +32,10 @@ public class ToolBuzzSaw extends ToolSaw {
     public ItemStack getBrokenStack(ItemStack stack) {
         IElectricItem electricItem = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         return MetaItems.POWER_UNIT_LV.getChargedStackWithOverride(electricItem);
+    }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolChainsaw.java
+++ b/src/main/java/gregtech/common/tools/ToolChainsaw.java
@@ -120,4 +120,9 @@ public class ToolChainsaw extends ToolSaw {
         }
         return powerUnit == null ? ItemStack.EMPTY : powerUnit.getChargedStackWithOverride(electricItem);
     }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack) {
+        return true;
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolChainsaw.java
+++ b/src/main/java/gregtech/common/tools/ToolChainsaw.java
@@ -122,7 +122,7 @@ public class ToolChainsaw extends ToolSaw {
     }
 
     @Override
-    public boolean canPlayBreakingSound(ItemStack stack) {
-        return true;
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
     }
 }

--- a/src/main/java/gregtech/common/tools/ToolCrowbar.java
+++ b/src/main/java/gregtech/common/tools/ToolCrowbar.java
@@ -49,4 +49,9 @@ public class ToolCrowbar extends ToolBase {
     public Set<String> getToolClasses(ItemStack stack) {
         return CROWBAR_TOOL_CLASSES;
     }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -89,6 +89,11 @@ public class ToolSaw extends ToolBase {
         return SAW_TOOL_CLASSES;
     }
 
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
+    }
+
     /**
      * Added to the world event listeners to hopefully catch and revert the ice-to-water conversion.
      * <p>

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -89,11 +89,6 @@ public class ToolSaw extends ToolBase {
         return SAW_TOOL_CLASSES;
     }
 
-    @Override
-    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
-        return canMineBlock(state, stack);
-    }
-
     /**
      * Added to the world event listeners to hopefully catch and revert the ice-to-water conversion.
      * <p>

--- a/src/main/java/gregtech/common/tools/ToolWireCutter.java
+++ b/src/main/java/gregtech/common/tools/ToolWireCutter.java
@@ -35,4 +35,9 @@ public class ToolWireCutter extends ToolBase {
     public Set<String> getToolClasses(ItemStack stack) {
         return CUTTER_TOOL_CLASSES;
     }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
+    }
 }

--- a/src/main/java/gregtech/common/tools/ToolWrench.java
+++ b/src/main/java/gregtech/common/tools/ToolWrench.java
@@ -61,4 +61,9 @@ public class ToolWrench extends ToolBase {
     public Set<String> getToolClasses(ItemStack stack) {
         return WRENCH_TOOL_CLASSES;
     }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
+    }
 }

--- a/src/main/java/gregtech/common/tools/largedrills/ToolDrillLarge.java
+++ b/src/main/java/gregtech/common/tools/largedrills/ToolDrillLarge.java
@@ -260,7 +260,7 @@ public abstract class ToolDrillLarge<E extends Enum<E> & IDrillMode> extends Too
     }
 
     @Override
-    public boolean canPlayBreakingSound(ItemStack stack) {
-        return true;
+    public boolean canPlayBreakingSound(ItemStack stack, IBlockState state) {
+        return canMineBlock(state, stack);
     }
 }

--- a/src/main/java/gregtech/common/tools/largedrills/ToolDrillLarge.java
+++ b/src/main/java/gregtech/common/tools/largedrills/ToolDrillLarge.java
@@ -258,4 +258,9 @@ public abstract class ToolDrillLarge<E extends Enum<E> & IDrillMode> extends Too
     public Set<String> getToolClasses(ItemStack stack) {
         return DRILL_TOOL_CLASSES;
     }
+
+    @Override
+    public boolean canPlayBreakingSound(ItemStack stack) {
+        return true;
+    }
 }


### PR DESCRIPTION
Does what is mentioned in the title, most notably in crafting menus, where crafting multiple items at once can create deafening noises.
This also fixes an issue with maintenance sounds.