### PR TITLE
Fix some recipe maps not having the correct yOffset

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -417,7 +417,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         int startInputsY = 33 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
         boolean wasGroup = itemHandler.getSlots() + fluidHandler.getTanks() == 12;
         if (wasGroup) startInputsY -= 9;
-        if (itemHandler.getSlots() == 6 && fluidHandler.getTanks() == 2 && !isOutputs) startInputsY -= 9;
+        else if (itemHandler.getSlots() >= 6 && fluidHandler.getTanks() >= 2 && !isOutputs) startInputsY -= 9;
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;


### PR DESCRIPTION
Prevents previews like this, where the tank count isn't exactly 2.
![image](https://user-images.githubusercontent.com/80226372/147982770-d0e2fd4b-e74b-40fc-a51f-b392410fc1e9.png)