### PR TITLE
Minor fixes for wool recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -286,9 +286,11 @@ public class VanillaStandardRecipes {
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(CountableIngredient.from("wool", 1))
-                .outputs(new ItemStack(Items.STRING, 2))
-                .chancedOutput(new ItemStack(Items.STRING, 1), 2000, 800)
-                .duration(400)
+                .outputs(new ItemStack(Items.STRING, 1))
+                .chancedOutput(new ItemStack(Items.STRING, 1), 9000, 0)
+                .chancedOutput(new ItemStack(Items.STRING, 1), 5000, 0)
+                .chancedOutput(new ItemStack(Items.STRING, 1), 2000, 0)
+                .duration(200)
                 .buildAndRegister();
     }
 
@@ -957,8 +959,8 @@ public class VanillaStandardRecipes {
         ModHandler.addSmeltingRecipe(new ItemStack(Items.SLIME_BALL), STICKY_RESIN.getStackForm());
 
         ASSEMBLER_RECIPES.recipeBuilder()
-                .inputs(new ItemStack(Items.STRING, 3))
-                .notConsumable(new IntCircuitIngredient(1))
+                .inputs(new ItemStack(Items.STRING, 4))
+                .notConsumable(new IntCircuitIngredient(4))
                 .outputs(new ItemStack(Blocks.WOOL, 1, 0))
                 .duration(100).EUt(4).buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -286,7 +286,7 @@ public class VanillaStandardRecipes {
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(CountableIngredient.from("wool", 1))
-                .outputs(new ItemStack(Items.STRING, 3))
+                .outputs(new ItemStack(Items.STRING, 2))
                 .chancedOutput(new ItemStack(Items.STRING, 1), 2000, 800)
                 .duration(400)
                 .buildAndRegister();
@@ -958,6 +958,7 @@ public class VanillaStandardRecipes {
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.STRING, 3))
+                .notConsumable(new IntCircuitIngredient(1))
                 .outputs(new ItemStack(Blocks.WOOL, 1, 0))
                 .duration(100).EUt(4).buildAndRegister();
 


### PR DESCRIPTION
**What:**

Minor fixes for wool recipes.

The String -> Wool recipe in the assembler would conflict with other recipes that used string in the assembler, such as the bow.

There was a possibility of an infinite String loop as Wool cost 3 string to make in the assembler, but macerated to 3 with a chance at a fourth 