### PR TITLE
Recipe conflict detection

### DIFF
--- a/src/main/java/gregtech/api/recipes/CountableIngredient.java
+++ b/src/main/java/gregtech/api/recipes/CountableIngredient.java
@@ -82,22 +82,4 @@ public class CountableIngredient {
                 ", count=" + count +
                 '}';
     }
-
-    public String toPrettyString() {
-        StringBuilder output = new StringBuilder();
-        if (ingredient instanceof OreIngredient) {
-            output.append("(OreDict) ");
-        }
-        output.append("{");
-        for (ItemStack stack : ingredient.getMatchingStacks()) {
-            output.append(stack.getItem().getRegistryName());
-            if (stack.getCount() != 1) {
-                output.append(" * ")
-                        .append(stack.getCount());
-            }
-        }
-        output.append("} * ")
-                .append(count);
-        return output.toString();
-    }
 }

--- a/src/main/java/gregtech/api/recipes/CountableIngredient.java
+++ b/src/main/java/gregtech/api/recipes/CountableIngredient.java
@@ -82,4 +82,22 @@ public class CountableIngredient {
                 ", count=" + count +
                 '}';
     }
+
+    public String toPrettyString() {
+        StringBuilder output = new StringBuilder();
+        if (ingredient instanceof OreIngredient) {
+            output.append("(OreDict) ");
+        }
+        output.append("{");
+        for (ItemStack stack : ingredient.getMatchingStacks()) {
+            output.append(stack.getItem().getRegistryName());
+            if (stack.getCount() != 1) {
+                output.append(" * ")
+                        .append(stack.getCount());
+            }
+        }
+        output.append("} * ")
+                .append(count);
+        return output.toString();
+    }
 }

--- a/src/main/java/gregtech/common/command/CommandRecipeCheck.java
+++ b/src/main/java/gregtech/common/command/CommandRecipeCheck.java
@@ -1,4 +1,4 @@
-package gregtech.common.command.util;
+package gregtech.common.command;
 
 import gregtech.api.items.materialitem.MetaPrefixItem;
 import gregtech.api.items.metaitem.MetaItem;

--- a/src/main/java/gregtech/common/command/CommandRecipeCheck.java
+++ b/src/main/java/gregtech/common/command/CommandRecipeCheck.java
@@ -1,18 +1,24 @@
 package gregtech.common.command.util;
 
+import gregtech.api.items.materialitem.MetaPrefixItem;
+import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.ingredients.IntCircuitIngredient;
+import gregtech.api.unification.material.Material;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.GTLog;
+import gregtech.common.items.MetaItems;
 import net.minecraft.command.CommandBase;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.fluids.FluidStack;
-import org.apache.commons.lang3.tuple.Pair;
+import net.minecraftforge.oredict.OreIngredient;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -37,7 +43,7 @@ public class CommandRecipeCheck extends CommandBase {
     public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) {
         sender.sendMessage(new TextComponentTranslation("gregtech.command.util.recipecheck.begin"));
 
-        List<Pair<Recipe, Recipe>> mismatchedRecipes = new ArrayList<>();
+        List<MismatchEntry> mismatchedRecipes = new ArrayList<>();
 
         GTLog.logger.info("[Recipe Checker] Starting recipe conflict check...");
         for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
@@ -63,27 +69,155 @@ public class CommandRecipeCheck extends CommandBase {
                     GTLog.logger.info(stack.getUnlocalizedName() + " * " + stack.amount);
                 }
                 GTLog.logger.info("[Recipe Checker] Testing inputs...");*/
-                Recipe foundRecipe = recipeMap.findRecipe(Long.MAX_VALUE, recipe.getInputs().stream().map(cir -> {
-                    ItemStack[] stacks = cir.getIngredient().getMatchingStacks();
-                    if (stacks.length > 0) {
-                        stacks[0].setCount(Math.max(1, cir.getCount()));
-                        return stacks[0];
-                    }
-                    return null;
-                }).filter(Objects::nonNull).collect(Collectors.toList()), recipe.getFluidInputs(), Integer.MAX_VALUE, MatchingMode.DEFAULT);
+                Recipe foundRecipe = recipeMap.findRecipe(Long.MAX_VALUE, recipe.getInputs().stream().map(ingredient -> {
+                        ItemStack[] stacks = ingredient.getIngredient().getMatchingStacks();
+                        if (stacks.length > 0) {
+                            ItemStack outStack = stacks[0].copy();
+                            outStack.setCount(Math.max(1, ingredient.getCount()) * 100);
+                            return outStack;
+                        }
+                        return null;
+                    }).filter(Objects::nonNull).collect(Collectors.toList()),
+                    recipe.getFluidInputs()
+                            .stream().map(stack -> new FluidStack(stack, stack.amount * 10000))
+                            .collect(Collectors.toList()),
+                    Integer.MAX_VALUE, MatchingMode.DEFAULT);
                 /*GTLog.logger.info("[Recipe Checker] Found: " + foundRecipe + " from " + recipe);
                 GTLog.logger.info("[Recipe Checker] Matched: " + (foundRecipe == recipe));*/
                 if (foundRecipe != recipe) {
-                    mismatchedRecipes.add(Pair.of(recipe, foundRecipe));
+                    mismatchedRecipes.add(new MismatchEntry(recipe, foundRecipe, recipeMap));
                 }
             }
         }
 
         GTLog.logger.info("[Recipe Checker] Completed recipe check!");
         GTLog.logger.info("[Recipe Checker] Found " + mismatchedRecipes.size() + " potential conflicts");
-        for (Pair<Recipe, Recipe> mismatch : mismatchedRecipes) {
-            GTLog.logger.error("Tried: " + mismatch.getLeft());
-            GTLog.logger.error("Found: " + mismatch.getRight());
+        for (MismatchEntry mismatch : mismatchedRecipes) {
+            GTLog.logger.error(
+                    "\nIn map " + mismatch.recipeMap.getUnlocalizedName() +
+                    "\nTried: " + prettyPrintRecipe(mismatch.attempted) +
+                    "\nFound: " + prettyPrintRecipe(mismatch.found)
+            );
+        }
+
+        sender.sendMessage(new TextComponentTranslation("gregtech.command.util.recipecheck.end", mismatchedRecipes.size()));
+    }
+
+    public String prettyPrintRecipe(Recipe recipe) {
+        if (recipe == null) {
+            return "null (Is something else going wrong?)\n";
+        }
+        StringBuilder output = new StringBuilder();
+        output.append("EU/t: ")
+                .append(recipe.getEUt())
+                .append(", Duration: ")
+                .append(recipe.getDuration());
+        if (recipe.isHidden()) {
+            output.append(", hidden");
+        }
+        output.append("\n");
+
+        if (recipe.getInputs().size() > 0) {
+            output.append("Item inputs:\n");
+            for (CountableIngredient ingredient : recipe.getInputs()) {
+                output.append("    ")
+                        .append(prettyPrintCountableIngredient(ingredient))
+                        .append("\n");
+            }
+        }
+
+        if (recipe.getFluidInputs().size() > 0) {
+            output.append("Fluid inputs:\n");
+            for (FluidStack fluid : recipe.getFluidInputs()) {
+                output.append("    ")
+                        .append(fluid.getUnlocalizedName())
+                        .append(" * ")
+                        .append(fluid.amount)
+                        .append("\n");
+            }
+        }
+
+        if (recipe.getOutputs().size() > 0) {
+            output.append("Item outputs:\n");
+            for (ItemStack stack : recipe.getOutputs()) {
+                output.append("    ")
+                        .append(prettyPrintItemStack(stack))
+                        .append("\n");
+            }
+        }
+
+        if (recipe.getChancedOutputs().size() > 0) {
+            output.append("Item chanced outputs:\n");
+            for (Recipe.ChanceEntry chanceEntry : recipe.getChancedOutputs()) {
+                output.append("    ")
+                        .append(prettyPrintItemStack(chanceEntry.getItemStack()))
+                        .append(" (Chance: ")
+                        .append(chanceEntry.getChance())
+                        .append(", Boost: ")
+                        .append(chanceEntry.getBoostPerTier())
+                        .append(")\n");
+            }
+        }
+
+        if (recipe.getFluidOutputs().size() > 0) {
+            output.append("Fluid outputs:\n");
+            for (FluidStack fluid : recipe.getFluidOutputs()) {
+                output.append("    ")
+                        .append(fluid.getUnlocalizedName())
+                        .append(" * ")
+                        .append(fluid.amount)
+                        .append("\n");
+            }
+        }
+
+        return output.toString();
+    }
+
+    public String prettyPrintCountableIngredient(CountableIngredient countableIngredient) {
+        StringBuilder output = new StringBuilder();
+        if (countableIngredient.getIngredient() instanceof OreIngredient) {
+            output.append("(OreDict) ");
+        }
+        output.append("{");
+        for (ItemStack stack : countableIngredient.getIngredient().getMatchingStacks()) {
+            output.append(" ")
+                    .append(prettyPrintItemStack(stack));
+        }
+        output.append(" } * ")
+                .append(countableIngredient.getCount());
+        return output.toString();
+    }
+
+    public String prettyPrintItemStack(ItemStack stack) {
+        if (stack.getItem() instanceof MetaItem) {
+            MetaItem<?> metaItem = (MetaItem<?>) stack.getItem();
+            MetaValueItem metaValueItem = metaItem.getItem(stack);
+            if (metaValueItem == null) {
+                if (metaItem instanceof MetaPrefixItem) {
+                    Material material = ((MetaPrefixItem) metaItem).getMaterial(stack);
+                    OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
+                    return "(MetaItem) OrePrefix: " + orePrefix.name + ", Material: " + material;
+                }
+            } else {
+                if (MetaItems.INTEGRATED_CIRCUIT.isItemEqual(stack)) {
+                    return "Config circuit #" + IntCircuitIngredient.getCircuitConfiguration(stack);
+                }
+                return "(MetaItem) " + metaValueItem.unlocalizedName;
+            }
+        }
+        //noinspection ConstantConditions
+        return stack.getItem().getRegistryName().toString() + " * " + stack.getCount() + " (Meta " + stack.getItemDamage() + ")";
+    }
+
+    private static class MismatchEntry {
+        public Recipe attempted;
+        public Recipe found;
+        public RecipeMap<?> recipeMap;
+
+        public MismatchEntry(Recipe attempted, Recipe found, RecipeMap<?> recipeMap) {
+            this.attempted = attempted;
+            this.found = found;
+            this.recipeMap = recipeMap;
         }
     }
 }

--- a/src/main/java/gregtech/common/command/CommandRecipeCheck.java
+++ b/src/main/java/gregtech/common/command/CommandRecipeCheck.java
@@ -1,0 +1,89 @@
+package gregtech.common.command.util;
+
+import gregtech.api.recipes.CountableIngredient;
+import gregtech.api.recipes.MatchingMode;
+import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.RecipeMap;
+import gregtech.api.util.GTLog;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.fluids.FluidStack;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class CommandRecipeCheck extends CommandBase {
+    @Nonnull
+    @Override
+    public String getName() {
+        return "recipecheck";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage(@Nonnull ICommandSender sender) {
+        return "gregtech.command.util.recipecheck.usage";
+    }
+
+    @Override
+    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) {
+        sender.sendMessage(new TextComponentTranslation("gregtech.command.util.recipecheck.begin"));
+
+        List<Pair<Recipe, Recipe>> mismatchedRecipes = new ArrayList<>();
+
+        GTLog.logger.info("[Recipe Checker] Starting recipe conflict check...");
+        for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
+            GTLog.logger.info("[Recipe Checker] Checking recipe map " + recipeMap.getUnlocalizedName());
+            GTLog.logger.info("[Recipe Checker] Iterating over " +recipeMap.getRecipeList().size() + " recipes");
+            for (Recipe recipe : recipeMap.getRecipeList()) {
+            //if (recipeMap.getRecipeList().size() > 0) {Recipe recipe = (Recipe) recipeMap.getRecipeList().toArray()[0];
+                /*GTLog.logger.info("[Recipe Checker] Check recipe:");
+                for (CountableIngredient stack : recipe.getInputs()) {
+                    GTLog.logger.info(stack.toPrettyString());
+                }
+                for (FluidStack stack : recipe.getFluidInputs()) {
+                    GTLog.logger.info(stack.getUnlocalizedName() + " * " + stack.amount);
+                }
+                GTLog.logger.info("outputs:");
+                for (ItemStack stack : recipe.getOutputs()) {
+                    GTLog.logger.info(stack.toString());
+                }
+                for (Recipe.ChanceEntry stack : recipe.getChancedOutputs()) {
+                    GTLog.logger.info(stack.getItemStack().toString());
+                }
+                for (FluidStack stack : recipe.getFluidOutputs()) {
+                    GTLog.logger.info(stack.getUnlocalizedName() + " * " + stack.amount);
+                }
+                GTLog.logger.info("[Recipe Checker] Testing inputs...");*/
+                Recipe foundRecipe = recipeMap.findRecipe(Long.MAX_VALUE, recipe.getInputs().stream().map(cir -> {
+                    ItemStack[] stacks = cir.getIngredient().getMatchingStacks();
+                    if (stacks.length > 0) {
+                        stacks[0].setCount(Math.max(1, cir.getCount()));
+                        return stacks[0];
+                    }
+                    return null;
+                }).filter(Objects::nonNull).collect(Collectors.toList()), recipe.getFluidInputs(), Integer.MAX_VALUE, MatchingMode.DEFAULT);
+                /*GTLog.logger.info("[Recipe Checker] Found: " + foundRecipe + " from " + recipe);
+                GTLog.logger.info("[Recipe Checker] Matched: " + (foundRecipe == recipe));*/
+                if (foundRecipe != recipe) {
+                    mismatchedRecipes.add(Pair.of(recipe, foundRecipe));
+                }
+            }
+        }
+
+        GTLog.logger.info("[Recipe Checker] Completed recipe check!");
+        GTLog.logger.info("[Recipe Checker] Found " + mismatchedRecipes.size() + " potential conflicts");
+        for (Pair<Recipe, Recipe> mismatch : mismatchedRecipes) {
+            GTLog.logger.error("Tried: " + mismatch.getLeft());
+            GTLog.logger.error("Found: " + mismatch.getRight());
+        }
+    }
+}

--- a/src/main/java/gregtech/common/command/GregTechCommand.java
+++ b/src/main/java/gregtech/common/command/GregTechCommand.java
@@ -19,6 +19,7 @@ public class GregTechCommand extends CommandTreeBase {
     public GregTechCommand() {
         addSubcommand(new CommandWorldgen());
         addSubcommand(new CommandHand());
+        addSubcommand(new CommandRecipeCheck());
     }
 
     @Nonnull

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4304,7 +4304,8 @@ gregtech.command.util.hand.tool_stats=Tool Stats Class: %s
 gregtech.command.util.hand.not_a_player=This command is only usable by a player.
 gregtech.command.util.hand.no_item=You must hold something in mainhand before executing this command.
 gregtech.command.util.recipecheck.usage=Usage: /gregtech util recipecheck
-gregtech.command.util.recipecheck.begin=Starting recipe conflict check... (This might take a while!)
+gregtech.command.util.recipecheck.begin=Starting recipe conflict check...
+gregtech.command.util.recipecheck.end=Recipe conflict check found %d possible conflicts. Check the server log for more info
 
 gregtech.universal.clear_nbt_recipe.tooltip=§cThis will destroy all contents!
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4303,7 +4303,7 @@ gregtech.command.util.hand.material_meta_item=Ore Prefix: %s; Material: %s
 gregtech.command.util.hand.tool_stats=Tool Stats Class: %s
 gregtech.command.util.hand.not_a_player=This command is only usable by a player.
 gregtech.command.util.hand.no_item=You must hold something in mainhand before executing this command.
-gregtech.command.util.recipecheck.usage=Usage: /gregtech util recipecheck
+gregtech.command.util.recipecheck.usage=Usage: /gregtech recipecheck
 gregtech.command.util.recipecheck.begin=Starting recipe conflict check...
 gregtech.command.util.recipecheck.end=Recipe conflict check found %d possible conflicts. Check the server log for more info
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4303,6 +4303,8 @@ gregtech.command.util.hand.material_meta_item=Ore Prefix: %s; Material: %s
 gregtech.command.util.hand.tool_stats=Tool Stats Class: %s
 gregtech.command.util.hand.not_a_player=This command is only usable by a player.
 gregtech.command.util.hand.no_item=You must hold something in mainhand before executing this command.
+gregtech.command.util.recipecheck.usage=Usage: /gregtech util recipecheck
+gregtech.command.util.recipecheck.begin=Starting recipe conflict check... (This might take a while!)
 
 gregtech.universal.clear_nbt_recipe.tooltip=§cThis will destroy all contents!
 

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -2488,7 +2488,7 @@ gregtech.command.util.hand.tool_stats=Класс инструмента: %s
 gregtech.command.util.hand.meta_item=Название мета-предмета: %s
 gregtech.command.util.hand.not_a_player=Эта команда может использоваться только игроком.
 gregtech.command.util.hand.no_item=Перед выполнением этой команды, вы должны держать что-то в основной руке.
-gregtech.command.util.recipecheck.usage=Применение: /gregtech util recipecheck
+gregtech.command.util.recipecheck.usage=Применение: /gregtech recipecheck
 
 gregtech.machine.locked_safe.name=Закрытый сейф
 gregtech.machine.locked_safe.malfunctioning=§cСломан!

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -2488,6 +2488,7 @@ gregtech.command.util.hand.tool_stats=Класс инструмента: %s
 gregtech.command.util.hand.meta_item=Название мета-предмета: %s
 gregtech.command.util.hand.not_a_player=Эта команда может использоваться только игроком.
 gregtech.command.util.hand.no_item=Перед выполнением этой команды, вы должны держать что-то в основной руке.
+gregtech.command.util.recipecheck.usage=Применение: /gregtech util recipecheck
 
 gregtech.machine.locked_safe.name=Закрытый сейф
 gregtech.machine.locked_safe.malfunctioning=§cСломан!

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2269,6 +2269,8 @@ gregtech.command.util.hand.tool_stats=工具状态类: %s
 gregtech.command.util.hand.meta_item=元物品名字: %s
 gregtech.command.util.hand.not_a_player=这条指令只能由玩家使用。
 gregtech.command.util.hand.no_item=必须在主手持握物品时执行这条指令。
+gregtech.command.util.recipecheck.usage=用法: /gregtech util recipecheck
+
 gregtech.top.transform_up=§cStep Up§r
 gregtech.top.transform_down=§aStep Down§r
 gregtech.top.transform_input=§6Input:§r

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2269,7 +2269,7 @@ gregtech.command.util.hand.tool_stats=工具状态类: %s
 gregtech.command.util.hand.meta_item=元物品名字: %s
 gregtech.command.util.hand.not_a_player=这条指令只能由玩家使用。
 gregtech.command.util.hand.no_item=必须在主手持握物品时执行这条指令。
-gregtech.command.util.recipecheck.usage=用法: /gregtech util recipecheck
+gregtech.command.util.recipecheck.usage=用法: /gregtech recipecheck
 
 gregtech.top.transform_up=§cStep Up§r
 gregtech.top.transform_down=§aStep Down§r


### PR DESCRIPTION
**What:**
Adds a command to check all Recipes in all RecipeMaps to see if anything seems to conflict with them.

**How solved:**
Iterate over all recipes in each map, and for each one:
* Generate a list of inputs that has 100x the number of items and 10000x the amount of fluid as usual
* Use `RecipeMap.findRecipe` on the input list
* Check if the recipe object returned is the same as the input recipe object

Afterwards, pretty-print all detected conflicts to the log.

**Outcome:**
Less recipe conflicts

**Additional info:**
Example conflict messages:
```
In map arc_furnace
Tried: EU/t: 30, Duration: 3312
Item inputs:
    { gregtech:meta_block_compressed_26 * 1 (Meta 15) } * 1
Fluid inputs:
    material.oxygen * 3312
Item outputs:
    gregtech:meta_block_compressed_26 * 1 (Meta 15)

Found: EU/t: 30, Duration: 368
Item inputs:
    { gregtech:meta_block_compressed_26 * 1 (Meta 15) } * 1
Fluid inputs:
    material.oxygen * 368
Item outputs:
    (MetaItem) OrePrefix: ingot, Material: enriched_naquadah_trinium_europium_duranide
```

(There unfortunately does not seem to be a good way to get the oredict name from the `CountableIngredient`)
```
In map assembler
Tried: EU/t: 4, Duration: 300
Item inputs:
    { minecraft:planks * 1 (Meta 3) } * 1
    { Config circuit #3 } * 0
Item outputs:
    minecraft:jungle_fence * 1 (Meta 0)

Found: EU/t: 4, Duration: 300
Item inputs:
    (OreDict) { minecraft:planks * 1 (Meta 0) minecraft:planks * 1 (Meta 1) minecraft:planks * 1 (Meta 2) minecraft:planks * 1 (Meta 3) minecraft:planks * 1 (Meta 4) minecraft:planks * 1 (Meta 5) gregtech:planks * 1 (Meta 0) (MetaItem) OrePrefix: plate, Material: wood } * 3
    { Config circuit #3 } * 0
Item outputs:
    minecraft:trapdoor * 2 (Meta 0)
```

```
In map macerator
Tried: EU/t: 2, Duration: 98
Item inputs:
    { } * 1
Item outputs:
    (MetaItem) OrePrefix: dust, Material: paper

Found: null (Is something else going wrong?)
```
**Possible compatibility issue:**
Will not detect conflicts only present when extra items are required to present the conflict, or conflicts that just happen to produce the correct recipe and do not occur when running the conflicting recipe due to extra inputs