### PR TITLE
Require empty hand to shift click open covers

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -393,7 +393,7 @@ public abstract class MetaTileEntity implements ICoverable {
                 MetaTileEntityUIFactory.INSTANCE.openUI(getHolder(), (EntityPlayerMP) playerIn);
             }
             return true;
-        } else if (playerIn.isSneaking()) {
+        } else if (playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
             EnumFacing hitFacing = hitResult.sideHit;
 
             CoverBehavior coverBehavior = hitFacing == null ? null : getCoverAtSide(hitFacing);

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -298,7 +298,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
         EnumActionResult result = coverBehavior.onRightClick(entityPlayer, hand, hit);
         if (result == EnumActionResult.PASS) {
-            return entityPlayer.isSneaking() && coverBehavior.onScrewdriverClick(entityPlayer, hand, hit) != EnumActionResult.PASS;
+            return entityPlayer.isSneaking() && entityPlayer.getHeldItemMainhand().isEmpty() && coverBehavior.onScrewdriverClick(entityPlayer, hand, hit) != EnumActionResult.PASS;
         } else if (result == EnumActionResult.SUCCESS) {
             if (!world.isRemote)
                 GTTriggers.FIRST_COVER_PLACE.trigger((EntityPlayerMP) entityPlayer);


### PR DESCRIPTION
**What:**
Requires the player to have an empty hand to shift click open covers