### PR TITLE
Ability to remove multiblock previews from Jei.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -201,6 +201,13 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(getBaseTexture(null).getParticleSprite(), getPaintingColorForRendering());
     }
+    
+    /**
+     * Override to disable Multiblock pattern from being added to Jei
+     */
+    public boolean shouldShowInJei(){
+        return true;
+    }
 
     /**
      * Override to disable MultiblockPart sharing for this Multiblock. (Rotor Holders always disallowed).

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
@@ -6,7 +6,7 @@ import stanhebben.zenscript.annotations.ZenMethod;
 
 import static gregtech.integration.jei.multiblock.MultiblockInfoCategory.*;
 
-@ZenClass("mods.gregtech.multiblock.utils")
+@ZenClass("mods.gregtech.general.utils")
 @ZenRegister
 public class CTUtilities {
 

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
@@ -1,0 +1,19 @@
+package gregtech.api.recipes.crafttweaker;
+
+import crafttweaker.annotations.ZenRegister;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import static gregtech.integration.jei.multiblock.MultiblockInfoCategory.*;
+
+@ZenClass("mods.gregtech.multiblock.utils")
+@ZenRegister
+public class CTUtilities {
+
+    @ZenMethod("RemoveMultiblockPreviewFromJei")
+    public static void removeMulti(String name) {
+
+        REGISTER.removeIf(multi -> multi.metaTileEntityId.toString().equals(name));
+
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -767,8 +767,10 @@ public class MetaTileEntities {
             IMultiblockAbilityPart<?> abilityPart = (IMultiblockAbilityPart<?>) sampleMetaTileEntity;
             MultiblockAbility.registerMultiblockAbility(abilityPart.getAbility(), sampleMetaTileEntity);
         }
-        if (sampleMetaTileEntity instanceof MultiblockControllerBase && GTValues.isModLoaded(GTValues.MODID_JEI)) {
-            MultiblockInfoCategory.registerMultiblock((MultiblockControllerBase) sampleMetaTileEntity);
+        if (sampleMetaTileEntity instanceof MultiblockControllerBase && GTValues.isModLoaded(GTValues.MODID_JEI) ) {
+            if (((MultiblockControllerBase) sampleMetaTileEntity).shouldShowInJei()) {
+                MultiblockInfoCategory.registerMultiblock((MultiblockControllerBase) sampleMetaTileEntity);
+            }
         }
         GregTechAPI.MTE_REGISTRY.register(id, sampleMetaTileEntity.metaTileEntityId, sampleMetaTileEntity);
         return sampleMetaTileEntity;


### PR DESCRIPTION
**What:**
Allows pack authors to remove Multiblock previews from Jei.

PR now includes a way to prevent the preview from being added to Jei java side.

**How solved:**
Created a new class for general CT utilities with the removal method. Thanks to KilaBash for method used.

Added a method check that can be overwritten to prevent the preview from being added at the registration.


**Possible compatibility issue:**
none