### PR TITLE
Fix cloud weirdness and high usage of tick time for clipboards

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/FakeModularGui.java
+++ b/src/main/java/gregtech/api/gui/impl/FakeModularGui.java
@@ -21,6 +21,9 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.List;
 
+import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
+import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
+
 @SideOnly(Side.CLIENT)
 public class FakeModularGui implements IRenderContext {
     public final ModularUI modularUI;
@@ -179,7 +182,9 @@ public class FakeModularGui implements IRenderContext {
             GlStateManager.pushMatrix();
             GlStateManager.color(1.0f, 1.0f, 1.0f);
             GlStateManager.enableBlend();
+            GlStateManager.blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             widget.drawInBackground(mouseX, mouseY, partialTicks, this);
+            GlStateManager.disableBlend();
             GlStateManager.popMatrix();
         }
     }

--- a/src/main/java/gregtech/common/items/behaviors/ClipboardBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ClipboardBehavior.java
@@ -64,7 +64,7 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 170, 238);
 
         builder.image(18, 8, 130, 14, GuiTextures.CLIPBOARD_TEXT_BOX);
-        builder.widget(new SimpleTextWidget(20, 10, "", 0xFFFFFF, () -> getTitle(holder), false).setCenter(false));
+        builder.widget(new SimpleTextWidget(20, 10, "", 0xFFFFFF, () -> getTitle(holder), true).setCenter(false));
 
 
         for (int i = 0; i < 8; i++) {
@@ -72,7 +72,7 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
             builder.widget(new ImageCycleButtonWidget(6, 37 + 20 * i, 15, 15, GuiTextures.CLIPBOARD_BUTTON, 4,
                     () -> getButtonState(holder, finalI), (x) -> setButton(holder, finalI, x)));
             builder.image(22, 38 + 20 * i, 140, 12, GuiTextures.CLIPBOARD_TEXT_BOX);
-            builder.widget(new SimpleTextWidget(24, 40 + 20 * i, "", 0xFFFFFF, () -> getString(holder, finalI), false).setCenter(false));
+            builder.widget(new SimpleTextWidget(24, 40 + 20 * i, "", 0xFFFFFF, () -> getString(holder, finalI), true).setCenter(false));
         }
 
         builder.widget(new ClickButtonWidget(30, 200, 16, 16, "", (x) -> incrPageNum(holder, -1))

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -64,7 +64,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     @Override
     public void update() {
         super.update();
-        if (guiCache == null || guiContainerCache == null) {
+        if (guiContainerCache == null) {
             createFakeGui();
             scheduleRenderUpdate();
         }
@@ -208,6 +208,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
 
                 world.removeTileEntity(pos);
                 world.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
+                this.scheduleRenderUpdate();
             }
         }
         return true;


### PR DESCRIPTION
Fixes the following issues:

1. Clipboards recreate their modular UI containers and GUIs on every server tick, creating massive amounts of lag (especially with the FakePlayer instantiation)
2. Blending is not reset at the end of drawing, so when clouds are off, it isn't reset anywhere, at least not until a vanilla TE (usually a chest or bed) is blended into the background accidentally.
3. The incorrect blending function is applied when clouds are off due to parameters deviating from GL_SRC_ALPHA and GL_ONE_MINUS_SRC_ALPHA.

This should make it significantly more stable for use in worlds.
Please test very thoroughly; bugs are often known to hide very well within this system.