### PR TITLE
Prevent Coke Oven Hatch from sharing

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -90,4 +90,9 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
     public int getDefaultPaintingColor() {
         return 0xFFFFFF;
     }
+
+    @Override
+    public boolean canPartShare() {
+        return false;
+    }
 }


### PR DESCRIPTION
**What:**

Prevents the coke over hatch from sharing