### PR TITLE
Re-add Coke Oven hatch limit

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
@@ -44,7 +44,7 @@ public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockControll
                 .aisle("XXX", "XXX", "XXX")
                 .aisle("XXX", "X#X", "XXX")
                 .aisle("XXX", "XYX", "XXX")
-                .where('X', states(getCasingState()).or(metaTileEntities(MetaTileEntities.COKE_OVEN_HATCH)))
+                .where('X', states(getCasingState()).or(metaTileEntities(MetaTileEntities.COKE_OVEN_HATCH).setMaxGlobalLimited(5)))
                 .where('#', air())
                 .where('Y', selfPredicate())
                 .build();


### PR DESCRIPTION
**What:**
Re-adds the coke oven hatch limit that was present before the structure rework PR