### PR TITLE
fix dupe in crafting station

### DIFF
--- a/src/main/java/gregtech/common/gui/widget/craftingstation/MemorizedRecipeWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/MemorizedRecipeWidget.java
@@ -27,7 +27,7 @@ public class MemorizedRecipeWidget extends SlotWidget {
     private final IItemHandlerModifiable craftingGrid;
 
     public MemorizedRecipeWidget(CraftingRecipeMemory recipeMemory, int index, IItemHandlerModifiable craftingGrid, int xPosition, int yPosition) {
-        super(new ItemStackHandler(1), 0, xPosition, yPosition, true, false);
+        super(new ItemStackHandler(1), 0, xPosition, yPosition, false, false);
         this.recipeMemory = recipeMemory;
         this.recipeIndex = index;
         this.craftingGrid = craftingGrid;


### PR DESCRIPTION
Fix crafting station dupe by now allowing items to be extracted from the widget