### PR TITLE
Fix Senses voiding some sugar cane when breaking

### DIFF
--- a/src/main/java/gregtech/common/tools/ToolSense.java
+++ b/src/main/java/gregtech/common/tools/ToolSense.java
@@ -52,8 +52,7 @@ public class ToolSense extends ToolBase {
                                 blockState.getMaterial() == Material.LEAVES ||
                                 blockState.getMaterial() == Material.VINE) {
 
-                            player.world.playEvent(2001, offsetPos, Block.getStateId(blockState));
-                            player.world.setBlockToAir(offsetPos);
+                            player.world.destroyBlock(offsetPos, true);
                             toolMetaItem.damageItem(stack, player, damagePerBlockBreak, false);
                         }
                     }


### PR DESCRIPTION
**What:**

Fixes Senses voiding some sugar cane when breaking it. This occurred because the sense worked from the bottom up, and directly set the bottom sugar cane to air, which voided it, but breaking caused the other 2 sugar cane to drop. So from 1 3 tall sugar cane, you only got 2 sugar cane when harvesting.

This was fixed by using the `world.destroyBlock()` call instead of directly setting the blocks to air. In this method, `true` was passed for dropping blocks, so all the sugar cane was actually harvested.