### PR TITLE
Fix Fluid Pipe voiding

### DIFF
--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/PipeTankList.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/PipeTankList.java
@@ -1,10 +1,8 @@
 package gregtech.common.pipelike.fluidpipe.net;
 
 import gregtech.common.pipelike.fluidpipe.tile.TileEntityFluidPipe;
-import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
-import net.minecraftforge.fluids.capability.FluidTankPropertiesWrapper;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
@@ -12,16 +10,19 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 public class PipeTankList implements IFluidHandler, Iterable<FluidTank> {
 
     private final TileEntityFluidPipe pipe;
     private final FluidTank[] tanks;
     private IFluidTankProperties[] properties;
+    private final FluidStack[] queued;
 
     public PipeTankList(TileEntityFluidPipe pipe, FluidTank... fluidTanks) {
         this.tanks = fluidTanks;
         this.pipe = pipe;
+        this.queued = new FluidStack[fluidTanks.length];
     }
 
     @Override
@@ -29,18 +30,19 @@ public class PipeTankList implements IFluidHandler, Iterable<FluidTank> {
         if (properties == null) {
             properties = new IFluidTankProperties[tanks.length];
             for (int i = 0; i < tanks.length; i++) {
-                properties[i] = new FluidTankPropertiesWrapper(tanks[i]);
+                final int tankIndex = i;
+                properties[tankIndex] = new PipeTankProperties(tanks[tankIndex], () -> queued[tankIndex]);
             }
         }
         return properties;
     }
 
     private int findChannel(FluidStack stack) {
-        if (stack == null || tanks == null)
+        if (stack == null)
             return -1;
         int empty = -1;
         for (int i = tanks.length - 1; i >= 0; i--) {
-            FluidStack f = tanks[i].getFluid();
+            FluidStack f = getTankProperties()[i].getContents();
             if (f == null)
                 empty = i;
             else if (f.isFluidEqual(stack))
@@ -49,17 +51,42 @@ public class PipeTankList implements IFluidHandler, Iterable<FluidTank> {
         return empty;
     }
 
+    public int setContainingFluid(FluidStack stack, int channel, boolean fill) {
+        if (channel < 0)
+            return stack == null ? 0 : stack.amount;
+        if (stack == null || stack.amount <= 0) {
+            tanks[channel].setFluid(null);
+            return 0;
+        }
+        this.queued[channel] = null;
+        FluidTank tank = tanks[channel];
+        FluidStack currentStack = tank.getFluid();
+        if (currentStack == null || currentStack.amount <= 0) {
+            pipe.checkAndDestroy(stack);
+        } else if (fill) {
+            int toFill = stack.amount;
+            if (toFill + currentStack.amount > tank.getCapacity())
+                toFill = tank.getCapacity() - currentStack.amount;
+            currentStack.amount += toFill;
+            return toFill;
+        }
+        stack.amount = Math.min(stack.amount, tank.getCapacity());
+        tank.setFluid(stack);
+        return stack.amount;
+    }
+
     @Override
     public int fill(FluidStack resource, boolean doFill) {
         int channel;
         if (resource == null || resource.amount <= 0 || (channel = findChannel(resource)) < 0)
             return 0;
-        FluidTank tank = tanks[channel];
-        int space = tank.getCapacity() - (tank.getFluid() == null ? 0 : tank.getFluid().amount);
+        IFluidTankProperties properties = getTankProperties()[channel];
+        FluidStack currentFluid = properties.getContents();
+        int space = properties.getCapacity() - (currentFluid == null ? 0 : currentFluid.amount);
         FluidStack copy = resource.copy();
         if (resource.amount <= space) {
             copy.amount = resource.amount;
-        } else if (space < tank.getCapacity() / 2) {
+        } else if (space < properties.getCapacity() / 2) {
             space = (int) FluidNetWalker.getSpaceFor(pipe.getWorld(), pipe.getPos(), resource, resource.amount);
             if (space <= 0)
                 return 0;
@@ -67,7 +94,18 @@ public class PipeTankList implements IFluidHandler, Iterable<FluidTank> {
         } else {
             copy.amount = space;
         }
-        return pipe.getFluidPipeNet().fill(copy, pipe.getPos(), doFill);
+        int filled = pipe.getFluidPipeNet().fill(copy, pipe.getPos(), doFill);
+        if (doFill) {
+            FluidStack queuedFluid = queued[channel];
+            if (queuedFluid == null || !queuedFluid.isFluidEqual(resource)) {
+                queuedFluid = resource.copy();
+                queuedFluid.amount = filled;
+            } else {
+                queuedFluid.amount = Math.min(properties.getCapacity(), queuedFluid.amount + filled);
+            }
+            queued[channel] = queuedFluid;
+        }
+        return filled;
     }
 
     @Nullable
@@ -95,5 +133,57 @@ public class PipeTankList implements IFluidHandler, Iterable<FluidTank> {
     @Nonnull
     public Iterator<FluidTank> iterator() {
         return Arrays.stream(tanks).iterator();
+    }
+
+    private static class PipeTankProperties implements IFluidTankProperties {
+
+        private final FluidTank tank;
+        private final Supplier<FluidStack> queued;
+
+        private PipeTankProperties(FluidTank tank, Supplier<FluidStack> queued) {
+            this.tank = tank;
+            this.queued = queued;
+        }
+
+        @Nullable
+        @Override
+        public FluidStack getContents() {
+            FluidStack fluid = tank.getFluid();
+            FluidStack queuedFluid = queued.get();
+            if (fluid == null) {
+                return queuedFluid;
+            }
+            if (queuedFluid == null || !fluid.isFluidEqual(queuedFluid)) {
+                return fluid;
+            }
+            fluid = fluid.copy();
+            fluid.amount += queuedFluid.amount;
+            return fluid;
+        }
+
+        @Override
+        public int getCapacity() {
+            return tank.getCapacity();
+        }
+
+        @Override
+        public boolean canFill() {
+            return tank.canFill();
+        }
+
+        @Override
+        public boolean canDrain() {
+            return tank.canDrain();
+        }
+
+        @Override
+        public boolean canFillFluidType(FluidStack fluidStack) {
+            return tank.canFillFluidType(fluidStack);
+        }
+
+        @Override
+        public boolean canDrainFluidType(FluidStack fluidStack) {
+            return tank.canDrainFluidType(fluidStack);
+        }
     }
 }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipe.java
@@ -209,31 +209,9 @@ public class TileEntityFluidPipe extends TileEntityMaterialPipeBase<FluidPipeTyp
         return fluids;
     }
 
-    public int setFluidAuto(FluidStack stack, boolean fill) {
-        return setContainingFluid(stack, findChannel(stack), fill);
-    }
-
     public int setContainingFluid(FluidStack stack, int channel, boolean fill) {
-        if (channel < 0)
-            return stack == null ? 0 : stack.amount;
-        if (stack == null || stack.amount <= 0) {
-            getFluidTanks()[channel].setFluid(null);
-            return 0;
-        }
-        FluidTank tank = getFluidTanks()[channel];
-        FluidStack currentStack = tank.getFluid();
-        if (currentStack == null || currentStack.amount <= 0) {
-            checkAndDestroy(stack);
-        } else if (fill) {
-            int toFill = stack.amount;
-            if (toFill + currentStack.amount > tank.getCapacity())
-                toFill = tank.getCapacity() - currentStack.amount;
-            currentStack.amount += toFill;
-            return toFill;
-        }
-        stack.amount = Math.min(stack.amount, tank.getCapacity());
-        tank.setFluid(stack);
-        return stack.amount;
+        PipeTankList tankList = getTankList();
+        return tankList == null ? 0 : tankList.setContainingFluid(stack, channel, fill);
     }
 
     public void checkAndDestroy(FluidStack stack) {
@@ -334,7 +312,7 @@ public class TileEntityFluidPipe extends TileEntityMaterialPipeBase<FluidPipeTyp
     }
 
     public FluidPipeNet getFluidPipeNet() {
-        if(world == null || world.isRemote)
+        if (world == null || world.isRemote)
             return null;
         FluidPipeNet currentPipeNet = this.currentPipeNet.get();
         if (currentPipeNet != null && currentPipeNet.isValid() &&
@@ -391,7 +369,7 @@ public class TileEntityFluidPipe extends TileEntityMaterialPipeBase<FluidPipeTyp
                             new TextComponentTranslation(GTUtility.formatNumbers(this.getCapacityPerTank())).setStyle(new Style().setColor(TextFormatting.YELLOW)),
                             new TextComponentTranslation(fluids[i].getFluid().getLocalizedName(fluids[i])).setStyle(new Style().setColor(TextFormatting.GOLD))
                     ));
-               }
+                }
             }
 
             if (allTanksEmpty)


### PR DESCRIPTION
When something is filled into fluid pipes, it is queued to the net, but not actually inserted into the pipe. This makes it possible to theoretically insert an infinite amount of fluids in a single tick.
I fixed this by storing the queued fluid in the pipe, which will be checked when something is inserted. That fluid will be reseted when the Pipenet handled the insertion in the next tick.

Should not cause other issues, but i did not test it too much.