### PR TITLE
Add Conversion Recipes for Hatches and buses

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -74,6 +74,7 @@ public class MachineRecipeLoader {
         registerStoneBricksRecipes();
         registerOrganicRecyclingRecipes();
         registerNBTRemoval();
+        ConvertHatchToHatch();
     }
 
     private static void registerBendingCompressingRecipes() {
@@ -956,5 +957,26 @@ public class MachineRecipeLoader {
         //Jetpacks
         ModHandler.addShapelessRecipe("fluid_jetpack_clear", SEMIFLUID_JETPACK.getStackForm(), SEMIFLUID_JETPACK.getStackForm());
 
+    }
+    private static void ConvertHatchToHatch() {
+        for (int i = 0; i < FLUID_IMPORT_HATCH.length; i++) {
+            if(FLUID_IMPORT_HATCH[i] != null) {
+
+                ModHandler.addShapelessRecipe(FLUID_IMPORT_HATCH[i].getMetaName() + FLUID_IMPORT_HATCH[i].getTier(), FLUID_IMPORT_HATCH[i].getStackForm(), FLUID_EXPORT_HATCH[i].getStackForm());
+                ModHandler.addShapelessRecipe(FLUID_EXPORT_HATCH[i].getMetaName() + FLUID_EXPORT_HATCH[i].getTier(), FLUID_EXPORT_HATCH[i].getStackForm(), FLUID_IMPORT_HATCH[i].getStackForm());
+            }
+        }
+        for (int i = 0; i < ITEM_IMPORT_BUS.length; i++) {
+            if(ITEM_IMPORT_BUS[i] != null) {
+
+                ModHandler.addShapelessRecipe(ITEM_IMPORT_BUS[i].getMetaName() + ITEM_IMPORT_BUS[i].getTier(), ITEM_IMPORT_BUS[i].getStackForm(), ITEM_EXPORT_BUS[i].getStackForm());
+                ModHandler.addShapelessRecipe(ITEM_EXPORT_BUS[i].getMetaName() + ITEM_EXPORT_BUS[i].getTier(), ITEM_EXPORT_BUS[i].getStackForm(), ITEM_IMPORT_BUS[i].getStackForm());
+            }
+        }
+        if (STEAM_EXPORT_BUS != null && STEAM_IMPORT_BUS != null){
+        //Steam
+        ModHandler.addShapelessRecipe( STEAM_EXPORT_BUS.getMetaName() + STEAM_EXPORT_BUS.getTier(), STEAM_EXPORT_BUS.getStackForm(), STEAM_IMPORT_BUS.getStackForm());
+        ModHandler.addShapelessRecipe( STEAM_IMPORT_BUS.getMetaName() + STEAM_IMPORT_BUS.getTier(), STEAM_IMPORT_BUS.getStackForm(), STEAM_EXPORT_BUS.getStackForm());
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -958,25 +958,26 @@ public class MachineRecipeLoader {
         ModHandler.addShapelessRecipe("fluid_jetpack_clear", SEMIFLUID_JETPACK.getStackForm(), SEMIFLUID_JETPACK.getStackForm());
 
     }
+
     private static void ConvertHatchToHatch() {
         for (int i = 0; i < FLUID_IMPORT_HATCH.length; i++) {
-            if(FLUID_IMPORT_HATCH[i] != null && FLUID_EXPORT_HATCH[i] != null ) {
+            if (FLUID_IMPORT_HATCH[i] != null && FLUID_EXPORT_HATCH[i] != null) {
 
-                ModHandler.addShapelessRecipe("fluid_hatch_output_to_input_" +FLUID_IMPORT_HATCH[i].getTier(), FLUID_IMPORT_HATCH[i].getStackForm(), FLUID_EXPORT_HATCH[i].getStackForm());
+                ModHandler.addShapelessRecipe("fluid_hatch_output_to_input_" + FLUID_IMPORT_HATCH[i].getTier(), FLUID_IMPORT_HATCH[i].getStackForm(), FLUID_EXPORT_HATCH[i].getStackForm());
                 ModHandler.addShapelessRecipe("fluid_hatch_input_to_output_" + FLUID_EXPORT_HATCH[i].getTier(), FLUID_EXPORT_HATCH[i].getStackForm(), FLUID_IMPORT_HATCH[i].getStackForm());
             }
         }
         for (int i = 0; i < ITEM_IMPORT_BUS.length; i++) {
-            if(ITEM_IMPORT_BUS[i] != null && ITEM_EXPORT_BUS[i] != null) {
+            if (ITEM_IMPORT_BUS[i] != null && ITEM_EXPORT_BUS[i] != null) {
 
                 ModHandler.addShapelessRecipe("item_bus_output_to_input_" + ITEM_IMPORT_BUS[i].getTier(), ITEM_IMPORT_BUS[i].getStackForm(), ITEM_EXPORT_BUS[i].getStackForm());
                 ModHandler.addShapelessRecipe("item_bus_input_to_output_" + ITEM_EXPORT_BUS[i].getTier(), ITEM_EXPORT_BUS[i].getStackForm(), ITEM_IMPORT_BUS[i].getStackForm());
             }
         }
-        if (STEAM_EXPORT_BUS != null && STEAM_IMPORT_BUS != null){
-        //Steam
-        ModHandler.addShapelessRecipe( "steam_bus_output_to_input_"+ STEAM_EXPORT_BUS.getTier(), STEAM_EXPORT_BUS.getStackForm(), STEAM_IMPORT_BUS.getStackForm());
-        ModHandler.addShapelessRecipe( "steam_bus_input_to_output_" + STEAM_IMPORT_BUS.getTier(), STEAM_IMPORT_BUS.getStackForm(), STEAM_EXPORT_BUS.getStackForm());
+        if (STEAM_EXPORT_BUS != null && STEAM_IMPORT_BUS != null) {
+            //Steam
+            ModHandler.addShapelessRecipe("steam_bus_output_to_input_" + STEAM_EXPORT_BUS.getTier(), STEAM_EXPORT_BUS.getStackForm(), STEAM_IMPORT_BUS.getStackForm());
+            ModHandler.addShapelessRecipe("steam_bus_input_to_output_" + STEAM_IMPORT_BUS.getTier(), STEAM_IMPORT_BUS.getStackForm(), STEAM_EXPORT_BUS.getStackForm());
         }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -960,23 +960,23 @@ public class MachineRecipeLoader {
     }
     private static void ConvertHatchToHatch() {
         for (int i = 0; i < FLUID_IMPORT_HATCH.length; i++) {
-            if(FLUID_IMPORT_HATCH[i] != null) {
+            if(FLUID_IMPORT_HATCH[i] != null && FLUID_EXPORT_HATCH[i] != null ) {
 
-                ModHandler.addShapelessRecipe(FLUID_IMPORT_HATCH[i].getMetaName() + FLUID_IMPORT_HATCH[i].getTier(), FLUID_IMPORT_HATCH[i].getStackForm(), FLUID_EXPORT_HATCH[i].getStackForm());
-                ModHandler.addShapelessRecipe(FLUID_EXPORT_HATCH[i].getMetaName() + FLUID_EXPORT_HATCH[i].getTier(), FLUID_EXPORT_HATCH[i].getStackForm(), FLUID_IMPORT_HATCH[i].getStackForm());
+                ModHandler.addShapelessRecipe("fluid_hatch_output_to_input_" +FLUID_IMPORT_HATCH[i].getTier(), FLUID_IMPORT_HATCH[i].getStackForm(), FLUID_EXPORT_HATCH[i].getStackForm());
+                ModHandler.addShapelessRecipe("fluid_hatch_input_to_output_" + FLUID_EXPORT_HATCH[i].getTier(), FLUID_EXPORT_HATCH[i].getStackForm(), FLUID_IMPORT_HATCH[i].getStackForm());
             }
         }
         for (int i = 0; i < ITEM_IMPORT_BUS.length; i++) {
-            if(ITEM_IMPORT_BUS[i] != null) {
+            if(ITEM_IMPORT_BUS[i] != null && ITEM_EXPORT_BUS[i] != null) {
 
-                ModHandler.addShapelessRecipe(ITEM_IMPORT_BUS[i].getMetaName() + ITEM_IMPORT_BUS[i].getTier(), ITEM_IMPORT_BUS[i].getStackForm(), ITEM_EXPORT_BUS[i].getStackForm());
-                ModHandler.addShapelessRecipe(ITEM_EXPORT_BUS[i].getMetaName() + ITEM_EXPORT_BUS[i].getTier(), ITEM_EXPORT_BUS[i].getStackForm(), ITEM_IMPORT_BUS[i].getStackForm());
+                ModHandler.addShapelessRecipe("item_bus_output_to_input_" + ITEM_IMPORT_BUS[i].getTier(), ITEM_IMPORT_BUS[i].getStackForm(), ITEM_EXPORT_BUS[i].getStackForm());
+                ModHandler.addShapelessRecipe("item_bus_input_to_output_" + ITEM_EXPORT_BUS[i].getTier(), ITEM_EXPORT_BUS[i].getStackForm(), ITEM_IMPORT_BUS[i].getStackForm());
             }
         }
         if (STEAM_EXPORT_BUS != null && STEAM_IMPORT_BUS != null){
         //Steam
-        ModHandler.addShapelessRecipe( STEAM_EXPORT_BUS.getMetaName() + STEAM_EXPORT_BUS.getTier(), STEAM_EXPORT_BUS.getStackForm(), STEAM_IMPORT_BUS.getStackForm());
-        ModHandler.addShapelessRecipe( STEAM_IMPORT_BUS.getMetaName() + STEAM_IMPORT_BUS.getTier(), STEAM_IMPORT_BUS.getStackForm(), STEAM_EXPORT_BUS.getStackForm());
+        ModHandler.addShapelessRecipe( "steam_bus_output_to_input_"+ STEAM_EXPORT_BUS.getTier(), STEAM_EXPORT_BUS.getStackForm(), STEAM_IMPORT_BUS.getStackForm());
+        ModHandler.addShapelessRecipe( "steam_bus_input_to_output_" + STEAM_IMPORT_BUS.getTier(), STEAM_IMPORT_BUS.getStackForm(), STEAM_EXPORT_BUS.getStackForm());
         }
     }
 }


### PR DESCRIPTION
**What:**
Allows Items/fluid inputs to be crafted into outputs and vice versa.

**Possible compatibility issue:**
None