### PR TITLE
Trim Factor and Fluid Trimming

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -259,19 +259,19 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     /**
      * Should the output items of a recipe be limited by some trim factor
      *
-     * @return A Pair of if the recipe should be trimmed, and to what resulting number
+     * @return The number of resulting item outputs, or -1 for no trim
      */
-    public Pair<Boolean, Integer> trimItemOutputs() {
-        return Pair.of(false, 1);
+    public int trimItemOutputs() {
+        return -1;
     }
 
     /**
      * Should the output fluids of a recipe be limited by some trim factor
      *
-     * @return A Pair of if the recipe fluid outputs should be trimmed, and to what resulting number
+     * @return The number of resulting fluid outputs, or -1 for no trim
      */
-    public Pair<Boolean, Integer> trimFluidOutputs() {
-        return Pair.of(false, 1);
+    public int trimFluidOutputs() {
+        return -1;
     }
 
     public boolean canVoidRecipeOutputs() {
@@ -643,27 +643,27 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.recipeEUt = resultOverclock[0];
 
         // Fluid Logic and trimming. TODO chanced fluid outputs?
-        Pair<Boolean, Integer> outputFluidTrim = trimFluidOutputs();
-        if(outputFluidTrim.getLeft() && parallelRecipesPerformed == 0 && recipe.getFluidOutputs().size() > outputFluidTrim.getRight()) {
+        int outputFluidTrim = trimFluidOutputs();
+        if(outputFluidTrim != -1 && parallelRecipesPerformed == 0 && recipe.getFluidOutputs().size() > outputFluidTrim) {
 
             // If there are more fluid outputs than the trim factor
-            this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs().subList(0, trimFluidOutputs().getRight()));
+            this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs().subList(0, trimFluidOutputs()));
         }
         else {
             this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
         }
 
         // Item Logic and trimming
-        Pair<Boolean, Integer> outputItemTrim = trimItemOutputs();
+        int outputItemTrim = trimItemOutputs();
         // if it's a paralleled recipe, the output is already trimmed
-        if (outputItemTrim.getLeft() && parallelRecipesPerformed == 0 && (recipe.getOutputs().size() + recipe.getChancedOutputs().size()) > outputItemTrim.getRight()) {
+        if (outputItemTrim != -1 && parallelRecipesPerformed == 0 && (recipe.getOutputs().size() + recipe.getChancedOutputs().size()) > outputItemTrim) {
             // If there are item outputs, and the number of outputs is greater than the trim factor
-            if (recipe.getOutputs().size() > 0 && recipe.getOutputs().size() >= outputItemTrim.getRight()) {
-                this.itemOutputs = GTUtility.copyStackList(recipe.getOutputs().subList(0, outputItemTrim.getRight()));
+            if (recipe.getOutputs().size() > 0 && recipe.getOutputs().size() >= outputItemTrim) {
+                this.itemOutputs = GTUtility.copyStackList(recipe.getOutputs().subList(0, outputItemTrim));
             }
             // Mix regular outputs and chanced outputs
             else if(recipe.getOutputs().size() > 0) {
-                int numChanced = outputItemTrim.getRight() - recipe.getOutputs().size();
+                int numChanced = outputItemTrim - recipe.getOutputs().size();
                 List<Recipe.ChanceEntry> tempChance = recipe.getChancedOutputs().subList(0, Math.min(numChanced, recipe.getChancedOutputs().size()));
                 this.itemOutputs = GTUtility.copyStackList(recipe.getOutputs());
                 List<ItemStack> chanced = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(), GTUtility.getTierByVoltage(recipeEUt), recipeMap)
@@ -677,9 +677,9 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             else {
                 // Which Chanced outputs were actually output by the recipe
                 NonNullList<ItemStack> tempOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(), GTUtility.getTierByVoltage(recipeEUt), recipeMap));
-                int numOutputs = Math.min(tempOutputs.size(), outputItemTrim.getRight());
+                int numOutputs = Math.min(tempOutputs.size(), outputItemTrim);
 
-                if(numOutputs <= outputItemTrim.getRight()) {
+                if(numOutputs <= outputItemTrim) {
                     this.itemOutputs = tempOutputs;
                 }
                 else {

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -28,7 +28,6 @@ import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
-import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -423,10 +422,14 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         IItemHandlerModifiable exportInventory = getOutputInventory();
         IMultipleTankHandler importFluids = getInputTank();
         IMultipleTankHandler exportFluids = getOutputTank();
+        int numFluidOutputs = recipe.getFluidOutputs().size();
+        int numItemOutputs = recipe.getAllItemOutputs(exportInventory.getSlots()).size();
+        int fluidTrimLength = trimFluidOutputs() == -1 ? numFluidOutputs : Math.min(numFluidOutputs, trimFluidOutputs());
+        int itemTrimLength = trimItemOutputs() == -1 ? numItemOutputs : Math.min(numItemOutputs, trimItemOutputs());
 
         if (!canVoidRecipeOutputs() &&
-                (!MetaTileEntity.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs(exportInventory.getSlots())) ||
-                 !MetaTileEntity.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs()))) {
+                (!MetaTileEntity.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs(exportInventory.getSlots()).subList(0, itemTrimLength)) ||
+                 !MetaTileEntity.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs().subList(0, fluidTrimLength)))) {
             this.isOutputsFull = true;
             return false;
         }

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -3,6 +3,7 @@ package gregtech.api.capability.impl;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.recipes.RecipeBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 
@@ -25,8 +26,8 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     }
 
     @Override
-    public boolean trimOutputs() {
-        return true;
+    public Pair<Boolean, Integer> trimItemOutputs() {
+        return Pair.of(true, 1);
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -26,8 +26,8 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     }
 
     @Override
-    public Pair<Boolean, Integer> trimItemOutputs() {
-        return Pair.of(true, 1);
+    public int trimItemOutputs() {
+        return 1;
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -20,7 +20,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -419,7 +418,7 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
      * @return the builder holding the multiplied recipe
      */
 
-    public R append(Recipe recipe, int multiplier, boolean multiplyDuration, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs) {
+    public R append(Recipe recipe, int multiplier, boolean multiplyDuration, int trimItemOutputs, int trimFluidOutputs) {
         for (Map.Entry<RecipeProperty<?>, Object> property : recipe.getPropertyValues()) {
             this.applyProperty(property.getKey().getKey(), property.getValue());
         }
@@ -438,20 +437,20 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.fluidInputs(newFluidInputs);
 
         // Item Output and Trimming logic
-        if (trimItemOutputs.getLeft()) {
+        if (trimItemOutputs != -1) {
             // If there are more outputs than the trim factor
-            if (!outputItems.isEmpty() && outputItems.size() >= trimItemOutputs.getRight()) {
-                this.outputs(outputItems.subList(0, trimItemOutputs.getRight()));
+            if (!outputItems.isEmpty() && outputItems.size() >= trimItemOutputs) {
+                this.outputs(outputItems.subList(0, trimItemOutputs));
             }
             // Combine regular outputs and chanced outputs to reach the trim factor
             else if(!outputItems.isEmpty()) {
-                int numChanced = trimItemOutputs.getRight() - outputItems.size();
+                int numChanced = trimItemOutputs - outputItems.size();
                 this.outputs(outputItems);
                 trimmedChancedOutputsMultiply(recipe, multiplier, Math.min(numChanced, recipe.getChancedOutputs().size()));
             }
             // Chanced outputs only
             else if (recipe.getChancedOutputs().size() > 0) {
-                trimmedChancedOutputsMultiply(recipe, multiplier, Math.min(trimItemOutputs.getRight(), recipe.getChancedOutputs().size()));
+                trimmedChancedOutputsMultiply(recipe, multiplier, Math.min(trimItemOutputs, recipe.getChancedOutputs().size()));
             }
         } else {
             this.outputs(outputItems);
@@ -459,8 +458,8 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
         }
 
         // Fluid Output and Trimming Logic TODO Chanced Fluid output support
-        if(trimFluidOutputs.getLeft() && outputFluids.size() > trimFluidOutputs.getRight()) {
-            this.fluidOutputs(outputFluids.subList(0, trimFluidOutputs.getRight()));
+        if(trimFluidOutputs != -1 && outputFluids.size() > trimFluidOutputs) {
+            this.fluidOutputs(outputFluids.subList(0, trimFluidOutputs));
         }
         else {
             this.fluidOutputs(outputFluids);

--- a/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
@@ -35,7 +35,9 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
+    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs,
+                                                          IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage,
+                                                          int trimItemOutputs, int trimFluidOutputs, boolean canVoidRecipeOutputs) {
         return ParallelLogic.doParallelRecipes(
                 currentRecipe,
                 recipeMap,
@@ -60,7 +62,7 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
+    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, int trimItemOutputs, int trimFluidOutputs, boolean canVoidRecipeOutputs) {
         return ParallelLogic.appendItemRecipes(
                 recipeMap,
                 inputs,

--- a/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
@@ -7,6 +7,7 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 
@@ -34,7 +35,7 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage, boolean trimOutputs, boolean canVoidRecipeOutputs) {
+    default RecipeBuilder<?> findMultipliedParallelRecipe(RecipeMap<?> recipeMap, Recipe currentRecipe, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, IItemHandlerModifiable outputs, IMultipleTankHandler fluidOutputs, int parallelLimit, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
         return ParallelLogic.doParallelRecipes(
                 currentRecipe,
                 recipeMap,
@@ -44,7 +45,8 @@ public interface IParallelableRecipeLogic {
                 fluidOutputs,
                 parallelLimit,
                 maxVoltage,
-                trimOutputs,
+                trimItemOutputs,
+                trimFluidOutputs,
                 canVoidRecipeOutputs);
     }
 
@@ -58,14 +60,15 @@ public interface IParallelableRecipeLogic {
      * @param parallelLimit the maximum number of parallel recipes to be performed
      * @return the recipe builder with the parallelized recipe. returns null the recipe cant fit
      */
-    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, boolean trimOutputs, boolean canVoidRecipeOutputs) {
+    default RecipeBuilder<?> findAppendedParallelItemRecipe(RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IItemHandlerModifiable outputs, int parallelLimit, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
         return ParallelLogic.appendItemRecipes(
                 recipeMap,
                 inputs,
                 outputs,
                 parallelLimit,
                 maxVoltage,
-                trimOutputs,
+                trimItemOutputs,
+                trimFluidOutputs,
                 canVoidRecipeOutputs);
     }
 
@@ -73,9 +76,9 @@ public interface IParallelableRecipeLogic {
         if (parallelLimit > 1) {
             RecipeBuilder<?> parallelBuilder = null;
             if (logic.getParallelLogicType() == ParallelLogicType.MULTIPLY) {
-                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage, logic.trimOutputs(), logic.canVoidRecipeOutputs());
+                parallelBuilder = findMultipliedParallelRecipe(logic.getRecipeMap(), currentRecipe, inputs, fluidInputs, outputs, fluidOutputs, parallelLimit, maxVoltage, logic.trimItemOutputs(), logic.trimFluidOutputs(), logic.canVoidRecipeOutputs());
             } else if (logic.getParallelLogicType() == ParallelLogicType.APPEND_ITEMS) {
-                parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage, logic.trimOutputs(), logic.canVoidRecipeOutputs());
+                parallelBuilder = findAppendedParallelItemRecipe(logic.getRecipeMap(), inputs, outputs, parallelLimit, maxVoltage, logic.trimItemOutputs(), logic.trimFluidOutputs(), logic.canVoidRecipeOutputs());
             }
             // if the builder returned is null, no recipe was found.
             if (parallelBuilder == null) {

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -10,6 +10,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
 
@@ -362,7 +363,7 @@ public class ParallelLogic {
         return minMultiplier;
     }
 
-    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, boolean trimOutputs, boolean canVoidRecipeOutputs) {
+    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
         int multiplierByInputs = getMaxRecipeMultiplier(currentRecipe, importInventory, importFluids, parallelAmount);
         if (multiplierByInputs == 0) {
             return null;
@@ -379,7 +380,7 @@ public class ParallelLogic {
         int parallelizable = Math.min(limitByVoltage, Math.min(multiplierByInputs, limitByOutput));
 
         if (parallelizable > 0) {
-            recipeBuilder.append(currentRecipe, parallelizable, false, trimOutputs);
+            recipeBuilder.append(currentRecipe, parallelizable, false, trimItemOutputs, trimFluidOutputs);
         }
 
         return recipeBuilder;
@@ -396,7 +397,7 @@ public class ParallelLogic {
      * @param maxVoltage      The maximum voltage of the machine
      * @return A {@link RecipeBuilder} containing the recipes that can be performed in parallel, limited by the ingredients available, and the output space available.
      */
-    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, boolean trimOutputs, boolean canVoidRecipeOutputs) {
+    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
         RecipeBuilder<?> recipeBuilder = null;
 
         OverlayedItemHandler overlayedItemHandler = new OverlayedItemHandler(exportInventory);
@@ -443,7 +444,7 @@ public class ParallelLogic {
             int multiplierRecipeAmount = Math.min(ingredientRatio, limitByOutput);
 
             if (multiplierRecipeAmount > 0) {
-                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, true, trimOutputs);
+                recipeBuilder.append(matchingRecipe, multiplierRecipeAmount, true, trimItemOutputs, trimFluidOutputs);
                 engagedItems += multiplierRecipeAmount;
             }
 

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -363,7 +363,7 @@ public class ParallelLogic {
         return minMultiplier;
     }
 
-    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
+    public static RecipeBuilder<?> doParallelRecipes(Recipe currentRecipe, RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IMultipleTankHandler importFluids, IItemHandlerModifiable exportInventory, IMultipleTankHandler exportFluids, int parallelAmount, long maxVoltage, int trimItemOutputs, int trimFluidOutputs, boolean canVoidRecipeOutputs) {
         int multiplierByInputs = getMaxRecipeMultiplier(currentRecipe, importInventory, importFluids, parallelAmount);
         if (multiplierByInputs == 0) {
             return null;
@@ -397,7 +397,7 @@ public class ParallelLogic {
      * @param maxVoltage      The maximum voltage of the machine
      * @return A {@link RecipeBuilder} containing the recipes that can be performed in parallel, limited by the ingredients available, and the output space available.
      */
-    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, Pair<Boolean, Integer> trimItemOutputs, Pair<Boolean, Integer> trimFluidOutputs, boolean canVoidRecipeOutputs) {
+    public static RecipeBuilder<?> appendItemRecipes(RecipeMap<?> recipeMap, IItemHandlerModifiable importInventory, IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, int trimItemOutputs, int trimFluidOutputs, boolean canVoidRecipeOutputs) {
         RecipeBuilder<?> recipeBuilder = null;
 
         OverlayedItemHandler overlayedItemHandler = new OverlayedItemHandler(exportInventory);

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.multi.electric;
 
+import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
@@ -30,6 +31,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
 
     public MetaTileEntityDistillationTower(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.DISTILLATION_RECIPES);
+        this.recipeMapWorkable = new DistillationTowerWorkable(this);
     }
 
     @Override
@@ -93,5 +95,18 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.DISTILLATION_TOWER_OVERLAY;
+    }
+
+    @SuppressWarnings("InnerClassMayBeStatic")
+    protected class DistillationTowerWorkable extends MultiblockRecipeLogic {
+
+        public DistillationTowerWorkable(RecipeMapMultiblockController tileEntity) {
+            super(tileEntity);
+        }
+
+        @Override
+        public int trimFluidOutputs() {
+            return getOutputTank().getTanks();
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -37,6 +37,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -274,11 +275,23 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
-        public boolean trimOutputs() {
+        public Pair<Boolean, Integer> trimItemOutputs() {
             MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(currentMachineStack);
 
+            boolean isLowMacerator = mte instanceof MetaTileEntityMacerator && machineTier < GTValues.HV;
+
+            boolean isHVMacerator = mte instanceof MetaTileEntityMacerator && machineTier == GTValues.HV;
+
             //Clear the chanced outputs of LV and MV macerators, as they do not have the slots to get byproducts
-            return mte instanceof MetaTileEntityMacerator && machineTier < GTValues.HV;
+            if(isLowMacerator) {
+                return Pair.of(isLowMacerator, 1);
+            }
+            // Trim HV macerators to 3 slots
+            else if(isHVMacerator) {
+                return Pair.of(isHVMacerator, 3);
+            }
+
+            return Pair.of(false, 1);
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -274,16 +274,16 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
-        public Pair<Boolean, Integer> trimItemOutputs() {
+        public int trimItemOutputs() {
             MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(currentMachineStack);
 
             int availableSlots = mte.getExportItems().getSlots();
 
             if(availableSlots < this.activeRecipeMap.getMaxOutputs()) {
-                return Pair.of(true, availableSlots);
+                return availableSlots;
             }
 
-            return Pair.of(false, 1);
+            return -1;
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -26,7 +26,6 @@ import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.metatileentities.electric.MetaTileEntityMacerator;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -278,17 +277,10 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         public Pair<Boolean, Integer> trimItemOutputs() {
             MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(currentMachineStack);
 
-            boolean isLowMacerator = mte instanceof MetaTileEntityMacerator && machineTier < GTValues.HV;
+            int availableSlots = mte.getExportItems().getSlots();
 
-            boolean isHVMacerator = mte instanceof MetaTileEntityMacerator && machineTier == GTValues.HV;
-
-            //Clear the chanced outputs of LV and MV macerators, as they do not have the slots to get byproducts
-            if(isLowMacerator) {
-                return Pair.of(isLowMacerator, 1);
-            }
-            // Trim HV macerators to 3 slots
-            else if(isHVMacerator) {
-                return Pair.of(isHVMacerator, 3);
+            if(availableSlots < this.activeRecipeMap.getMaxOutputs()) {
+                return Pair.of(true, availableSlots);
             }
 
             return Pair.of(false, 1);

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -98,7 +98,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
 
         //rebuild the recipe and adjust voltage to match the turbine
         RecipeBuilder<?> recipeBuilder = getRecipeMap().recipeBuilder();
-        recipeBuilder.append(recipe, parallel, false, false)
+        recipeBuilder.append(recipe, parallel, false, trimItemOutputs(), trimFluidOutputs())
                 .EUt(-turbineMaxVoltage);
         applyParallelBonus(recipeBuilder);
         recipe = recipeBuilder.build().getResult();

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -215,7 +215,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, Pair.of(false, 1), Pair.of(false, 1), false);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, -1, -1, false);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
@@ -269,7 +269,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, Pair.of(false, 1), Pair.of(false, 1), false);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, -1, -1, false);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());
@@ -323,7 +323,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 120, Pair.of(false, 1), Pair.of(false, 1), false);
+                exportItemBus.getExportItems(), parallelLimit, 120, -1, -1, false);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
@@ -374,7 +374,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 120, Pair.of(false, 1), Pair.of(false, 1), false);
+                exportItemBus.getExportItems(), parallelLimit, 120, -1, -1, false);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -25,6 +25,7 @@ import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -214,7 +215,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, false, false);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, Pair.of(false, 1), Pair.of(false, 1), false);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
@@ -268,7 +269,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findMultipliedParallelRecipe(map, recipe, importItemBus.getImportItems(), importFluidBus.getImportFluids(),
-                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, false, false);
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE, Pair.of(false, 1), Pair.of(false, 1), false);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());
@@ -322,7 +323,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 120, false, false);
+                exportItemBus.getExportItems(), parallelLimit, 120, Pair.of(false, 1), Pair.of(false, 1), false);
 
         //Check if the correct number of parallels were done
         assertEquals(4, parallelRecipe.getParallel());
@@ -373,7 +374,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
         importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 2), false);
 
         RecipeBuilder<?> parallelRecipe = findAppendedParallelItemRecipe(map, importItemBus.getImportItems(),
-                exportItemBus.getExportItems(), parallelLimit, 120, false, false);
+                exportItemBus.getExportItems(), parallelLimit, 120, Pair.of(false, 1), Pair.of(false, 1), false);
 
         //Check if the correct number of parallels were done
         assertEquals(2, parallelRecipe.getParallel());


### PR DESCRIPTION
**What:**
Introduces a "Trim Factor" for how much recipes should be trimmed to. This is useful for EG macerators in the PA, where we want to trim to 1 for LV and MV macerators, to 3 for HV macerators, and not at all for EV+ macerators.

This trim factor is modified in a Pair<Boolean, Integer> where the boolean value controls if the trimming actually happens.

This PR also introduces Fluid output trimming, with support for chanced fluid outputs marked as TODO, as we don't have any recipes that take advantage of them yet. This will be useful in the upcoming generator PR by trimming outputs to 0 if there is no fluid output hatch in the structure. This should allow the structure to run without requiring a fluid output

This "Trim Factor" can function like a rudimentary voiding system, by simply trimming the number of outputs to 0. This is rudimentary logic because it does not depend on the state of the output bus/available room for outputs at all, but rather hard trimming all recipe outputs to a certain number