### PR TITLE
fix pipe connection init sync issue

### DIFF
--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -188,12 +188,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
 
     private void updateSideBlockedConnection(EnumFacing side) {
         WorldPipeNet<?, ?> worldPipeNet = getPipeBlock().getWorldPipeNet(getWorld());
-        boolean isSideOpen = false;
-        int sideIndex = 1 << side.getIndex();
-        for (int blockedConnections : openConnectionsMap.values()) {
-            isSideOpen |= (blockedConnections & sideIndex) > 0;
-        }
-        worldPipeNet.updateBlockedConnections(getPos(), side, !isSideOpen);
+        worldPipeNet.updateBlockedConnections(getPos(), side, !isConnectionOpen(AttachmentType.PIPE, side));
     }
 
     private int withSideConnectionBlocked(int blockedConnections, EnumFacing side, boolean blocked) {
@@ -311,7 +306,12 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Override
     public void writeInitialSyncData(PacketBuffer buf) {
         writePipeProperties(buf);
-        buf.writeVarInt(openConnections);
+        buf.writeVarInt(openConnectionsMap.size());
+        openConnectionsMap.forEachEntry((key, value) -> {
+            buf.writeVarInt(key);
+            buf.writeVarInt(value);
+            return true;
+        });
         buf.writeInt(insulationColor);
         this.coverableImplementation.writeInitialSyncData(buf);
     }
@@ -319,7 +319,11 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Override
     public void receiveInitialSyncData(PacketBuffer buf) {
         readPipeProperties(buf);
-        this.openConnections = buf.readVarInt();
+        int size = buf.readVarInt();
+        for(int i = 0; i < size; i++) {
+            openConnectionsMap.put(buf.readVarInt(), buf.readVarInt());
+        }
+        recomputeBlockedConnections();
         this.insulationColor = buf.readInt();
         this.coverableImplementation.readInitialSyncData(buf);
     }


### PR DESCRIPTION
Fixes the issue when you reenter the world and remove a pipe cover. This is because the connection map is not synced but instead just the connections. When a connection is changed, the map will be edited and synced, causing the open connections to recompute. To fix this i simply sync the connections map in init.