### PR TITLE
Add Gallium recipe from Bauxite washing

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
+++ b/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
@@ -232,7 +232,7 @@ public class MaterialFlagAddition {
         oreProp.setOreByProducts(GarnetRed, Manganese);
 
         oreProp = Sphalerite.getProperty(PropertyKey.ORE);
-        oreProp.setOreByProducts(GarnetYellow, Cadmium, Gallium, Zinc);
+        oreProp.setOreByProducts(GarnetYellow, Gallium, Cadmium, Zinc);
         oreProp.setWashedIn(SodiumPersulfate);
         oreProp.setDirectSmeltResult(Zinc);
 

--- a/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
+++ b/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
@@ -169,7 +169,8 @@ public class MaterialFlagAddition {
         oreProp.setSeparatedInto(Iron);
 
         oreProp = Bauxite.getProperty(PropertyKey.ORE);
-        oreProp.setOreByProducts(Grossular, Rutile, Gallium);
+        oreProp.setOreByProducts(Grossular, Rutile, Gallium, Gallium);
+        oreProp.setWashedIn(SodiumPersulfate);
 
         oreProp = Lazurite.getProperty(PropertyKey.ORE);
         oreProp.setOreByProducts(Sodalite, Lapis);

--- a/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
+++ b/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
@@ -169,7 +169,7 @@ public class MaterialFlagAddition {
         oreProp.setSeparatedInto(Iron);
 
         oreProp = Bauxite.getProperty(PropertyKey.ORE);
-        oreProp.setOreByProducts(Grossular, Rutile, Gallium, Gallium);
+        oreProp.setOreByProducts(Grossular, Rutile, Gallium);
         oreProp.setWashedIn(SodiumPersulfate);
 
         oreProp = Lazurite.getProperty(PropertyKey.ORE);


### PR DESCRIPTION
**What:**

Adds Gallium output from Bauxite Ore Washing, as another way to get it in LV besides the sphalerite electrolyzer recipe.

I would also like some feedback on swapping the Cadmium and Gallium byproduct places in Sphalerite. This means that you could get Gallium from the TC (I am ok with this) and the Centrifuge (not sure about this) in LV, instead of waiting to have to get it from HV+ Sphalerite maceration.