### PR TITLE
Fix Overclocking sometimes occurring when it should not

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -491,8 +491,12 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             return false;
 
         // check if the voltage to run at is higher than the recipe, and that it is not ULV tier
-        int tier = getOverclockingTier(getMaxVoltage());
-        return tier != 0 && tier > GTUtility.getTierByVoltage(recipeEUt);
+        int overclockTier = getOverclockingTier(getOverclockVoltage());
+        int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
+
+        // Don't overclock if the machine is ULV.
+        // Do overclock if the overclock tier is greater than the recipe tier
+        return overclockTier != 0 && overclockTier > recipeTier;
     }
 
     /**
@@ -502,7 +506,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
     protected int[] performOverclocking(Recipe recipe, boolean negativeEU) {
-        int maxOverclocks = getOverclockingTier(getMaxVoltage()) - 1; // exclude ULV overclocking
+        int maxOverclocks = getOverclockingTier(getOverclockVoltage()) - 1; // exclude ULV overclocking
 
         return runOverclockingLogic(recipe, negativeEU, maxOverclocks);
     }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -247,6 +247,11 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         return overclock;
     }
 
+    @Override
+    public long getOverclockVoltage() {
+        return getMaxVoltage();
+    }
+
     protected Tuple<Integer, Double> getMaintenanceValues() {
         MultiblockWithDisplayBase displayBase = this.metaTileEntity instanceof MultiblockWithDisplayBase ? (MultiblockWithDisplayBase) metaTileEntity : null;
         int numMaintenanceProblems = displayBase == null || !displayBase.hasMaintenanceMechanics() || !ConfigHolder.machines.enableMaintenance ? 0 : displayBase.getNumMaintenanceProblems();

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
@@ -113,6 +113,11 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
+    public long getOverclockVoltage() {
+        return 0;
+    }
+
+    @Override
     protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
         RecipeMapSteamMultiblockController controller = (RecipeMapSteamMultiblockController) metaTileEntity;
         if (controller.checkRecipe(recipe, false) &&


### PR DESCRIPTION
**What:**

Fixes overclocking some times happening when it was not supposed to, like when the Overclocking voltage was decreased with the overclocking button.

Simply checks the overclock voltage instead of the maximum voltage when calculating overclocks