### PR TITLE
Allow the Hammering enchant on only pickaxes

### DIFF
--- a/src/main/java/gregtech/api/enchants/EnchantmentHardHammer.java
+++ b/src/main/java/gregtech/api/enchants/EnchantmentHardHammer.java
@@ -1,10 +1,14 @@
 package gregtech.api.enchants;
 
 import gregtech.api.GTValues;
+import gregtech.api.items.toolitem.ToolMetaItem;
+import gregtech.common.tools.ToolPickaxe;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.init.Enchantments;
 import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemPickaxe;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
 
@@ -37,6 +41,23 @@ public class EnchantmentHardHammer extends Enchantment {
         return 1;
     }
 
+    @Override
+    public boolean canApply(ItemStack stack) {
+        boolean isPick = false;
+
+        if(stack.getItem() instanceof ItemPickaxe) {
+            isPick = true;
+        }
+        else if(stack.getItem() instanceof ToolMetaItem) {
+            ToolMetaItem<?> toolMetaItem = (ToolMetaItem<?>) stack.getItem();
+            ToolMetaItem.MetaToolValueItem toolValueItem = toolMetaItem.getItem(stack);
+            if(toolValueItem.getToolStats() instanceof ToolPickaxe) {
+                isPick = true;
+            }
+        }
+
+        return isPick && super.canApply(stack);
+    }
 
     @Override
     protected boolean canApplyTogether(@Nonnull Enchantment ench) {

--- a/src/main/java/gregtech/common/tools/ToolUtility.java
+++ b/src/main/java/gregtech/common/tools/ToolUtility.java
@@ -5,6 +5,7 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.TaskScheduler;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCrops;
@@ -94,8 +95,9 @@ public class ToolUtility {
     }
 
     public static void applyHammerDrops(Random random, IBlockState blockState, List<ItemStack> drops, int fortuneLevel, EntityPlayer player) {
-        MaterialStack input = OreDictUnifier.getMaterial(new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState)));
-        if (input != null && input.material.hasProperty(PropertyKey.ORE) && !(player instanceof FakePlayer)) {
+        ItemStack inputStack = new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState));
+        MaterialStack input = OreDictUnifier.getMaterial(inputStack);
+        if (input != null && input.material.hasProperty(PropertyKey.ORE) && GTUtility.isOre(blockState.getBlock()) && !(player instanceof FakePlayer)) {
             drops.clear();
             ItemStack output = OreDictUnifier.get(OrePrefix.crushed, input.material);
 


### PR DESCRIPTION
**What:**
Restricts the Hammering enchantment to only be applied on pickaxes

Additionally fixes the enchantment activating on things that were not ores, but whose materials had the ore PropertyKey, like iron blocks