### PR TITLE
Add bus automatic Itemstack collapsing

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -166,7 +166,9 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
-        this.autoCollapse = data.getBoolean("autoCollapse");
+        if (data.hasKey("autoCollapse")) {
+            this.autoCollapse = data.getBoolean("autoCollapse");
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -146,7 +146,8 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
         if (!playerIn.isSneaking()){
     setAutoCollapse(!this.autoCollapse);
-    if(getWorld().isRemote) {
+    if (getWorld().isRemote) {
+        
         playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse", this.autoCollapse));
     }
             return true;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -56,7 +56,7 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
             } else {
                 pullItemsFromNearbyHandlers(getFrontFacing());
             }
-            if (isAutoCollapse()){
+            if (isAutoCollapse() && (isExportHatch ? this.getNotifiedItemOutputList().contains(inventory) : this.getNotifiedItemInputList().contains(inventory))){
                 collapseInventorySlotContents(inventory);
             }
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -29,10 +29,11 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
 public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IItemHandlerModifiable> {
- private boolean autoCollapse;
+    private boolean autoCollapse;
 
     private static final int[] INVENTORY_SIZES = {1, 4, 9, 16, 25, 36, 49};
 
@@ -140,6 +141,18 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
                 }
             }
         }
+        ArrayList<ItemStack> inventoryContents = new ArrayList<>();
+        for (int i = 0; i < inventory.getSlots(); i++) {
+            ItemStack itemStack = inventory.getStackInSlot(i);
+            if (!itemStack.isEmpty()) {
+                inventory.setStackInSlot(i, ItemStack.EMPTY);
+                inventoryContents.add(itemStack);
+            }
+        }
+        for (int i = 0; i < inventoryContents.size(); i++) {
+            inventory.setStackInSlot(i, inventoryContents.get(i));
+        }
+
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
+import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
@@ -17,7 +18,12 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -144,15 +144,23 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
 
     @Override
     public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
+        IItemHandlerModifiable inventory = (isExportHatch ? this.getExportItems() : this.getImportItems());
         if (!playerIn.isSneaking()){
-    setAutoCollapse(!this.autoCollapse);
-    if (getWorld().isRemote) {
-        
-        playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse", this.autoCollapse));
-    }
+            boolean isAttached = false;
+            if (isExportHatch ? this.getNotifiedItemOutputList().contains(inventory) : this.getNotifiedItemInputList().contains(inventory)){
+                setAutoCollapse(!this.autoCollapse);
+                isAttached = true;
+            }
+
+            if(!getWorld().isRemote) {
+                if (isAttached) {
+                    playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse", this.autoCollapse));
+                } else {
+                    playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse.error"));
+                }
+            }
             return true;
         }
-
         return super.onScrewdriverClick(playerIn, hand, facing, hitResult);
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3836,6 +3836,8 @@ gregtech.machine.item_bus.export.zpm.name=ZPM Output Bus
 gregtech.machine.item_bus.export.uv.name=UV Output Bus
 gregtech.machine.item_bus.export.uhv.name=UHV Output Bus
 
+gregtech.bus.collapse=Allow Bus to auto combine item stacks %s
+
 gregtech.machine.fluid_hatch.import.tooltip=Fluid Input for Multiblocks
 
 gregtech.machine.fluid_hatch.import.ulv.name=ULV Input Hatch

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3837,6 +3837,7 @@ gregtech.machine.item_bus.export.uv.name=UV Output Bus
 gregtech.machine.item_bus.export.uhv.name=UHV Output Bus
 
 gregtech.bus.collapse=Allow Bus to auto combine item stacks %s
+gregtech.bus.collapse.error=Bus must be attacked to multiblock first
 
 gregtech.machine.fluid_hatch.import.tooltip=Fluid Input for Multiblocks
 


### PR DESCRIPTION
**What:**
Allows Buses to automatically collapse the items in their inventory down. Screwdriver to enable/disable

**How solved:**
I based the implementation on the code that collapses and sorts crates. I have removed the shorting section.

**Outcome:**
Solves instances where items in a bus that are too small to run in a recipe could get spread out across multiple slots impeding other items. Examples where this could happen is tiny piles in a PA with packers.

**Possible compatibility issue:**
None

