### PR TITLE
Remove double Post Init subscribers

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -174,10 +174,6 @@ public class GregTechMod {
     @Mod.EventHandler
     public void onPostInit(FMLPostInitializationEvent event) {
         proxy.onPostLoad();
-    }
-
-    @Mod.EventHandler
-    public void postInit(FMLPostInitializationEvent event) {
         BedrockFluidVeinHandler.recalculateChances(true);
 
     }


### PR DESCRIPTION
**What:**

Removes a doubled subscriber to `FMLPostInitializationEvent` and combines everything into one