### PR TITLE
Allow Steam Lava Boiler to boil other fluids

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
@@ -11,7 +11,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
-import gregtech.api.recipes.ModHandler;
+import gregtech.api.unification.material.Materials;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
@@ -20,12 +20,19 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
 
-    private FluidTank lavaFluidTank;
+    private FluidTank fuelFluidTank;
+
+    private final List<FluidStack> boilerFuels = new ArrayList<FluidStack>() {{
+        boilerFuels.add(Materials.Lava.getFluid(100));
+        boilerFuels.add(Materials.Creosote.getFluid(250));
+    }};
 
     public SteamLavaBoiler(ResourceLocation metaTileEntityId, boolean isHighPressure) {
         super(metaTileEntityId, isHighPressure, Textures.LAVA_BOILER_OVERLAY);
@@ -44,19 +51,19 @@ public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
     @Override
     protected FluidTankList createImportFluidHandler() {
         FluidTankList superHandler = super.createImportFluidHandler();
-        this.lavaFluidTank = new FilteredFluidHandler(16000)
-                .setFillPredicate(ModHandler::isLava);
-        return new FluidTankList(false, superHandler, lavaFluidTank);
+        this.fuelFluidTank = new FilteredFluidHandler(16000)
+                .setFillPredicate(boilerFuels::contains);
+        return new FluidTankList(false, superHandler, fuelFluidTank);
 
     }
 
-    public static final int LAVA_PER_OPERATION = 100; // todo this may be too good?
-
     @Override
     protected void tryConsumeNewFuel() {
-        if (lavaFluidTank.getFluidAmount() >= LAVA_PER_OPERATION) {
-            lavaFluidTank.drain(LAVA_PER_OPERATION, true);
-            setFuelMaxBurnTime(LAVA_PER_OPERATION);
+        for(FluidStack fuel : boilerFuels) {
+            if(fuel.containsFluid(fuel) && fuelFluidTank.getFluidAmount() >= fuel.amount) {
+                fuelFluidTank.drain(fuel.amount, true);
+                setFuelMaxBurnTime((1000 / fuel.amount) * 10);
+            }
         }
     }
 
@@ -77,19 +84,19 @@ public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
 
     @Override
     public Collection<IFuelInfo> getFuels() {
-        FluidStack lava = lavaFluidTank.drain(Integer.MAX_VALUE, false);
-        if (lava == null || lava.amount == 0)
+        FluidStack fuel = fuelFluidTank.drain(Integer.MAX_VALUE, false);
+        if (fuel == null || fuel.amount == 0)
             return Collections.emptySet();
-        final int fuelRemaining = lava.amount;
-        final int fuelCapacity = lavaFluidTank.getCapacity();
+        final int fuelRemaining = fuel.amount;
+        final int fuelCapacity = fuelFluidTank.getCapacity();
         final long burnTime = (long) fuelRemaining * (this.isHighPressure ? 6 : 12); // 100 mb lasts 600 or 1200 ticks
-        return Collections.singleton(new FluidFuelInfo(lava, fuelRemaining, fuelCapacity, LAVA_PER_OPERATION, burnTime));
+        return Collections.singleton(new FluidFuelInfo(fuel, fuelRemaining, fuelCapacity, boilerFuels.get(boilerFuels.indexOf(fuel)).amount, burnTime));
     }
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         return createUITemplate(entityPlayer)
-                .widget(new TankWidget(lavaFluidTank, 119, 26, 10, 54)
+                .widget(new TankWidget(fuelFluidTank, 119, 26, 10, 54)
                         .setBackgroundTexture(GuiTextures.PROGRESS_BAR_BOILER_EMPTY.get(isHighPressure)))
                 .build(getHolder(), entityPlayer);
     }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2533,10 +2533,10 @@ gregtech.machine.steam_boiler_solar_bronze.name=Steam Solar Boiler
 gregtech.machine.steam_boiler_solar_bronze.tooltip=Steam Power by Sun
 gregtech.machine.steam_boiler_solar_steel.name=High Pressure Steam Solar Boiler
 gregtech.machine.steam_boiler_solar_steel.tooltip=Steam Power by Sun
-gregtech.machine.steam_boiler_lava_bronze.name=Small Steam Lava Boiler
+gregtech.machine.steam_boiler_lava_bronze.name=Small Steam Semi-Fuel Boiler
 gregtech.machine.steam_boiler_lava_bronze.tooltip=A Boiler running off Lava
-gregtech.machine.steam_boiler_lava_steel.name=High Pressure Steam Lava Boiler
-gregtech.machine.steam_boiler_lava_steel.tooltip=Faster than Small Steam Lava Boiler
+gregtech.machine.steam_boiler_lava_steel.name=High Pressure Steam Semi-Fuel Boiler
+gregtech.machine.steam_boiler_lava_steel.tooltip=Faster than Small Steam Semi-Fuel Boiler
 
 gregtech.machine.steam_extractor_bronze.name=Steam Extractor
 gregtech.machine.steam_extractor_bronze.tooltip=Extracting your first Rubber

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2525,18 +2525,18 @@ tile.stone_bricks_square.concrete_dark.name=Square Dark Concrete Bricks
 # Steam machines
 gregtech.machine.steam_boiler.tooltip_produces=Produces %,dL of Steam per second
 
-gregtech.machine.steam_boiler_coal_bronze.name=Small Steam Coal Boiler
+gregtech.machine.steam_boiler_coal_bronze.name=Small Steam Solid Fuel Boiler
 gregtech.machine.steam_boiler_coal_bronze.tooltip=An early way to get Steam Power
-gregtech.machine.steam_boiler_coal_steel.name=High Pressure Steam Coal Boiler
-gregtech.machine.steam_boiler_coal_steel.tooltip=Faster than the Small Steam Coal Boiler
+gregtech.machine.steam_boiler_coal_steel.name=High Pressure Steam Solid Fuel Boiler
+gregtech.machine.steam_boiler_coal_steel.tooltip=Faster than the Small Steam Solid Fuel Boiler
 gregtech.machine.steam_boiler_solar_bronze.name=Steam Solar Boiler
 gregtech.machine.steam_boiler_solar_bronze.tooltip=Steam Power by Sun
 gregtech.machine.steam_boiler_solar_steel.name=High Pressure Steam Solar Boiler
 gregtech.machine.steam_boiler_solar_steel.tooltip=Steam Power by Sun
-gregtech.machine.steam_boiler_lava_bronze.name=Small Steam Semi-Fuel Boiler
+gregtech.machine.steam_boiler_lava_bronze.name=Small Steam Liquid Boiler
 gregtech.machine.steam_boiler_lava_bronze.tooltip=A Boiler running off Lava
-gregtech.machine.steam_boiler_lava_steel.name=High Pressure Steam Semi-Fuel Boiler
-gregtech.machine.steam_boiler_lava_steel.tooltip=Faster than Small Steam Semi-Fuel Boiler
+gregtech.machine.steam_boiler_lava_steel.name=High Pressure Steam Liquid Boiler
+gregtech.machine.steam_boiler_lava_steel.tooltip=Faster than Small Steam Liquid Boiler
 
 gregtech.machine.steam_extractor_bronze.name=Steam Extractor
 gregtech.machine.steam_extractor_bronze.tooltip=Extracting your first Rubber


### PR DESCRIPTION
**What:**
Allows the Steam Lava Boiler to boil other fluids than lava. This PR currently adds Creosote (Worse than lava), let me know if there are any other fluids that are desired.

A Slight change in burn time calculation (lava is kept the same):
Previously the burn time would be set to the amount of fluid consumed, now the burn time decreases with the amount of fluid consumed, aka less efficient fuels.
Alternative, have a constant burn time for all fuels, but consume different amounts of fluid