### PR TITLE
2.1 fixes

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -63,6 +63,7 @@ public class GregtechDataCodes {
     // Multiblock implementation update codes
     public static final int SYNC_CONTROLLER = 100;
     public static final int IS_ROTOR_LOOPING = 200;
+    public static final int FRONT_FACE_FREE = 201;
     public static final int UPDATE_ROTOR_COLOR = 201;
     public static final int STRUCTURE_FORMED = 400;
     public static final int IS_TAPED = 550;

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -289,8 +289,8 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     @Override
     public void onLoad() {
         super.onLoad();
-        if(metaTileEntity != null) {
-            if(!getWorld().isRemote) {
+        if(metaTileEntity != null && world != null) {
+            if(!world.isRemote) {
                 TaskScheduler.scheduleTask(getWorld(), () -> {
                     metaTileEntity.onLoad();
                     return false;

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -77,7 +77,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
         return metaTileEntity;
     }
 
-    protected void setRawMetaTileEntity(MetaTileEntity metaTileEntity){
+    protected void setRawMetaTileEntity(MetaTileEntity metaTileEntity) {
         this.metaTileEntity = metaTileEntity;
         this.metaTileEntity.holder = this;
     }
@@ -159,7 +159,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
                 world.setBlockToAir(pos);
             }
         }
-        
+
         if (this.needToUpdateLightning) {
             getWorld().checkLight(getPos());
             this.needToUpdateLightning = false;
@@ -289,15 +289,8 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     @Override
     public void onLoad() {
         super.onLoad();
-        if(metaTileEntity != null && world != null) {
-            if(!world.isRemote) {
-                TaskScheduler.scheduleTask(getWorld(), () -> {
-                    metaTileEntity.onLoad();
-                    return false;
-                });
-            } else {
-                metaTileEntity.onLoad();
-            }
+        if (metaTileEntity != null) {
+            metaTileEntity.onLoad();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -9,6 +9,7 @@ import gregtech.api.net.NetworkHandler;
 import gregtech.api.net.packets.CPacketRecoverMTE;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TaskScheduler;
 import gregtech.client.particle.GTNameTagParticle;
 import gregtech.client.particle.GTParticleManager;
 import net.minecraft.block.state.IBlockState;
@@ -288,8 +289,15 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     @Override
     public void onLoad() {
         super.onLoad();
-        if (metaTileEntity != null) {
-            metaTileEntity.onLoad();
+        if(metaTileEntity != null) {
+            if(!getWorld().isRemote) {
+                TaskScheduler.scheduleTask(getWorld(), () -> {
+                    metaTileEntity.onLoad();
+                    return false;
+                });
+            } else {
+                metaTileEntity.onLoad();
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -11,6 +11,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
@@ -95,7 +96,7 @@ public class TraceabilityPredicate {
      * Add tooltips for candidates. They are shown in JEI Pages.
      */
     public TraceabilityPredicate addTooltips(String... tips) {
-        if (tips.length > 0) {
+        if (FMLCommonHandler.instance().getSide() == Side.CLIENT && tips.length > 0) {
             List<String> tooltips = Arrays.stream(tips).collect(Collectors.toList());
             common.forEach(predicate -> {
                 if (predicate.candidates == null) return;
@@ -227,6 +228,7 @@ public class TraceabilityPredicate {
 
         public final Predicate<BlockWorldState> predicate;
 
+        @SideOnly(Side.CLIENT)
         private List<String> toolTips;
 
         public int minGlobalCount = -1;

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 public class TraceabilityPredicate {
 
     // Allow any block.
-    public static TraceabilityPredicate ANY =new TraceabilityPredicate((state)->true);
+    public static TraceabilityPredicate ANY = new TraceabilityPredicate((state) -> true);
     // Allow the air block.
     public static TraceabilityPredicate AIR = new TraceabilityPredicate(blockWorldState -> blockWorldState.getBlockState().getBlock().isAir(blockWorldState.getBlockState(), blockWorldState.getWorld(), blockWorldState.getPos()));
     // Allow all heating coils, and require them to have the same type.
@@ -42,8 +42,8 @@ public class TraceabilityPredicate {
             return true;
         }
         return false;
-    }, ()-> ArrayUtils.addAll(
-            Arrays.stream(BlockWireCoil.CoilType.values()).map(type->new BlockInfo(MetaBlocks.WIRE_COIL.getState(type), null)).toArray(BlockInfo[]::new)))
+    }, () -> ArrayUtils.addAll(
+            Arrays.stream(BlockWireCoil.CoilType.values()).map(type -> new BlockInfo(MetaBlocks.WIRE_COIL.getState(type), null)).toArray(BlockInfo[]::new)))
             .addTooltips("gregtech.multiblock.pattern.error.coils");
 
 
@@ -53,7 +53,8 @@ public class TraceabilityPredicate {
     protected boolean hasAir = false;
     protected boolean isSingle = true;
 
-    public TraceabilityPredicate() {}
+    public TraceabilityPredicate() {
+    }
 
     public TraceabilityPredicate(TraceabilityPredicate predicate) {
         common.addAll(predicate.common);
@@ -94,6 +95,8 @@ public class TraceabilityPredicate {
 
     /**
      * Add tooltips for candidates. They are shown in JEI Pages.
+     * Do NOT pass {@link I18n#format(String, Object...)} calls here! Everything is will be translated when it's needed.
+     * If you need parameters, use {@link #addTooltip(String, Object...)} instead.
      */
     public TraceabilityPredicate addTooltips(String... tips) {
         if (FMLCommonHandler.instance().getSide() == Side.CLIENT && tips.length > 0) {
@@ -112,6 +115,16 @@ public class TraceabilityPredicate {
                 }
                 predicate.toolTips.addAll(tooltips);
             });
+        }
+        return this;
+    }
+
+    /**
+     * Note: This method does not translate dynamically!! Parameters can not be updated once set.
+     */
+    public TraceabilityPredicate addTooltip(String langKey, Object... data) {
+        if (FMLCommonHandler.instance().getSide() == Side.CLIENT) {
+            addTooltips(I18n.format(langKey, data));
         }
         return this;
     }
@@ -182,6 +195,7 @@ public class TraceabilityPredicate {
 
     /**
      * Sets the Minimum and Maximum limit to the passed value
+     *
      * @param limit The Maximum and Minimum limit
      */
     public TraceabilityPredicate setExactLimit(int limit) {
@@ -204,7 +218,7 @@ public class TraceabilityPredicate {
                 flag = true;
             }
         }
-        return flag || common.stream().anyMatch(predicate->predicate.test(blockWorldState));
+        return flag || common.stream().anyMatch(predicate -> predicate.test(blockWorldState));
     }
 
     public TraceabilityPredicate or(TraceabilityPredicate other) {
@@ -223,7 +237,7 @@ public class TraceabilityPredicate {
         return this;
     }
 
-    public static class SimplePredicate{
+    public static class SimplePredicate {
         public final Supplier<BlockInfo[]> candidates;
 
         public final Predicate<BlockWorldState> predicate;
@@ -247,7 +261,7 @@ public class TraceabilityPredicate {
         public List<String> getToolTips(TraceabilityPredicate predicates) {
             List<String> result = new ArrayList<>();
             if (toolTips != null) {
-                toolTips.forEach(tip->result.add(I18n.format(tip)));
+                toolTips.forEach(tip -> result.add(I18n.format(tip)));
             }
             if (minGlobalCount == maxGlobalCount && maxGlobalCount != -1) {
                 result.add(I18n.format("gregtech.multiblock.pattern.error.limited_exact", minGlobalCount));
@@ -308,7 +322,7 @@ public class TraceabilityPredicate {
         }
 
         public List<ItemStack> getCandidates() {
-            return candidates == null ? Collections.emptyList() : Arrays.stream(this.candidates.get()).filter(info -> info.getBlockState().getBlock() != Blocks.AIR).map(info->{
+            return candidates == null ? Collections.emptyList() : Arrays.stream(this.candidates.get()).filter(info -> info.getBlockState().getBlock() != Blocks.AIR).map(info -> {
                 IBlockState blockState = info.getBlockState();
                 MetaTileEntity metaTileEntity = info.getTileEntity() instanceof MetaTileEntityHolder ? ((MetaTileEntityHolder) info.getTileEntity()).getMetaTileEntity() : null;
                 if (metaTileEntity != null) {

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -382,7 +382,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         if (worldIn.isRemote) {
             return getClientCollisionRayTrace(worldIn, pos, start, end);
         }
-        return RayTracer.rayTraceCuboidsClosest(start, end, pos, FULL_CUBE_COLLISION);
+        return RayTracer.rayTraceCuboidsClosest(start, end, pos, getCollisionBox(worldIn, pos, null));
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -282,9 +282,9 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
         if (!(hit.cuboid6.data instanceof CoverSideData)) {
             switch (onPipeToolUsed(world, pos, itemStack, coverSide, pipeTile, entityPlayer)) {
-                case 1:
+                case SUCCESS:
                     return true;
-                case 0:
+                case FAIL:
                     return false;
             }
         }
@@ -315,7 +315,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
      * @return 1 if successfully used tool, 0 if failed to use tool,
      * -1 if ItemStack failed the capability check (no action done, continue checks).
      */
-    public int onPipeToolUsed(World world, BlockPos pos, ItemStack stack, EnumFacing coverSide, IPipeTile<PipeType, NodeDataType> pipeTile, EntityPlayer entityPlayer) {
+    public EnumActionResult onPipeToolUsed(World world, BlockPos pos, ItemStack stack, EnumFacing coverSide, IPipeTile<PipeType, NodeDataType> pipeTile, EntityPlayer entityPlayer) {
         IWrenchItem wrenchItem = stack.getCapability(GregtechCapabilities.CAPABILITY_WRENCH, null);
         if (wrenchItem != null) {
             if (wrenchItem.damageItem(DamageValues.DAMAGE_FOR_WRENCH, true)) {
@@ -330,11 +330,11 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                     wrenchItem.damageItem(DamageValues.DAMAGE_FOR_WRENCH, false);
                     IToolStats.onOtherUse(stack, world, pos);
                 }
-                return 1;
+                return EnumActionResult.SUCCESS;
             }
-            return 0;
+            return EnumActionResult.FAIL;
         }
-        return -1;
+        return EnumActionResult.PASS;
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -382,7 +382,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         if (worldIn.isRemote) {
             return getClientCollisionRayTrace(worldIn, pos, start, end);
         }
-        return RayTracer.rayTraceCuboidsClosest(start, end, pos, getCollisionBox(worldIn, pos, null));
+        return RayTracer.rayTraceCuboidsClosest(start, end, pos, FULL_CUBE_COLLISION);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
+++ b/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
@@ -346,7 +346,7 @@ public class PipeCoverableImplementation implements ICoverable {
 
     @Override
     public boolean isValid() {
-        return !holder.isValidTile();
+        return holder.isValidTile();
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -343,13 +343,15 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Override
     public void onLoad() {
         super.onLoad();
-        if (!world.isRemote) {
-            TaskScheduler.scheduleTask(world, () -> {
+        if(world != null) {
+            if (!world.isRemote) {
+                TaskScheduler.scheduleTask(world, () -> {
+                    this.coverableImplementation.onLoad();
+                    return false;
+                });
+            } else {
                 this.coverableImplementation.onLoad();
-                return false;
-            });
-        } else {
-            this.coverableImplementation.onLoad();
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -343,16 +343,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Override
     public void onLoad() {
         super.onLoad();
-        if(world != null) {
-            if (!world.isRemote) {
-                TaskScheduler.scheduleTask(world, () -> {
-                    this.coverableImplementation.onLoad();
-                    return false;
-                });
-            } else {
-                this.coverableImplementation.onLoad();
-            }
-        }
+        this.coverableImplementation.onLoad();
     }
 
     protected void writePipeProperties(PacketBuffer buf) {

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -6,6 +6,7 @@ import gregtech.api.metatileentity.SyncedTileEntityBase;
 import gregtech.api.pipenet.WorldPipeNet;
 import gregtech.api.pipenet.block.BlockPipe;
 import gregtech.api.pipenet.block.IPipeType;
+import gregtech.api.util.TaskScheduler;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
@@ -342,7 +343,14 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Override
     public void onLoad() {
         super.onLoad();
-        this.coverableImplementation.onLoad();
+        if (!world.isRemote) {
+            TaskScheduler.scheduleTask(world, () -> {
+                this.coverableImplementation.onLoad();
+                return false;
+            });
+        } else {
+            this.coverableImplementation.onLoad();
+        }
     }
 
     protected void writePipeProperties(PacketBuffer buf) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
@@ -23,9 +23,6 @@ public class MetaTileEntityRockBreaker extends SimpleMachineMetaTileEntity {
 
     public MetaTileEntityRockBreaker(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, ICubeRenderer renderer, int tier) {
         super(metaTileEntityId, recipeMap, renderer, tier, true);
-        if (getWorld() != null && !getWorld().isRemote) {
-            checkAdjacentFluids();
-        }
     }
 
     @Override
@@ -47,6 +44,10 @@ public class MetaTileEntityRockBreaker extends SimpleMachineMetaTileEntity {
     }
 
     private void checkAdjacentFluids() {
+        if (getWorld() == null || getWorld().isRemote) {
+            hasValidFluids = false;
+            return;
+        }
         boolean hasLava = false;
         boolean hasWater = false;
         for (EnumFacing side : EnumFacing.VALUES) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -13,7 +13,6 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
-import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.client.renderer.ICubeRenderer;
 import net.minecraft.block.state.IBlockState;
@@ -125,7 +124,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController impleme
                     textList.add(new TextComponentTranslation("gregtech.multiblock.turbine.rotor_durability", rotorDurability).setStyle(new Style().setColor(TextFormatting.RED)));
                 }
             }
-            if(!isRotorFaceFree()) {
+            if (!isRotorFaceFree()) {
                 textList.add(new TextComponentTranslation("gregtech.multiblock.turbine.obstructed")
                         .setStyle(new Style().setColor(TextFormatting.RED)));
             }
@@ -153,7 +152,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController impleme
                         .filter(mte -> (mte instanceof ITieredMetaTileEntity) && (((ITieredMetaTileEntity) mte).getTier() >= tier))
                         .toArray(MetaTileEntity[]::new))
                         .addTooltips("gregtech.multiblock.pattern.clear_amount_3")
-                        .addTooltips(I18n.format("gregtech.multiblock.pattern.error.limited.1", GTValues.VN[tier]))
+                        .addTooltip("gregtech.multiblock.pattern.error.limited.1", GTValues.VN[tier])
                         .setExactLimit(1)
                         .or(abilities(MultiblockAbility.OUTPUT_ENERGY)).setExactLimit(1))
                 .where('H', states(getCasingState()).or(autoAbilities(false, true, false, false, true, true, true)))

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -91,7 +91,11 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
             return;
 
         if (getOffsetTimer() % 20 == 0) {
-            this.frontFaceFree = checkTurbineFaceFree();
+            boolean isFrontFree = checkTurbineFaceFree();
+            if (isFrontFree != this.frontFaceFree) {
+                this.frontFaceFree = isFrontFree;
+                writeCustomData(GregtechDataCodes.FRONT_FACE_FREE, buf -> buf.writeBoolean(this.frontFaceFree));
+            }
         }
 
         MetaTileEntityLargeTurbine controller = (MetaTileEntityLargeTurbine) getController();
@@ -294,6 +298,8 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         if (dataId == GregtechDataCodes.IS_ROTOR_LOOPING) {
             this.isRotorSpinning = buf.readBoolean();
             scheduleRenderUpdate();
+        } else if (dataId == GregtechDataCodes.FRONT_FACE_FREE) {
+            this.frontFaceFree = buf.readBoolean();
         }
     }
 
@@ -302,6 +308,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         super.writeInitialSyncData(buf);
         buf.writeBoolean(isRotorSpinning);
         buf.writeInt(rotorColor);
+        buf.writeBoolean(frontFaceFree);
     }
 
     @Override
@@ -309,6 +316,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         super.receiveInitialSyncData(buf);
         this.isRotorSpinning = buf.readBoolean();
         this.rotorColor = buf.readInt();
+        this.frontFaceFree = buf.readBoolean();
         getHolder().scheduleChunkForRenderUpdate();
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -282,6 +282,8 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         super.writeToNBT(data);
         data.setTag("inventory", inventory.serializeNBT());
         data.setInteger("currentSpeed", currentSpeed);
+        data.setBoolean("Spinning", isRotorSpinning);
+        data.setBoolean("FrontFree", frontFaceFree);
         return data;
     }
 
@@ -290,6 +292,8 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         super.readFromNBT(data);
         this.inventory.deserializeNBT(data.getCompoundTag("inventory"));
         this.currentSpeed = data.getInteger("currentSpeed");
+        this.isRotorSpinning = data.getBoolean("Spinning");
+        this.frontFaceFree = data.getBoolean("FrontFree");
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -6,14 +6,11 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.tool.ICutterItem;
 import gregtech.api.damagesources.DamageSources;
 import gregtech.api.items.toolitem.IToolStats;
-import gregtech.api.pipenet.Node;
-import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.block.material.BlockMaterialPipe;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.WireProperties;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.pipe.CableRenderer;
 import gregtech.common.advancement.GTTriggers;
@@ -33,11 +30,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -99,7 +96,7 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     @Override
-    public int onPipeToolUsed(World world, BlockPos pos, ItemStack stack, EnumFacing coverSide, IPipeTile<Insulation, WireProperties> pipeTile, EntityPlayer entityPlayer) {
+    public EnumActionResult onPipeToolUsed(World world, BlockPos pos, ItemStack stack, EnumFacing coverSide, IPipeTile<Insulation, WireProperties> pipeTile, EntityPlayer entityPlayer) {
         ICutterItem cutterItem = stack.getCapability(GregtechCapabilities.CAPABILITY_CUTTER, null);
         if (cutterItem != null) {
             if (cutterItem.damageItem(DamageValues.DAMAGE_FOR_CUTTER, true)) {
@@ -109,11 +106,11 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
                     cutterItem.damageItem(DamageValues.DAMAGE_FOR_CUTTER, false);
                     IToolStats.onOtherUse(stack, world, pos);
                 }
-                return 1;
+                return EnumActionResult.SUCCESS;
             }
-            return 0;
+            return EnumActionResult.FAIL;
         }
-        return -1;
+        return EnumActionResult.PASS;
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -145,9 +145,8 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
                 break;
 
             int inserted = pair.getKey().fill(toInsert, true);
-            int extracted;
-            if (inserted > 0 && (extracted = extract(tank, inserted)) != inserted) {
-                GTLog.logger.error(" - could not extract the correct amount of channel {}. Should extract {} * {}, but extracted {} * {}", channel, fluid.getFluid().getName(), inserted, fluid.getFluid().getName(), extracted);
+            if (inserted > 0) {
+                extract(tank, inserted);
             }
         }
 


### PR DESCRIPTION
 - `onPipeToolUsed` now returns a `EnumActionResult` instead of int.
 - fixes a rock braker npe on load 
 - fixes guis not being openable on pipes
 - removes error logging of fluid pipes
 - allows raytracing pipes/cables raytracing on server. This fixes an issue where when you place a fluid with a bucket, it would always treat pipes/cables as if they had full block collision. (see discord)