### PR TITLE
Stone type fix

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -161,14 +161,14 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> list) {
         if (tab == CreativeTabs.SEARCH) {
             blockState.getValidStates().stream().filter(state -> state.getValue(STONE_TYPE).shouldBeDroppedAsItem).forEach(blockState -> list.add(getItem(blockState)));
-        } else if (tab == GregTechAPI.TAB_GREGTECH_ORES) {
+        } else if (tab == GregTechAPI.TAB_GREGTECH_ORES && getRegistryName() != null && getRegistryName().getPath().endsWith("_0")) {
             list.add(getItem(getDefaultState()));
         }
     }
 
     @Override
     public boolean canRenderInLayer(@Nonnull IBlockState state, @Nonnull BlockRenderLayer layer) {
-        return layer == BlockRenderLayer.CUTOUT_MIPPED || (material.getProperty(PropertyKey.ORE).isEmissive() && layer == BloomEffectUtil.getRealBloomLayer()) ;
+        return layer == BlockRenderLayer.CUTOUT_MIPPED || (material.getProperty(PropertyKey.ORE).isEmissive() && layer == BloomEffectUtil.getRealBloomLayer());
     }
 
     private BlockStateContainer createStateContainer() {
@@ -182,7 +182,8 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void onTextureStitch(TextureStitchEvent.Pre event) { }
+    public void onTextureStitch(TextureStitchEvent.Pre event) {
+    }
 
     @Override
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -538,7 +538,7 @@ public class MetaBlocks {
         for (BlockOre blockOre : ORES) {
             Material material = blockOre.material;
             for (StoneType stoneType : blockOre.STONE_TYPE.getAllowedValues()) {
-                if (stoneType == null || !stoneType.shouldBeDroppedAsItem) continue;
+                if (stoneType == null) continue;
                 ItemStack normalStack = blockOre.getItem(blockOre.getDefaultState()
                         .withProperty(blockOre.STONE_TYPE, stoneType));
                 OreDictUnifier.registerOre(normalStack, stoneType.processingPrefix, material);


### PR DESCRIPTION
This fixes that custom stone type ores are not appearing on prospectors. This is because the ore dict is only given to items that 'should drop'.
I simply added the ore dict to all ore items

Also fixes a issue when a stone type with a id higher than 15 is registered, it would appear in creative inventory and jei with `shouldDropAsItem` false