### PR TITLE
Change the amount of sticky resin from rubber logs

### DIFF
--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
@@ -50,7 +50,11 @@ public class BlockRubberLog extends BlockLog {
     public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, IBlockState state, int fortune) {
         Random rand = world instanceof World ? ((World) world).rand : RANDOM;
         if (state.getValue(NATURAL)) {
-            drops.add(MetaItems.STICKY_RESIN.getStackForm(1 + rand.nextInt(2)));
+            double chance = rand.nextDouble();
+            int amount  = chance <= 0.95D ? 1 : 0;
+            if(amount != 0) {
+                drops.add(MetaItems.STICKY_RESIN.getStackForm());
+            }
         }
         drops.add(new ItemStack(this));
     }

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
@@ -51,7 +51,7 @@ public class BlockRubberLog extends BlockLog {
         Random rand = world instanceof World ? ((World) world).rand : RANDOM;
         if (state.getValue(NATURAL)) {
             double chance = rand.nextDouble();
-            int amount  = chance <= 0.95D ? 1 : 0;
+            int amount  = chance <= 0.85D ? 1 : 0;
             if(amount != 0) {
                 drops.add(MetaItems.STICKY_RESIN.getStackForm());
             }

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
@@ -50,9 +50,7 @@ public class BlockRubberLog extends BlockLog {
     public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, IBlockState state, int fortune) {
         Random rand = world instanceof World ? ((World) world).rand : RANDOM;
         if (state.getValue(NATURAL)) {
-            double chance = rand.nextDouble();
-            int amount  = chance <= 0.85D ? 1 : 0;
-            if(amount != 0) {
+            if(rand.nextDouble() <= .85D) {
                 drops.add(MetaItems.STICKY_RESIN.getStackForm());
             }
         }


### PR DESCRIPTION
**What:**

Changes the amount of sticky resin dropped from logs of rubber trees.

previously: guaranteed 1, which a chance at a second
now: 95% chance at 1