### PR TITLE
Prevent Coal Boilers from consuming fuel buckets

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
@@ -17,6 +17,7 @@ import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
@@ -44,6 +45,10 @@ public class SteamCoalBoiler extends SteamBoiler implements IFuelable {
     protected void tryConsumeNewFuel() {
         ItemStack fuelInSlot = importItems.extractItem(0, 1, true);
         if (fuelInSlot.isEmpty()) return;
+        // Prevent consuming buckets with burn time
+        if(FluidUtil.getFluidHandler(fuelInSlot) != null) {
+            return;
+        }
         int burnTime = TileEntityFurnace.getItemBurnTime(fuelInSlot);
         if (burnTime <= 0) return;
         importItems.extractItem(0, 1, false);


### PR DESCRIPTION
**What:**

Prevent Coal boilers from consuming fluid containers with burnable fuels.

This both:
Prevents the voiding of the container
Incentivizes the (soon to be) Reworked Lava Boiler, which can accept fluid fuels