### PR TITLE
Fix crash under certain predicates

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -185,7 +185,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     }
 
     public static TraceabilityPredicate heatingCoils() {
-        return TraceabilityPredicate.HEATING_COILS;
+        return TraceabilityPredicate.HEATING_COILS.get();
     }
 
     public TraceabilityPredicate selfPredicate() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -185,7 +185,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     }
 
     public static TraceabilityPredicate heatingCoils() {
-        return TraceabilityPredicate.HEATING_COILS.get();
+        return TraceabilityPredicate.HEATING_COILS;
     }
 
     public TraceabilityPredicate selfPredicate() {

--- a/src/main/java/gregtech/api/pattern/BlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/BlockPattern.java
@@ -211,7 +211,7 @@ public class BlockPattern {
                         TraceabilityPredicate predicate = this.blockMatches[c][b][a];
                         BlockPos pos = setActualRelativeOffset(x, y, z, facing).add(centerPos.getX(), centerPos.getY(), centerPos.getZ());
                         worldState.update(world, pos, matchContext, globalCount, layerCount, predicate);
-                        if (world.getBlockState(pos).getBlock() != Blocks.AIR) {
+                        if (!world.isAirBlock(pos)) {
                             blocks.put(pos, world.getBlockState(pos));
                             for (TraceabilityPredicate.SimplePredicate limit : predicate.limited) {
                                 limit.testLimited(worldState);
@@ -356,7 +356,7 @@ public class BlockPattern {
                 }
                 if (!find) {
                     for (EnumFacing enumFacing : FACINGS) {
-                        if (world.getBlockState(pos.offset(enumFacing)).getBlock() == Blocks.AIR && metaTileEntity.isValidFrontFacing(enumFacing)) {
+                        if (world.isAirBlock(pos.offset(enumFacing)) && metaTileEntity.isValidFrontFacing(enumFacing)) {
                             metaTileEntity.setFrontFacing(enumFacing);
                             break;
                         }

--- a/src/main/java/gregtech/api/pattern/FactoryBlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/FactoryBlockPattern.java
@@ -118,13 +118,6 @@ public class FactoryBlockPattern {
     }
 
     public FactoryBlockPattern where(char symbol, TraceabilityPredicate blockMatcher) {
-        if (blockMatcher == TraceabilityPredicate.AIR || blockMatcher == TraceabilityPredicate.ANY) {
-            this.symbolMap.put(symbol, blockMatcher);
-            return this;
-        }
-        if (blockMatcher.limited.size() + blockMatcher.common.size() == 1) {
-            blockMatcher.addTooltips("gregtech.multiblock.pattern.single");
-        }
         this.symbolMap.put(symbol, new TraceabilityPredicate(blockMatcher).sort());
         return this;
     }

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -49,6 +49,7 @@ public class TraceabilityPredicate {
     public final List<SimplePredicate> common = new ArrayList<>();
     public final List<SimplePredicate> limited = new ArrayList<>();
     protected boolean isCenter;
+    public boolean hasAir = false;
 
     public TraceabilityPredicate() {}
 
@@ -56,6 +57,7 @@ public class TraceabilityPredicate {
         common.addAll(predicate.common);
         limited.addAll(predicate.limited);
         isCenter = predicate.isCenter;
+        hasAir = predicate.hasAir;
     }
 
     public TraceabilityPredicate(Predicate<BlockWorldState> predicate, Supplier<BlockInfo[]> candidates) {
@@ -76,6 +78,9 @@ public class TraceabilityPredicate {
 
     public TraceabilityPredicate sort() {
         limited.sort(Comparator.comparingInt(a -> ((a.minLayerCount + 1) * 100 + a.minGlobalCount)));
+        if(hasAir) {
+            this.addTooltips(I18n.format("gregtech.multiblock.pattern.replaceable_air"));
+        }
         return this;
     }
 
@@ -193,6 +198,9 @@ public class TraceabilityPredicate {
     }
 
     public TraceabilityPredicate or(TraceabilityPredicate other) {
+        if(other == AIR) {
+            hasAir = true;
+        }
         if (other != null) {
             TraceabilityPredicate newPredicate = new TraceabilityPredicate(this);
             newPredicate.common.addAll(other.common);

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -49,7 +49,7 @@ public class TraceabilityPredicate {
     public final List<SimplePredicate> common = new ArrayList<>();
     public final List<SimplePredicate> limited = new ArrayList<>();
     protected boolean isCenter;
-    public boolean hasAir = false;
+    protected boolean hasAir = false;
 
     public TraceabilityPredicate() {}
 
@@ -198,11 +198,9 @@ public class TraceabilityPredicate {
     }
 
     public TraceabilityPredicate or(TraceabilityPredicate other) {
-        if(other == AIR) {
-            hasAir = true;
-        }
         if (other != null) {
             TraceabilityPredicate newPredicate = new TraceabilityPredicate(this);
+            newPredicate.hasAir = newPredicate.hasAir || this == AIR || other == AIR;
             newPredicate.common.addAll(other.common);
             newPredicate.limited.addAll(other.limited);
             return newPredicate;

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -27,7 +27,7 @@ public class TraceabilityPredicate {
     // Allow the air block.
     public static TraceabilityPredicate AIR = new TraceabilityPredicate(blockWorldState -> blockWorldState.getBlockState().getBlock().isAir(blockWorldState.getBlockState(), blockWorldState.getWorld(), blockWorldState.getPos()));
     // Allow all heating coils, and require them to have the same type.
-    public static TraceabilityPredicate HEATING_COILS = new TraceabilityPredicate(blockWorldState -> {
+    public static Supplier<TraceabilityPredicate> HEATING_COILS = () -> new TraceabilityPredicate(blockWorldState -> {
         IBlockState blockState = blockWorldState.getBlockState();
         if ((blockState.getBlock() instanceof BlockWireCoil)) {
             BlockWireCoil blockWireCoil = (BlockWireCoil) blockState.getBlock();

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -265,6 +265,7 @@ public class TraceabilityPredicate {
             if (maxLayerCount != -1) {
                 result.add(I18n.format("gregtech.multiblock.pattern.error.limited.2", maxLayerCount));
             }
+            if (predicates == null) return result;
             if (predicates.isSingle) {
                 result.add(I18n.format("gregtech.multiblock.pattern.single"));
             }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -231,8 +231,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             getCurrentRenderer().setCameraLookAt(center, zoom, Math.toRadians(rotationPitch), Math.toRadians(rotationYaw));
             if (this.selected != null) {
                 this.selected = null;
-                for (int i = 0; i < predicates.size(); i++) {
-                    recipeLayout.getItemStacks().set(i + MAX_PARTS, ItemStack.EMPTY);
+                int counter = 0;
+                for (TraceabilityPredicate.SimplePredicate predicate : predicates) {
+                    if(predicate.candidates == null) {
+                        continue;
+                    }
+                    recipeLayout.getItemStacks().set(counter + MAX_PARTS, ItemStack.EMPTY);
+                    counter++;
                 }
                 predicates.clear();
             }
@@ -279,8 +284,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         }
 
         // draw candidates slots
-        for (int i = 0; i < predicates.size(); i++) {
-            this.slot.draw(minecraft, 5 + (i / 6) * SLOT_SIZE, (i % 6) * SLOT_SIZE + 10);
+        int counter = 0;
+        for (TraceabilityPredicate.SimplePredicate predicate : predicates) {
+            if(predicate.candidates == null) {
+                continue;
+            }
+            this.slot.draw(minecraft, 5 + (counter / 6) * SLOT_SIZE, (counter % 6) * SLOT_SIZE + 10);
+            counter++;
         }
 
         // draw buttons
@@ -375,8 +385,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             if (getCurrentRenderer().getLastTraceResult() == null) {
                 if (this.selected != null) {
                     this.selected = null;
-                    for (int i = 0; i < predicates.size(); i++) {
-                        recipeLayout.getItemStacks().set(i + MAX_PARTS, ItemStack.EMPTY);
+                    int counter = 0;
+                    for (TraceabilityPredicate.SimplePredicate predicate : predicates) {
+                        if(predicate.candidates == null) {
+                            continue;
+                        }
+                        recipeLayout.getItemStacks().set(counter + MAX_PARTS, ItemStack.EMPTY);
+                        counter++;
                     }
                     predicates.clear();
                     return true;
@@ -385,8 +400,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             }
             BlockPos selected = getCurrentRenderer().getLastTraceResult().getBlockPos();
             if (!Objects.equals(this.selected, selected)) {
-                for (int i = 0; i < predicates.size(); i++) {
-                    recipeLayout.getItemStacks().set(i + MAX_PARTS, ItemStack.EMPTY);
+                int counter = 0;
+                for (TraceabilityPredicate.SimplePredicate predicate : predicates) {
+                    if(predicate.candidates == null) {
+                        continue;
+                    }
+                    recipeLayout.getItemStacks().set(counter + MAX_PARTS, ItemStack.EMPTY);
+                    counter++;
                 }
                 predicates.clear();
                 this.selected = selected;
@@ -405,22 +425,29 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
 
     private void setItemStackGroup() {
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
-        for (int i = 0; i < predicates.size(); i++) {
-            itemStackGroup.init(i + MAX_PARTS, true, 5 + (i / 6) * SLOT_SIZE, (i % 6) * SLOT_SIZE + 10);
-            List<ItemStack> candidates = new ArrayList<>();
+        int counter = 0;
+        for (TraceabilityPredicate.SimplePredicate predicate : predicates) {
+
+            List<ItemStack> candidates;
+
             // This can happen because of predicate.or(air())
-            if(predicates.get(i).candidates == null) {
-                candidates.add(ItemStack.EMPTY);
+            if(predicate.candidates == null) {
+                continue;
             }
             else {
-                candidates.addAll(predicates.get(i).getCandidates());
+                candidates = new ArrayList<>(predicate.getCandidates());
             }
 
-            itemStackGroup.set(i + MAX_PARTS, candidates);
+            itemStackGroup.init(counter + MAX_PARTS, true, 5 + (counter / 6) * SLOT_SIZE, (counter % 6) * SLOT_SIZE + 10);
+
+            itemStackGroup.set(counter + MAX_PARTS, candidates);
+            counter++;
         }
+
+        int finalCounter = counter;
         itemStackGroup.addTooltipCallback((slotIndex, input, itemStack, tooltip)->{
             if (slotIndex >= MAX_PARTS && slotIndex < MAX_PARTS + predicates.size()) {
-                tooltip.addAll(predicates.get(slotIndex - MAX_PARTS).getToolTips());
+                tooltip.addAll(predicates.get(slotIndex - MAX_PARTS + (predicates.size() - finalCounter)).getToolTips());
             }
         });
     }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -407,7 +407,16 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         for (int i = 0; i < predicates.size(); i++) {
             itemStackGroup.init(i + MAX_PARTS, true, 5 + (i / 6) * SLOT_SIZE, (i % 6) * SLOT_SIZE + 10);
-            itemStackGroup.set(i + MAX_PARTS, predicates.get(i).getCandidates());
+            List<ItemStack> candidates = new ArrayList<>();
+            // This can happen because of predicate.or(air())
+            if(predicates.get(i).candidates == null) {
+                candidates.add(ItemStack.EMPTY);
+            }
+            else {
+                candidates.addAll(predicates.get(i).getCandidates());
+            }
+
+            itemStackGroup.set(i + MAX_PARTS, candidates);
         }
         itemStackGroup.addTooltipCallback((slotIndex, input, itemStack, tooltip)->{
             if (slotIndex >= MAX_PARTS && slotIndex < MAX_PARTS + predicates.size()) {

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -232,6 +232,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             updateParts();
             getCurrentRenderer().setCameraLookAt(center, zoom, Math.toRadians(rotationPitch), Math.toRadians(rotationYaw));
             if (this.selected != null) {
+                this.selected = null;
                 for (int i = 0; i < predicates.size(); i++) {
                     recipeLayout.getItemStacks().set(i + MAX_PARTS, ItemStack.EMPTY);
                 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4233,6 +4233,7 @@ gregtech.multiblock.pattern.clear_amount_1=§6Must have a clear 1x1x1 space in f
 gregtech.multiblock.pattern.clear_amount_3=§6Must have a clear 3x3x1 space in front§r
 gregtech.multiblock.pattern.single=§6Only this block can be used§r
 gregtech.multiblock.pattern.location_end=§cVery End§r
+gregtech.multiblock.pattern.replaceable_air=Replaceable by Air
 
 gregtech.multiblock.blast_furnace.max_temperature=Heat Capacity: §c%sK
 gregtech.multiblock.multi_furnace.heating_coil_level=Heating Coil Level: %s


### PR DESCRIPTION
**What:**

Fixes a crash when a preview uses `predicate.or(air())`. I decided to display an empty item stack in slot to represent the air, but this could be expressed better some way most likely.