### PR TITLE
Fix Capes given to Developers

### DIFF
--- a/src/main/java/gregtech/api/util/CapesRegistry.java
+++ b/src/main/java/gregtech/api/util/CapesRegistry.java
@@ -1,8 +1,6 @@
 package gregtech.api.util;
 
 import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import crafttweaker.api.world.IWorld;
 import gregtech.api.GTValues;
 import gregtech.api.net.NetworkHandler;
 import gregtech.api.net.packets.SPacketNotifyCapeChange;
@@ -24,7 +22,6 @@ import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import scala.Tuple3;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -100,12 +97,10 @@ public class CapesRegistry {
         } catch (IOException exception) {
             GTLog.logger.error(exception);
         }
+        clearMaps();
         if (comp == null) {
-            UNLOCKED_CAPES.clear();
-            WORN_CAPES.clear();
             return;
         }
-        UNLOCKED_CAPES.clear();
         NBTTagList unlockedCapesTag = comp.getTagList("UnlockedCapesValList", Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < unlockedCapesTag.tagCount(); i++) {
             NBTTagCompound tag = unlockedCapesTag.getCompoundTagAt(i);
@@ -122,7 +117,6 @@ public class CapesRegistry {
             UNLOCKED_CAPES.put(uuid, capes);
         }
 
-        WORN_CAPES.clear();
         NBTTagList wornCapesTag = comp.getTagList("WornCapesValList", Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < wornCapesTag.tagCount(); i++) {
             NBTTagCompound tag = wornCapesTag.getCompoundTagAt(i);
@@ -132,6 +126,7 @@ public class CapesRegistry {
             UUID uuid = tag.getUniqueId("UUID");
             WORN_CAPES.put(uuid, new ResourceLocation(capeLocation));
         }
+        registerDevCapes();
     }
 
     public static void checkAdvancements(World world) {

--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -14,7 +14,6 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.DustProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.util.CapesRegistry;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.advancement.GTTrigger;
 import gregtech.common.advancement.GTTriggers;
@@ -299,7 +298,6 @@ public class CommonProxy {
 
     public void onPostLoad() {
         GTRecipeManager.postLoad();
-        CapesRegistry.registerDevCapes();
         TerminalRegistry.init();
     }
 


### PR DESCRIPTION
The rewards were being deleted on load, so a reload for dev rewards was put there. Also cleans up a few minor parts of the code.