### PR TITLE
Revamp OreDictItem addition

### DIFF
--- a/src/main/java/gregtech/api/items/crafttweaker/CTItemRegistry.java
+++ b/src/main/java/gregtech/api/items/crafttweaker/CTItemRegistry.java
@@ -1,11 +1,12 @@
 package gregtech.api.items.crafttweaker;
 
 import crafttweaker.annotations.ZenRegister;
-import gregtech.api.items.metaitem.MetaOreDictItem;
 import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.ore.OrePrefix;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
+
+import static gregtech.common.items.MetaItems.CT_OREDICT_ITEM;
 
 @ZenClass("mods.gregtech.item.ItemRegistry")
 @ZenRegister
@@ -14,7 +15,13 @@ public class CTItemRegistry {
 
     @ZenMethod("registerItem")
     public static void registerItem(String name, short id, int rgb, String materialIconSet, String orePrefix) {
-        new MetaOreDictItem.OreDictValueItem(
+        CT_OREDICT_ITEM.addOreDictItem(
                 id, name, rgb, MaterialIconSet.ICON_SETS.get(materialIconSet), OrePrefix.getPrefix(orePrefix));
+    }
+
+    @ZenMethod("registerItem")
+    public static void registerItem(String name, short id, int rgb, String materialIconSet, String orePrefix, String chemicalFormula) {
+        CT_OREDICT_ITEM.addOreDictItem(
+                id, name, rgb, MaterialIconSet.ICON_SETS.get(materialIconSet), OrePrefix.getPrefix(orePrefix), chemicalFormula);
     }
 }

--- a/src/main/java/gregtech/api/items/crafttweaker/CTItemRegistry.java
+++ b/src/main/java/gregtech/api/items/crafttweaker/CTItemRegistry.java
@@ -3,6 +3,7 @@ package gregtech.api.items.crafttweaker;
 import crafttweaker.annotations.ZenRegister;
 import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.ore.OrePrefix;
+import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -14,14 +15,9 @@ import static gregtech.common.items.MetaItems.CT_OREDICT_ITEM;
 public class CTItemRegistry {
 
     @ZenMethod("registerItem")
-    public static void registerItem(String name, short id, int rgb, String materialIconSet, String orePrefix) {
+    public static void registerItem(String name, short id, int rgb, String materialIconSet, String orePrefix, @Optional String chemicalFormula) {
         CT_OREDICT_ITEM.addOreDictItem(
-                id, name, rgb, MaterialIconSet.ICON_SETS.get(materialIconSet), OrePrefix.getPrefix(orePrefix));
+                id, name, rgb, MaterialIconSet.ICON_SETS.get(materialIconSet), OrePrefix.getPrefix(orePrefix), chemicalFormula.equals("") ? null : chemicalFormula);
     }
 
-    @ZenMethod("registerItem")
-    public static void registerItem(String name, short id, int rgb, String materialIconSet, String orePrefix, String chemicalFormula) {
-        CT_OREDICT_ITEM.addOreDictItem(
-                id, name, rgb, MaterialIconSet.ICON_SETS.get(materialIconSet), OrePrefix.getPrefix(orePrefix), chemicalFormula);
-    }
 }

--- a/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
@@ -85,6 +85,7 @@ public class MetaOreDictItem extends StandardMetaItem {
         }
     }
 
+    @SuppressWarnings("unused")
     public OreDictValueItem addOreDictItem(int id, String materialName, int rgb, MaterialIconSet materialIconSet, OrePrefix orePrefix) {
         return this.addOreDictItem(id, materialName, rgb, materialIconSet, orePrefix, null);
     }

--- a/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class MetaOreDictItem extends StandardMetaItem {
 
-    public final Map<String, OreDictValueItem> FORMULA_TO_OREDICTITEM = new HashMap<>();
+    public final Map<String, String> OREDICT_TO_FORMULA = new HashMap<>();
     private final Map<Short, OreDictValueItem> ITEMS = new HashMap<>();
     private static final List<MaterialIconType> DISALLOWED_TYPES = ImmutableList.of(
             MaterialIconType.block, MaterialIconType.foilBlock, MaterialIconType.wire,
@@ -30,10 +30,6 @@ public class MetaOreDictItem extends StandardMetaItem {
             MaterialIconType.pipeLarge, MaterialIconType.pipeSide, MaterialIconType.pipeSmall,
             MaterialIconType.pipeMedium, MaterialIconType.pipeTiny);
     private static final ModelResourceLocation MISSING_LOCATION = new ModelResourceLocation("builtin/missing", "inventory");
-
-    public MetaOreDictItem() {
-        this((short) 0);
-    }
 
     public MetaOreDictItem(short metaItemOffset) {
         super(metaItemOffset);
@@ -60,7 +56,6 @@ public class MetaOreDictItem extends StandardMetaItem {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerModels() {
-        //super.registerModels();
         ModelLoader.setCustomMeshDefinition(this, itemStack -> {
             short itemDamage = formatRawItemDamage((short) itemStack.getItemDamage());
             if (specialItemsModels.containsKey(itemDamage)) {
@@ -95,7 +90,7 @@ public class MetaOreDictItem extends StandardMetaItem {
     }
 
     public OreDictValueItem addOreDictItem(int id, String materialName, int materialRGB, MaterialIconSet materialIconSet, OrePrefix orePrefix, String chemicalFormula) {
-        return new OreDictValueItem(id, materialName, materialRGB, materialIconSet, orePrefix, chemicalFormula);
+        return new OreDictValueItem((short) id, materialName, materialRGB, materialIconSet, orePrefix, chemicalFormula);
     }
 
     public class OreDictValueItem {
@@ -108,15 +103,15 @@ public class MetaOreDictItem extends StandardMetaItem {
 
         protected String chemicalFormula;
 
-        public OreDictValueItem(int id, String materialName, int materialRGB, MaterialIconSet materialIconSet, OrePrefix orePrefix, String chemicalFormula) {
-            this.id = (short) id;
+        private OreDictValueItem(short id, String materialName, int materialRGB, MaterialIconSet materialIconSet, OrePrefix orePrefix, String chemicalFormula) {
+            this.id = id;
             this.materialName = materialName;
             this.materialRGB = materialRGB;
             this.materialIconSet = materialIconSet;
             this.orePrefix = orePrefix;
             this.chemicalFormula = chemicalFormula;
             MetaOreDictItem.this.ITEMS.put(this.id, this);
-            MetaOreDictItem.this.FORMULA_TO_OREDICTITEM.put(calculateChemicalFormula(chemicalFormula), this);
+            MetaOreDictItem.this.OREDICT_TO_FORMULA.put(this.getOre(), calculateChemicalFormula(chemicalFormula));
         }
 
         public String getOre() {

--- a/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
@@ -22,14 +22,18 @@ import java.util.Map;
 
 public class MetaOreDictItem extends StandardMetaItem {
 
-    public static final Map<String, OreDictValueItem> FORMULA_TO_OREDICTITEM = new HashMap<>();
-    private static final Map<Short, OreDictValueItem> ITEMS = new HashMap<>();
+    public final Map<String, OreDictValueItem> FORMULA_TO_OREDICTITEM = new HashMap<>();
+    private final Map<Short, OreDictValueItem> ITEMS = new HashMap<>();
     private static final List<MaterialIconType> DISALLOWED_TYPES = ImmutableList.of(
             MaterialIconType.block, MaterialIconType.foilBlock, MaterialIconType.wire,
             MaterialIconType.ore, MaterialIconType.frameGt, MaterialIconType.pipeHuge,
             MaterialIconType.pipeLarge, MaterialIconType.pipeSide, MaterialIconType.pipeSmall,
             MaterialIconType.pipeMedium, MaterialIconType.pipeTiny);
     private static final ModelResourceLocation MISSING_LOCATION = new ModelResourceLocation("builtin/missing", "inventory");
+
+    public MetaOreDictItem() {
+        this((short) 0);
+    }
 
     public MetaOreDictItem(short metaItemOffset) {
         super(metaItemOffset);
@@ -86,7 +90,15 @@ public class MetaOreDictItem extends StandardMetaItem {
         }
     }
 
-    public static class OreDictValueItem {
+    public OreDictValueItem addOreDictItem(int id, String materialName, int rgb, MaterialIconSet materialIconSet, OrePrefix orePrefix) {
+        return this.addOreDictItem(id, materialName, rgb, materialIconSet, orePrefix, null);
+    }
+
+    public OreDictValueItem addOreDictItem(int id, String materialName, int materialRGB, MaterialIconSet materialIconSet, OrePrefix orePrefix, String chemicalFormula) {
+        return new OreDictValueItem(id, materialName, materialRGB, materialIconSet, orePrefix, chemicalFormula);
+    }
+
+    public class OreDictValueItem {
 
         private final String materialName;
         private final int materialRGB;
@@ -96,10 +108,6 @@ public class MetaOreDictItem extends StandardMetaItem {
 
         protected String chemicalFormula;
 
-        public OreDictValueItem(int id, String materialName, int rgb, MaterialIconSet materialIconSet, OrePrefix orePrefix) {
-            this(id, materialName, rgb, materialIconSet, orePrefix, null);
-        }
-
         public OreDictValueItem(int id, String materialName, int materialRGB, MaterialIconSet materialIconSet, OrePrefix orePrefix, String chemicalFormula) {
             this.id = (short) id;
             this.materialName = materialName;
@@ -107,8 +115,8 @@ public class MetaOreDictItem extends StandardMetaItem {
             this.materialIconSet = materialIconSet;
             this.orePrefix = orePrefix;
             this.chemicalFormula = chemicalFormula;
-            ITEMS.put(this.id, this);
-            FORMULA_TO_OREDICTITEM.put(calculateChemicalFormula(chemicalFormula), this);
+            MetaOreDictItem.this.ITEMS.put(this.id, this);
+            MetaOreDictItem.this.FORMULA_TO_OREDICTITEM.put(calculateChemicalFormula(chemicalFormula), this);
         }
 
         public String getOre() {

--- a/src/main/java/gregtech/client/ClientProxy.java
+++ b/src/main/java/gregtech/client/ClientProxy.java
@@ -208,10 +208,11 @@ public class ClientProxy extends CommonProxy {
             // Water buckets have a separate registry name from other buckets
         } else if (itemStack.getItem().equals(Items.WATER_BUCKET)) {
             chemicalFormula = FluidTooltipUtil.getWaterTooltip();
-        } else {
+        } else if (itemStack.getItem() instanceof MetaOreDictItem){
+            MetaOreDictItem oreDictItem = (MetaOreDictItem) itemStack.getItem();
             Optional<String> oreDictName = OreDictUnifier.getOreDictionaryNames(itemStack).stream().findFirst();
-            if (oreDictName.isPresent() && MetaOreDictItem.FORMULA_TO_OREDICTITEM.containsKey(oreDictName.get())) {
-                MetaOreDictItem.OreDictValueItem material = MetaOreDictItem.FORMULA_TO_OREDICTITEM.get(oreDictName.get());
+            if (oreDictName.isPresent() && oreDictItem.FORMULA_TO_OREDICTITEM.containsKey(oreDictName.get())) {
+                MetaOreDictItem.OreDictValueItem material = oreDictItem.FORMULA_TO_OREDICTITEM.get(oreDictName.get());
                 if (material != null) {
                     chemicalFormula = material.getFormula();
                 }

--- a/src/main/java/gregtech/client/ClientProxy.java
+++ b/src/main/java/gregtech/client/ClientProxy.java
@@ -188,7 +188,17 @@ public class ClientProxy extends CommonProxy {
 
         // Test for Items
         UnificationEntry unificationEntry = OreDictUnifier.getUnificationEntry(itemStack);
-        if (unificationEntry != null && unificationEntry.material != null) {
+
+        if (itemStack.getItem() instanceof MetaOreDictItem) { // Test for OreDictItems
+            MetaOreDictItem oreDictItem = (MetaOreDictItem) itemStack.getItem();
+            Optional<String> oreDictName = OreDictUnifier.getOreDictionaryNames(itemStack).stream().findFirst();
+            if (oreDictName.isPresent() && oreDictItem.OREDICT_TO_FORMULA.containsKey(oreDictName.get())) {
+                String foundFormula = oreDictItem.OREDICT_TO_FORMULA.get(oreDictName.get());
+                if (foundFormula != null) {
+                    chemicalFormula = foundFormula;
+                }
+            }
+        } else if (unificationEntry != null && unificationEntry.material != null) {
             chemicalFormula = unificationEntry.material.getChemicalFormula();
         } else if (ItemNBTUtils.hasTag(itemStack)) { // Test for Fluids
             // Vanilla bucket
@@ -203,20 +213,11 @@ public class ClientProxy extends CommonProxy {
             }
         } else if (itemStack.getItem().equals(Items.WATER_BUCKET)) { // Water buckets have a separate registry name from other buckets
             chemicalFormula = FluidTooltipUtil.getWaterTooltip();
-        } else if (itemStack.getItem() instanceof MetaOreDictItem) {
-            MetaOreDictItem oreDictItem = (MetaOreDictItem) itemStack.getItem();
-            Optional<String> oreDictName = OreDictUnifier.getOreDictionaryNames(itemStack).stream().findFirst();
-            if (oreDictName.isPresent() && oreDictItem.FORMULA_TO_OREDICTITEM.containsKey(oreDictName.get())) {
-                MetaOreDictItem.OreDictValueItem material = oreDictItem.FORMULA_TO_OREDICTITEM.get(oreDictName.get());
-                if (material != null) {
-                    chemicalFormula = material.getFormula();
-                }
-            }
         }
+
         if (chemicalFormula != null && !chemicalFormula.isEmpty()) {
             event.getToolTip().add(1, ChatFormatting.YELLOW.toString() + chemicalFormula);
         }
-
     }
 
     private static final String[] clearRecipes = new String[]{

--- a/src/main/java/gregtech/client/ClientProxy.java
+++ b/src/main/java/gregtech/client/ClientProxy.java
@@ -193,10 +193,7 @@ public class ClientProxy extends CommonProxy {
             MetaOreDictItem oreDictItem = (MetaOreDictItem) itemStack.getItem();
             Optional<String> oreDictName = OreDictUnifier.getOreDictionaryNames(itemStack).stream().findFirst();
             if (oreDictName.isPresent() && oreDictItem.OREDICT_TO_FORMULA.containsKey(oreDictName.get())) {
-                String foundFormula = oreDictItem.OREDICT_TO_FORMULA.get(oreDictName.get());
-                if (foundFormula != null) {
-                    chemicalFormula = foundFormula;
-                }
+                chemicalFormula = oreDictItem.OREDICT_TO_FORMULA.get(oreDictName.get());
             }
         } else if (unificationEntry != null && unificationEntry.material != null) {
             chemicalFormula = unificationEntry.material.getChemicalFormula();

--- a/src/main/java/gregtech/client/ClientProxy.java
+++ b/src/main/java/gregtech/client/ClientProxy.java
@@ -190,10 +190,7 @@ public class ClientProxy extends CommonProxy {
         UnificationEntry unificationEntry = OreDictUnifier.getUnificationEntry(itemStack);
         if (unificationEntry != null && unificationEntry.material != null) {
             chemicalFormula = unificationEntry.material.getChemicalFormula();
-
-            // Test for Fluids
-        } else if (ItemNBTUtils.hasTag(itemStack)) {
-
+        } else if (ItemNBTUtils.hasTag(itemStack)) { // Test for Fluids
             // Vanilla bucket
             chemicalFormula = FluidTooltipUtil.getFluidTooltip(ItemNBTUtils.getString(itemStack, "FluidName"));
 
@@ -204,11 +201,9 @@ public class ClientProxy extends CommonProxy {
                     chemicalFormula = FluidTooltipUtil.getFluidTooltip(FluidStack.loadFluidStackFromNBT(compound.getCompoundTag(FluidHandlerItemStack.FLUID_NBT_KEY)));
                 }
             }
-
-            // Water buckets have a separate registry name from other buckets
-        } else if (itemStack.getItem().equals(Items.WATER_BUCKET)) {
+        } else if (itemStack.getItem().equals(Items.WATER_BUCKET)) { // Water buckets have a separate registry name from other buckets
             chemicalFormula = FluidTooltipUtil.getWaterTooltip();
-        } else if (itemStack.getItem() instanceof MetaOreDictItem){
+        } else if (itemStack.getItem() instanceof MetaOreDictItem) {
             MetaOreDictItem oreDictItem = (MetaOreDictItem) itemStack.getItem();
             Optional<String> oreDictName = OreDictUnifier.getOreDictionaryNames(itemStack).stream().findFirst();
             if (oreDictName.isPresent() && oreDictItem.FORMULA_TO_OREDICTITEM.containsKey(oreDictName.get())) {

--- a/src/main/java/gregtech/common/items/MetaItems.java
+++ b/src/main/java/gregtech/common/items/MetaItems.java
@@ -533,6 +533,9 @@ public final class MetaItems {
     public static MetaItem<?>.MetaValueItem SUS_RECORD;
     public static MetaItem<?>.MetaValueItem NAN_CERTIFICATE;
 
+
+    public static MetaOreDictItem CT_OREDICT_ITEM;
+
     private static final List<OrePrefix> orePrefixes = new ArrayList<OrePrefix>() {{
         add(OrePrefix.dust);
         add(OrePrefix.dustSmall);
@@ -589,8 +592,8 @@ public final class MetaItems {
         first.setRegistryName("meta_item_1");
         MetaTool tool = new MetaTool();
         tool.setRegistryName("meta_tool");
-        MetaOreDictItem oreDictItem = new MetaOreDictItem((short) 0);
-        oreDictItem.setRegistryName("meta_oredict_item");
+        CT_OREDICT_ITEM = new MetaOreDictItem((short) 0);
+        CT_OREDICT_ITEM.setRegistryName("meta_oredict_item_ct");
         MetaArmor armor = new MetaArmor();
         armor.setRegistryName("gt_armor");
         for (OrePrefix prefix : orePrefixes) {


### PR DESCRIPTION
Revamps the MetaOreDictItem system in order to make it more compatible with addons. This is done by making the class more abstract, and creating a more accurate way to add items.

Possible compatibility issues:
GTFO may have ID shifts, although I think it can be avoided.