### PR TITLE
fix prospector mode persistence and prospector use in remote worlds

### DIFF
--- a/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
@@ -22,7 +22,6 @@ import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
-import org.jline.reader.Widget;
 
 import javax.annotation.Nonnull;
 import java.util.List;

--- a/src/main/java/gregtech/common/terminal/app/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/terminal/app/prospector/widget/WidgetProspectingMap.java
@@ -53,6 +53,7 @@ public class WidgetProspectingMap extends Widget {
         this.mode = mode;
         this.scanTick = scanTick;
         oreList = widgetOreList;
+
         if (oreList != null) {
             oreList.onSelected = name->{
                 if (texture != null) {
@@ -198,7 +199,8 @@ public class WidgetProspectingMap extends Widget {
                     (cX + 1) * 16 + this.getPosition().x,
                     (cZ + 1) * 16 + this.getPosition().y,
                     new Color(0x4B6C6C6C, true).getRGB());
-            if (this.mode == 0) { // draw ore
+
+            if (this.mode == ORE_PROSPECTING_MODE) { // draw ore
                 tooltips.add(I18n.format("terminal.prospector.ore"));
                 HashMap<String, Integer> oreInfo = new HashMap<>();
                 for (int i = 0; i < 16; i++) {
@@ -214,7 +216,7 @@ public class WidgetProspectingMap extends Widget {
                     }
                 }
                 oreInfo.forEach((name, count)->tooltips.add(name + " --- " + count));
-            } else if(this.mode == 1){
+            } else if(this.mode == FLUID_PROSPECTING_MODE){
                 tooltips.add(I18n.format("terminal.prospector.fluid"));
                 if (texture.map[cX][cZ] != null && !texture.map[cX][cZ].isEmpty()) {
                     if (texture.getSelected().equals("[all]") || texture.getSelected().equals(texture.map[cX][cZ].get((byte) 1))) {


### PR DESCRIPTION
**What:**

Fixes prospector use for non-ores on servers, persists prospector mode across client & server restarts.

**How solved:**

`Mode` integer NBT tag added to prospector to store mode on the ItemStack;  prospector scanner behavior re-organized to pull mode off of the held item.

**Outcome:**

Hovering over the fluid prospector render on servers doesn't crash the client and the prospector mode persists across server 
 (and client) restarts.


I don't know if this is the right approach.  I also didn't know how to add the tags to the scanners at initialization time;  to work around that in testing I initialized the key if it was missing, but this puts a missing check into every usage and that's probably not necessary.