### PR TITLE
Add Maintenance TOP Info Provider

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechTileCapabilities.java
+++ b/src/main/java/gregtech/api/capability/GregtechTileCapabilities.java
@@ -2,6 +2,7 @@ package gregtech.api.capability;
 
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.cover.ICoverable;
+import gregtech.api.metatileentity.multiblock.IMaintenance;
 import gregtech.api.metatileentity.multiblock.IMultipleRecipeMaps;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
@@ -24,6 +25,9 @@ public class GregtechTileCapabilities {
     public static Capability<AbstractRecipeLogic> CAPABILITY_RECIPE_LOGIC = null;
 
     @CapabilityInject(IMultipleRecipeMaps.class)
-    public static Capability<IMultipleRecipeMaps> MULTIPLE_RECIPEMAPS = null;
+    public static Capability<IMultipleRecipeMaps> CAPABILITY_MULTIPLE_RECIPEMAPS = null;
+
+    @CapabilityInject(IMaintenance.class)
+    public static Capability<IMaintenance> CAPABILITY_MAINTENANCE = null;
 
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -1,6 +1,7 @@
 package gregtech.api.metatileentity.multiblock;
 
 import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMaintenanceHatch;
 import gregtech.api.capability.IMufflerHatch;
 import gregtech.api.gui.GuiTextures;
@@ -18,6 +19,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
@@ -27,6 +29,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.HoverEvent;
 import net.minecraft.util.text.event.HoverEvent.Action;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -371,5 +374,13 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
         if (dataId == STORE_TAPED) {
             storedTaped = buf.readBoolean();
         }
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing side) {
+        T capabilityResult = super.getCapability(capability, side);
+        if (capabilityResult == null && capability == GregtechTileCapabilities.CAPABILITY_MAINTENANCE)
+            return (T) this;
+        return capabilityResult;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -367,7 +367,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     @Override
     public <T> T getCapability(Capability<T> capability, EnumFacing side) {
         T capabilityResult = super.getCapability(capability, side);
-        if (capabilityResult == null && capability == GregtechTileCapabilities.MULTIPLE_RECIPEMAPS) {
+        if (capabilityResult == null && capability == GregtechTileCapabilities.CAPABILITY_MULTIPLE_RECIPEMAPS) {
             return (T) this;
         }
         return capabilityResult;

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
@@ -16,6 +16,7 @@ public class TheOneProbeCompatibility {
         oneProbe.registerProvider(new TransformerInfoProvider());
         oneProbe.registerProvider(new DiodeInfoProvider());
         oneProbe.registerProvider(new MultiblockInfoProvider());
+        oneProbe.registerProvider(new MaintenanceInfoProvider());
         oneProbe.registerProvider(new MultiRecipeMapInfoProvider());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
@@ -1,0 +1,36 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.metatileentity.multiblock.IMaintenance;
+import gregtech.common.ConfigHolder;
+import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+
+public class MaintenanceInfoProvider extends CapabilityInfoProvider<IMaintenance> {
+
+    @Override
+    protected Capability<IMaintenance> getCapability() {
+        return GregtechTileCapabilities.CAPABILITY_MAINTENANCE;
+    }
+
+    @Override
+    protected void addProbeInfo(IMaintenance capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+        if (ConfigHolder.machines.enableMaintenance && capability.hasMaintenanceMechanics()) {
+            IProbeInfo horizontalPaneMaintenance = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+            if (capability.hasMaintenanceProblems()) {
+                horizontalPaneMaintenance.text(TextStyleClass.INFO + "{*gregtech.top.maintenance_broken*}");
+            } else {
+                horizontalPaneMaintenance.text(TextStyleClass.INFO + "{*gregtech.top.maintenance_fixed*}");
+            }
+        }
+    }
+
+    @Override
+    public String getID() {
+        return "gregtech:multiblock_maintenance_provider";
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -29,7 +29,7 @@ public class MultiRecipeMapInfoProvider implements IProbeInfoProvider {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (tileEntity == null) return;
             try {
-                IMultipleRecipeMaps resultCapability = tileEntity.getCapability(GregtechTileCapabilities.MULTIPLE_RECIPEMAPS, null);
+                IMultipleRecipeMaps resultCapability = tileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_MULTIPLE_RECIPEMAPS, null);
                 if (resultCapability != null) {
                     addProbeInfo(resultCapability, probeInfo, tileEntity, sideHit);
                 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -38,9 +38,11 @@ gregtech.top.fuel_min_consume=needs
 gregtech.top.fuel_name=Fuel:
 gregtech.top.fuel_none=No fuel
 
-gregtech.top.invalid_structure=§cInvalid Structure
+gregtech.top.invalid_structure=§cStructure Incomplete
 gregtech.top.valid_structure=§aStructure Formed
 gregtech.top.obstructed_structure=§cStructure Obstructed
+gregtech.top.maintenance_fixed=§aMaintenance Fine
+gregtech.top.maintenance_broken=§cNeeds Maintenance
 
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.


### PR DESCRIPTION
**What:**
Adds a TOP info provider to display whether multiblocks need maintenance fixed or not.