### PR TITLE
Fix some autogen recipes using incorrect material amounts

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -474,13 +474,13 @@ public class MaterialRecipeHandler {
                         .buildAndRegister();
             } else if (material.hasProperty(PropertyKey.GEM)) {
                 COMPRESSOR_RECIPES.recipeBuilder()
-                        .input(gem, material, 9)
+                        .input(gem, material, (int) (block.getMaterialAmount(material) / M))
                         .output(block, material)
                         .duration(300).EUt(2).buildAndRegister();
 
                 FORGE_HAMMER_RECIPES.recipeBuilder()
                         .input(block, material)
-                        .output(gem, material, 9)
+                        .output(gem, material, (int) (block.getMaterialAmount(material) / M))
                         .duration(100).EUt(24).buildAndRegister();
             }
         }


### PR DESCRIPTION
**What:**

Fixes some autogen recipes using hardcoded amounts instead of the material amounts.

Closes #545 