### PR TITLE
allow primitive recipe logic to use maintenance

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -1,9 +1,14 @@
 package gregtech.api.capability.impl;
 
 import gregtech.api.GTValues;
+import gregtech.api.capability.IMaintenanceHatch;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.common.ConfigHolder;
+import net.minecraft.util.Tuple;
 
 import javax.annotation.Nonnull;
 
@@ -42,14 +47,44 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
+    protected void trySearchNewRecipe() {
+        // do not run recipes when there are more than 5 maintenance problems
+        // Maintenance can apply to all multiblocks, so cast to a base multiblock class
+        MultiblockWithDisplayBase controller = (MultiblockWithDisplayBase) metaTileEntity;
+        if (ConfigHolder.machines.enableMaintenance && controller.hasMaintenanceMechanics() && controller.getNumMaintenanceProblems() > 5) {
+            return;
+        }
+        super.trySearchNewRecipe();
+    }
+
+    @Override
     protected int[] runOverclockingLogic(@Nonnull Recipe recipe, boolean negativeEU, int maxOverclocks) {
-        return standardOverclockingLogic(1,
-                getMaxVoltage(),
-                recipe.getDuration(),
-                getOverclockingDurationDivisor(),
-                getOverclockingVoltageMultiplier(),
-                maxOverclocks
-        );
+        // apply maintenance penalties
+        Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+
+        int[] overclock = null;
+        if (maintenanceValues.getSecond() != 1.0)
+            overclock = overclockRecipe(recipe.getRecipePropertyStorage(), 1, negativeEU, getMaxVoltage(),
+                    (int) Math.round(recipe.getDuration() * maintenanceValues.getSecond()), maxOverclocks);
+
+        if (overclock == null)
+            overclock = overclockRecipe(recipe.getRecipePropertyStorage(), 1, negativeEU, getMaxVoltage(), recipe.getDuration(), maxOverclocks);
+
+        if (maintenanceValues.getFirst() > 0)
+            overclock[1] = (int) (overclock[1] * (1 + 0.1 * maintenanceValues.getFirst()));
+
+        return overclock;
+    }
+
+    protected Tuple<Integer, Double> getMaintenanceValues() {
+        MultiblockWithDisplayBase displayBase = this.metaTileEntity instanceof MultiblockWithDisplayBase ? (MultiblockWithDisplayBase) metaTileEntity : null;
+        int numMaintenanceProblems = displayBase == null || !displayBase.hasMaintenanceMechanics() || !ConfigHolder.machines.enableMaintenance ? 0 : displayBase.getNumMaintenanceProblems();
+        double durationMultiplier = 1.0D;
+        if (displayBase != null && displayBase.hasMaintenanceMechanics() && ConfigHolder.machines.enableMaintenance) {
+            IMaintenanceHatch hatch = displayBase.getAbilities(MultiblockAbility.MAINTENANCE_HATCH).get(0);
+            durationMultiplier = hatch.getDurationMultiplier();
+        }
+        return new Tuple<>(numMaintenanceProblems, durationMultiplier);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -1,6 +1,5 @@
 package gregtech.common.metatileentities.multi;
 
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.texture.TextureUtils;
@@ -16,21 +15,21 @@ import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.CubeRendererState;
-import gregtech.client.renderer.texture.Textures;
+import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.cclop.ColourOperation;
 import gregtech.client.renderer.cclop.LightMapOperation;
-import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import org.apache.commons.lang3.ArrayUtils;
@@ -54,7 +53,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
                 .aisle("XXX", "XXX", "XXX", "XXX")
                 .aisle("XXX", "X#X", "X#X", "X#X")
                 .aisle("XXX", "XYX", "XXX", "XXX")
-                .where('X', states(MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.PRIMITIVE_BRICKS)))
+                .where('X', states(MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.PRIMITIVE_BRICKS)).or(abilities(MultiblockAbility.MAINTENANCE_HATCH)))
                 .where('#', air())
                 .where('Y', selfPredicate())
                 .build();
@@ -114,7 +113,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
 
     @Override
     public boolean hasMaintenanceMechanics() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Allows multiblocks using `PrimitiveRecipeLogic` to use maintenance. Currently the PBF has maintenance enabled and the hatch allowed in the structure for testing. The implementation is identical to that of `MultiblockRecipeLogic`. The changes made to the PBF should be reverted before merging.