### PR TITLE
Improve charcoal smelting removal recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -17,12 +17,8 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-
-import java.util.Iterator;
-import java.util.Map;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
@@ -52,10 +48,6 @@ public class VanillaOverrideRecipes {
         toolArmorRecipes();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:tnt"));
-
-        if(ConfigHolder.recipes.harderCharcoalRecipe) {
-            removeCharcoalRecipes();
-        }
     }
 
     private static void woodRecipes() {
@@ -1069,20 +1061,5 @@ public class VanillaOverrideRecipes {
         ModHandler.addShapedRecipe(regName, output, "P P", "PhP",
                 'P', new UnificationEntry(OrePrefix.plate, material)
         );
-    }
-
-    private static void removeCharcoalRecipes() {
-        Map<ItemStack, ItemStack> furnaceRecipes = FurnaceRecipes.instance().getSmeltingList();
-
-        Iterator<Map.Entry<ItemStack, ItemStack>> recipeIterator = furnaceRecipes.entrySet().iterator();
-
-        while(recipeIterator.hasNext()) {
-            Map.Entry<ItemStack, ItemStack> recipe = recipeIterator.next();
-            if(recipe.getValue().isItemEqual(new ItemStack(Items.COAL, 1, 1))) {
-                if(OreDictUnifier.getOreDictionaryNames(recipe.getKey()).contains("logWood")) {
-                    recipeIterator.remove();
-                }
-            }
-        }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -92,6 +92,10 @@ public class WoodMachineRecipes {
 
                 ModHandler.addShapedRecipe(slabStack.getDisplayName() + "_saw", GTUtility.copyAmount(2, slabStack), "sS", 'S', GTUtility.copyAmount(1, plankStack));
             }
+
+            if (ConfigHolder.recipes.harderCharcoalRecipe) {
+                ModHandler.removeFurnaceSmelting(stack);
+            }
         }
     }
 


### PR DESCRIPTION
Moves Charcoal smelting removals to the `WoodMachineRecipes` class where we are already iterating over all `logWood` OreDictionary entries.

Also moves the removal to a later phase, which should catch other mods like Forestry which are known to register recipes too late