### PR TITLE
Cleanup overclocking logic

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -34,14 +34,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static gregtech.api.recipes.logic.OverclockingLogic.*;
+
 public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable, IParallelableRecipeLogic {
 
     private static final String ALLOW_OVERCLOCKING = "AllowOverclocking";
     private static final String OVERCLOCK_VOLTAGE = "OverclockVoltage";
 
-    public static final double STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER = 4.0;
-    public static final double STANDARD_OVERCLOCK_DURATION_DIVISOR = ConfigHolder.machines.overclockDivisor;
-    public static final double PERFECT_OVERCLOCK_DURATION_DIVISOR = 4.0;
 
     private final RecipeMap<?> recipeMap;
 
@@ -551,53 +550,6 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      */
     protected double getOverclockingVoltageMultiplier() {
         return STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER;
-    }
-
-    /**
-     * applies standard logic for overclocking, where each overclock modifies energy and duration
-     *
-     * @param recipeEUt         the EU/t of the recipe to overclock
-     * @param maximumVoltage    the maximum voltage the recipe is allowed to be run at
-     * @param recipeDuration    the duration of the recipe to overclock
-     * @param durationDivisor   the value to divide the duration by for each overclock
-     * @param voltageMultiplier the value to multiply the voltage by for each overclock
-     * @param maxOverclocks     the maximum amount of overclocks allowed
-     * @return an int array of {OverclockedEUt, OverclockedDuration}
-     */
-    public static int[] standardOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, double durationDivisor, double voltageMultiplier, int maxOverclocks) {
-        int overclockedEUt = recipeEUt;
-        double overclockedDuration = recipeDuration;
-
-        while (overclockedEUt * voltageMultiplier <= GTValues.V[GTUtility.getTierByVoltage(maximumVoltage)] && overclockedDuration / durationDivisor > 0 && maxOverclocks > 0) {
-            overclockedEUt *= voltageMultiplier;
-            overclockedDuration /= durationDivisor;
-            maxOverclocks--;
-        }
-        return new int[]{overclockedEUt, (int) Math.ceil(overclockedDuration)};
-    }
-
-    /**
-     * Identical to {@link AbstractRecipeLogic#standardOverclockingLogic(int, long, int, double, double, int)}, except
-     * it does not enforce "maximumVoltage" being in-line with a voltage-tier.
-     *
-     * @param recipeEUt the EU/t of the recipe to overclock
-     * @param maximumVoltage the maximum voltage the recipe is allowed to be run at
-     * @param recipeDuration the duration of the recipe to overclock
-     * @param durationDivisor the value to divide the duration by for each overclock
-     * @param voltageMultiplier the value to multiply the voltage by for each overclock
-     * @param maxOverclocks the maximum amount of overclocks allowed
-     * @return an int array of {OverclockedEUt, OverclockedDuration}
-     */
-    public static int[] unlockedVoltageOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, double durationDivisor, double voltageMultiplier, int maxOverclocks) {
-        int overclockedEUt = recipeEUt;
-        double overclockedDuration = recipeDuration;
-
-        while (overclockedEUt * voltageMultiplier <= maximumVoltage && overclockedDuration / durationDivisor > 0 && maxOverclocks > 0) {
-            overclockedEUt *= voltageMultiplier;
-            overclockedDuration /= durationDivisor;
-            maxOverclocks--;
-        }
-        return new int[]{overclockedEUt, (int) Math.ceil(overclockedDuration)};
     }
 
     /**

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -8,6 +8,7 @@ import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;
@@ -19,10 +20,10 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
     }
 
     @Override
-    protected int[] runOverclockingLogic(@Nonnull Recipe recipe, boolean negativeEU, int maxOverclocks) {
+    protected int[] runOverclockingLogic(RecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
         // no overclocking happens other than parallelization,
         // so return the recipe's values, with EUt made positive for it to be made negative later
-        return new int[]{recipe.getEUt() * -1, recipe.getDuration()};
+        return new int[]{recipeEUt * -1, recipeDuration};
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -18,8 +18,8 @@ public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected int[] overclockRecipe(@Nonnull RecipePropertyStorage propertyStorage, int recipeEUt, boolean negativeEU, long maxVoltage, int duration, int maxOverclocks) {
-        return heatingCoilOverclockingLogic(recipeEUt * (negativeEU ? -1 : 1),
+    protected int[] runOverclockingLogic(@Nonnull RecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int maxOverclocks) {
+        return heatingCoilOverclockingLogic(Math.abs(recipeEUt),
                 maxVoltage,
                 duration,
                 maxOverclocks,

--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -7,6 +7,8 @@ import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 
 import javax.annotation.Nonnull;
 
+import static gregtech.api.recipes.logic.OverclockingLogic.heatingCoilOverclockingLogic;
+
 /**
  * RecipeLogic for multiblocks that use temperature for raising speed and lowering energy usage
  * Used with RecipeMaps that run recipes using the {@link TemperatureProperty}
@@ -28,24 +30,5 @@ public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
         );
     }
 
-    @Nonnull
-    public static int[] heatingCoilOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, int maxOverclocks, int currentTemp, int recipeRequiredTemp) {
-        int amountEUDiscount = Math.max(0, (currentTemp - recipeRequiredTemp) / 900);
-        int amountPerfectOC = amountEUDiscount / 2;
 
-        // apply a multiplicative 95% energy multiplier for every 900k over recipe temperature
-        recipeEUt *= Math.min(1, Math.pow(0.95, amountEUDiscount));
-
-        // perfect overclock for every 1800k over recipe temperature
-        if (amountPerfectOC > 0) {
-            // use the normal overclock logic to do perfect OCs up to as many times as calculated
-            int[] overclock = standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, PERFECT_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER, amountPerfectOC);
-
-            // overclock normally as much as possible after perfects are exhausted
-            return standardOverclockingLogic(overclock[0], maximumVoltage, overclock[1], STANDARD_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER, maxOverclocks);
-        }
-
-        // no perfects are performed, do normal overclocking
-        return standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, STANDARD_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER, maxOverclocks);
-    }
 }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -7,6 +7,7 @@ import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
+import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 import gregtech.common.ConfigHolder;
 
 import javax.annotation.Nonnull;
@@ -20,7 +21,7 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(@Nonnull Recipe recipe, boolean negativeEU, int maxOverclocks) {
+    protected int[] runOverclockingLogic(RecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
         // apply maintenance penalties
         MultiblockWithDisplayBase displayBase = this.metaTileEntity instanceof MultiblockWithDisplayBase ? (MultiblockWithDisplayBase) metaTileEntity : null;
         int numMaintenanceProblems = displayBase == null ? 0 : displayBase.getNumMaintenanceProblems();
@@ -30,10 +31,13 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
             IMaintenanceHatch hatch = displayBase.getAbilities(MultiblockAbility.MAINTENANCE_HATCH).get(0);
             double durationMultiplier = hatch.getDurationMultiplier();
             if (durationMultiplier != 1.0) {
-                overclock = new int[]{recipe.getEUt() * -1, (int) Math.round(recipe.getDuration() / durationMultiplier)};
+                overclock = new int[]{recipeEUt * -1, (int) Math.round(recipeDuration / durationMultiplier)};
             }
         }
-        if (overclock == null) overclock = new int[]{recipe.getEUt() * -1, recipe.getDuration()};
+        if (overclock == null) {
+            overclock = new int[]{recipeEUt * -1, recipeDuration};
+        }
+
         overclock[1] = (int) (overclock[1] * (1 - 0.1 * numMaintenanceProblems));
 
         // no overclocking happens other than parallelization,

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -5,7 +5,6 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 import gregtech.common.ConfigHolder;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -236,11 +236,22 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
         int[] overclock = null;
         if (maintenanceValues.getSecond() != 1.0)
-            overclock = runOverclockingLogic(propertyStorage, recipeEUt, getMaxVoltage(),
-                    (int) Math.round(recipeDuration * maintenanceValues.getSecond()), maxOverclocks);
+
+            overclock = standardOverclockingLogic(Math.abs(recipeEUt),
+                    maxVoltage,
+                    (int) Math.round(recipeDuration * maintenanceValues.getSecond()),
+                    getOverclockingDurationDivisor(),
+                    getOverclockingVoltageMultiplier(),
+                    maxOverclocks
+            );
 
         if (overclock == null)
-            overclock = runOverclockingLogic(propertyStorage, recipeEUt, getMaxVoltage(), recipeDuration, maxOverclocks);
+            overclock = standardOverclockingLogic(Math.abs(recipeEUt),
+                    maxVoltage,
+                    recipeDuration,
+                    getOverclockingDurationDivisor(),
+                    getOverclockingVoltageMultiplier(),
+                    maxOverclocks);
 
         if (maintenanceValues.getFirst() > 0)
             overclock[1] = (int) (overclock[1] * (1 + 0.1 * maintenanceValues.getFirst()));

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -20,6 +20,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
+
 public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
     // Used for distinct mode

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -11,6 +11,7 @@ import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 import gregtech.common.ConfigHolder;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -229,17 +230,17 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(@Nonnull Recipe recipe, boolean negativeEU, int maxOverclocks) {
+    protected int[] runOverclockingLogic(RecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         int[] overclock = null;
         if (maintenanceValues.getSecond() != 1.0)
-            overclock = overclockRecipe(recipe.getRecipePropertyStorage(), recipe.getEUt(), negativeEU, getMaxVoltage(),
-                    (int) Math.round(recipe.getDuration() * maintenanceValues.getSecond()), maxOverclocks);
+            overclock = runOverclockingLogic(propertyStorage, recipeEUt, getMaxVoltage(),
+                    (int) Math.round(recipeDuration * maintenanceValues.getSecond()), maxOverclocks);
 
         if (overclock == null)
-            overclock = overclockRecipe(recipe.getRecipePropertyStorage(), recipe.getEUt(), negativeEU, getMaxVoltage(), recipe.getDuration(), maxOverclocks);
+            overclock = runOverclockingLogic(propertyStorage, recipeEUt, getMaxVoltage(), recipeDuration, maxOverclocks);
 
         if (maintenanceValues.getFirst() > 0)
             overclock[1] = (int) (overclock[1] * (1 + 0.1 * maintenanceValues.getFirst()));

--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 
 import javax.annotation.Nonnull;
 
@@ -42,10 +43,10 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(@Nonnull Recipe recipe, boolean negativeEU, int maxOverclocks) {
+    protected int[] runOverclockingLogic(RecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
         return standardOverclockingLogic(1,
                 getMaxVoltage(),
-                recipe.getDuration(),
+                recipeDuration,
                 getOverclockingDurationDivisor(),
                 getOverclockingVoltageMultiplier(),
                 maxOverclocks

--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -8,6 +8,8 @@ import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 
 import javax.annotation.Nonnull;
 
+import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
+
 /**
  * Recipe Logic for a Multiblock that does not require power.
  */

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -28,6 +28,8 @@ import net.minecraftforge.fluids.IFluidTank;
 
 import javax.annotation.Nonnull;
 
+import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
+
 public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
 
     private final IFluidTank steamFluidTank;

--- a/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
@@ -9,7 +9,7 @@ import gregtech.api.util.ValidationResult;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import static gregtech.api.capability.impl.AbstractRecipeLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR;
+import static gregtech.api.recipes.logic.OverclockingLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR;
 
 public class UniversalDistillationRecipeBuilder extends RecipeBuilder<UniversalDistillationRecipeBuilder> {
 

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -1,0 +1,86 @@
+package gregtech.api.recipes.logic;
+
+import gregtech.api.GTValues;
+import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A class for holding all the various Overclocking logics
+ */
+public class OverclockingLogic {
+
+    public static final double STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER = 4.0;
+    public static final double STANDARD_OVERCLOCK_DURATION_DIVISOR = ConfigHolder.machines.overclockDivisor;
+    public static final double PERFECT_OVERCLOCK_DURATION_DIVISOR = 4.0;
+
+
+    /**
+     * applies standard logic for overclocking, where each overclock modifies energy and duration
+     *
+     * @param recipeEUt         the EU/t of the recipe to overclock
+     * @param maximumVoltage    the maximum voltage the recipe is allowed to be run at
+     * @param recipeDuration    the duration of the recipe to overclock
+     * @param durationDivisor   the value to divide the duration by for each overclock
+     * @param voltageMultiplier the value to multiply the voltage by for each overclock
+     * @param maxOverclocks     the maximum amount of overclocks allowed
+     * @return an int array of {OverclockedEUt, OverclockedDuration}
+     */
+    public static int[] standardOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, double durationDivisor, double voltageMultiplier, int maxOverclocks) {
+        int overclockedEUt = recipeEUt;
+        double overclockedDuration = recipeDuration;
+
+        while (overclockedEUt * voltageMultiplier <= GTValues.V[GTUtility.getTierByVoltage(maximumVoltage)] && overclockedDuration / durationDivisor > 0 && maxOverclocks > 0) {
+            overclockedEUt *= voltageMultiplier;
+            overclockedDuration /= durationDivisor;
+            maxOverclocks--;
+        }
+        return new int[]{overclockedEUt, (int) Math.ceil(overclockedDuration)};
+    }
+
+    /**
+     * Identical to {@link OverclockingLogic#standardOverclockingLogic(int, long, int, double, double, int)}, except
+     * it does not enforce "maximumVoltage" being in-line with a voltage-tier.
+     *
+     * @param recipeEUt the EU/t of the recipe to overclock
+     * @param maximumVoltage the maximum voltage the recipe is allowed to be run at
+     * @param recipeDuration the duration of the recipe to overclock
+     * @param durationDivisor the value to divide the duration by for each overclock
+     * @param voltageMultiplier the value to multiply the voltage by for each overclock
+     * @param maxOverclocks the maximum amount of overclocks allowed
+     * @return an int array of {OverclockedEUt, OverclockedDuration}
+     */
+    public static int[] unlockedVoltageOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, double durationDivisor, double voltageMultiplier, int maxOverclocks) {
+        int overclockedEUt = recipeEUt;
+        double overclockedDuration = recipeDuration;
+
+        while (overclockedEUt * voltageMultiplier <= maximumVoltage && overclockedDuration / durationDivisor > 0 && maxOverclocks > 0) {
+            overclockedEUt *= voltageMultiplier;
+            overclockedDuration /= durationDivisor;
+            maxOverclocks--;
+        }
+        return new int[]{overclockedEUt, (int) Math.ceil(overclockedDuration)};
+    }
+
+    @Nonnull
+    public static int[] heatingCoilOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, int maxOverclocks, int currentTemp, int recipeRequiredTemp) {
+        int amountEUDiscount = Math.max(0, (currentTemp - recipeRequiredTemp) / 900);
+        int amountPerfectOC = amountEUDiscount / 2;
+
+        // apply a multiplicative 95% energy multiplier for every 900k over recipe temperature
+        recipeEUt *= Math.min(1, Math.pow(0.95, amountEUDiscount));
+
+        // perfect overclock for every 1800k over recipe temperature
+        if (amountPerfectOC > 0) {
+            // use the normal overclock logic to do perfect OCs up to as many times as calculated
+            int[] overclock = standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, PERFECT_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER, amountPerfectOC);
+
+            // overclock normally as much as possible after perfects are exhausted
+            return standardOverclockingLogic(overclock[0], maximumVoltage, overclock[1], STANDARD_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER, maxOverclocks);
+        }
+
+        // no perfects are performed, do normal overclocking
+        return standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, STANDARD_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER, maxOverclocks);
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -110,8 +110,8 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected int[] performOverclocking(Recipe recipe, boolean negativeEU) {
-            int[] overclock = super.performOverclocking(recipe, negativeEU);
+        protected int[] performOverclocking(Recipe recipe) {
+            int[] overclock = super.performOverclocking(recipe);
 
             int coilTier = ((MetaTileEntityCrackingUnit) metaTileEntity).getCoilTier();
             if (coilTier <= 0)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -43,6 +43,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.recipes.logic.OverclockingLogic.unlockedVoltageOverclockingLogic;
+
 public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController implements IMachineHatchMultiblock {
 
     private final int tier;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -121,8 +121,8 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected int[] performOverclocking(Recipe recipe, boolean negativeEU) {
-            int[] overclock = super.performOverclocking(recipe, negativeEU);
+        protected int[] performOverclocking(Recipe recipe) {
+            int[] overclock = super.performOverclocking(recipe);
 
             int coilTier = ((MetaTileEntityPyrolyseOven) metaTileEntity).getCoilTier();
             if (coilTier == -1)


### PR DESCRIPTION
**What:**

Cleans up overclocking logic

Removes a `runOverclockingLogic` method in favor of renaming the old `overclockRecipe` into `runOverclockingLogic`. Everything that was overriding the old `runOverclockingLogic` method now overrides the new `runOverclockingLogic` method (which was previously `overclockRecipe`.

Stops passing the `negativeEU` parameter into the methods that performed the overclocking logic, as all it was used for was basically performing a `Math.abs()` call.