### PR TITLE
Adjust the limits of Large boiler hatches/buses

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -163,8 +163,8 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
                 .where('S', selfPredicate())
                 .where('P', states(boilerType.pipeState))
                 .where('X', states(boilerType.fireboxState).setMinGlobalLimited(4)
-                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1))
-                        .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMinGlobalLimited(1))
+                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1).setMaxGlobalLimited(2))
+                        .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
                         .or(autoAbilities())) // muffler, maintenance
                 .where('C', states(boilerType.casingState).setMinGlobalLimited(20)
                         .or(abilities(MultiblockAbility.EXPORT_FLUIDS).setMinGlobalLimited(1)))

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -163,7 +163,7 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
                 .where('S', selfPredicate())
                 .where('P', states(boilerType.pipeState))
                 .where('X', states(boilerType.fireboxState).setMinGlobalLimited(4)
-                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1).setMaxGlobalLimited(2))
+                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1))
                         .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
                         .or(autoAbilities())) // muffler, maintenance
                 .where('C', states(boilerType.casingState).setMinGlobalLimited(20)


### PR DESCRIPTION
**What:**

Adjusts the limits for Large Boilers bus limits.

Now limited to maximum 1 bus instead of minimum 1 bus, in case you don't want to burn items.
