### PR TITLE
CraftTweaker Helper

### DIFF
--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -28,7 +28,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -135,18 +134,6 @@ public class MetaPrefixItem extends StandardMetaItem {
             ResourceLocation defaultLocation = OrePrefix.ingot.materialIconType.getItemModelPath(defaultIcon);
             ModelBakery.registerItemVariants(this, defaultLocation);
         }
-
-        ModelLoader.setCustomMeshDefinition(this, itemStack -> {
-            short itemDamage = formatRawItemDamage((short) itemStack.getItemDamage());
-            if (specialItemsModels.containsKey(itemDamage)) {
-                int modelIndex = getModelIndex(itemStack);
-                return specialItemsModels.get(itemDamage)[modelIndex];
-            }
-            if (metaItemsModels.containsKey(itemDamage)) {
-                return metaItemsModels.get(itemDamage);
-            }
-            return MISSING_LOCATION;
-        });
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -4,6 +4,7 @@ import gnu.trove.map.hash.TShortObjectHashMap;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.damagesources.DamageSources;
+import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.StandardMetaItem;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
@@ -12,6 +13,7 @@ import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.material.properties.DustProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.UnificationEntry;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelBakery;
@@ -31,15 +33,12 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class MetaPrefixItem extends StandardMetaItem {
 
-    private final ArrayList<Short> generatedItems = new ArrayList<>();
-    private final ArrayList<ItemStack> items = new ArrayList<>();
     private final OrePrefix prefix;
 
     public static final Map<OrePrefix, OrePrefix> purifyMap = new HashMap<OrePrefix, OrePrefix>() {{
@@ -51,21 +50,24 @@ public class MetaPrefixItem extends StandardMetaItem {
     public MetaPrefixItem(OrePrefix orePrefix) {
         super();
         this.prefix = orePrefix;
+    }
+
+    @Override
+    public void registerSubItems() {
         for (Material material : GregTechAPI.MATERIAL_REGISTRY) {
             short i = (short) GregTechAPI.MATERIAL_REGISTRY.getIDForObject(material);
-            if (orePrefix != null && canGenerate(orePrefix, material)) {
-                generatedItems.add(i);
+            if (prefix != null && canGenerate(prefix, material)) {
+                addItem(i, new UnificationEntry(prefix, material).toString());
             }
         }
     }
 
     public void registerOreDict() {
-        for (short metaItem : generatedItems) {
+        for (short metaItem : metaItems.keySet()) {
             Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(metaItem);
             ItemStack item = new ItemStack(this, 1, metaItem);
             OreDictUnifier.registerOre(item, prefix, material);
             registerSpecialOreDict(item, material, prefix);
-            items.add(item);
         }
     }
 
@@ -82,10 +84,6 @@ public class MetaPrefixItem extends StandardMetaItem {
         } else if (material == Materials.Saltpeter) {
             OreDictUnifier.registerOre(item, prefix.name() + material.toCamelCaseString());
         }
-    }
-
-    public List<ItemStack> getEntries() {
-        return items;
     }
 
     protected boolean canGenerate(OrePrefix orePrefix, Material material) {
@@ -118,7 +116,7 @@ public class MetaPrefixItem extends StandardMetaItem {
     public void registerModels() {
         super.registerModels();
         TShortObjectHashMap<ModelResourceLocation> alreadyRegistered = new TShortObjectHashMap<>();
-        for (short metaItem : generatedItems) {
+        for (short metaItem : metaItems.keySet()) {
             MaterialIconSet materialIconSet = GregTechAPI.MATERIAL_REGISTRY.getObjectById(metaItem).getMaterialIconSet();
 
             short registrationKey = (short) (prefix.id + materialIconSet.id);
@@ -132,7 +130,7 @@ public class MetaPrefixItem extends StandardMetaItem {
         }
 
         // Make some default model for meta prefix items without any materials associated
-        if (generatedItems.isEmpty()) {
+        if (metaItems.keySet().isEmpty()) {
             MaterialIconSet defaultIcon = MaterialIconSet.DULL;
             ResourceLocation defaultLocation = OrePrefix.ingot.materialIconType.getItemModelPath(defaultIcon);
             ModelBakery.registerItemVariants(this, defaultLocation);
@@ -151,8 +149,11 @@ public class MetaPrefixItem extends StandardMetaItem {
     public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
         super.getSubItems(tab, subItems);
         if (tab == GregTechAPI.TAB_GREGTECH_MATERIALS || tab == CreativeTabs.SEARCH) {
-            for (short metadata : generatedItems) {
-                subItems.add(new ItemStack(this, 1, metadata));
+            for (MetaItem<?>.MetaValueItem enabledItem : metaItems.values()) {
+                if (!enabledItem.isVisible())
+                    continue;
+                ItemStack itemStack = enabledItem.getStackForm();
+                enabledItem.getSubItemHandler().getSubItems(itemStack, tab, subItems);
             }
         }
     }
@@ -160,7 +161,7 @@ public class MetaPrefixItem extends StandardMetaItem {
     @Override
     public void onUpdate(@Nonnull ItemStack itemStack, @Nonnull World worldIn, @Nonnull Entity entityIn, int itemSlot, boolean isSelected) {
         super.onUpdate(itemStack, worldIn, entityIn, itemSlot, isSelected);
-        if (generatedItems.contains((short) itemStack.getItemDamage()) && entityIn instanceof EntityLivingBase) {
+        if (metaItems.containsKey((short) itemStack.getItemDamage()) && entityIn instanceof EntityLivingBase) {
             EntityLivingBase entity = (EntityLivingBase) entityIn;
             if (worldIn.getTotalWorldTime() % 20 == 0) {
                 if (prefix.heatDamage != 0.0 && prefix.heatDamage > 0.0) {
@@ -180,10 +181,6 @@ public class MetaPrefixItem extends StandardMetaItem {
         Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
         if (prefix == null || material == null) return;
         addMaterialTooltip(lines, itemStack);
-
-        if(tooltipFlag.isAdvanced()) {
-            lines.add("MetaItem Id: " + prefix.name() + material.toCamelCaseString());
-        }
     }
 
     public Material getMaterial(ItemStack itemStack) {

--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -28,6 +28,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -134,6 +135,18 @@ public class MetaPrefixItem extends StandardMetaItem {
             ResourceLocation defaultLocation = OrePrefix.ingot.materialIconType.getItemModelPath(defaultIcon);
             ModelBakery.registerItemVariants(this, defaultLocation);
         }
+
+        ModelLoader.setCustomMeshDefinition(this, itemStack -> {
+            short itemDamage = formatRawItemDamage((short) itemStack.getItemDamage());
+            if (specialItemsModels.containsKey(itemDamage)) {
+                int modelIndex = getModelIndex(itemStack);
+                return specialItemsModels.get(itemDamage)[modelIndex];
+            }
+            if (metaItemsModels.containsKey(itemDamage)) {
+                return metaItemsModels.get(itemDamage);
+            }
+            return MISSING_LOCATION;
+        });
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -114,7 +114,6 @@ public class MetaPrefixItem extends StandardMetaItem {
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("ConstantConditions")
     public void registerModels() {
-        super.registerModels();
         TShortObjectHashMap<ModelResourceLocation> alreadyRegistered = new TShortObjectHashMap<>();
         for (short metaItem : metaItems.keySet()) {
             MaterialIconSet materialIconSet = GregTechAPI.MATERIAL_REGISTRY.getObjectById(metaItem).getMaterialIconSet();
@@ -147,7 +146,6 @@ public class MetaPrefixItem extends StandardMetaItem {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
-        super.getSubItems(tab, subItems);
         if (tab == GregTechAPI.TAB_GREGTECH_MATERIALS || tab == CreativeTabs.SEARCH) {
             for (MetaItem<?>.MetaValueItem enabledItem : metaItems.values()) {
                 if (!enabledItem.isVisible())

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -88,7 +88,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     private final Map<String, T> names = new Object2ObjectOpenHashMap<>();
     protected final Short2ObjectMap<ModelResourceLocation> metaItemsModels = new Short2ObjectOpenHashMap<>();
     protected final Short2ObjectMap<ModelResourceLocation[]> specialItemsModels = new Short2ObjectOpenHashMap<>();
-    private static final ModelResourceLocation MISSING_LOCATION = new ModelResourceLocation("builtin/missing", "inventory");
+    protected static final ModelResourceLocation MISSING_LOCATION = new ModelResourceLocation("builtin/missing", "inventory");
 
     protected final short metaItemOffset;
 

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -125,7 +125,10 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             }
             metaItemsModels.put((short) (metaItemOffset + itemMetaKey), new ModelResourceLocation(resourceLocation, "inventory"));
         }
+    }
 
+    @SideOnly(Side.CLIENT)
+    public void registerTextureMesh() {
         ModelLoader.setCustomMeshDefinition(this, itemStack -> {
             short itemDamage = formatRawItemDamage((short) itemStack.getItemDamage());
             if (specialItemsModels.containsKey(itemDamage)) {

--- a/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
@@ -13,7 +13,6 @@ import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -57,17 +56,6 @@ public class MetaOreDictItem extends StandardMetaItem {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerModels() {
-        ModelLoader.setCustomMeshDefinition(this, itemStack -> {
-            short itemDamage = formatRawItemDamage((short) itemStack.getItemDamage());
-            if (specialItemsModels.containsKey(itemDamage)) {
-                int modelIndex = getModelIndex(itemStack);
-                return specialItemsModels.get(itemDamage)[modelIndex];
-            }
-            if (metaItemsModels.containsKey(itemDamage)) {
-                return metaItemsModels.get(itemDamage);
-            }
-            return MISSING_LOCATION;
-        });
         TIntObjectHashMap<ModelResourceLocation> alreadyRegistered = new TIntObjectHashMap<>();
         for (Map.Entry<Short, OreDictValueItem> metaItem : ITEMS.entrySet()) {
             OrePrefix prefix = metaItem.getValue().orePrefix;

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
@@ -1,8 +1,26 @@
 package gregtech.api.recipes.crafttweaker;
 
 import crafttweaker.annotations.ZenRegister;
+import gregtech.api.block.machines.MachineItemBlock;
+import gregtech.api.items.materialitem.MetaPrefixItem;
+import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.pipenet.block.material.BlockMaterialPipe;
+import gregtech.api.unification.material.Material;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.api.util.GTLog;
+import gregtech.common.blocks.BlockCompressed;
+import gregtech.common.blocks.BlockFrame;
+import gregtech.common.blocks.CompressedItemBlock;
+import gregtech.common.blocks.FrameItemBlock;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nullable;
 
 import static gregtech.integration.jei.multiblock.MultiblockInfoCategory.*;
 
@@ -15,5 +33,47 @@ public class CTUtilities {
 
         REGISTER.removeIf(multi -> multi.metaTileEntityId.toString().equals(name));
 
+    }
+
+    @Nullable
+    public static String getMetaItemId(ItemStack item) {
+        if (item.getItem() instanceof MetaItem) {
+            MetaItem<?> metaItem = (MetaItem<?>) item.getItem();
+            if (item.getItem() instanceof MetaPrefixItem) {
+                Material material = ((MetaPrefixItem) metaItem).getMaterial(item);
+                OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
+                return new UnificationEntry(orePrefix, material).toString();
+            }
+            return metaItem.getItem(item).unlocalizedName;
+        }
+        if (item.getItem() instanceof ItemBlock) {
+            Block block = ((ItemBlock) item.getItem()).getBlock();
+            if (item.getItem() instanceof MachineItemBlock) {
+                MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(item);
+                if (mte != null) {
+                    return (mte.metaTileEntityId.getNamespace().equals("gregtech") ? mte.metaTileEntityId.getPath() : mte.metaTileEntityId.toString());
+                }
+            }
+            if (block instanceof BlockCompressed) {
+                return "block" + ((BlockCompressed) block).getGtMaterial(item.getMetadata()).toCamelCaseString();
+            }
+            if (block instanceof BlockFrame) {
+                return "frame" + ((BlockFrame) block).getGtMaterial(item.getMetadata()).toCamelCaseString();
+            }
+            if (block instanceof BlockMaterialPipe) {
+                return ((BlockMaterialPipe<?, ?, ?>) block).getPrefix().name + ((BlockMaterialPipe<?, ?, ?>) block).getItemMaterial(item).toCamelCaseString();
+            }
+        }
+
+        return null;
+    }
+
+    public static String getItemIdFor(ItemStack item) {
+        String id = getMetaItemId(item);
+        if (id != null)
+            return id;
+        if (item.getItem().getRegistryName() == null)
+            return "null";
+        return item.getItem().getRegistryName().toString();
     }
 }

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
@@ -1,28 +1,10 @@
 package gregtech.api.recipes.crafttweaker;
 
 import crafttweaker.annotations.ZenRegister;
-import gregtech.api.block.machines.MachineItemBlock;
-import gregtech.api.items.materialitem.MetaPrefixItem;
-import gregtech.api.items.metaitem.MetaItem;
-import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.pipenet.block.material.BlockMaterialPipe;
-import gregtech.api.unification.material.Material;
-import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.UnificationEntry;
-import gregtech.api.util.GTLog;
-import gregtech.common.blocks.BlockCompressed;
-import gregtech.common.blocks.BlockFrame;
-import gregtech.common.blocks.CompressedItemBlock;
-import gregtech.common.blocks.FrameItemBlock;
-import net.minecraft.block.Block;
-import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nullable;
-
-import static gregtech.integration.jei.multiblock.MultiblockInfoCategory.*;
+import static gregtech.integration.jei.multiblock.MultiblockInfoCategory.REGISTER;
 
 @ZenClass("mods.gregtech.general.utils")
 @ZenRegister
@@ -30,50 +12,6 @@ public class CTUtilities {
 
     @ZenMethod("RemoveMultiblockPreviewFromJei")
     public static void removeMulti(String name) {
-
         REGISTER.removeIf(multi -> multi.metaTileEntityId.toString().equals(name));
-
-    }
-
-    @Nullable
-    public static String getMetaItemId(ItemStack item) {
-        if (item.getItem() instanceof MetaItem) {
-            MetaItem<?> metaItem = (MetaItem<?>) item.getItem();
-            if (item.getItem() instanceof MetaPrefixItem) {
-                Material material = ((MetaPrefixItem) metaItem).getMaterial(item);
-                OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
-                return new UnificationEntry(orePrefix, material).toString();
-            }
-            return metaItem.getItem(item).unlocalizedName;
-        }
-        if (item.getItem() instanceof ItemBlock) {
-            Block block = ((ItemBlock) item.getItem()).getBlock();
-            if (item.getItem() instanceof MachineItemBlock) {
-                MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(item);
-                if (mte != null) {
-                    return (mte.metaTileEntityId.getNamespace().equals("gregtech") ? mte.metaTileEntityId.getPath() : mte.metaTileEntityId.toString());
-                }
-            }
-            if (block instanceof BlockCompressed) {
-                return "block" + ((BlockCompressed) block).getGtMaterial(item.getMetadata()).toCamelCaseString();
-            }
-            if (block instanceof BlockFrame) {
-                return "frame" + ((BlockFrame) block).getGtMaterial(item.getMetadata()).toCamelCaseString();
-            }
-            if (block instanceof BlockMaterialPipe) {
-                return ((BlockMaterialPipe<?, ?, ?>) block).getPrefix().name + ((BlockMaterialPipe<?, ?, ?>) block).getItemMaterial(item).toCamelCaseString();
-            }
-        }
-
-        return null;
-    }
-
-    public static String getItemIdFor(ItemStack item) {
-        String id = getMetaItemId(item);
-        if (id != null)
-            return id;
-        if (item.getItem().getRegistryName() == null)
-            return "null";
-        return item.getItem().getRegistryName().toString();
     }
 }

--- a/src/main/java/gregtech/api/recipes/crafttweaker/MetaItemBracketHandler.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/MetaItemBracketHandler.java
@@ -48,16 +48,6 @@ public class MetaItemBracketHandler implements IBracketHandler {
     public static void rebuildComponentRegistry() {
         metaItemNames.clear();
         for (MetaItem<?> item : MetaItem.getMetaItems()) {
-            if (item instanceof MetaPrefixItem) {
-                MetaPrefixItem metaPrefixItem = ((MetaPrefixItem) item);
-                OrePrefix prefix = metaPrefixItem.getOrePrefix();
-                for (ItemStack entry : ((MetaPrefixItem) item).getEntries()) {
-                    MaterialStack material = OreDictUnifier.getMaterial(entry);
-                    if (material != null) {
-                        metaItemNames.put(prefix.name() + OreDictUnifier.getMaterial(entry).material.toCamelCaseString(), entry);
-                    } else GTLog.logger.error("Material in entry {} is null!", entry.toString());
-                }
-            }
             for (MetaValueItem entry : item.getAllItems()) {
                 if (!entry.unlocalizedName.equals("meta_item")) {
                     metaItemNames.put(entry.unlocalizedName, entry.getStackForm());

--- a/src/main/java/gregtech/api/util/CTRecipeHelper.java
+++ b/src/main/java/gregtech/api/util/CTRecipeHelper.java
@@ -2,16 +2,12 @@ package gregtech.api.util;
 
 import crafttweaker.mc1120.data.NBTConverter;
 import gregtech.api.block.machines.MachineItemBlock;
-import gregtech.api.items.materialitem.MetaPrefixItem;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.pipenet.block.material.BlockMaterialPipe;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.unification.material.Material;
-import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.common.blocks.BlockCompressed;
 import gregtech.common.blocks.BlockFrame;
 import net.minecraft.block.Block;
@@ -27,11 +23,6 @@ public class CTRecipeHelper {
     public static String getMetaItemId(ItemStack item) {
         if (item.getItem() instanceof MetaItem) {
             MetaItem<?> metaItem = (MetaItem<?>) item.getItem();
-            if (item.getItem() instanceof MetaPrefixItem) {
-                Material material = ((MetaPrefixItem) metaItem).getMaterial(item);
-                OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
-                return new UnificationEntry(orePrefix, material).toString();
-            }
             return metaItem.getItem(item).unlocalizedName;
         }
         if (item.getItem() instanceof ItemBlock) {

--- a/src/main/java/gregtech/api/util/CTRecipeHelper.java
+++ b/src/main/java/gregtech/api/util/CTRecipeHelper.java
@@ -1,0 +1,170 @@
+package gregtech.api.util;
+
+import crafttweaker.mc1120.data.NBTConverter;
+import gregtech.api.block.machines.MachineItemBlock;
+import gregtech.api.items.materialitem.MetaPrefixItem;
+import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.pipenet.block.material.BlockMaterialPipe;
+import gregtech.api.recipes.CountableIngredient;
+import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.RecipeMap;
+import gregtech.api.unification.material.Material;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.common.blocks.BlockCompressed;
+import gregtech.common.blocks.BlockFrame;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nullable;
+
+public class CTRecipeHelper {
+
+    @Nullable
+    public static String getMetaItemId(ItemStack item) {
+        if (item.getItem() instanceof MetaItem) {
+            MetaItem<?> metaItem = (MetaItem<?>) item.getItem();
+            if (item.getItem() instanceof MetaPrefixItem) {
+                Material material = ((MetaPrefixItem) metaItem).getMaterial(item);
+                OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
+                return new UnificationEntry(orePrefix, material).toString();
+            }
+            return metaItem.getItem(item).unlocalizedName;
+        }
+        if (item.getItem() instanceof ItemBlock) {
+            Block block = ((ItemBlock) item.getItem()).getBlock();
+            if (item.getItem() instanceof MachineItemBlock) {
+                MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(item);
+                if (mte != null) {
+                    return (mte.metaTileEntityId.getNamespace().equals("gregtech") ? mte.metaTileEntityId.getPath() : mte.metaTileEntityId.toString());
+                }
+            }
+            if (block instanceof BlockCompressed) {
+                return "block" + ((BlockCompressed) block).getGtMaterial(item.getMetadata()).toCamelCaseString();
+            }
+            if (block instanceof BlockFrame) {
+                return "frame" + ((BlockFrame) block).getGtMaterial(item.getMetadata()).toCamelCaseString();
+            }
+            if (block instanceof BlockMaterialPipe) {
+                return ((BlockMaterialPipe<?, ?, ?>) block).getPrefix().name + ((BlockMaterialPipe<?, ?, ?>) block).getItemMaterial(item).toCamelCaseString();
+            }
+        }
+
+        return null;
+    }
+
+    public static String getItemIdFor(ItemStack item) {
+        String id = getMetaItemId(item);
+        if (id != null)
+            return id;
+        if (item.getItem().getRegistryName() == null)
+            return "null";
+        return item.getItem().getRegistryName().toString();
+    }
+
+    public static String getRecipeRemoveLine(RecipeMap<?> recipeMap, Recipe recipe) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<recipemap:")
+                .append(recipeMap.unlocalizedName)
+                .append(">.findRecipe(")
+                .append(recipe.getEUt())
+                .append(", ");
+
+        if (recipe.getInputs().size() > 0) {
+            builder.append("[");
+            for (CountableIngredient ci : recipe.getInputs()) {
+                String ingredient = getCtItemString(ci);
+                if (ingredient != null)
+                    builder.append(ingredient);
+            }
+            builder.delete(builder.length() - 2, builder.length())
+                    .append("], ");
+        } else {
+            builder.append("null, ");
+        }
+
+        if (recipe.getFluidInputs().size() > 0) {
+            builder.append("[");
+            for (FluidStack fluidStack : recipe.getFluidInputs()) {
+                builder.append("<liquid:")
+                        .append(fluidStack.getFluid().getName())
+                        .append(">");
+
+                if (fluidStack.amount > 1) {
+                    builder.append(" * ")
+                            .append(fluidStack.amount);
+                }
+
+                builder.append(", ");
+            }
+            builder.delete(builder.length() - 2, builder.length())
+                    .append("]");
+        } else {
+            builder.append("null");
+        }
+
+
+        builder.append(").remove();");
+        return builder.toString();
+    }
+
+    public static String getFirstOutputString(Recipe recipe) {
+        String output = "";
+        if (!recipe.getOutputs().isEmpty()) {
+            ItemStack item = recipe.getOutputs().get(0);
+            output = item.getDisplayName() + " * " + item.getCount();
+        } else if (!recipe.getFluidOutputs().isEmpty()) {
+            FluidStack fluid = recipe.getFluidOutputs().get(0);
+            output = fluid.getLocalizedName() + " * " + fluid.amount;
+        }
+        return output;
+    }
+
+    public static String getCtItemString(CountableIngredient ci) {
+        StringBuilder builder = new StringBuilder();
+        ItemStack itemStack = null;
+        String itemId = null;
+        for (ItemStack item : ci.getIngredient().getMatchingStacks()) {
+            itemId = getMetaItemId(item);
+            if (itemId != null) {
+                builder.append("<metaitem:")
+                        .append(itemId)
+                        .append(">");
+                itemStack = item;
+                break;
+            } else if (itemStack == null) {
+                itemStack = item;
+            }
+        }
+        if (itemStack != null) {
+            if (itemId == null) {
+                if (itemStack.getItem().getRegistryName() == null) {
+                    GTLog.logger.info("Could not remove recipe {}, because of unregistered Item", builder);
+                    return null;
+                }
+                builder.append("<")
+                        .append(itemStack.getItem().getRegistryName().toString())
+                        .append(":")
+                        .append(itemStack.getItemDamage())
+                        .append(">");
+            }
+
+            if (itemStack.serializeNBT().hasKey("tag")) {
+                String nbt = NBTConverter.from(itemStack.serializeNBT().getCompoundTag("tag"), false).toString();
+                if (nbt.length() > 0) {
+                    builder.append(".withTag(").append(nbt).append(")");
+                }
+            }
+        }
+
+        if (ci.getCount() > 1) {
+            builder.append(" * ")
+                    .append(ci.getCount());
+        }
+        builder.append(", ");
+        return builder.toString();
+    }
+}

--- a/src/main/java/gregtech/common/command/CommandHand.java
+++ b/src/main/java/gregtech/common/command/CommandHand.java
@@ -1,25 +1,15 @@
 package gregtech.common.command;
 
-import gregtech.api.block.machines.MachineItemBlock;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
-import gregtech.api.items.materialitem.MetaPrefixItem;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.items.toolitem.ToolMetaItem.MetaToolValueItem;
-import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.pipenet.block.material.BlockMaterialPipe;
-import gregtech.api.recipes.crafttweaker.CTUtilities;
 import gregtech.api.unification.OreDictUnifier;
-import gregtech.api.unification.material.Material;
-import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.api.util.CTRecipeHelper;
 import gregtech.api.util.ClipboardUtil;
-import gregtech.common.blocks.BlockCompressed;
-import gregtech.common.blocks.BlockFrame;
-import net.minecraft.block.Block;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -102,8 +92,8 @@ public class CommandHand extends CommandBase {
                 }
             }
 
-            String id = CTUtilities.getMetaItemId(stackInHand);
-            if(id != null) {
+            String id = CTRecipeHelper.getMetaItemId(stackInHand);
+            if (id != null) {
                 String ctId = "<metaitem:" + id + ">";
                 ClipboardUtil.copyToClipboard(player, ctId);
                 player.sendMessage(new TextComponentString("MetaItem Id: ").appendSibling(new TextComponentString(id).setStyle(new Style().setColor(TextFormatting.GREEN)))

--- a/src/main/java/gregtech/common/command/CommandHand.java
+++ b/src/main/java/gregtech/common/command/CommandHand.java
@@ -11,6 +11,7 @@ import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.items.toolitem.ToolMetaItem.MetaToolValueItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.pipenet.block.material.BlockMaterialPipe;
+import gregtech.api.recipes.crafttweaker.CTUtilities;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
@@ -93,55 +94,20 @@ public class CommandHand extends CommandBase {
             if (stackInHand.getItem() instanceof MetaItem) {
                 MetaItem<?> metaItem = (MetaItem<?>) stackInHand.getItem();
                 MetaValueItem metaValueItem = metaItem.getItem(stackInHand);
-                if(metaItem instanceof MetaPrefixItem) {
-                    Material material = ((MetaPrefixItem) metaItem).getMaterial(stackInHand);
-                    OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
-                    String oreDictName = new UnificationEntry(orePrefix, material).toString();
-                    String copyName = "<metaitem:" + oreDictName + ">";
-                    ClipboardUtil.copyToClipboard(player, copyName);
-                    player.sendMessage(new TextComponentString("MetaItem Id: ").appendSibling(new TextComponentString(oreDictName)
-                            .setStyle(new Style().setColor(TextFormatting.GREEN))).setStyle(getCopyStyle(copyName, true)));
-                }
-                else if (metaValueItem != null) {
+                if (metaValueItem != null) {
                     if (metaValueItem instanceof ToolMetaItem.MetaToolValueItem) {
                         IToolStats toolStats = ((MetaToolValueItem) metaValueItem).getToolStats();
                         player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.tool_stats", toolStats.getClass().getName()));
                     }
-                    String id = metaValueItem.unlocalizedName;
-                    String ctId = "<metaitem:" + metaValueItem.unlocalizedName + ">";
-                    ClipboardUtil.copyToClipboard(player, ctId);
-                    player.sendMessage(new TextComponentString("MetaItem Id: ").appendSibling(new TextComponentString(id).setStyle(new Style().setColor(TextFormatting.GREEN)))
-                            .setStyle(getCopyStyle(ctId, true)));
+                }
+            }
 
-                }
-            } else if (stackInHand.getItem() instanceof MachineItemBlock) {
-                MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(stackInHand);
-                if (mte != null) {
-                    String id = mte.metaTileEntityId.toString();
-                    if (mte.metaTileEntityId.getNamespace().equals("gregtech"))
-                        id = mte.metaTileEntityId.getPath();
-                    String ctId = "<metaitem:" + id + ">";
-                    ClipboardUtil.copyToClipboard(player, ctId);
-                    player.sendMessage(new TextComponentString("MetaItem Id: ").appendSibling(new TextComponentString(id).setStyle(new Style().setColor(TextFormatting.GREEN)))
-                            .setStyle(getCopyStyle(ctId, true)));
-                }
-            } else {
-                Block block = Block.getBlockFromItem(stackInHand.getItem());
-                String id = null;
-                if (block instanceof BlockCompressed) {
-                    id = "block" + ((BlockCompressed) block).getGtMaterial(stackInHand.getMetadata()).toCamelCaseString();
-                } else if (block instanceof BlockFrame) {
-                    id = "frame" + ((BlockFrame) block).getGtMaterial(stackInHand.getMetadata()).toCamelCaseString();
-                } else if (block instanceof BlockMaterialPipe) {
-                    id = ((BlockMaterialPipe<?, ?, ?>) block).getPrefix().name + ((BlockMaterialPipe<?, ?, ?>) block).getItemMaterial(stackInHand).toCamelCaseString();
-                }
-
-                if (id != null) {
-                    String ctId = "<metaitem:" + id + ">";
-                    ClipboardUtil.copyToClipboard(player, ctId);
-                    player.sendMessage(new TextComponentString("MetaItem Id: ").appendSibling(new TextComponentString(id).setStyle(new Style().setColor(TextFormatting.GREEN)))
-                            .setStyle(getCopyStyle(ctId, true)));
-                }
+            String id = CTUtilities.getMetaItemId(stackInHand);
+            if(id != null) {
+                String ctId = "<metaitem:" + id + ">";
+                ClipboardUtil.copyToClipboard(player, ctId);
+                player.sendMessage(new TextComponentString("MetaItem Id: ").appendSibling(new TextComponentString(id).setStyle(new Style().setColor(TextFormatting.GREEN)))
+                        .setStyle(getCopyStyle(ctId, true)));
             }
 
             Set<String> oreDicts = OreDictUnifier.getOreDictionaryNames(stackInHand);

--- a/src/main/java/gregtech/common/items/MetaItems.java
+++ b/src/main/java/gregtech/common/items/MetaItems.java
@@ -672,6 +672,7 @@ public final class MetaItems {
     public static void registerColors() {
         for (MetaItem<?> item : ITEMS) {
             item.registerColor();
+            item.registerTextureMesh();
         }
     }
 

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -1,32 +1,41 @@
 package gregtech.integration.jei.recipe;
 
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.mc1120.data.NBTConverter;
+import gregtech.api.GTValues;
+import gregtech.api.gui.GuiTextures;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.crafttweaker.CTUtilities;
 import gregtech.api.recipes.recipeproperties.PrimitiveProperty;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.util.ClipboardUtil;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
+import gregtech.integration.jei.utils.AdvancedRecipeWrapper;
 import gregtech.integration.jei.utils.JEIHelpers;
+import gregtech.integration.jei.utils.JeiButton;
 import it.unimi.dsi.fastutil.ints.Int2BooleanMap;
 import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fluids.FluidStack;
 
 import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class GTRecipeWrapper implements IRecipeWrapper {
+public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
     private static final int LINE_HEIGHT = 10;
 
@@ -120,6 +129,7 @@ public class GTRecipeWrapper implements IRecipeWrapper {
 
     @Override
     public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+        super.drawInfo(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
         int yPosition = recipeHeight - getPropertyListHeight();
         if (!recipe.hasProperty(PrimitiveProperty.getInstance())) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
@@ -131,6 +141,17 @@ public class GTRecipeWrapper implements IRecipeWrapper {
                 propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += LINE_HEIGHT, 0x111111, propertyEntry.getValue());
             }
         }
+    }
+
+    @Override
+    public void initExtras() {
+        buttons.add(new JeiButton(180, 2, 10, 10)
+                .setTextures(GuiTextures.BUTTON_CLEAR_GRID)
+                .setClickAction((minecraft, mouseX, mouseY, mouseButton) -> {
+                    outputRemoveLine();
+                    return true;
+                })
+                .setActiveSupplier(() -> Minecraft.getMinecraft().player != null && Minecraft.getMinecraft().player.isCreative() && GTValues.isModLoaded(GTValues.MODID_CT)));
     }
 
     public Int2ObjectMap<ChanceEntry> getChanceOutputMap() {
@@ -146,7 +167,104 @@ public class GTRecipeWrapper implements IRecipeWrapper {
     }
 
     private int getPropertyListHeight() {
-        if (recipeMap == RecipeMaps.COKE_OVEN_RECIPES) return LINE_HEIGHT - 6; // fun hack TODO Make this easier to position
+        if (recipeMap == RecipeMaps.COKE_OVEN_RECIPES)
+            return LINE_HEIGHT - 6; // fun hack TODO Make this easier to position
         return (recipe.getPropertyCount() + 3) * LINE_HEIGHT - 3;
+    }
+
+    private void outputRemoveLine() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<recipemap:")
+                .append(recipeMap.unlocalizedName)
+                .append(">.findRecipe(")
+                .append(recipe.getEUt())
+                .append(", ");
+
+        if (recipe.getInputs().size() > 0) {
+            builder.append("[");
+            for (CountableIngredient ci : recipe.getInputs()) {
+                ItemStack itemStack = null;
+                String itemId = null;
+                for (ItemStack item : ci.getIngredient().getMatchingStacks()) {
+                    itemId = CTUtilities.getMetaItemId(item);
+                    if (itemId != null) {
+                        builder.append("<metaitem:")
+                                .append(itemId)
+                                .append(">");
+                        itemStack = item;
+                        break;
+                    } else if (itemStack == null) {
+                        itemStack = item;
+                    }
+                }
+                if (itemStack != null) {
+                    if (itemId == null) {
+                        if (itemStack.getItem().getRegistryName() == null) {
+                            GTLog.logger.info("Could not remove recipe {}, because of unregistered Item", builder);
+                            return;
+                        }
+                        builder.append("<")
+                                .append(itemStack.getItem().getRegistryName().toString())
+                                .append(":")
+                                .append(itemStack.getItemDamage())
+                                .append(">");
+                    }
+
+                    if (itemStack.serializeNBT().hasKey("tag")) {
+                        String nbt = NBTConverter.from(itemStack.serializeNBT().getCompoundTag("tag"), false).toString();
+                        if (nbt.length() > 0) {
+                            builder.append(".withTag(").append(nbt).append(")");
+                        }
+                    }
+                }
+
+                if (ci.getCount() != 1) {
+                    builder.append(" * ")
+                            .append(ci.getCount());
+                }
+                builder.append(", ");
+            }
+            builder.delete(builder.length() - 2, builder.length())
+                    .append("], ");
+        } else {
+            builder.append("null, ");
+        }
+
+        if (recipe.getFluidInputs().size() > 0) {
+            builder.append("[");
+            for (FluidStack fluidStack : recipe.getFluidInputs()) {
+                builder.append("<liquid:")
+                        .append(fluidStack.getFluid().getName())
+                        .append(">");
+
+                if (fluidStack.amount != 1) {
+                    builder.append(" * ")
+                            .append(fluidStack.amount);
+                }
+
+                builder.append(", ");
+            }
+            builder.delete(builder.length() - 2, builder.length())
+                    .append("]");
+        } else {
+            builder.append("null");
+        }
+
+
+        builder.append(").remove();");
+
+        String output = "";
+        if (recipe.getOutputs().size() > 0) {
+            output = recipe.getOutputs().get(0).getDisplayName() + " * " + recipe.getOutputs().get(0).getCount();
+        } else if (recipe.getFluidOutputs().size() > 0) {
+            output = recipe.getFluidOutputs().get(0).getLocalizedName() + " * " + recipe.getFluidOutputs().get(0).amount;
+        }
+
+        if (!output.isEmpty()) {
+            output = "// " + output + "\n";
+        }
+
+        ClipboardUtil.copyToClipboard(output + builder.toString() + "\n");
+        Minecraft.getMinecraft().player.sendMessage(new TextComponentString("Copied [\u00A76" + builder.toString() + "\u00A7r] to the clipboard"));
     }
 }

--- a/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
@@ -1,0 +1,38 @@
+package gregtech.integration.jei.utils;
+
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.init.SoundEvents;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
+
+    protected final List<JeiButton> buttons = new ArrayList<>();
+
+    public AdvancedRecipeWrapper() {
+        initExtras();
+    }
+
+    public abstract void initExtras();
+
+    @Override
+    public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+        for (JeiButton button : buttons) {
+            button.render(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
+        }
+    }
+
+    @Override
+    public boolean handleClick(Minecraft minecraft, int mouseX, int mouseY, int mouseButton) {
+        for (JeiButton button : buttons) {
+            if (button.isHovering(mouseX, mouseY) && button.getClickAction().click(minecraft, mouseX, mouseY, mouseButton)) {
+                Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
@@ -3,7 +3,10 @@ package gregtech.integration.jei.utils;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.client.config.GuiUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +25,19 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
     public void drawInfo(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         for (JeiButton button : buttons) {
             button.render(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
+            if (button.isHovering(mouseX, mouseY)) {
+                List<String> lines = new ArrayList<>();
+                button.buildTooltip(lines);
+                if (lines.isEmpty())
+                    continue;
+                Minecraft mc = Minecraft.getMinecraft();
+                int width = (int) (mc.displayWidth / 2f + recipeWidth / 2f);
+                int maxWidth = Math.min(200, width - mouseX - 5);
+                GuiUtils.drawHoveringText(ItemStack.EMPTY, lines, mouseX, mouseY,
+                        width,
+                        mc.displayHeight, maxWidth, mc.fontRenderer);
+                GlStateManager.disableLighting();
+            }
         }
     }
 

--- a/src/main/java/gregtech/integration/jei/utils/JeiButton.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiButton.java
@@ -3,7 +3,9 @@ package gregtech.integration.jei.utils;
 import gregtech.api.gui.resources.IGuiTexture;
 import net.minecraft.client.Minecraft;
 
+import java.util.List;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 public class JeiButton {
 
@@ -14,6 +16,7 @@ public class JeiButton {
     private final int height;
     private ClickAction clickAction;
     private BooleanSupplier activeSupplier = () -> true;
+    private Consumer<List<String>> tooltipBuilder = null;
 
     public JeiButton(float x, float y, int width, int height) {
         this.x = x;
@@ -35,6 +38,17 @@ public class JeiButton {
     public JeiButton setActiveSupplier(BooleanSupplier activeSupplier) {
         this.activeSupplier = activeSupplier;
         return this;
+    }
+
+    public JeiButton setTooltipBuilder(Consumer<List<String>> tooltipBuilder) {
+        this.tooltipBuilder = tooltipBuilder;
+        return this;
+    }
+
+    public void buildTooltip(List<String> lines) {
+        if (tooltipBuilder != null) {
+            tooltipBuilder.accept(lines);
+        }
     }
 
     public boolean isHovering(int mouseX, int mouseY) {

--- a/src/main/java/gregtech/integration/jei/utils/JeiButton.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiButton.java
@@ -1,0 +1,60 @@
+package gregtech.integration.jei.utils;
+
+import gregtech.api.gui.resources.IGuiTexture;
+import net.minecraft.client.Minecraft;
+
+import java.util.function.BooleanSupplier;
+
+public class JeiButton {
+
+    private IGuiTexture[] textures = {};
+    private final float x;
+    private final float y;
+    private final int width;
+    private final int height;
+    private ClickAction clickAction;
+    private BooleanSupplier activeSupplier = () -> true;
+
+    public JeiButton(float x, float y, int width, int height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    public JeiButton setTextures(IGuiTexture... textures) {
+        this.textures = textures;
+        return this;
+    }
+
+    public JeiButton setClickAction(ClickAction clickAction) {
+        this.clickAction = clickAction;
+        return this;
+    }
+
+    public JeiButton setActiveSupplier(BooleanSupplier activeSupplier) {
+        this.activeSupplier = activeSupplier;
+        return this;
+    }
+
+    public boolean isHovering(int mouseX, int mouseY) {
+        return mouseX >= x && mouseY >= y && mouseX <= x + width && mouseY <= y + height && activeSupplier.getAsBoolean();
+    }
+
+    public void render(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+        if (!activeSupplier.getAsBoolean())
+            return;
+        for (IGuiTexture texture : textures) {
+            texture.draw(x, y, width, height);
+        }
+    }
+
+    public ClickAction getClickAction() {
+        return clickAction;
+    }
+
+    @FunctionalInterface
+    public interface ClickAction {
+        boolean click(Minecraft minecraft, int mouseX, int mouseY, int mouseButton);
+    }
+}


### PR DESCRIPTION
Adds a button to JEI that will copy a CT script line that removes the recipe.

!
Changes `MetaPrefixItem` to use `MetaValueItem`. Before it stored it's items in it's own list. With `MetaValueItem` we don't need to specifiacally support `MetaPrefixItem`. (see `MetaItemBracketHandler` for example)
It does not shift any id's

Button in top right
![grafik](https://user-images.githubusercontent.com/45517902/150385351-263ba9fc-24d6-46ed-ac57-a37837fb7015.png)
Command output after clicking the button
![grafik](https://user-images.githubusercontent.com/45517902/150385538-0f6c7e5d-89ed-455c-a9db-95705d875650.png)
Copied result (Including the comment) (it will show the localized name of the first output item/fluid)
![grafik](https://user-images.githubusercontent.com/45517902/150385732-9b625e75-a859-4088-94c6-e1e56c34f028.png)
