### PR TITLE
Pipe connection fix

### DIFF
--- a/src/main/java/gregtech/api/pipenet/PipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/PipeNet.java
@@ -47,8 +47,20 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
         return isValid;
     }
 
-    protected void onConnectionsUpdate() {
+    /**
+     * Is only called when connections changed of nodes. Nodes can ONLY connect to other nodes.
+     */
+    protected void onNodeConnectionsUpdate() {
         this.lastUpdate = System.currentTimeMillis();
+    }
+
+    /**
+     * Is called when any connection of any pipe in the net changes
+     */
+    protected void onPipeConnectionsUpdate() {
+    }
+
+    public void onNeighbourUpdate(BlockPos fromPos) {
     }
 
     public Map<BlockPos, Node<NodeDataType>> getAllNodes() {
@@ -70,7 +82,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
 
     protected void addNode(BlockPos nodePos, Node<NodeDataType> node) {
         addNodeSilently(nodePos, node);
-        onConnectionsUpdate();
+        onNodeConnectionsUpdate();
         worldData.markDirty();
     }
 
@@ -158,7 +170,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
                 uniteNetworks(pipeNetAtOffset);
             }
         }
-        onConnectionsUpdate();
+        onNodeConnectionsUpdate();
         worldData.markDirty();
     }
 
@@ -209,7 +221,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
                 }
             }
         }
-        onConnectionsUpdate();
+        onNodeConnectionsUpdate();
         worldData.markDirty();
     }
 
@@ -225,7 +237,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
         if (containsNode(nodePos) && getNodeAt(nodePos).isActive != isActive) {
             getNodeAt(nodePos).isActive = isActive;
             worldData.markDirty();
-            onConnectionsUpdate();
+            onNodeConnectionsUpdate();
             return true;
         }
         return false;
@@ -323,7 +335,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
             //if this energy net is empty now, remove it
             worldData.removePipeNet(this);
         }
-        onConnectionsUpdate();
+        onNodeConnectionsUpdate();
         worldData.markDirty();
     }
 
@@ -344,7 +356,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
      */
     protected void transferNodeData(Map<BlockPos, Node<NodeDataType>> transferredNodes, PipeNet<NodeDataType> parentNet) {
         transferredNodes.forEach(this::addNodeSilently);
-        onConnectionsUpdate();
+        onNodeConnectionsUpdate();
         worldData.markDirty();
     }
 

--- a/src/main/java/gregtech/api/pipenet/WorldPipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/WorldPipeNet.java
@@ -42,7 +42,7 @@ public abstract class WorldPipeNet<NodeDataType, T extends PipeNet<NodeDataType>
     }
 
     protected void onWorldSet() {
-        this.pipeNets.forEach(PipeNet::onConnectionsUpdate);
+        this.pipeNets.forEach(PipeNet::onNodeConnectionsUpdate);
     }
 
     public void addNode(BlockPos nodePos, NodeDataType nodeData, int mark, int openConnections, boolean isActive) {
@@ -92,6 +92,7 @@ public abstract class WorldPipeNet<NodeDataType, T extends PipeNet<NodeDataType>
         T pipeNet = getNetFromPos(nodePos);
         if (pipeNet != null) {
             pipeNet.updateBlockedConnections(nodePos, side, isBlocked);
+            pipeNet.onPipeConnectionsUpdate();
         }
     }
 

--- a/src/main/java/gregtech/api/pipenet/block/ItemBlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/ItemBlockPipe.java
@@ -1,6 +1,7 @@
 package gregtech.api.pipenet.block;
 
 import gregtech.api.pipenet.tile.IPipeTile;
+import gregtech.common.ConfigHolder;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
@@ -48,6 +49,8 @@ public class ItemBlockPipe<PipeType extends Enum<PipeType> & IPipeType<NodeDataT
                             otherPipe.setConnection(facing.getOpposite(), false, true);
                         }
                     }
+                } else if (!ConfigHolder.machines.gt6StylePipesCables && selfTile.getPipeBlock().canPipeConnectToBlock(selfTile, facing, te)) {
+                    selfTile.setConnection(facing, true, false);
                 }
             }
         }

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -152,6 +152,9 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     public void setConnection(EnumFacing side, boolean connected, boolean fromNeighbor) {
         // fix desync between two connections. Can happen if a pipe side is blocked, and a new pipe is placed next to it.
         if (!getWorld().isRemote) {
+            if (isConnected(side) == connected) {
+                return;
+            }
             TileEntity tile = getWorld().getTileEntity(getPos().offset(side));
             // block connections if Pipe Types do not match
             if (connected && tile instanceof IPipeTile && ((IPipeTile<?, ?>) tile).getPipeType().getClass() != this.getPipeType().getClass()) {

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -249,6 +249,9 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
                         connections |= 1 << (facing.getIndex() + 6);
                     }
                 }
+                if (getCoverableImplementation().getCoverAtSide(facing) != null) {
+                    connections |= 1 << (facing.getIndex() + 12);
+                }
             }
         }
         return connections;

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -6,18 +6,23 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.tool.ICutterItem;
 import gregtech.api.damagesources.DamageSources;
 import gregtech.api.items.toolitem.IToolStats;
+import gregtech.api.pipenet.Node;
+import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.block.material.BlockMaterialPipe;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.WireProperties;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.pipe.CableRenderer;
 import gregtech.common.advancement.GTTriggers;
+import gregtech.common.pipelike.cable.net.EnergyNet;
 import gregtech.common.pipelike.cable.net.WorldENet;
 import gregtech.common.pipelike.cable.tile.TileEntityCable;
 import gregtech.common.pipelike.cable.tile.TileEntityCableTickable;
 import gregtech.common.tools.DamageValues;
+import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -32,6 +37,7 @@ import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -108,6 +114,15 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
             return 0;
         }
         return -1;
+    }
+
+    @Override
+    public void observedNeighborChange(IBlockState observerState, World world, BlockPos observerPos, Block changedBlock, BlockPos changedBlockPos) {
+        super.observedNeighborChange(observerState, world, observerPos, changedBlock, changedBlockPos);
+        EnergyNet pipeNet = getWorldPipeNet(world).getNetFromPos(observerPos);
+        if (pipeNet != null) {
+            pipeNet.onNeighbourStateChanged();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -14,12 +14,10 @@ import gregtech.api.unification.material.properties.WireProperties;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.pipe.CableRenderer;
 import gregtech.common.advancement.GTTriggers;
-import gregtech.common.pipelike.cable.net.EnergyNet;
 import gregtech.common.pipelike.cable.net.WorldENet;
 import gregtech.common.pipelike.cable.tile.TileEntityCable;
 import gregtech.common.pipelike.cable.tile.TileEntityCableTickable;
 import gregtech.common.tools.DamageValues;
-import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -110,17 +108,6 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
             return 0;
         }
         return -1;
-    }
-
-    @Override
-    public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos) {
-        super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
-        if (!worldIn.isRemote) {
-            EnergyNet enet = getWorldPipeNet(worldIn).getNetFromPos(pos);
-            if (enet != null) {
-                enet.nodeNeighbourChanged(pos);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/cable/net/EnergyNet.java
+++ b/src/main/java/gregtech/common/pipelike/cable/net/EnergyNet.java
@@ -35,8 +35,7 @@ public class EnergyNet extends PipeNet<WireProperties> {
         return data;
     }
 
-    @Override
-    public void onNeighbourUpdate(BlockPos fromPos) {
+    public void onNeighbourStateChanged() {
         NET_DATA.clear();
     }
 

--- a/src/main/java/gregtech/common/pipelike/cable/net/EnergyNet.java
+++ b/src/main/java/gregtech/common/pipelike/cable/net/EnergyNet.java
@@ -5,10 +5,8 @@ import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.WorldPipeNet;
 import gregtech.api.unification.material.properties.WireProperties;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -37,7 +35,8 @@ public class EnergyNet extends PipeNet<WireProperties> {
         return data;
     }
 
-    public void nodeNeighbourChanged(BlockPos pos) {
+    @Override
+    public void onNeighbourUpdate(BlockPos fromPos) {
         NET_DATA.clear();
     }
 
@@ -60,8 +59,7 @@ public class EnergyNet extends PipeNet<WireProperties> {
     }
 
     @Override
-    protected void onConnectionsUpdate() {
-        super.onConnectionsUpdate();
+    protected void onPipeConnectionsUpdate() {
         NET_DATA.clear();
     }
 

--- a/src/main/java/gregtech/common/pipelike/itempipe/BlockItemPipe.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/BlockItemPipe.java
@@ -8,11 +8,9 @@ import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.ItemPipeProperties;
 import gregtech.client.renderer.pipe.ItemPipeRenderer;
-import gregtech.common.pipelike.itempipe.net.ItemPipeNet;
 import gregtech.common.pipelike.itempipe.net.WorldItemPipeNet;
 import gregtech.common.pipelike.itempipe.tile.TileEntityItemPipe;
 import gregtech.common.pipelike.itempipe.tile.TileEntityItemPipeTickable;
-import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.creativetab.CreativeTabs;
@@ -54,17 +52,6 @@ public class BlockItemPipe extends BlockMaterialPipe<ItemPipeType, ItemPipePrope
     @Override
     public TileEntityPipeBase<ItemPipeType, ItemPipeProperties> createNewTileEntity(boolean supportsTicking) {
         return supportsTicking ? new TileEntityItemPipeTickable() : new TileEntityItemPipe();
-    }
-
-    @Override
-    public void neighborChanged(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Block blockIn, @Nonnull BlockPos fromPos) {
-        super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
-        if (!worldIn.isRemote) {
-            ItemPipeNet itemPipeNet = getWorldPipeNet(worldIn).getNetFromPos(pos);
-            if (itemPipeNet != null) {
-                itemPipeNet.nodeNeighbourChanged(pos);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/itempipe/net/ItemPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/net/ItemPipeNet.java
@@ -13,7 +13,10 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ItemPipeNet extends PipeNet<ItemPipeProperties> {
 
@@ -33,13 +36,8 @@ public class ItemPipeNet extends PipeNet<ItemPipeProperties> {
         return data;
     }
 
-    public void nodeNeighbourChanged(BlockPos pos) {
-        NET_DATA.clear();
-    }
-
     @Override
-    protected void updateBlockedConnections(BlockPos nodePos, EnumFacing facing, boolean isBlocked) {
-        super.updateBlockedConnections(nodePos, facing, isBlocked);
+    public void onNeighbourUpdate(BlockPos fromPos) {
         NET_DATA.clear();
     }
 
@@ -51,8 +49,7 @@ public class ItemPipeNet extends PipeNet<ItemPipeProperties> {
     }
 
     @Override
-    protected void onConnectionsUpdate() {
-        super.onConnectionsUpdate();
+    protected void onPipeConnectionsUpdate() {
         NET_DATA.clear();
     }
 


### PR DESCRIPTION
When gt6 mode of, pipes and cables were not automatically connecting to blocks.
When a cable connection was changed the net was not properly notified.

Updated Energy net to only clear cache when a neighbour state changed and not when a neighbour called `markDirty`.

Fixes cover z fighting on pipes (noticable on large pipes)