### PR TITLE
custom fusion bloom

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -336,7 +336,7 @@ public class ConfigHolder {
 
             @Config.Comment({"Bloom Strength", "OUTPUT = BACKGROUND + BLOOM * {strength} * (base + LT + (1 - BACKGROUND_BRIGHTNESS)*(HT-LT)))", "Default: 2"})
             @Config.RangeDouble(min = 0)
-            public double strength = 2;
+            public double strength = 1.5;
 
             @Config.Comment({"Blur Step (bloom range)", "Default: 1"})
             @Config.RangeDouble(min = 0)

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -300,6 +300,10 @@ public class ConfigHolder {
 
         public static class ShaderOptions {
 
+            @Config.Comment("Bloom config options for the fusion reactor.")
+            @Config.Name("Fusion Reactor")
+            public FusionBloom fusionBloom = new FusionBloom();
+
             @Config.Comment({"Whether to use shader programs.", "Default: true"})
             public boolean useShader = true;
 
@@ -338,6 +342,34 @@ public class ConfigHolder {
             @Config.RangeDouble(min = 0)
             public double step = 1;
         }
+    }
+
+    public static class FusionBloom {
+        @Config.Comment({"Whether to use shader programs.", "Default: true"})
+        public boolean useShader = true;
+
+        @Config.Comment({"Bloom Strength", "OUTPUT = BACKGROUND + BLOOM * {strength} * (base + LT + (1 - BACKGROUND_BRIGHTNESS)*(HT-LT)))", "Default: 2"})
+        @Config.RangeDouble(min = 0)
+        public double strength = 1.5;
+
+        @Config.Comment({"Bloom Algorithm", "0 - Simple Gaussian Blur Bloom (Fast)", "1 - Unity Bloom", "2 - Unreal Bloom", "Default: 2"})
+        @Config.RangeInt(min = 0, max = 2)
+        @Config.SlidingOption
+        public int bloomStyle = 1;
+
+        @Config.Comment({"The brightness after bloom should not exceed this value. It can be used to limit the brightness of highlights " +
+                "(e.g., daytime).", "OUTPUT = BACKGROUND + BLOOM * strength * (base + LT + (1 - BACKGROUND_BRIGHTNESS)*({HT}-LT)))", "This value should be greater than lowBrightnessThreshold.", "Default: 0.5"})
+        @Config.RangeDouble(min = 0)
+        public double highBrightnessThreshold = 1.3;
+
+        @Config.Comment({"The brightness after bloom should not smaller than this value. It can be used to limit the brightness of dusky parts " +
+                "(e.g., night/caves).", "OUTPUT = BACKGROUND + BLOOM * strength * (base + {LT} + (1 - BACKGROUND_BRIGHTNESS)*(HT-{LT})))", "This value should be smaller than highBrightnessThreshold.", "Default: 0.2"})
+        @Config.RangeDouble(min = 0)
+        public double lowBrightnessThreshold = 0.3;
+
+        @Config.Comment({"The base brightness of the bloom.", "It is similar to strength", "This value should be smaller than highBrightnessThreshold.", "OUTPUT = BACKGROUND + BLOOM * strength * ({base} + LT + (1 - BACKGROUND_BRIGHTNESS)*(HT-LT)))", "Default: 0.1"})
+        @Config.RangeDouble(min = 0)
+        public double baseBrightness = 0;
     }
 
     public static class ToolOptions {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -19,11 +19,12 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.recipeproperties.FusionEUToStartProperty;
 import gregtech.api.util.interpolate.Eases;
 import gregtech.client.renderer.ICubeRenderer;
-import gregtech.client.renderer.ICustomRenderFast;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.client.shader.postprocessing.BloomEffect;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.client.utils.RenderBufferHelper;
 import gregtech.client.utils.RenderUtil;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockFusionCasing;
 import gregtech.common.blocks.BlockGlassCasing;
 import gregtech.common.blocks.MetaBlocks;
@@ -366,7 +367,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
     public void renderMetaTileEntity(double x, double y, double z, float partialTicks) {
         if (color != null && MinecraftForgeClient.getRenderPass() == 0) {
             final int c = color;
-            BloomEffectUtil.requestRenderFast(RENDER_HANDLER, (buffer)->{
+            BloomEffectUtil.requestCustomBloom(RENDER_HANDLER, (buffer)->{
                 int color = RenderUtil.colorInterpolator(c, -1).apply(Eases.EaseQuadIn.getInterpolation(Math.abs((Math.abs(getOffsetTimer() % 50) + partialTicks) - 25) / 25));
                 float a = (float)(color >> 24 & 255) / 255.0F;
                 float r = (float)(color >> 16 & 255) / 255.0F;
@@ -403,13 +404,24 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         return true;
     }
 
-    static ICustomRenderFast RENDER_HANDLER = new ICustomRenderFast(){
+    static BloomEffectUtil.IBloomRenderFast RENDER_HANDLER = new BloomEffectUtil.IBloomRenderFast(){
+        @Override
+        public int customBloomStyle() {
+            return ConfigHolder.client.shader.fusionBloom.useShader ? ConfigHolder.client.shader.fusionBloom.bloomStyle : -1;
+        }
+
         float lastBrightnessX;
         float lastBrightnessY;
 
         @Override
         @SideOnly(Side.CLIENT)
         public void preDraw(BufferBuilder buffer) {
+            BloomEffect.strength = (float) ConfigHolder.client.shader.fusionBloom.strength;
+            BloomEffect.baseBrightness = (float) ConfigHolder.client.shader.fusionBloom.baseBrightness;
+            BloomEffect.highBrightnessThreshold = (float) ConfigHolder.client.shader.fusionBloom.highBrightnessThreshold;
+            BloomEffect.lowBrightnessThreshold = (float) ConfigHolder.client.shader.fusionBloom.lowBrightnessThreshold;
+            BloomEffect.step = 1;
+
             lastBrightnessX = OpenGlHelper.lastBrightnessX;
             lastBrightnessY = OpenGlHelper.lastBrightnessY;
             GlStateManager.color(1,1,1,1);

--- a/src/main/resources/assets/gregtech/shaders/bloom_combine.frag
+++ b/src/main/resources/assets/gregtech/shaders/bloom_combine.frag
@@ -11,18 +11,21 @@ uniform float threshold_up;
 uniform float threshold_down;
 
 // All components are in the range [0…1], including hue.
-vec3 rgb2hsv(vec3 c) {
-    vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
-    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
-
-    float d = q.x - min(q.w, q.y);
-    float e = 1.0e-10;
-    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-}
+//vec3 rgb2hsv(vec3 c) {
+//    vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+//    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+//    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+//
+//    float d = q.x - min(q.w, q.y);
+//    float e = 1.0e-10;
+//    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+//}
 
 void main(void){
     vec3 bloom = texture2D(buffer_b, textureCoords).rgb * intensive;
     vec3 background = texture2D(buffer_a, textureCoords).rgb;
-    gl_FragColor = vec4(background + bloom * ((1 - rgb2hsv(background).z) * (threshold_up - threshold_down) + threshold_down + base), 1.);
+//    gl_FragColor = vec4(background + bloom * ((1 - rgb2hsv(background).z) * (threshold_up - threshold_down) + threshold_down + base), 1.);
+    float max = max(background.b, max(background.r, background.g));
+    float min = min(background.b, min(background.r, background.g));
+    gl_FragColor = vec4(background + bloom * ((1. - (max + min) / 2.) * (threshold_up - threshold_down) + threshold_down + base), 1.);
 }


### PR DESCRIPTION
To make the bloom less intense, the effect is now set low. But that was a little too low for Fusion Reactor to render well. Post-processing rendering pipelines are now separated, and instead of only a default fixed Bloom pipeline (for models) can be used, multiple rendering pipelines can be customized. Fusion now uses a bloom pipeline of its own, with its own bloom configs. 