### PR TITLE
Persist Prospector, Magnet states to NBT

### DIFF
--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -46,7 +46,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     }
 
     private boolean isActive(ItemStack stack) {
-        if (stack == ItemStack.EMPTY || stack == null) {
+        if (stack == ItemStack.EMPTY) {
             return false;
         }
         NBTTagCompound tag = stack.getTagCompound();
@@ -119,7 +119,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
 
     @SubscribeEvent
     public void onItemToss(@Nonnull ItemTossEvent event) {
-        if (!isActive(event.getEntityItem().getItem()) || event.getPlayer() == null)
+        if (event.getPlayer() == null)
             return;
 
         ItemStack stack = event.getEntityItem().getItem();

--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -128,12 +128,12 @@ public class ItemMagnetBehavior implements IItemBehaviour {
         }
 
         for (ItemStack itemStack : event.getPlayer().inventory.mainInventory) {
-            if (isMagnet(itemStack)) {
+            if (isMagnet(itemStack) && isActive(itemStack)) {
                 event.getEntityItem().setPickupDelay(60);
                 return;
             }
         }
-        if (isMagnet(event.getPlayer().inventory.offHandInventory.get(0))) {
+        if (isMagnet(event.getPlayer().inventory.offHandInventory.get(0)) && isActive(event.getPlayer().inventory.offHandInventory.get(0))) {
             event.getEntityItem().setPickupDelay(60);
         }
     }

--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -40,7 +40,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, @Nonnull EntityPlayer player, EnumHand hand) {
         if (!player.world.isRemote && player.isSneaking()) {
-            player.sendMessage(new TextComponentTranslation(toggleActive(player.getHeldItem(hand)) ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"));
+            player.sendStatusMessage(new TextComponentTranslation(toggleActive(player.getHeldItem(hand)) ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"), true);
         }
         return ActionResult.newResult(EnumActionResult.PASS, player.getHeldItem(hand));
     }

--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
@@ -29,7 +30,6 @@ public class ItemMagnetBehavior implements IItemBehaviour {
 
     private final int range;
     private final float speed;
-    private boolean isActive;
 
     public ItemMagnetBehavior(int range, float speed) {
         this.range = range;
@@ -40,15 +40,38 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, @Nonnull EntityPlayer player, EnumHand hand) {
         if (!player.world.isRemote && player.isSneaking()) {
-            this.isActive = !this.isActive;
-            player.sendMessage(new TextComponentTranslation(isActive ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"));
+            player.sendMessage(new TextComponentTranslation(toggleActive(player.getHeldItem(hand)) ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"));
         }
         return ActionResult.newResult(EnumActionResult.PASS, player.getHeldItem(hand));
     }
 
+    private boolean isActive(ItemStack stack) {
+        if (stack == ItemStack.EMPTY || stack == null) {
+            return false;
+        }
+        NBTTagCompound tag = stack.getTagCompound();
+        if (tag == null) {
+            return false;
+        }
+        if (tag.hasKey("IsActive")) {
+            return tag.getBoolean("IsActive");
+        }
+        return false;
+    }
+
+    private boolean toggleActive(ItemStack stack) {
+        boolean isActive = isActive(stack);
+        if (!stack.hasTagCompound()) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        //noinspection ConstantConditions
+        stack.getTagCompound().setBoolean("IsActive", !isActive);
+        return !isActive;
+    }
+
     @Override
     public void onUpdate(ItemStack itemStack, Entity entity) {
-        if (!isActive || !(entity instanceof EntityPlayer) || entity.getEntityWorld().isRemote)
+        if (!isActive(itemStack) || !(entity instanceof EntityPlayer) || entity.getEntityWorld().isRemote)
             return;
 
         EntityPlayer entityPlayer = (EntityPlayer) entity;
@@ -96,7 +119,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
 
     @SubscribeEvent
     public void onItemToss(@Nonnull ItemTossEvent event) {
-        if (!isActive || event.getPlayer() == null)
+        if (!isActive(event.getEntityItem().getItem()) || event.getPlayer() == null)
             return;
 
         ItemStack stack = event.getEntityItem().getItem();
@@ -135,6 +158,6 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     @Override
     public void addInformation(ItemStack itemStack, List<String> lines) {
         IItemBehaviour.super.addInformation(itemStack, lines);
-        lines.add(I18n.format(isActive ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"));
+        lines.add(I18n.format(isActive(itemStack) ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"));
     }
 }

--- a/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
@@ -56,11 +56,11 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
                 if (nextMode == WidgetProspectingMap.FLUID_PROSPECTING_MODE) {
                     if (tier >= FLUID_PROSPECTION_THRESHOLD) {
                         setMode(stack, nextMode);
-                        player.sendMessage(new TextComponentTranslation("metaitem.prospector.mode.fluid"));
+                        player.sendStatusMessage(new TextComponentTranslation("metaitem.prospector.mode.fluid"), true);
                     }
                 } else {
                     setMode(stack, nextMode);
-                    player.sendMessage(new TextComponentTranslation("metaitem.prospector.mode.ores"));
+                    player.sendStatusMessage(new TextComponentTranslation("metaitem.prospector.mode.ores"), true);
                 }
             } else if (checkCanUseScanner(heldItem, player, true)) {
                 new PlayerInventoryHolder(player, hand).openUI();
@@ -132,6 +132,7 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
         } else {
             lines.add(I18n.format("metaitem.prospector.tooltip.ores", radius));
         }
+        lines.add(I18n.format(getMode(itemStack) == WidgetProspectingMap.ORE_PROSPECTING_MODE ? "metaitem.prospector.mode.ores" : "metaitem.prospector.mode.fluid"));
     }
 
     @Override

--- a/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
@@ -72,7 +72,7 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
     }
 
     private int getMode(ItemStack stack) {
-        if (stack == ItemStack.EMPTY || stack == null) {
+        if (stack == ItemStack.EMPTY) {
             return 0;
         }
         NBTTagCompound tag = stack.getTagCompound();

--- a/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
@@ -127,12 +127,12 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
     public void addInformation(ItemStack itemStack, List<String> lines) {
         IItemBehaviour.super.addInformation(itemStack, lines);
 
-        if (tier >= GTValues.HV) {
+        if (tier >= FLUID_PROSPECTION_THRESHOLD) {
             lines.add(I18n.format("metaitem.prospector.tooltip.fluids", radius));
+            lines.add(I18n.format(getMode(itemStack) == WidgetProspectingMap.ORE_PROSPECTING_MODE ? "metaitem.prospector.mode.ores" : "metaitem.prospector.mode.fluid"));
         } else {
             lines.add(I18n.format("metaitem.prospector.tooltip.ores", radius));
         }
-        lines.add(I18n.format(getMode(itemStack) == WidgetProspectingMap.ORE_PROSPECTING_MODE ? "metaitem.prospector.mode.ores" : "metaitem.prospector.mode.fluid"));
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2264,8 +2264,8 @@ gregtech.block.surface_rock.underground_materials=Underground Materials: %s
 metaitem.prospector.lv.name=Electric Prospector's Scanner (LV)
 metaitem.prospector.hv.name=Electric Prospector's Scanner (HV)
 metaitem.prospector.luv.name=Electric Prospector's Scanner (LuV)
-metaitem.prospector.mode.ores=Ore Prospection Mode
-metaitem.prospector.mode.fluid=Fluid Prospection Mode
+metaitem.prospector.mode.ores=§aOre Prospection Mode
+metaitem.prospector.mode.fluid=§bFluid Prospection Mode
 metaitem.prospector.tooltip.ores=Scans Ores in a %s Chunk Radius
 metaitem.prospector.tooltip.fluids=Scans Ores and Fluids in a %s Chunk Radius
 behavior.prospector.not_enough_energy=Not Enough Energy!
@@ -2309,8 +2309,8 @@ behavior.tricorder.debug_lag_count=Caused %s Lag Spike Warnings (anything taking
 
 metaitem.item_magnet.lv.name=Low Voltage Item Magnet
 metaitem.item_magnet.hv.name=High Voltage Item Magnet
-behavior.item_magnet.enabled=Magnetic Field Enabled
-behavior.item_magnet.disabled=Magnetic Field Disabled
+behavior.item_magnet.enabled=§aMagnetic Field Enabled
+behavior.item_magnet.disabled=§cMagnetic Field Disabled
 
 metaitem.terminal.name=Terminal
 metaitem.terminal.tooltip=Sharp tools make good work


### PR DESCRIPTION
- Saves Prospectors' mode to NBT
- Saves Item Magnets' "enabled status" to NBT
- Changes the messages on-mode-swap to displayed Status Messages (now matches Batteries toggling discharge mode)
- Adds a tooltip to Prospectors to show their current prospecting mode (if it can do both Ores and Fluids)

This PR fixes the server-sided crash with packet mismatches in prospectors due to improperly synchronized/persisted mode data