### PR TITLE
Fix craftingLensWhite oredict being applied to other lenses

### DIFF
--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -48,7 +48,7 @@ public class OreDictionaryLoader {
 
         OreDictUnifier.registerOre(OreDictUnifier.get(OrePrefix.dust, Materials.MetalMixture), OrePrefix.dye, Color.Brown);
 
-        OreDictUnifier.registerOre(OreDictUnifier.get(OrePrefix.craftingLens, Materials.Glass), OrePrefix.craftingLens, MarkerMaterials.Color.White);
+        OreDictUnifier.registerOre(OreDictUnifier.get(OrePrefix.lens, Materials.Glass), OrePrefix.craftingLens, MarkerMaterials.Color.White);
 
         OreDictUnifier.registerOre(new ItemStack(Blocks.COAL_ORE), OrePrefix.ore, Materials.Coal);
         OreDictUnifier.registerOre(new ItemStack(Blocks.IRON_ORE), OrePrefix.ore, Materials.Iron);


### PR DESCRIPTION
**What:**

Fixes the `craftingLensWhite` oredict being applied to other colored lenses. By the time this call in OreDictionaryLoader is made, the other lenses have already been registered under `craftingLensColor`, so there was a chance that one of those lenses would be pulled and have the `craftingLensWhite` oredict applied