### PR TITLE
Register Glowstone block oredict so it gets decomp recipes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -275,7 +275,7 @@ public class UnknownCompositionMaterials {
         Glowstone = new Material.Builder(1601, "glowstone")
                 .dust(1).fluid()
                 .color(0xFFFF00).iconSet(SHINY)
-                .flags(NO_SMASHING, GENERATE_PLATE, EXCLUDE_PLATE_COMPRESSOR_RECIPE)
+                .flags(NO_SMASHING, GENERATE_PLATE, EXCLUDE_PLATE_COMPRESSOR_RECIPE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .build();
 
         NetherStar = new Material.Builder(1602, "nether_star")

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -80,6 +80,7 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Items.GUNPOWDER), OrePrefix.DUST_REGULAR, Materials.Gunpowder);
         OreDictUnifier.registerOre(new ItemStack(Items.GLOWSTONE_DUST), OrePrefix.dust, Materials.Glowstone);
         OreDictUnifier.registerOre(new ItemStack(Items.GLOWSTONE_DUST), OrePrefix.DUST_REGULAR, Materials.Glowstone);
+        OreDictUnifier.registerOre(new ItemStack(Blocks.GLOWSTONE), OrePrefix.block, Materials.Glowstone);
         OreDictUnifier.registerOre(new ItemStack(Items.DYE, 1, 15), OrePrefix.dust, Materials.Bone);
         OreDictUnifier.registerOre(new ItemStack(Items.DYE, 1, 15), OrePrefix.DUST_REGULAR, Materials.Bone);
         OreDictUnifier.registerOre(new ItemStack(Items.BONE), OrePrefix.stick, Materials.Bone);


### PR DESCRIPTION
**What:**

Registers Glowstone block oredict so it gets autogenerated decomposition recipes.

With this change, I think Glowstone should get the Flag `EXCLUDE_BLOCK_CRAFTING_RECIPES`, as it rarely breaks to 4 dusts, so being able to craft it to 4 dusts does not make much sense