### PR TITLE
Ore filter logic rework

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/DrawableWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/DrawableWidget.java
@@ -1,0 +1,55 @@
+package gregtech.api.gui.widgets;
+
+import gregtech.api.gui.IRenderContext;
+import gregtech.api.gui.Widget;
+import gregtech.api.util.Position;
+import gregtech.api.util.Size;
+
+/**
+ * @author brachy84
+ */
+public class DrawableWidget extends Widget {
+
+    private BackgroundDrawer backgroundDrawer;
+    private ForegroundDrawer foregroundDrawer;
+
+    public DrawableWidget(Position selfPosition, Size size) {
+        super(selfPosition, size);
+    }
+
+    public DrawableWidget(int x, int y, int width, int height) {
+        super(x, y, width, height);
+    }
+
+    public DrawableWidget setBackgroundDrawer(BackgroundDrawer backgroundDrawer) {
+        this.backgroundDrawer = backgroundDrawer;
+        return this;
+    }
+
+    public DrawableWidget setForegroundDrawer(ForegroundDrawer foregroundDrawer) {
+        this.foregroundDrawer = foregroundDrawer;
+        return this;
+    }
+
+    @Override
+    public void drawInBackground(int mouseX, int mouseY, float partialTicks, IRenderContext context) {
+        if(backgroundDrawer != null)
+            backgroundDrawer.draw(mouseX, mouseY, partialTicks, context, this);
+    }
+
+    @Override
+    public void drawInForeground(int mouseX, int mouseY) {
+        if(foregroundDrawer != null)
+            foregroundDrawer.draw(mouseX, mouseY, this);
+    }
+
+    @FunctionalInterface
+    public interface BackgroundDrawer {
+        void draw(int mouseX, int mouseY, float partialTicks, IRenderContext context, Widget widget);
+    }
+
+    @FunctionalInterface
+    public interface ForegroundDrawer {
+        void draw(int mouseX, int mouseY, Widget widget);
+    }
+}

--- a/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
+++ b/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
@@ -1,0 +1,132 @@
+package gregtech.api.gui.widgets;
+
+import com.google.common.collect.Lists;
+import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.IRenderContext;
+import gregtech.api.gui.Widget;
+import gregtech.api.gui.impl.ModularUIGui;
+import gregtech.api.gui.ingredient.IGhostIngredientTarget;
+import gregtech.api.util.GTLog;
+import gregtech.api.util.Position;
+import gregtech.api.util.Size;
+import gregtech.api.util.SlotUtil;
+import mezz.jei.api.gui.IGhostIngredientHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.ClickType;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * @author brachy84
+ */
+public class OreDictFilterTestSlot extends Widget implements IGhostIngredientTarget {
+
+    private ItemStack testStack = ItemStack.EMPTY;
+    private Consumer<ItemStack> listener;
+
+    public OreDictFilterTestSlot(int xPosition, int yPosition) {
+        super(xPosition, yPosition, 18, 18);
+    }
+
+    public OreDictFilterTestSlot setListener(Consumer<ItemStack> listener) {
+        this.listener = listener;
+        return this;
+    }
+
+    public OreDictFilterTestSlot setTestStack(ItemStack testStack) {
+        if (testStack != null) {
+            GTLog.logger.info("set testStack to {}", testStack);
+            this.testStack = testStack;
+        }
+        return this;
+    }
+
+    @Override
+    public boolean mouseClicked(int mouseX, int mouseY, int button) {
+        if (isMouseOverElement(mouseX, mouseY)) {
+            // this is only called on client, so this is fine
+            EntityPlayer player = Minecraft.getMinecraft().player;
+            ItemStack cursorStack = player.inventory.getItemStack();
+            putItem(cursorStack);
+            return true;
+        }
+        return false;
+    }
+
+    @SideOnly(Side.CLIENT)
+    private void putItem(ItemStack stack) {
+        if ((stack.isEmpty() ^ testStack.isEmpty()) || !testStack.isItemEqual(stack) || !ItemStack.areItemStackTagsEqual(testStack, stack)) {
+            testStack = stack.copy();
+            testStack.setCount(1);
+            if (listener != null)
+                listener.accept(testStack);
+        }
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void drawInBackground(int mouseX, int mouseY, float partialTicks, IRenderContext context) {
+        Position pos = getPosition();
+        GuiTextures.SLOT.draw(pos.x, pos.y, 18, 18);
+
+        if (!testStack.isEmpty()) {
+            GlStateManager.enableBlend();
+            GlStateManager.enableDepth();
+            GlStateManager.disableRescaleNormal();
+            GlStateManager.disableLighting();
+            RenderHelper.disableStandardItemLighting();
+            RenderHelper.enableStandardItemLighting();
+            RenderHelper.enableGUIStandardItemLighting();
+            GlStateManager.pushMatrix();
+            RenderItem itemRender = Minecraft.getMinecraft().getRenderItem();
+            itemRender.renderItemAndEffectIntoGUI(testStack, pos.x + 1, pos.y + 1);
+            itemRender.renderItemOverlayIntoGUI(Minecraft.getMinecraft().fontRenderer, testStack, pos.x + 1, pos.y + 1, null);
+            GlStateManager.enableAlpha();
+            GlStateManager.popMatrix();
+            RenderHelper.disableStandardItemLighting();
+        }
+        if (isActive() && isMouseOverElement(mouseX, mouseY)) {
+            GlStateManager.disableDepth();
+            GlStateManager.colorMask(true, true, true, false);
+            drawSolidRect(getPosition().x + 1, getPosition().y + 1, 16, 16, -2130706433);
+            GlStateManager.colorMask(true, true, true, true);
+            GlStateManager.enableDepth();
+            GlStateManager.enableBlend();
+        }
+    }
+
+    @Override
+    public List<IGhostIngredientHandler.Target<?>> getPhantomTargets(Object ingredient) {
+        if (!(ingredient instanceof ItemStack)) {
+            return Collections.emptyList();
+        }
+        Rectangle rectangle = toRectangleBox();
+        return Lists.newArrayList(new IGhostIngredientHandler.Target<Object>() {
+            @Nonnull
+            @Override
+            public Rectangle getArea() {
+                return rectangle;
+            }
+
+            @Override
+            public void accept(@Nonnull Object ingredient) {
+                if (ingredient instanceof ItemStack) {
+                    putItem((ItemStack) ingredient);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
+++ b/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
@@ -4,27 +4,23 @@ import com.google.common.collect.Lists;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
-import gregtech.api.gui.impl.ModularUIGui;
 import gregtech.api.gui.ingredient.IGhostIngredientTarget;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.Position;
-import gregtech.api.util.Size;
-import gregtech.api.util.SlotUtil;
 import mezz.jei.api.gui.IGhostIngredientHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.ClickType;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.client.config.GuiUtils;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.lwjgl.input.Keyboard;
-import org.lwjgl.input.Mouse;
 
 import javax.annotation.Nonnull;
 import java.awt.*;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -104,6 +100,19 @@ public class OreDictFilterTestSlot extends Widget implements IGhostIngredientTar
             GlStateManager.colorMask(true, true, true, true);
             GlStateManager.enableDepth();
             GlStateManager.enableBlend();
+        }
+    }
+
+    @Override
+    public void drawInForeground(int mouseX, int mouseY) {
+        if (isActive() && isMouseOverElement(mouseX, mouseY)) {
+            if (!testStack.isEmpty()) {
+                GuiUtils.preItemToolTip(testStack);
+                this.drawHoveringText(testStack, getItemToolTip(testStack), 300, mouseX, mouseY);
+                GuiUtils.postItemToolTip();
+            } else {
+                drawHoveringText(ItemStack.EMPTY, Arrays.asList(I18n.format("cover.ore_dictionary_filter.test_slot.info").split("/n")), 300, mouseX, mouseY);
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
+++ b/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
@@ -48,7 +48,6 @@ public class OreDictFilterTestSlot extends Widget implements IGhostIngredientTar
 
     public OreDictFilterTestSlot setTestStack(ItemStack testStack) {
         if (testStack != null) {
-            GTLog.logger.info("set testStack to {}", testStack);
             this.testStack = testStack;
         }
         return this;

--- a/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
+++ b/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
@@ -316,6 +316,16 @@ public class TextFieldWidget2 extends Widget {
                 }
                 return true;
             }
+            if(keyCode == Keyboard.KEY_DELETE && text.length() > 0) {
+                if (cursorPos != cursorPos2) {
+                    replaceMarkedText(null);
+                } else if(cursorPos < text.length()) {
+                    String t1 = text.substring(0, cursorPos);
+                    String t2 = text.substring(cursorPos + 1);
+                    text = t1 + t2;
+                    cursorPos2 = cursorPos;
+                }
+            }
             if (charTyped != Character.MIN_VALUE && text.length() < maxLength) {
                 int min = Math.min(cursorPos, cursorPos2);
                 int max = Math.max(cursorPos, cursorPos2);

--- a/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
+++ b/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
@@ -1,6 +1,5 @@
 package gregtech.api.gui.widgets;
 
-import com.google.common.collect.Lists;
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import net.minecraft.client.Minecraft;
@@ -51,6 +50,7 @@ public class TextFieldWidget2 extends Widget {
     private int cursorPos;
     private int cursorPos2;
 
+    private int clickTime = 20;
     private int cursorTime = 0;
     private boolean drawCursor = true;
 
@@ -70,6 +70,7 @@ public class TextFieldWidget2 extends Widget {
 
     @Override
     public void updateScreen() {
+        clickTime++;
         if (++cursorTime == 10) {
             cursorTime = 0;
             drawCursor = !drawCursor;
@@ -193,17 +194,14 @@ public class TextFieldWidget2 extends Widget {
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
         if (isMouseOverElement(mouseX, mouseY)) {
             focused = true;
-            int base = mouseX - getTextX();
-            float x = 1;
-            int i = 0;
-            while (x < base) {
-                if (i == text.length())
-                    break;
-                x += (Minecraft.getMinecraft().fontRenderer.getCharWidth(text.charAt(i)) + 1) * scale;
-                i++;
+            if (clickTime < 5) {
+                cursorPos = text.length();
+                cursorPos2 = 0;
+            } else {
+                cursorPos = getCursorPosFromMouse(mouseX);
+                cursorPos2 = cursorPos;
             }
-            cursorPos = i;
-            cursorPos2 = i;
+            clickTime = 0;
         } else
             unFocus();
         return focused;
@@ -216,18 +214,22 @@ public class TextFieldWidget2 extends Widget {
                 cursorPos = 0;
                 return true;
             }
-            int base = mouseX - (getTextX());
-            int x = 1;
-            int i = 0;
-            while (x < base) {
-                if (i == text.length())
-                    break;
-                x += (Minecraft.getMinecraft().fontRenderer.getCharWidth(text.charAt(i)) + 1) * scale;
-                i++;
-            }
-            cursorPos = i;
+            cursorPos = getCursorPosFromMouse(mouseX);
         }
         return focused;
+    }
+
+    private int getCursorPosFromMouse(int mouseX) {
+        int base = mouseX - getTextX();
+        float x = 1;
+        int i = 0;
+        while (x < base) {
+            if (i == text.length())
+                break;
+            x += (Minecraft.getMinecraft().fontRenderer.getCharWidth(text.charAt(i))) * scale;
+            i++;
+        }
+        return i;
     }
 
     public String getSelectedText() {
@@ -340,17 +342,18 @@ public class TextFieldWidget2 extends Widget {
         int max = Math.max(cursorPos, cursorPos2);
         String t1 = text.substring(0, min);
         String t2 = text.substring(max);
-        if(replacement != null) {
-            if(t1.length() + t2.length() + replacement.length() > maxLength)
+        if (replacement != null) {
+            if (t1.length() + t2.length() + replacement.length() > maxLength)
                 return;
-            cursorPos = max;
-        } else
-            cursorPos = min;
-        cursorPos2 = cursorPos;
-        if (replacement == null)
+        }
+        if (replacement == null) {
             text = t1 + t2;
-        else
+            cursorPos = min;
+        } else {
             text = t1 + replacement + t2;
+            cursorPos = t1.length() + replacement.length();
+        }
+        cursorPos2 = cursorPos;
     }
 
     public String getText() {

--- a/src/main/java/gregtech/api/util/OreDictExprFilter.java
+++ b/src/main/java/gregtech/api/util/OreDictExprFilter.java
@@ -1,0 +1,276 @@
+package gregtech.api.util;
+
+import gregtech.api.unification.OreDictUnifier;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author brachy84
+ */
+public class OreDictExprFilter {
+
+    /**
+     * Parses the given expression and creates a List.
+     *
+     * @param expression expr to parse
+     * @return match rule list
+     */
+    public static List<MatchRule> parseExpression(String expression) {
+        List<MatchRule> rules = new ArrayList<>();
+        parseExpression(rules, expression);
+        return rules;
+    }
+
+    /**
+     * Parses the given expression and puts them into the given list.
+     *
+     * @param rules      list to fill
+     * @param expression expr to parse
+     * @return the position of the expr. Is only relevant for sub rules
+     */
+    public static int parseExpression(List<MatchRule> rules, String expression) {
+        rules.clear();
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < expression.length(); i++) {
+            char c = expression.charAt(i);
+            if (c == ' ')
+                continue;
+            if (builder.length() > 0) {
+                switch (c) {
+                    case '&':
+                        rules.add(new MatchRule(builder.toString()));
+                        rules.add(new MatchRule(MatchLogic.AND));
+                        builder = new StringBuilder();
+                        break;
+                    case '|':
+                        rules.add(new MatchRule(builder.toString()));
+                        rules.add(new MatchRule(MatchLogic.OR));
+                        builder = new StringBuilder();
+                        break;
+                    case '^':
+                        rules.add(new MatchRule(builder.toString()));
+                        rules.add(new MatchRule(MatchLogic.XOR));
+                        builder = new StringBuilder();
+                        break;
+                    case '!':
+                        break;
+                    case ')':
+                        rules.add(new MatchRule(builder.toString()));
+                        return i + 1;
+                    default:
+                        builder.append(c);
+                }
+            } else {
+                if (c == '(') {
+                    List<MatchRule> subRules = new ArrayList<>();
+                    i = parseExpression(subRules, expression.substring(i + 1)) + i + 1;
+                    rules.add(MatchRule.group(subRules));
+                } else
+                    builder.append(c);
+            }
+        }
+        if (builder.length() > 0) {
+            rules.add(new MatchRule(builder.toString()));
+        }
+        return expression.length();
+    }
+
+    /**
+     * Matches the given item against a list of rules
+     *
+     * @param rules to check against
+     * @param stack item to check
+     * @return if any of the items oreDicts matches the rules
+     */
+    public static boolean matchesOreDict(List<MatchRule> rules, ItemStack stack) {
+        Set<String> oreDicts = OreDictUnifier.getOreDictionaryNames(stack);
+        if (oreDicts.size() == 0)
+            return false;
+
+        if (rules == null || rules.isEmpty())
+            return true;
+
+        for (String oreDict : oreDicts) {
+            if (matches(rules, oreDict))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Matches the given string against a list of rules.
+     * The string does not have to be an oreDict.
+     *
+     * @param rules   to check against
+     * @param oreDict string to check
+     * @return if the string matches the rules
+     */
+    public static boolean matches(List<MatchRule> rules, String oreDict) {
+        boolean first = true;
+        boolean lastResult = false;
+        MatchLogic lastLogic = null;
+        for (MatchRule rule : rules) {
+            if (lastLogic == null) {
+                if (rule.logic == MatchLogic.AND || rule.logic == MatchLogic.OR || rule.logic == MatchLogic.XOR) {
+                    lastLogic = rule.logic;
+                    continue;
+                }
+            }
+            if (lastLogic != null || first) {
+                if (lastLogic != null) {
+                    switch (lastLogic) {
+                        case AND: {
+                            if (!lastResult)
+                                return false;
+                            break;
+                        }
+                        case OR: {
+                            if (lastResult)
+                                return true;
+                            break;
+                        }
+                    }
+                }
+
+                boolean newResult;
+                if (rule.isGroup())
+                    newResult = matches(rule.subRules, oreDict);
+                else
+                    newResult = matches(rule, oreDict);
+
+                if (lastLogic == MatchLogic.XOR) {
+                    if (lastResult == newResult)
+                        return false;
+                }
+
+                lastLogic = null;
+                lastResult = newResult;
+                first = false;
+            }
+
+        }
+
+        return lastResult;
+    }
+
+    private static boolean matches(MatchRule rule, String oreDict) {
+        String filter = rule.expression;
+
+        if (filter.equals("*"))
+            return true;
+
+        boolean startWild = filter.startsWith("*"), endWild = filter.endsWith("*");
+        if (startWild) {
+            filter = filter.substring(1);
+        }
+
+        String[] parts = filter.split("\\*+");
+
+        return (rule.logic == MatchLogic.NOT) ^ matches(parts, oreDict, startWild, endWild);
+    }
+
+    private static boolean matches(String[] filter, String oreDict, boolean startWild, boolean endWild) {
+        String lastlastPart = filter[0];
+        String lastPart = filter[0];
+        int index = oreDict.indexOf(lastPart);
+        if ((!startWild && index != 0) || index < 0)
+            return false;
+        boolean didGoBack = false;
+
+        for (int i = 1; i < filter.length; i++) {
+            String part = filter[i];
+            int newIndex = oreDict.indexOf(part, index + lastPart.length());
+            if (newIndex < 0) {
+                if (i > 1 && !didGoBack) {
+                    i -= 2;
+                    lastPart = lastlastPart;
+                    didGoBack = true;
+                    continue;
+                }
+                return false;
+            }
+            lastlastPart = lastPart;
+            lastPart = part;
+            index = newIndex;
+            if (didGoBack)
+                didGoBack = false;
+        }
+
+        if (endWild || lastPart.length() + index == oreDict.length())
+            return true;
+
+        for (int i = filter.length - 1; i < filter.length; i++) {
+            String part = filter[i];
+            int newIndex = oreDict.indexOf(part, index + lastPart.length());
+            if (newIndex < 0) {
+                if (i > 1 && !didGoBack) {
+                    i -= 2;
+                    lastPart = lastlastPart;
+                    didGoBack = true;
+                    continue;
+                }
+                return false;
+            }
+            lastlastPart = lastPart;
+            lastPart = part;
+            index = newIndex;
+            if (didGoBack)
+                didGoBack = false;
+        }
+        return lastPart.length() + index == oreDict.length();
+    }
+
+    public static class MatchRule {
+        public final MatchLogic logic;
+        public final String expression;
+        private final List<MatchRule> subRules;
+
+        private MatchRule(MatchLogic logic, String expression, List<MatchRule> subRules) {
+            if (expression.startsWith("!")) {
+                logic = MatchLogic.NOT;
+                expression = expression.substring(1);
+            }
+            this.logic = logic;
+            this.expression = expression;
+            this.subRules = subRules;
+        }
+
+        public MatchRule(MatchLogic logic, String expression) {
+            this(logic, expression, null);
+        }
+
+        public MatchRule(MatchLogic logic) {
+            this(logic, "");
+        }
+
+        public MatchRule(String expression) {
+            this(MatchLogic.ANY, expression);
+        }
+
+        public static MatchRule not(String expression, boolean not) {
+            return new MatchRule(not ? MatchLogic.NOT : MatchLogic.ANY, expression);
+        }
+
+        public static MatchRule group(List<MatchRule> subRules) {
+            return new MatchRule(MatchLogic.ANY, "", subRules);
+        }
+
+        public boolean isGroup() {
+            return subRules != null;
+        }
+
+        @Nullable
+        public List<MatchRule> getSubRules() {
+            return subRules;
+        }
+    }
+
+    public enum MatchLogic {
+        OR, AND, XOR, NOT, ANY
+    }
+}

--- a/src/main/java/gregtech/api/util/OreDictExprFilter.java
+++ b/src/main/java/gregtech/api/util/OreDictExprFilter.java
@@ -45,10 +45,8 @@ public class OreDictExprFilter {
                 i = parseExpression(subRules, expression.substring(i + 1)) + i + 1;
                 rules.add(MatchRule.group(subRules, builder.toString()));
                 builder = new StringBuilder();
-            } else if (builder.length() > 0) {
+            } else {
                 switch (c) {
-                    case '!':
-                        break;
                     case '&':
                         rules.add(new MatchRule(builder.toString()));
                         rules.add(new MatchRule(MatchLogic.AND));
@@ -70,8 +68,6 @@ public class OreDictExprFilter {
                     default:
                         builder.append(c);
                 }
-            } else {
-                builder.append(c);
             }
         }
         if (builder.length() > 0) {

--- a/src/main/java/gregtech/api/util/OreDictExprFilter.java
+++ b/src/main/java/gregtech/api/util/OreDictExprFilter.java
@@ -93,7 +93,7 @@ public class OreDictExprFilter {
             return false;
 
         if (rules == null || rules.isEmpty())
-            return true;
+            return false;
 
         for (String oreDict : oreDicts) {
             if (matches(rules, oreDict))

--- a/src/main/java/gregtech/api/util/OreDictExprFilter.java
+++ b/src/main/java/gregtech/api/util/OreDictExprFilter.java
@@ -40,8 +40,15 @@ public class OreDictExprFilter {
             char c = expression.charAt(i);
             if (c == ' ')
                 continue;
-            if (builder.length() > 0) {
+            if (c == '(') {
+                List<MatchRule> subRules = new ArrayList<>();
+                i = parseExpression(subRules, expression.substring(i + 1)) + i + 1;
+                rules.add(MatchRule.group(subRules, builder.toString()));
+                builder = new StringBuilder();
+            } else if (builder.length() > 0) {
                 switch (c) {
+                    case '!':
+                        break;
                     case '&':
                         rules.add(new MatchRule(builder.toString()));
                         rules.add(new MatchRule(MatchLogic.AND));
@@ -57,8 +64,6 @@ public class OreDictExprFilter {
                         rules.add(new MatchRule(MatchLogic.XOR));
                         builder = new StringBuilder();
                         break;
-                    case '!':
-                        break;
                     case ')':
                         rules.add(new MatchRule(builder.toString()));
                         return i + 1;
@@ -66,12 +71,7 @@ public class OreDictExprFilter {
                         builder.append(c);
                 }
             } else {
-                if (c == '(') {
-                    List<MatchRule> subRules = new ArrayList<>();
-                    i = parseExpression(subRules, expression.substring(i + 1)) + i + 1;
-                    rules.add(MatchRule.group(subRules));
-                } else
-                    builder.append(c);
+                builder.append(c);
             }
         }
         if (builder.length() > 0) {
@@ -256,8 +256,9 @@ public class OreDictExprFilter {
             return new MatchRule(not ? MatchLogic.NOT : MatchLogic.ANY, expression);
         }
 
-        public static MatchRule group(List<MatchRule> subRules) {
-            return new MatchRule(MatchLogic.ANY, "", subRules);
+        public static MatchRule group(List<MatchRule> subRules, String expression) {
+            MatchLogic logic = expression.startsWith("!") ? MatchLogic.NOT : MatchLogic.ANY;
+            return new MatchRule(logic, "", subRules);
         }
 
         public boolean isGroup() {

--- a/src/main/java/gregtech/api/util/OreDictExprFilter.java
+++ b/src/main/java/gregtech/api/util/OreDictExprFilter.java
@@ -139,7 +139,7 @@ public class OreDictExprFilter {
 
                 boolean newResult;
                 if (rule.isGroup())
-                    newResult = matches(rule.subRules, oreDict);
+                    newResult = rule.logic == MatchLogic.NOT ^ matches(rule.subRules, oreDict);
                 else
                     newResult = matches(rule, oreDict);
 

--- a/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.message.FormattedMessage;
 
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 
 public class CoverFluidRegulator extends CoverPump {
@@ -298,7 +299,7 @@ public class CoverFluidRegulator extends CoverPump {
             }
         })
                 .setCentered(true)
-                .setAllowedChars("0123456789")
+                .setAllowedChars(TextFieldWidget2.NATURAL_NUMS)
                 .setMaxLength(10)
                 .setValidator(getTextFieldValidator(() -> transferMode == TransferMode.TRANSFER_EXACT ? maxFluidTransferRate : Integer.MAX_VALUE))
                 .setScale(0.6f));

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -42,6 +42,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
+import java.util.regex.Pattern;
 
 public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
 
@@ -186,7 +187,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
             }
         })
                 .setCentered(true)
-                .setAllowedChars("0123456789")
+                .setAllowedChars(TextFieldWidget2.NATURAL_NUMS)
                 .setMaxLength(8)
                 .setValidator(getTextFieldValidator(() -> bucketMode == BucketMode.BUCKET ? maxFluidTransferRate / 1000 : maxFluidTransferRate));
         primaryGroup.addWidget(textField);

--- a/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
@@ -99,7 +99,7 @@ public class ItemFilterContainer implements INBTSerializable<NBTTagCompound> {
                     if (val != null && !val.isEmpty())
                         setTransferStackSize(Integer.parseInt(val));
                 })
-                        .setAllowedChars("0123456789")
+                        .setAllowedChars(TextFieldWidget2.NATURAL_NUMS)
                         .setMaxLength(4)
                         .setValidator(getTextFieldValidator(() -> Integer.MAX_VALUE))
                         .setScale(0.9f)

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -2,19 +2,16 @@ package gregtech.common.covers.filter;
 
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.Widget;
-import gregtech.api.gui.impl.ModularUIGui;
 import gregtech.api.gui.widgets.DrawableWidget;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.OreDictFilterTestSlot;
 import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.util.ItemStackKey;
 import gregtech.api.util.OreDictExprFilter;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fml.client.config.GuiUtils;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -109,14 +106,6 @@ public class OreDictionaryItemFilter extends ItemFilter {
         widgetGroup.accept(new DrawableWidget(36, 1, 100, 18)
                 .setBackgroundDrawer(((mouseX, mouseY, partialTicks, context, widget) -> {
                     if (testStack.isEmpty()) {
-                        if (Widget.isMouseOver(widget.getPosition().x, widget.getPosition().y, 18, 18, mouseX, mouseY)) {
-                            Minecraft mc = Minecraft.getMinecraft();
-                            ModularUIGui gui = (ModularUIGui) context;
-                            GuiUtils.drawHoveringText(Arrays.asList(I18n.format("cover.ore_dictionary_filter.test_slot.info").split("/n")), mouseX, mouseY,
-                                    gui.width,
-                                    gui.height, 300, mc.fontRenderer);
-                            GlStateManager.disableLighting();
-                        }
                         return;
                     }
                     int color = 0xD15858;

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -109,7 +109,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
         widgetGroup.accept(new DrawableWidget(36, 1, 100, 18)
                 .setBackgroundDrawer(((mouseX, mouseY, partialTicks, context, widget) -> {
                     if (testStack.isEmpty()) {
-                        if (Widget.isMouseOver(widget.getPosition().x, widget.getPosition().y, widget.getSize().width, widget.getSize().height, mouseX, mouseY)) {
+                        if (Widget.isMouseOver(widget.getPosition().x, widget.getPosition().y, 18, 18, mouseX, mouseY)) {
                             Minecraft mc = Minecraft.getMinecraft();
                             ModularUIGui gui = (ModularUIGui) context;
                             GuiUtils.drawHoveringText(Arrays.asList(I18n.format("cover.ore_dictionary_filter.test_slot.info").split("/n")), mouseX, mouseY,

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -2,12 +2,19 @@ package gregtech.common.covers.filter;
 
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.Widget;
+import gregtech.api.gui.impl.ModularUIGui;
+import gregtech.api.gui.widgets.DrawableWidget;
 import gregtech.api.gui.widgets.ImageWidget;
+import gregtech.api.gui.widgets.OreDictFilterTestSlot;
 import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.util.ItemStackKey;
 import gregtech.api.util.OreDictExprFilter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.client.config.GuiUtils;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -15,9 +22,10 @@ import java.util.regex.Pattern;
 
 public class OreDictionaryItemFilter extends ItemFilter {
 
-    private static final Pattern ORE_DICTIONARY_FILTER = Pattern.compile("\\*?[a-zA-Z0-9_]*\\*?");
-
     protected String oreDictFilterExpression = "";
+    private String testMsg = "";
+    private boolean testResult;
+    private ItemStack testStack = ItemStack.EMPTY;
 
     private final List<OreDictExprFilter.MatchRule> matchRules = new ArrayList<>();
     private final Map<ItemStack, Boolean> recentlyChecked = new HashMap<>();
@@ -27,6 +35,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
         OreDictExprFilter.parseExpression(matchRules, oreDictFilterExpression);
         recentlyChecked.clear();
         markDirty();
+        updateTestMsg();
     }
 
     public String getOreDictFilterExpression() {
@@ -36,8 +45,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
     @Override
     public void initUI(Consumer<Widget> widgetGroup) {
         widgetGroup.accept(new ImageWidget(12, 0, 20, 20, GuiTextures.INFO_ICON)
-                .setTooltip("cover.ore_dictionary_filter.info")
-        );
+                .setTooltip("cover.ore_dictionary_filter.info"));
         widgetGroup.accept(new ImageWidget(10, 25, 156, 14, GuiTextures.DISPLAY));
         widgetGroup.accept(new TextFieldWidget2(14, 29, 152, 12, () -> oreDictFilterExpression, this::setOreDictFilterExpression)
                 .setAllowedChars(Pattern.compile("[(!]* *[0-9a-zA-Z*]* *\\)*( *[&|^]? *[(!]* *[0-9a-zA-Z*]* *\\)*)*"))
@@ -55,8 +63,9 @@ public class OreDictionaryItemFilter extends ItemFilter {
                     char last = ' ';
                     for (int i = 0; i < input.length(); i++) {
                         char c = input.charAt(i);
-                        if (c == ' ' && last != '(') {
-                            builder.append(" ");
+                        if (c == ' ') {
+                            if (last != '(')
+                                builder.append(" ");
                             continue;
                         }
                         if (c == '(')
@@ -64,8 +73,9 @@ public class OreDictionaryItemFilter extends ItemFilter {
                         else if (c == ')') {
                             unclosed--;
                             if (last == '&' || last == '|' || last == '^') {
-                                int l = input.lastIndexOf(" " + last);
-                                builder.insert(l == i - 1 ? i - 1 : i, ")");
+                                int l = builder.lastIndexOf(" " + last);
+                                int l2 = builder.lastIndexOf("" + last);
+                                builder.insert(l == l2 - 1 ? l : l2, ")");
                                 continue;
                             }
                             if (i > 0 && builder.charAt(builder.length() - 1) == ' ') {
@@ -95,6 +105,53 @@ public class OreDictionaryItemFilter extends ItemFilter {
                     return input;
                 })
         );
+
+        widgetGroup.accept(new DrawableWidget(36, 1, 100, 18)
+                .setBackgroundDrawer(((mouseX, mouseY, partialTicks, context, widget) -> {
+                    if (testStack.isEmpty()) {
+                        if (Widget.isMouseOver(widget.getPosition().x, widget.getPosition().y, widget.getSize().width, widget.getSize().height, mouseX, mouseY)) {
+                            Minecraft mc = Minecraft.getMinecraft();
+                            ModularUIGui gui = (ModularUIGui) context;
+                            GuiUtils.drawHoveringText(Arrays.asList(I18n.format("cover.ore_dictionary_filter.test_slot.info").split("/n")), mouseX, mouseY,
+                                    gui.width,
+                                    gui.height, 300, mc.fontRenderer);
+                            GlStateManager.disableLighting();
+                        }
+                        return;
+                    }
+                    int color = 0xD15858;
+                    if (testResult) {
+                        color = 0x66C261;
+                    }
+                    GlStateManager.pushMatrix();
+                    GlStateManager.translate(widget.getPosition().x, widget.getPosition().y, 0);
+                    GlStateManager.colorMask(true, true, true, true);
+                    Widget.drawText(I18n.format(testMsg), 22, 6.5f, 0.75f, color, false);
+                    color |= (140 & 0xFF) << 24;
+                    Widget.drawGradientRect(0, 0, 18, 18, color, color);
+                    GlStateManager.popMatrix();
+
+                }))
+        );
+        widgetGroup.accept(new OreDictFilterTestSlot(36, 1)
+                .setListener(stack -> {
+                    testStack = stack;
+                    updateTestMsg();
+                }));
+    }
+
+    private void updateTestMsg() {
+        if (testStack.isEmpty()) {
+            testMsg = "";
+            return;
+        }
+
+        testResult = matchesItemStack(testStack);
+        if (testResult) {
+            testMsg = "cover.ore_dictionary_filter.matches";
+        } else {
+            testMsg = "cover.ore_dictionary_filter.matches_not";
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -1,14 +1,15 @@
 package gregtech.common.covers.filter;
 
+import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.Widget;
-import gregtech.api.gui.widgets.LabelWidget;
-import gregtech.api.gui.widgets.TextFieldWidget;
-import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.gui.widgets.ImageWidget;
+import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.util.ItemStackKey;
+import gregtech.api.util.OreDictExprFilter;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -16,30 +17,101 @@ public class OreDictionaryItemFilter extends ItemFilter {
 
     private static final Pattern ORE_DICTIONARY_FILTER = Pattern.compile("\\*?[a-zA-Z0-9_]*\\*?");
 
-    protected String oreDictionaryFilter = "";
+    protected String oreDictFilterExpression = "";
 
-    protected void setOreDictionaryFilter(String oreDictionaryFilter) {
-        this.oreDictionaryFilter = oreDictionaryFilter;
+    private final List<OreDictExprFilter.MatchRule> matchRules = new ArrayList<>();
+    private final Map<ItemStack, Boolean> recentlyChecked = new HashMap<>();
+
+    protected void setOreDictFilterExpression(String oreDictFilterExpression) {
+        this.oreDictFilterExpression = oreDictFilterExpression;
+        OreDictExprFilter.parseExpression(matchRules, oreDictFilterExpression);
+        recentlyChecked.clear();
         markDirty();
     }
 
-    public String getOreDictionaryFilter() {
-        return oreDictionaryFilter;
+    public String getOreDictFilterExpression() {
+        return oreDictFilterExpression;
     }
 
     @Override
     public void initUI(Consumer<Widget> widgetGroup) {
-        widgetGroup.accept(new LabelWidget(10, 0, "cover.ore_dictionary_filter.title1"));
-        widgetGroup.accept(new LabelWidget(10, 10, "cover.ore_dictionary_filter.title2"));
-        widgetGroup.accept(new TextFieldWidget(10, 25, 100, 12, true,
-                () -> oreDictionaryFilter, this::setOreDictionaryFilter)
-                .setMaxStringLength(64)
-                .setValidator(str -> ORE_DICTIONARY_FILTER.matcher(str).matches()));
+        widgetGroup.accept(new ImageWidget(12, 0, 20, 20, GuiTextures.INFO_ICON)
+                .setTooltip("cover.ore_dictionary_filter.info")
+        );
+        widgetGroup.accept(new ImageWidget(10, 25, 156, 14, GuiTextures.DISPLAY));
+        widgetGroup.accept(new TextFieldWidget2(14, 29, 152, 12, () -> oreDictFilterExpression, this::setOreDictFilterExpression)
+                .setAllowedChars(Pattern.compile("[(!]* *[0-9a-zA-Z*]* *\\)*( *[&|^]? *[(!]* *[0-9a-zA-Z*]* *\\)*)*"))
+                .setMaxLength(64)
+                .setScale(0.75f)
+                .setValidator(input -> {
+                    input = input.replaceAll("\\*{2,}", "*");
+                    input = input.replaceAll("&{2,}", "&");
+                    input = input.replaceAll("\\|{2,}", "|");
+                    input = input.replaceAll("!{2,}", "!");
+                    input = input.replaceAll("\\^{2,}", "^");
+                    input = input.replaceAll(" {2,}", " ");
+                    StringBuilder builder = new StringBuilder();
+                    int unclosed = 0;
+                    char last = ' ';
+                    for (int i = 0; i < input.length(); i++) {
+                        char c = input.charAt(i);
+                        if (c == ' ' && last != '(') {
+                            builder.append(" ");
+                            continue;
+                        }
+                        if (c == '(')
+                            unclosed++;
+                        else if (c == ')') {
+                            unclosed--;
+                            if (last == '&' || last == '|' || last == '^') {
+                                int l = input.lastIndexOf(" " + last);
+                                builder.insert(l == i - 1 ? i - 1 : i, ")");
+                                continue;
+                            }
+                            if (i > 0 && builder.charAt(builder.length() - 1) == ' ') {
+                                builder.deleteCharAt(builder.length() - 1);
+                            }
+                        } else if ((c == '&' || c == '|' || c == '^') && last == '(') {
+                            builder.deleteCharAt(builder.lastIndexOf("("));
+                            builder.append(c).append(" (");
+                            continue;
+                        }
+
+                        builder.append(c);
+                        last = c;
+                    }
+                    if (unclosed > 0) {
+                        for (int i = 0; i < unclosed; i++) {
+                            builder.append(")");
+                        }
+                    } else if (unclosed < 0) {
+                        unclosed = -unclosed;
+                        for (int i = 0; i < unclosed; i++) {
+                            builder.insert(0, "(");
+                        }
+                    }
+                    input = builder.toString();
+                    input = input.replaceAll(" {2,}", " ");
+                    return input;
+                })
+        );
     }
 
     @Override
     public Object matchItemStack(ItemStack itemStack) {
-        return matchesOreDictionaryFilter(getOreDictionaryFilter(), itemStack);
+        return matchesItemStack(itemStack) ? "wtf is this system?? i can put any non null object here and it i will work??? $arch" : null;
+    }
+
+    public boolean matchesItemStack(ItemStack itemStack) {
+        Boolean b = recentlyChecked.get(itemStack);
+        if (b != null)
+            return b;
+        if (OreDictExprFilter.matchesOreDict(matchRules, itemStack)) {
+            recentlyChecked.put(itemStack, true);
+            return true;
+        }
+        recentlyChecked.put(itemStack, false);
+        return false;
     }
 
     @Override
@@ -59,43 +131,12 @@ public class OreDictionaryItemFilter extends ItemFilter {
 
     @Override
     public void writeToNBT(NBTTagCompound tagCompound) {
-        tagCompound.setString("OreDictionaryFilter", oreDictionaryFilter);
+        tagCompound.setString("OreDictionaryFilter", oreDictFilterExpression);
     }
 
     @Override
     public void readFromNBT(NBTTagCompound tagCompound) {
-        this.oreDictionaryFilter = tagCompound.getString("OreDictionaryFilter");
-    }
-
-    public static String matchesOreDictionaryFilter(String oreDictionaryFilter, ItemStack itemStack) {
-        if (oreDictionaryFilter.isEmpty()) {
-            return null;
-        }
-        boolean startWildcard = oreDictionaryFilter.charAt(0) == '*';
-        boolean endWildcard = oreDictionaryFilter.length() > 1 && oreDictionaryFilter.charAt(oreDictionaryFilter.length() - 1) == '*';
-        if (startWildcard) {
-            oreDictionaryFilter = oreDictionaryFilter.substring(1);
-        }
-        if (endWildcard) {
-            oreDictionaryFilter = oreDictionaryFilter.substring(0, oreDictionaryFilter.length() - 1);
-        }
-        for (String stackOreName : OreDictUnifier.getOreDictionaryNames(itemStack)) {
-            if (areOreDictNamesEqual(startWildcard, endWildcard, oreDictionaryFilter, stackOreName)) {
-                return stackOreName;
-            }
-        }
-        return null;
-    }
-
-    private static boolean areOreDictNamesEqual(boolean startWildcard, boolean endWildcard, String oreDictName, String stackOreName) {
-        if (startWildcard && endWildcard) {
-            return stackOreName.contains(oreDictName);
-        } else if (startWildcard) {
-            return stackOreName.endsWith(oreDictName);
-        } else if (endWildcard) {
-            return stackOreName.startsWith(oreDictName);
-        } else {
-            return stackOreName.equals(oreDictName);
-        }
+        this.oreDictFilterExpression = tagCompound.getString("OreDictionaryFilter");
+        OreDictExprFilter.parseExpression(this.matchRules, this.oreDictFilterExpression);
     }
 }

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -49,12 +49,15 @@ public class OreDictionaryItemFilter extends ItemFilter {
                 .setMaxLength(64)
                 .setScale(0.75f)
                 .setValidator(input -> {
+                    // remove all operators that are double
                     input = input.replaceAll("\\*{2,}", "*");
                     input = input.replaceAll("&{2,}", "&");
                     input = input.replaceAll("\\|{2,}", "|");
                     input = input.replaceAll("!{2,}", "!");
                     input = input.replaceAll("\\^{2,}", "^");
                     input = input.replaceAll(" {2,}", " ");
+                    // move ( and ) so it doesn't create invalid expressions f.e. xxx (& yyy) => xxx & (yyy)
+                    // append or prepend ( and ) if the amount is not equal
                     StringBuilder builder = new StringBuilder();
                     int unclosed = 0;
                     char last = ' ';

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeChest.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 public class MetaTileEntityCreativeChest extends MetaTileEntityQuantumChest {
 
@@ -82,7 +83,7 @@ public class MetaTileEntityCreativeChest extends MetaTileEntityQuantumChest {
             if (!value.isEmpty()) {
                 itemsPerCycle = Integer.parseInt(value);
             }
-        }).setAllowedChars("0123456789").setMaxLength(19).setValidator(getTextFieldValidator()));
+        }).setAllowedChars(TextFieldWidget2.NATURAL_NUMS).setMaxLength(19).setValidator(getTextFieldValidator()));
         builder.label(7, 28, "Items per cycle");
 
         builder.widget(new ImageWidget(7, 85, 154, 14, GuiTextures.DISPLAY));

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEnergyContainer {
 
@@ -85,7 +86,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEne
                 voltage = Long.parseLong(value);
                 setTier = 0;
             }
-        }).setAllowedChars("0123456789").setMaxLength(19).setValidator(getTextFieldValidator()));
+        }).setAllowedChars(TextFieldWidget2.NATURAL_NUMS).setMaxLength(19).setValidator(getTextFieldValidator()));
 
         builder.label(7, 74, "Amperage");
         builder.widget(new ClickButtonWidget(7, 87, 20, 20, "-", data -> amps = amps-- == -1 ? 0 : amps--));

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import static net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack.FLUID_NBT_KEY;
 
@@ -77,7 +78,7 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
             if (!value.isEmpty()) {
                 mBPerCycle = Integer.parseInt(value);
             }
-        }).setAllowedChars("0123456789").setMaxLength(19).setValidator(getTextFieldValidator()));
+        }).setAllowedChars(TextFieldWidget2.NATURAL_NUMS).setMaxLength(19).setValidator(getTextFieldValidator()));
         builder.label(7, 28, "mB per cycle");
 
         builder.widget(new ImageWidget(7, 82, 154, 14, GuiTextures.DISPLAY));

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1018,6 +1018,9 @@ cover.filter.blacklist.enabled=Blacklist
 
 cover.ore_dictionary_filter.title=Ore Dictionary Filter
 cover.ore_dictionary_filter.info=§bAccepts complex expressions/n& = AND/n| = OR/n^ = XOR/n! = NOT/n( ) for priority/n* for wildcard/n§bExample:/n§6dust*Gold | (plate* & !*Double*)/nWill match all gold dusts of all sizes or all plates, but not double plates
+cover.ore_dictionary_filter.test_slot.info=Insert a item to test if it matches the filter expression
+cover.ore_dictionary_filter.matches=Item matches
+cover.ore_dictionary_filter.matches_not=Item does not match
 
 cover.fluid_filter.title=Fluid Filter
 cover.fluid_filter.mode.filter_fill=Filter Fill

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1017,8 +1017,7 @@ cover.filter.blacklist.disabled=Whitelist
 cover.filter.blacklist.enabled=Blacklist
 
 cover.ore_dictionary_filter.title=Ore Dictionary Filter
-cover.ore_dictionary_filter.title1=Ore Dictionary Name
-cover.ore_dictionary_filter.title2=(use * for wildcard)
+cover.ore_dictionary_filter.info=§bAccepts complex expressions/n& = AND/n| = OR/n^ = XOR/n! = NOT/n( ) for priority/n* for wildcard/n§bExample:/n§6dust*Gold | (plate* & !*Double*)/nWill match all gold dusts of all sizes or all plates, but not double plates
 
 cover.fluid_filter.title=Fluid Filter
 cover.fluid_filter.mode.filter_fill=Filter Fill


### PR DESCRIPTION
The ore filter can parse complex expressions like `dust*Gold | (plate* & !*Double*)`. This will match all gold dusts of all sizes or all plates, but not double plates.

& for AND
| for OR
^ for XOR
! for NOT
() for priority
and * for wildcard

Also fixes a bunch of minor issues with `TextFieldWidget2`

It also has a Test slot where you can insert any item to see if it matches the expression
(It's just a ghost slot)
![grafik](https://user-images.githubusercontent.com/45517902/148658741-eda1b692-9083-49e2-a84e-526b667c3f72.png)
Tooltip of the i
![grafik](https://user-images.githubusercontent.com/45517902/148658787-30a11888-f74d-462b-a776-2c9e9c063ddd.png)
You can also drag items from jei here
![grafik](https://user-images.githubusercontent.com/45517902/148658811-36b7797a-e887-4c29-b633-937e6570a873.png)
