### PR TITLE
Don't tick the preview world from updateFormedValid

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -16,6 +16,7 @@ import gregtech.client.renderer.handler.MultiblockPreviewRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.BlockInfo;
 import gregtech.api.util.GTUtility;
+import gregtech.client.utils.TrackedDummyWorld;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.VariantActiveBlock;
 import net.minecraft.block.Block;
@@ -75,7 +76,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
             if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
                 checkStructurePattern();
             }
-            if (isStructureFormed()) {
+            if (isStructureFormed() && !(getWorld() instanceof TrackedDummyWorld)) {
                 updateFormedValid();
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -76,6 +76,8 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
             if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
                 checkStructurePattern();
             }
+            // TrackedDummyWorld is the world for the JEI preview. We do not want to update the Multi in this world,
+            // besides initially forming it in checkStructurePattern
             if (isStructureFormed() && !(getWorld() instanceof TrackedDummyWorld)) {
                 updateFormedValid();
             }


### PR DESCRIPTION
**What:**

Don't call `updateFormedValid` if the world is the JEI preview world. 

When launching the game with a debug breakpoint in ARL#trySearchNewRecipe, I noticed that the breakpoint would get hit several times before loading the game finished, by the PBF, Coke Oven, Fusion Reactor, and Steam Multiblocks specifically.

I have therefore added a check that we are not in the JEI preview world before ticking `updateFormedValid`.
The check cannot be at the main `if` statement, where it is checked `if(!getWorld.isRemote())` as we still need to call `checkStructurePattern` so that the multiblocks are formed in the JEI previews.