### PR TITLE
 PipeNet hotfix for desync on unload

### DIFF
--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -159,7 +159,7 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
                 FluidStack copy = stack.copy();
                 while (copy.amount > 0 && pairs2.size() > 0) {
                     int c = copy.amount / pairs2.size();
-                    int m = copy.amount / pairs2.size();
+                    int m = copy.amount % pairs2.size();
                     Iterator<Pair<FluidPipeNet, TileEntityFluidPipe>> iterator = pairs2.iterator();
                     while (iterator.hasNext()) {
                         Pair<FluidPipeNet, TileEntityFluidPipe> pair = iterator.next();

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -71,6 +71,7 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
 
     private void markDirty(FluidStack stack, BlockPos pos, int amount) {
         dirtyStacks.computeIfAbsent(stack, key -> new HashMap<>()).merge(pos, amount, Integer::sum);
+        worldData.markDirty();
     }
 
     public int fill(FluidStack stack, BlockPos pos, boolean doFill) {

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/FluidPipeNet.java
@@ -229,6 +229,7 @@ public class FluidPipeNet extends PipeNet<FluidPipeProperties> implements ITicka
                     }
                 }
                 dirtyStacks.clear();
+                worldData.markDirty();
             }
         }
     }


### PR DESCRIPTION
**What:**
Fixes a desync between pipe state and pipe network state upon unloading them.

**How solved:**
markDirty()