### PR TITLE
Update the tier of the creative energy after getting a voltage value

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -84,7 +84,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEne
         builder.widget(new TextFieldWidget2(9, 50, 152, 16, () -> String.valueOf(voltage), value -> {
             if (!value.isEmpty()) {
                 voltage = Long.parseLong(value);
-                setTier = 0;
+                setTier = GTUtility.getTierByVoltage(voltage);
             }
         }).setAllowedChars(TextFieldWidget2.NATURAL_NUMS).setMaxLength(19).setValidator(getTextFieldValidator()));
 


### PR DESCRIPTION
**What:**

Updates the Tier of the Creative Energy Emitter after having a voltage typed in by hand.

Note that you have to press enter after typing in the voltage, or unfocus the text box by clicking off of it to update the voltage tier. For some reason, clicking on the "Active/Not Active" button does not do this.