### PR TITLE
Add config option for removing smelting recipes for EBF ingots

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -9,7 +9,6 @@ import gregtech.api.cover.CoverDefinition;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.items.gui.PlayerInventoryUIFactory;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
-import gregtech.api.recipes.ModHandler;
 import gregtech.api.sound.GTSounds;
 import gregtech.api.net.NetworkHandler;
 import gregtech.api.recipes.RecipeMap;
@@ -175,10 +174,6 @@ public class GregTechMod {
     @Mod.EventHandler
     public void onPostInit(FMLPostInitializationEvent event) {
         proxy.onPostLoad();
-
-        if(ConfigHolder.compat.removeSmeltingForEBFMetals) {
-            ModHandler.removeSmeltingEBFMetals();
-        }
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -9,6 +9,7 @@ import gregtech.api.cover.CoverDefinition;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.items.gui.PlayerInventoryUIFactory;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.sound.GTSounds;
 import gregtech.api.net.NetworkHandler;
 import gregtech.api.recipes.RecipeMap;
@@ -174,6 +175,10 @@ public class GregTechMod {
     @Mod.EventHandler
     public void onPostInit(FMLPostInitializationEvent event) {
         proxy.onPostLoad();
+
+        if(ConfigHolder.compat.removeSmeltingForEBFMetals) {
+            ModHandler.removeSmeltingEBFMetals();
+        }
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -751,14 +751,20 @@ public class ModHandler {
             Map.Entry<ItemStack, ItemStack> recipe = recipeIterator.next();
 
             ItemStack output = recipe.getValue();
+            ItemStack input = recipe.getKey();
             MaterialStack ms = OreDictUnifier.getMaterial(output);
 
             if(ms != null) {
                 Material material = ms.material;
                 if(material.hasProperty(PropertyKey.BLAST)) {
-                    recipeIterator.remove();
-                    if(ConfigHolder.misc.debug) {
-                        GTLog.logger.info("Removing Smelting Recipe for EBF material {}", LocalizationUtils.format(material.getUnlocalizedName()));
+                    ItemStack dust = OreDictUnifier.get(OrePrefix.dust, material);
+                    ItemStack ingot = OreDictUnifier.get(OrePrefix.ingot, material);
+                    //Check if the inputs are actually dust -> ingot
+                    if(ingot.isItemEqual(output) && dust.isItemEqual(input)) {
+                        recipeIterator.remove();
+                        if(ConfigHolder.misc.debug) {
+                            GTLog.logger.info("Removing Smelting Recipe for EBF material {}", LocalizationUtils.format(material.getUnlocalizedName()));
+                        }
                     }
                 }
             }

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -8,12 +8,14 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterial;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.DummyContainer;
 import gregtech.api.util.GTLog;
+import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.ShapedOreEnergyTransferRecipe;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.ConfigHolder;
@@ -737,5 +739,30 @@ public class ModHandler {
     public static ItemStack getSmeltingOutput(ItemStack input) {
         if (input.isEmpty()) return ItemStack.EMPTY;
         return OreDictUnifier.getUnificated(FurnaceRecipes.instance().getSmeltingResult(input));
+    }
+
+    public static void removeSmeltingEBFMetals() {
+
+        Map<ItemStack, ItemStack> furnaceList = FurnaceRecipes.instance().getSmeltingList();
+
+        Iterator<Map.Entry<ItemStack, ItemStack>> recipeIterator = furnaceList.entrySet().iterator();
+
+        while(recipeIterator.hasNext()) {
+            Map.Entry<ItemStack, ItemStack> recipe = recipeIterator.next();
+
+            ItemStack output = recipe.getValue();
+            MaterialStack ms = OreDictUnifier.getMaterial(output);
+
+            if(ms != null) {
+                Material material = ms.material;
+                if(material.hasProperty(PropertyKey.BLAST)) {
+                    recipeIterator.remove();
+                    if(ConfigHolder.misc.debug) {
+                        GTLog.logger.info("Removing Smelting Recipe for EBF material {}", LocalizationUtils.format(material.getUnlocalizedName()));
+                    }
+                }
+            }
+
+        }
     }
 }

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -743,6 +743,11 @@ public class ModHandler {
         return OreDictUnifier.getUnificated(FurnaceRecipes.instance().getSmeltingResult(input));
     }
 
+    /* Note: If a Furnace recipe is added through CT that is the exact same as one of the recipes that will be removed
+       then this recipe will not be added. Forge will prevent the duplicate smelting recipe from being added before we
+       remove the recipe added by another mod, therefore the CT recipe will fail. At this point, disable the config and
+       remove the recipes manually
+     */
     public static void removeSmeltingEBFMetals() {
 
         boolean isCTLoaded = GTValues.isModLoaded(GTValues.MODID_CT);

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -753,7 +753,7 @@ public class ModHandler {
 
         Iterator<Map.Entry<ItemStack, ItemStack>> recipeIterator = furnaceList.entrySet().iterator();
 
-        while(recipeIterator.hasNext()) {
+        outer: while(recipeIterator.hasNext()) {
             Map.Entry<ItemStack, ItemStack> recipe = recipeIterator.next();
 
             ItemStack output = recipe.getValue();
@@ -780,16 +780,16 @@ public class ModHandler {
                                 try {
                                     // Check for equality, if the stack added into FurnaceManager..
                                     // ..was a cached stack in an existing ActionAddFurnaceRecipe as well
-                                    if(actionAddFurnaceRecipe$output.get(aafr) != output) {
-                                        recipeIterator.remove();
+                                    if(actionAddFurnaceRecipe$output.get(aafr) == output) {
+                                        GTLog.logger.debug("Not removing Smelting Recipe for EBF material {} as it is added via CT", LocalizationUtils.format(material.getUnlocalizedName()));
+                                        continue outer;
                                     }
                                 } catch (IllegalAccessException e) {
                                     e.printStackTrace();
                                 }
                             }
-                        }else{
-                            recipeIterator.remove();
                         }
+                        recipeIterator.remove();
                         if(ConfigHolder.misc.debug) {
                             GTLog.logger.info("Removing Smelting Recipe for EBF material {}", LocalizationUtils.format(material.getUnlocalizedName()));
                         }

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -781,7 +781,9 @@ public class ModHandler {
                                     // Check for equality, if the stack added into FurnaceManager..
                                     // ..was a cached stack in an existing ActionAddFurnaceRecipe as well
                                     if(actionAddFurnaceRecipe$output.get(aafr) == output) {
-                                        GTLog.logger.debug("Not removing Smelting Recipe for EBF material {} as it is added via CT", LocalizationUtils.format(material.getUnlocalizedName()));
+                                        if(ConfigHolder.misc.debug) {
+                                            GTLog.logger.info("Not removing Smelting Recipe for EBF material {} as it is added via CT", LocalizationUtils.format(material.getUnlocalizedName()));
+                                        }
                                         continue outer;
                                     }
                                 } catch (IllegalAccessException e) {
@@ -796,7 +798,6 @@ public class ModHandler {
                     }
                 }
             }
-
         }
     }
 }

--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -6,6 +6,7 @@ import gregtech.api.block.machines.MachineItemBlock;
 import gregtech.api.enchants.EnchantmentEnderDamage;
 import gregtech.api.enchants.EnchantmentHardHammer;
 import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.crafttweaker.MetaItemBracketHandler;
 import gregtech.api.recipes.recipeproperties.FusionEUToStartProperty;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
@@ -301,6 +302,10 @@ public class CommonProxy {
         GTRecipeManager.postLoad();
         CapesRegistry.registerDevCapes();
         TerminalRegistry.init();
+
+        if(ConfigHolder.compat.removeSmeltingForEBFMetals) {
+            ModHandler.removeSmeltingEBFMetals();
+        }
     }
 
     public void onLoadComplete(FMLLoadCompleteEvent event) {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -209,6 +209,9 @@ public class ConfigHolder {
                 "gregtech"
         };
 
+        @Config.Comment({"Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.", "Default: false"})
+        public boolean removeSmeltingForEBFMetals = false;
+
         public static class EnergyCompatOptions {
 
             @Config.Comment({"Enable Native GTEU to Forge Energy (RF and alike) on GT Cables and Wires.", "Default: true"})

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -209,8 +209,8 @@ public class ConfigHolder {
                 "gregtech"
         };
 
-        @Config.Comment({"Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.", "Default: false"})
-        public boolean removeSmeltingForEBFMetals = false;
+        @Config.Comment({"Whether Gregtech should remove smelting recipes from the vanilla furnace for ingots requiring the Electric Blast Furnace.", "Default: true"})
+        public boolean removeSmeltingForEBFMetals = true;
 
         public static class EnergyCompatOptions {
 


### PR DESCRIPTION
**What:**

Adds a config option for removing smelting recipes for ingots that require the EBF to make.

Someone noticed that Ender IO added a whole bunch of smelting recipes from dust -> ingot, which included metals like aluminum.

