### PR TITLE
SimpleCubeRenderer

### DIFF
--- a/src/main/java/gregtech/client/renderer/texture/cube/SimpleCubeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/SimpleCubeRenderer.java
@@ -1,0 +1,50 @@
+package gregtech.client.renderer.texture.cube;
+
+import codechicken.lib.render.CCRenderState;
+import codechicken.lib.render.pipeline.IVertexOperation;
+import codechicken.lib.vec.Cuboid6;
+import codechicken.lib.vec.Matrix4;
+import gregtech.api.GTValues;
+import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+
+public class SimpleCubeRenderer implements ICubeRenderer {
+
+    protected final String basePath;
+
+    protected TextureAtlasSprite sprite;
+
+    public SimpleCubeRenderer(String basePath) {
+        this.basePath = basePath;
+        Textures.CUBE_RENDERER_REGISTRY.put(basePath, this);
+        Textures.iconRegisters.add(this);
+    }
+
+    @Override
+    public void registerIcons(TextureMap textureMap) {
+        String modID = GTValues.MODID;
+        String basePath = this.basePath;
+        String[] split = this.basePath.split(":");
+        if (split.length == 2) {
+            modID = split[0];
+            basePath = split[1];
+        }
+        sprite = textureMap.registerSprite(new ResourceLocation(modID, basePath));
+    }
+
+    @Override
+    public TextureAtlasSprite getParticleSprite() {
+        return sprite;
+    }
+
+    @Override
+    public void renderOrientedState(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline, Cuboid6 bounds, EnumFacing frontFacing, boolean isActive, boolean isWorkingEnabled) {
+        Textures.renderFace(renderState, translation, pipeline, frontFacing, bounds, sprite, BlockRenderLayer.CUTOUT_MIPPED);
+    }
+
+}


### PR DESCRIPTION
`SimpleCubeRenderer` allows a specification of any generic sprite to be rendered onto all faces of the cube.