### PR TITLE
Fix a bunch of recipe conflicts

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/AcidRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/AcidRecipes.java
@@ -103,14 +103,6 @@ public class AcidRecipes {
                 .duration(240).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .notConsumable(new IntCircuitIngredient(2))
-                .fluidInputs(NitrogenDioxide.getFluid(2000))
-                .fluidInputs(Water.getFluid(1000))
-                .fluidInputs(Oxygen.getFluid(1000))
-                .fluidOutputs(NitricAcid.getFluid(2000))
-                .duration(240).EUt(VA[LV]).buildAndRegister();
-
-        CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(3))
                 .fluidInputs(Water.getFluid(1000))
                 .fluidInputs(Oxygen.getFluid(1000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/FuelRecipeChains.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/FuelRecipeChains.java
@@ -35,13 +35,6 @@ public class FuelRecipeChains {
                 .fluidOutputs(NitrousOxide.getFluid(1000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(50)
-                .notConsumable(new IntCircuitIngredient(24))
-                .fluidInputs(Nitrogen.getFluid(20000))
-                .fluidInputs(Oxygen.getFluid(10000))
-                .fluidOutputs(NitrousOxide.getFluid(10000))
-                .buildAndRegister();
-
         // Ethyl Tert-Butyl Ether
         CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(400)
                 .fluidInputs(Butene.getFluid(1000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -300,6 +300,7 @@ public class PolymerRecipes {
                 .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
+                .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(HydrochloricAcid.getFluid(1000))
                 .fluidInputs(Acetone.getFluid(1000))
                 .fluidInputs(Phenol.getFluid(2000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -414,6 +414,7 @@ public class ReactorRecipes {
                 .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
+                .notConsumable(new IntCircuitIngredient(2))
                 .fluidInputs(Ammonia.getFluid(1000))
                 .fluidInputs(Methanol.getFluid(2000))
                 .fluidOutputs(Water.getFluid(2000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -21,12 +21,14 @@ public class ReactorRecipes {
     public static void init() {
 
         CHEMICAL_RECIPES.recipeBuilder()
+                .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Isoprene.getFluid(144))
                 .fluidInputs(Air.getFluid(2000))
                 .output(dust, RawRubber)
                 .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
+                .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Isoprene.getFluid(144))
                 .fluidInputs(Oxygen.getFluid(2000))
                 .output(dust, RawRubber, 3)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -33,7 +33,7 @@ public class ReactorRecipes {
                 .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .notConsumable(new IntCircuitIngredient(2))
+                .notConsumable(new IntCircuitIngredient(3))
                 .fluidInputs(Propene.getFluid(2000))
                 .fluidOutputs(Methane.getFluid(1000))
                 .fluidOutputs(Isoprene.getFluid(1000))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -301,6 +301,7 @@ public class ReactorRecipes {
                 .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
+                .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(PhosphoricAcid.getFluid(1000))
                 .fluidInputs(Benzene.getFluid(8000))
                 .fluidInputs(Propene.getFluid(8000))

--- a/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
@@ -318,7 +318,7 @@ public class OreRecipeHandler {
 
         RecipeMaps.ORE_WASHER_RECIPES.recipeBuilder()
                 .input(dustPrefix, material)
-                .notConsumable(new IntCircuitIngredient(1))
+                .notConsumable(new IntCircuitIngredient(2))
                 .fluidInputs(Materials.Water.getFluid(100))
                 .outputs(dustStack)
                 .duration(8).EUt(4).buildAndRegister();
@@ -365,7 +365,7 @@ public class OreRecipeHandler {
 
         RecipeMaps.ORE_WASHER_RECIPES.recipeBuilder()
                 .input(purePrefix, material)
-                .notConsumable(new IntCircuitIngredient(1))
+                .notConsumable(new IntCircuitIngredient(2))
                 .fluidInputs(Materials.Water.getFluid(100))
                 .outputs(dustStack)
                 .duration(8).EUt(4).buildAndRegister();


### PR DESCRIPTION
The changes:
- Fixes Bisphenol A (Chemical Reactor) conflicting with Epychlorohydrin (Large Chemical Reactor)
- Removes a duplicated Nitric Acid recipe, which conflicted with Nitrogen Tetroxide
- Removes a duplicated Nitrous Oxide recipe, which conflicted with Nitric Acid
- Fixes Cumene (Chemical Reactor) conflicting with its shortcut recipe (outputting Phenol + Acetone in LCR)
- Fixes Isoprene + Methane (Chemical Reactor) conflicting Steam-cracked Propene
- Added config circuit in Isoprene to Rubber (Chemical Reactor) for compat reasons with Gregicality
- Fixes Dimethylamine (Chemical Reactor) conflicting with the shortcut 1,1-Dimethylhydrazine recipe
- Made quick washing always use configuration 2