### PR TITLE
Allow for JEI to detect hovered ingredients in MultiblockInfoRecipeWrapper

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -189,6 +189,11 @@ public class GregTechMod {
     }
 
     @Mod.EventHandler
+    public void loadComplete(FMLLoadCompleteEvent event) {
+        proxy.onLoadComplete();
+    }
+
+    @Mod.EventHandler
     public void onServerLoad(FMLServerStartingEvent event) {
         event.registerServerCommand(new GregTechCommand());
     }

--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -29,6 +29,7 @@ import gregtech.common.pipelike.fluidpipe.BlockFluidPipe;
 import gregtech.common.pipelike.fluidpipe.ItemBlockFluidPipe;
 import gregtech.common.pipelike.itempipe.BlockItemPipe;
 import gregtech.common.pipelike.itempipe.ItemBlockItemPipe;
+import gregtech.integration.jei.GTJeiPlugin;
 import gregtech.loaders.MaterialInfoLoader;
 import gregtech.loaders.OreDictionaryLoader;
 import gregtech.loaders.recipe.CraftingComponent;
@@ -288,5 +289,10 @@ public class CommonProxy {
     public void onPostLoad() {
         GTRecipeManager.postLoad();
         TerminalRegistry.init();
+    }
+
+    public void onLoadComplete() {
+        if(GTValues.isModLoaded(GTValues.MODID_JEI))
+            GTJeiPlugin.setupInputHandler();
     }
 }

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -35,17 +35,23 @@ import gregtech.integration.jei.recipe.primitive.OreByProductCategory;
 import gregtech.integration.jei.utils.CustomItemReturnRecipeWrapper;
 import gregtech.integration.jei.utils.MachineSubtypeHandler;
 import gregtech.integration.jei.utils.MetaItemSubtypeHandler;
+import gregtech.integration.jei.utils.MultiblockInfoRecipeFocusShower;
 import gregtech.loaders.recipe.CustomItemReturnShapedOreRecipeRecipe;
+import mezz.jei.Internal;
 import mezz.jei.api.*;
 import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.config.Constants;
+import mezz.jei.input.IShowsRecipeFocuses;
+import mezz.jei.input.InputHandler;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
 import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -234,6 +240,20 @@ public class GTJeiPlugin implements IModPlugin {
                 registry.addIngredientInfo(mte.getStackForm(), VanillaTypes.ITEM, mte.getDescription());
             }
         });
+    }
+
+    public static void setupInputHandler() {
+        try {
+            Field inputHandlerField = Internal.class.getDeclaredField("inputHandler");
+            inputHandlerField.setAccessible(true);
+            InputHandler inputHandler = (InputHandler) inputHandlerField.get(null);
+            List<IShowsRecipeFocuses> showsRecipeFocuses = ObfuscationReflectionHelper.getPrivateValue(InputHandler.class, inputHandler, "showsRecipeFocuses");
+
+            showsRecipeFocuses.add(new MultiblockInfoRecipeFocusShower());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private static void registerRecipeMapCatalyst(IModRegistry registry, RecipeMap<?> recipeMap, MetaTileEntity metaTileEntity) {

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -101,7 +101,8 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     private IDrawable slot;
     private IDrawable infoIcon;
     private boolean drawInfoIcon;
-    private ItemStack tooltipBlockStack;
+    private static ItemStack tooltipBlockStack;
+    private static long lastRender;
     private List<String> predicateTips;
 
     private BlockPos selected;
@@ -287,7 +288,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             button.drawButton(minecraft, mouseX, mouseY, 0.0f);
         }
 
-        this.tooltipBlockStack = null;
+        tooltipBlockStack = null;
         this.predicateTips = null;
         RayTraceResult rayTraceResult = renderer.getLastTraceResult();
         boolean insideView = mouseX >= 0 && mouseY >= 0 &&
@@ -338,11 +339,12 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
                     }
                 }
             }
-            if (itemStack != null && !itemStack.isEmpty()) {
-                this.tooltipBlockStack = itemStack;
+            if (!itemStack.isEmpty()) {
+                tooltipBlockStack = itemStack;
             }
         }
 
+        lastRender = System.currentTimeMillis();
         this.lastMouseX = mouseX;
         this.lastMouseY = mouseY;
 
@@ -572,5 +574,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GlStateManager.color(1, 1, 1, 1);
     }
+
+    public static ItemStack getHoveredItemStack() {
+        if(lastRender > System.currentTimeMillis() - 100) {
+            return tooltipBlockStack;
+        }
+        return null;
+    }
+
 
 }

--- a/src/main/java/gregtech/integration/jei/utils/MultiblockInfoRecipeFocusShower.java
+++ b/src/main/java/gregtech/integration/jei/utils/MultiblockInfoRecipeFocusShower.java
@@ -1,0 +1,21 @@
+package gregtech.integration.jei.utils;
+
+import gregtech.integration.jei.multiblock.MultiblockInfoRecipeWrapper;
+import mezz.jei.input.ClickedIngredient;
+
+import mezz.jei.input.IClickedIngredient;
+import mezz.jei.input.IShowsRecipeFocuses;
+
+public class MultiblockInfoRecipeFocusShower implements IShowsRecipeFocuses {
+    @Override
+    public IClickedIngredient<?> getIngredientUnderMouse(int mouseX, int mouseY) {
+        if (MultiblockInfoRecipeWrapper.getHoveredItemStack() != null)
+            return ClickedIngredient.create(MultiblockInfoRecipeWrapper.getHoveredItemStack(), null);
+        return null;
+    }
+
+    @Override
+    public boolean canSetFocusWithMouse() {
+        return false;
+    }
+}


### PR DESCRIPTION
This PR does exactly as the title says. It does this by, during loadComplete, to modify JEI's internal input handler to insert a condition for the specific case. This can be extended later, but so far, it doesn't seem to need to. I would have used a method other than reflection if it was possible, but in this instance, it was not. 
I also set up a timer in MultiblockInfoRecipeWrapper so that it would only work for a short time after it had last rendered, preventing a user from just accessing the last block they hovered over from anywhere.

The effect of this is to allow the A, R, and U keybinds from JEI to work on these blocks, as seen below.

https://user-images.githubusercontent.com/80226372/147370622-0df443a6-16cf-4ac9-8ba6-7b78865fa407.mp4
