### PR TITLE
Add the ability for custom chance functions per RecipeMap

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -45,8 +45,7 @@ import java.util.stream.Collectors;
 public class RecipeMap<R extends RecipeBuilder<R>> {
 
     private static final Map<String, RecipeMap<?>> RECIPE_MAP_REGISTRY = new HashMap<>();
-    @ZenProperty
-    public static final IChanceFunction chanceFunction = (chance, boostPerTier, tier) -> chance + (boostPerTier * tier);
+    public static IChanceFunction chanceFunction = (chance, boostPerTier, tier) -> chance + (boostPerTier * tier);
 
     public final String unlocalizedName;
 
@@ -151,6 +150,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     public RecipeMap<R> setSound(SoundEvent sound) {
         this.sound = sound;
+        return this;
+    }
+
+    @ZenMethod("setChanceFunction")
+    public RecipeMap<R> setChanceFunction(IChanceFunction function) {
+        chanceFunction = function;
         return this;
     }
 


### PR DESCRIPTION
**What:**

Introduces something that allows for Recipe Maps to set their own chanced output scaling function. This also works for CT.

Examples: adding `.setChanceFunction(((chance, boostPerTier, boostTier) -> chance))` to a Recipe Map will mean that all chanced recipes in that machine do not have any scaling boosts, despite what is defined in the recipe. After adding this, if you define a recipe on that recipe map that has `chancedOutput(item, 1000, 10000)`, which would normally be 10% chance, with 100% boost per tier, there will instead just be a 10% chance.

This is useful for CT, which can now do something like:
```less
import mods.gregtech.recipe.RecipeMap;

global chem     as RecipeMap = RecipeMap.getByName("chemical_reactor");

chem.setChanceFunction(function(chance as int, boostPerTier as int, tier as int) as int {
                       	return chance;
                       });
```

To achieve the same as in the first example.


TODO: The chance scaling tooltip above chanced outputs needs to be fixed to display the new values, if the scaling is changed for the recipeMap, but I am not sure of a way to retrieve the values from the IChanceFunction