### PR TITLE
Fix most cases of duplicate recipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -89,6 +89,7 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.duration = recipeBuilder.duration;
         this.EUt = recipeBuilder.EUt;
         this.hidden = recipeBuilder.hidden;
+        this.onBuildAction = recipeBuilder.onBuildAction;
     }
 
     public boolean applyProperty(String key, Object value) {
@@ -538,6 +539,11 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     protected R onBuild(Consumer<RecipeBuilder<?>> consumer) {
         this.onBuildAction = consumer;
+        return (R) this;
+    }
+
+    protected R invalidateOnBuildAction() {
+        this.onBuildAction = null;
         return (R) this;
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -221,7 +221,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 recipeFluidMap.computeIfAbsent(fluidKey, k -> new HashSet<>()).add(recipe);
             }
         } else if (ConfigHolder.misc.debug) {
-            GTLog.logger.debug("Recipe: " + recipe.toString() + " is a duplicate and was not added");
+            GTLog.logger.warn(String.format("Recipe: %s for Recipe Map %s is a duplicate and was not added", recipe.toString(), this.unlocalizedName));
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -221,7 +221,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 recipeFluidMap.computeIfAbsent(fluidKey, k -> new HashSet<>()).add(recipe);
             }
         } else if (ConfigHolder.misc.debug) {
-            GTLog.logger.warn(String.format("Recipe: %s for Recipe Map %s is a duplicate and was not added", recipe.toString(), this.unlocalizedName));
+            GTLog.logger.warn("Recipe: {} for Recipe Map {} is a duplicate and was not added", recipe.toString(), this.unlocalizedName);
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -228,7 +228,6 @@ public class RecipeMaps {
                             .buildAndRegister();
 
                     recipeBuilder
-                            .copy()
                             .fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())))
                             .buildAndRegister();
                 }
@@ -301,7 +300,6 @@ public class RecipeMaps {
                             .buildAndRegister();
 
                     recipeBuilder
-                            .copy()
                             .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, recipeBuilder.duration * recipeBuilder.EUt / 1280))))
                             .duration(Math.max(1, recipeBuilder.duration))
                             .buildAndRegister();

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -227,9 +227,10 @@ public class RecipeMaps {
                             .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1, (GTValues.L / 2) * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())))
                             .buildAndRegister();
 
+                    // Don't call buildAndRegister as we are mutating the original recipe and already in the middle of a buildAndRegister call.
+                    // Adding a second call will result in duplicate recipe generation attempts
                     recipeBuilder
-                            .fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())))
-                            .buildAndRegister();
+                            .fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())));
                 }
             });
 
@@ -299,10 +300,12 @@ public class RecipeMaps {
                             .duration((int) (recipeBuilder.duration * 1.5))
                             .buildAndRegister();
 
+                    // Don't call buildAndRegister as we are mutating the original recipe and already in the middle of a buildAndRegister call.
+                    // Adding a second call will result in duplicate recipe generation attempts
                     recipeBuilder
                             .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, recipeBuilder.duration * recipeBuilder.EUt / 1280))))
-                            .duration(Math.max(1, recipeBuilder.duration))
-                            .buildAndRegister();
+                            .duration(Math.max(1, recipeBuilder.duration));
+
                 }
             });
 

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -31,6 +31,7 @@ public class RecipeMaps {
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARC_FURNACE, MoveType.HORIZONTAL)
             .setSound(GTSounds.ARC)
             .onRecipeBuild(recipeBuilder -> {
+                recipeBuilder.invalidateOnBuildAction();
                 if (recipeBuilder.getFluidInputs().isEmpty()) {
                     recipeBuilder.fluidInputs(Materials.Oxygen.getFluid(recipeBuilder.duration));
                 }
@@ -200,6 +201,7 @@ public class RecipeMaps {
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
             .setSound(GTValues.FOOLS.get() ? GTSounds.SCIENCE : GTSounds.CHEMICAL_REACTOR)
             .onRecipeBuild(recipeBuilder -> {
+                recipeBuilder.invalidateOnBuildAction();
                 RecipeMaps.LARGE_CHEMICAL_RECIPES.recipeBuilder()
                         .inputs(recipeBuilder.getInputs().toArray(new CountableIngredient[0]))
                         .fluidInputs(recipeBuilder.getFluidInputs())
@@ -218,12 +220,16 @@ public class RecipeMaps {
             .setProgressBar(GuiTextures.PROGRESS_BAR_CIRCUIT_ASSEMBLER, ProgressWidget.MoveType.HORIZONTAL)
             .setSound(GTSounds.ASSEMBLER)
             .onRecipeBuild(recipeBuilder -> {
+                recipeBuilder.invalidateOnBuildAction();
                 if (recipeBuilder.getFluidInputs().isEmpty()) {
-                    recipeBuilder.copy()
+                    recipeBuilder
+                            .copy()
                             .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1, (GTValues.L / 2) * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())))
                             .buildAndRegister();
 
-                    recipeBuilder.fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())))
+                    recipeBuilder
+                            .copy()
+                            .fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L * ((CircuitAssemblerRecipeBuilder) recipeBuilder).getSolderMultiplier())))
                             .buildAndRegister();
                 }
             });
@@ -279,18 +285,24 @@ public class RecipeMaps {
             .setProgressBar(GuiTextures.PROGRESS_BAR_SLICE, MoveType.HORIZONTAL)
             .setSound(GTSounds.CUT)
             .onRecipeBuild(recipeBuilder -> {
+                recipeBuilder.invalidateOnBuildAction();
                 if (recipeBuilder.getFluidInputs().isEmpty()) {
-                    recipeBuilder.copy()
+
+                    recipeBuilder
+                            .copy()
                             .fluidInputs(Materials.Water.getFluid(Math.max(4, Math.min(1000, recipeBuilder.duration * recipeBuilder.EUt / 320))))
                             .duration(recipeBuilder.duration * 2)
                             .buildAndRegister();
 
-                    recipeBuilder.copy()
+                    recipeBuilder
+                            .copy()
                             .fluidInputs(Materials.DistilledWater.getFluid(Math.max(3, Math.min(750, recipeBuilder.duration * recipeBuilder.EUt / 426))))
                             .duration((int) (recipeBuilder.duration * 1.5))
                             .buildAndRegister();
 
-                    recipeBuilder.fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, recipeBuilder.duration * recipeBuilder.EUt / 1280))))
+                    recipeBuilder
+                            .copy()
+                            .fluidInputs(Materials.Lubricant.getFluid(Math.max(1, Math.min(250, recipeBuilder.duration * recipeBuilder.EUt / 1280))))
                             .duration(Math.max(1, recipeBuilder.duration))
                             .buildAndRegister();
                 }

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -245,7 +245,6 @@ public class MaterialInfoLoader {
         OreDictUnifier.registerOre(new ItemStack(Items.SNOWBALL, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Water, M / 4)));
         OreDictUnifier.registerOre(new ItemStack(Blocks.SNOW, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Water, M)));
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ICE, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Ice, M)));
         OreDictUnifier.registerOre(new ItemStack(Blocks.PACKED_ICE, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Ice, M * 2)));
 
         OreDictUnifier.registerOre(new ItemStack(Items.BOOK, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -96,7 +96,6 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.REDSTONE_BLOCK), OrePrefix.block, Materials.Redstone);
         OreDictUnifier.registerOre(new ItemStack(Blocks.QUARTZ_BLOCK), OrePrefix.block, Materials.NetherQuartz);
         OreDictUnifier.registerOre(new ItemStack(Blocks.BONE_BLOCK), OrePrefix.block, Materials.Bone);
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ICE), OrePrefix.block, Materials.Ice);
         OreDictUnifier.registerOre(new ItemStack(Blocks.OBSIDIAN), OrePrefix.block, Materials.Obsidian);
         OreDictUnifier.registerOre(new ItemStack(Blocks.GLASS), OrePrefix.block, Materials.Glass);
 

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -96,6 +96,7 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.REDSTONE_BLOCK), OrePrefix.block, Materials.Redstone);
         OreDictUnifier.registerOre(new ItemStack(Blocks.QUARTZ_BLOCK), OrePrefix.block, Materials.NetherQuartz);
         OreDictUnifier.registerOre(new ItemStack(Blocks.BONE_BLOCK), OrePrefix.block, Materials.Bone);
+        OreDictUnifier.registerOre(new ItemStack(Blocks.ICE), OrePrefix.block, Materials.Ice);
         OreDictUnifier.registerOre(new ItemStack(Blocks.OBSIDIAN), OrePrefix.block, Materials.Obsidian);
         OreDictUnifier.registerOre(new ItemStack(Blocks.GLASS), OrePrefix.block, Materials.Glass);
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -457,6 +457,7 @@ public class MachineRecipeLoader {
             ASSEMBLER_RECIPES.recipeBuilder()
                     .inputs(new ItemStack(Blocks.REDSTONE_TORCH))
                     .input(plate, material)
+                    .fluidInputs(solder)
                     .outputs(COVER_ACTIVITY_DETECTOR.getStackForm())
                     .EUt(16).duration(400)
                     .buildAndRegister();


### PR DESCRIPTION
**What:**

Fixes most cases of "Duplicate Recipe" log warnings. These were occurring because the `onBuildAction` was being called from within the `onBuildAction` when the new recipes called `buildAndRegister()`. This was fixed by invalidating the action before the new recipes were created. 

In addition, calling `RecipeBuilder().copy()` now copies the onBuildAction.

The Ice maceration recipe was a duplicate because its oredict was registered twice, once in `OreDictionaryLoader` and the other in `MaterialInfoLoader`

