### PR TITLE
Minor terminal improvements

### DIFF
--- a/src/main/java/gregtech/api/terminal/app/AbstractApplication.java
+++ b/src/main/java/gregtech/api/terminal/app/AbstractApplication.java
@@ -41,6 +41,10 @@ public abstract class AbstractApplication extends AnimaWidgetGroup {
         return this;
     }
 
+    public boolean canOpenMenuOnEdge() {
+        return true;
+    }
+
     /**
      * App theme color
      */

--- a/src/main/java/gregtech/api/terminal/gui/widgets/ColorWidget.java
+++ b/src/main/java/gregtech/api/terminal/gui/widgets/ColorWidget.java
@@ -11,6 +11,7 @@ import gregtech.api.util.Size;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.math.MathHelper;
 
+import java.awt.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -98,6 +99,14 @@ public class ColorWidget extends WidgetGroup {
     public ColorWidget setColorSupplier(Supplier<Integer> colorSupplier, boolean isClient) {
         this.colorSupplier = colorSupplier;
         this.isClient = isClient;
+        return this;
+    }
+
+    public ColorWidget setStartColor(int color) {
+        setRed((color >> 16) & 0xFF);
+        setGreen((color >> 8) & 0xFF);
+        setBlue(color & 0xFF);
+        setAlpha((color >> 24) & 0xFF);
         return this;
     }
 

--- a/src/main/java/gregtech/api/terminal/gui/widgets/ColorWidget.java
+++ b/src/main/java/gregtech/api/terminal/gui/widgets/ColorWidget.java
@@ -11,7 +11,6 @@ import gregtech.api.util.Size;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.math.MathHelper;
 
-import java.awt.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -32,14 +31,14 @@ public class ColorWidget extends WidgetGroup {
     private Supplier<Integer> colorSupplier;
     private boolean isClient;
 
-    public ColorWidget(int x, int y, int barWidth, int barHeight){
+    public ColorWidget(int x, int y, int barWidth, int barHeight) {
         super(new Position(x, y), new Size(barWidth + 35, 3 * (barHeight + 5) + 10));
         this.barWidth = barWidth;
-        this.barHeight= barHeight;
+        this.barHeight = barHeight;
         IGuiTexture textFieldBackground = new ColorRectTexture(0x9f000000);
         TextFieldWidget redField = new TextFieldWidget(barWidth + 5, 0, 30, barHeight, textFieldBackground, null, null)
                 .setTextResponder((t) -> {
-                    setRed(t.isEmpty()?  0 : Integer.parseInt(t));
+                    setRed(t.isEmpty() ? 0 : Integer.parseInt(t));
                     if (onColorChanged != null) {
                         onColorChanged.accept(getColor());
                     }
@@ -49,7 +48,7 @@ public class ColorWidget extends WidgetGroup {
                 .setValidator(this::checkValid);
         TextFieldWidget greenField = new TextFieldWidget(barWidth + 5, barHeight + 5, 30, barHeight, textFieldBackground, null, null)
                 .setTextResponder((t) -> {
-                    setGreen(t.isEmpty()?  0 : Integer.parseInt(t));
+                    setGreen(t.isEmpty() ? 0 : Integer.parseInt(t));
                     if (onColorChanged != null) {
                         onColorChanged.accept(getColor());
                     }
@@ -59,7 +58,7 @@ public class ColorWidget extends WidgetGroup {
                 .setValidator(this::checkValid);
         TextFieldWidget blueField = new TextFieldWidget(barWidth + 5, (barHeight + 5) * 2, 30, barHeight, textFieldBackground, null, null)
                 .setTextResponder((t) -> {
-                    setBlue(t.isEmpty()?  0 : Integer.parseInt(t));
+                    setBlue(t.isEmpty() ? 0 : Integer.parseInt(t));
                     if (onColorChanged != null) {
                         onColorChanged.accept(getColor());
                     }
@@ -69,7 +68,7 @@ public class ColorWidget extends WidgetGroup {
                 .setValidator(this::checkValid);
         TextFieldWidget alphaField = new TextFieldWidget(barWidth + 5, (barHeight + 5) * 3, 30, barHeight, textFieldBackground, null, null)
                 .setTextResponder((t) -> {
-                    setAlpha(t.isEmpty()?  0 : Integer.parseInt(t));
+                    setAlpha(t.isEmpty() ? 0 : Integer.parseInt(t));
                     if (onColorChanged != null) {
                         onColorChanged.accept(getColor());
                     }
@@ -117,13 +116,13 @@ public class ColorWidget extends WidgetGroup {
     @Override
     public void detectAndSendChanges() {
         super.detectAndSendChanges();
-        if (!isClient && colorSupplier!= null) {
+        if (!isClient && colorSupplier != null) {
             int c = colorSupplier.get();
             int r = (c & 0x00ff0000) >>> 16;
             int g = (c & 0x0000ff00) >>> 8;
             int b = (c & 0x000000ff);
             int a = (c & 0xff000000) >>> 24;
-            if (r != red || g != green || b != blue || a !=alpha) {
+            if (r != red || g != green || b != blue || a != alpha) {
                 setRed(r);
                 setGreen(g);
                 setBlue(b);
@@ -136,7 +135,7 @@ public class ColorWidget extends WidgetGroup {
     @Override
     public void updateScreen() {
         super.updateScreen();
-        if (isClient && colorSupplier!= null) {
+        if (isClient && colorSupplier != null) {
             int c = colorSupplier.get();
             int r = (c & 0x00ff0000) >>> 16;
             int g = (c & 0x0000ff00) >>> 8;
@@ -214,7 +213,7 @@ public class ColorWidget extends WidgetGroup {
         if (input.isEmpty()) return true;
         try {
             int value = Integer.parseInt(input);
-            if(value >= 0 && value <= 255) {
+            if (value >= 0 && value <= 255) {
                 return true;
             }
         } catch (Exception e) {
@@ -254,7 +253,7 @@ public class ColorWidget extends WidgetGroup {
         boolean flag = false;
         for (int i = widgets.size() - 1; i >= 0; i--) {
             Widget widget = widgets.get(i);
-            if(widget.isVisible() && widget.mouseClicked(mouseX, mouseY, button)) {
+            if (widget.isVisible() && widget.mouseClicked(mouseX, mouseY, button)) {
                 flag = true;
             }
         }

--- a/src/main/java/gregtech/api/terminal/gui/widgets/SelectorWidget.java
+++ b/src/main/java/gregtech/api/terminal/gui/widgets/SelectorWidget.java
@@ -20,6 +20,7 @@ public class SelectorWidget extends WidgetGroup {
     protected boolean isShow;
     private IGuiTexture background;
     private Consumer<String> onChanged;
+    private Consumer<Boolean> onShowChange;
     private boolean isUp;
     private final int fontColor;
 
@@ -28,7 +29,12 @@ public class SelectorWidget extends WidgetGroup {
         this.button = new RectButtonWidget(0,0,width,height);
         this.candidates = candidates;
         this.fontColor = fontColor;
-        button.setClickListener(d->isShow = !isShow);
+        button.setClickListener(d -> {
+            if(onShowChange != null) {
+                onShowChange.accept(!isShow);
+            }
+            isShow = !isShow;
+        });
         this.addWidget(button);
         this.addWidget(new SimpleTextWidget(width / 2, height / 2, "", fontColor, supplier, isClient));
     }
@@ -48,6 +54,11 @@ public class SelectorWidget extends WidgetGroup {
         return this;
     }
 
+    public SelectorWidget setOnShowChange(Consumer<Boolean> onShowChange) {
+        this.onShowChange = onShowChange;
+        return this;
+    }
+
     public SelectorWidget setColors(int stroke, int anima, int fill) {
         button.setColors(stroke, anima, fill);
         return this;
@@ -61,6 +72,10 @@ public class SelectorWidget extends WidgetGroup {
     public SelectorWidget setBackground(IGuiTexture background) {
         this.background = background;
         return this;
+    }
+
+    public void hide() {
+        this.isShow = false;
     }
 
     @Override
@@ -110,7 +125,6 @@ public class SelectorWidget extends WidgetGroup {
                 y += height;
             }
         }
-        isShow = false;
         return super.mouseClicked(mouseX, mouseY, button);
     }
 

--- a/src/main/java/gregtech/api/terminal/os/TerminalDialogWidget.java
+++ b/src/main/java/gregtech/api/terminal/os/TerminalDialogWidget.java
@@ -170,9 +170,10 @@ public class TerminalDialogWidget extends AnimaWidgetGroup {
      * Show Color Dialog
      * @return color (rgba)
      */
-    public static TerminalDialogWidget showColorDialog(TerminalOSWidget os, String title, Consumer<Integer> result) {
+    public static TerminalDialogWidget showColorDialog(TerminalOSWidget os, String title, Consumer<Integer> result, int startColor) {
         TerminalDialogWidget dialog = createEmptyTemplate(os).addTitle(title);
         ColorWidget colorWidget = new ColorWidget(WIDTH / 2 - 60, HEIGHT / 2 - 35, 80, 10);
+        colorWidget.setStartColor(startColor);
         dialog.addWidget(colorWidget);
         dialog.addConfirmButton(b -> {
             if (b) {

--- a/src/main/java/gregtech/api/terminal/os/TerminalOSWidget.java
+++ b/src/main/java/gregtech/api/terminal/os/TerminalOSWidget.java
@@ -14,8 +14,8 @@ import gregtech.api.terminal.hardware.Hardware;
 import gregtech.api.terminal.hardware.HardwareProvider;
 import gregtech.api.terminal.os.menu.TerminalMenuWidget;
 import gregtech.api.util.Position;
-import gregtech.client.utils.RenderUtil;
 import gregtech.api.util.Size;
+import gregtech.client.utils.RenderUtil;
 import gregtech.common.items.behaviors.TerminalBehaviour;
 import gregtech.common.terminal.app.settings.widgets.OsSettings;
 import gregtech.common.terminal.hardware.BatteryHardware;
@@ -56,6 +56,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     private int tickCounter;
     private long lastCharge;
     private boolean maximize;
+    private boolean showMenuHover = false;
 
     public TerminalOSWidget(int xPosition, int yPosition, ItemStack itemStack) {
         super(new Position(xPosition, yPosition), new Size(DEFAULT_WIDTH, DEFAULT_HEIGHT));
@@ -93,7 +94,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
         }
     }
 
-    public ModularUI getModularUI(){
+    public ModularUI getModularUI() {
         return this.gui;
     }
 
@@ -114,10 +115,10 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     }
 
     public <T extends Hardware> List<T> getHardware(Class<T> clazz) {
-        return getHardware().stream().filter(hw->hw.getClass() == clazz).map(hw->(T)hw).collect(Collectors.toList());
+        return getHardware().stream().filter(hw -> hw.getClass() == clazz).map(hw -> (T) hw).collect(Collectors.toList());
     }
 
-    public void installApplication(AbstractApplication application){
+    public void installApplication(AbstractApplication application) {
         desktop.installApplication(application);
         installedApps.add(application);
     }
@@ -158,7 +159,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
         if (!application.canPlayerUse(gui.entityPlayer)) {
             return;
         }
-        if (focusApp != null ) {
+        if (focusApp != null) {
             closeApplication(focusApp, isClient);
         }
         for (AbstractApplication app : openedApps) {
@@ -181,7 +182,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     public void maximizeApplication(AbstractApplication application, boolean isClient) {
         application.setActive(true);
         if (isClient) {
-            application.maximizeWidget(app->desktop.hideDesktop());
+            application.maximizeWidget(app -> desktop.hideDesktop());
             if (!menu.isHide) {
                 menu.hideMenu();
             }
@@ -193,10 +194,10 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
 
     public void minimizeApplication(AbstractApplication application, boolean isClient) {
         desktop.removeAllDialogs();
-        if (application != null ) {
+        if (application != null) {
             if (focusApp == application) {
                 if (isClient) {
-                    application.minimizeWidget(app->{
+                    application.minimizeWidget(app -> {
                         if (!application.isBackgroundApp()) {
                             application.setActive(false);
                         }
@@ -233,7 +234,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
                 desktop.waitToRemoved(application);
             }
             openedApps.remove(application);
-            if(focusApp == application) {
+            if (focusApp == application) {
                 focusApp = null;
             }
             menu.removeComponents();
@@ -242,7 +243,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     }
 
     public void callMenu(boolean isClient) {
-        if(isClient) {
+        if (isClient) {
             if (menu.isHide) {
                 menu.showMenu();
             } else {
@@ -266,7 +267,8 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
             }
             writeClientAction(-1, buffer -> buffer.writeCompoundTag(nbt));
         } else { //request shutdown from the server side
-            writeUpdateInfo(-2, packetBuffer -> {});
+            writeUpdateInfo(-2, packetBuffer -> {
+            });
         }
     }
 
@@ -274,7 +276,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
         if (isRemote()) {
             widget.onOSSizeUpdate(getSize().width, getSize().height);
             widget.maximizeWidget(null);
-        } else if(widget.isClient()) {
+        } else if (widget.isClient()) {
             return;
         }
         desktop.addWidget(widget);
@@ -283,7 +285,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     protected void closeDialog(TerminalDialogWidget widget) {
         if (isRemote()) {
             widget.minimizeWidget(desktop::waitToRemoved);
-        } else if(!widget.isClient()) {
+        } else if (!widget.isClient()) {
             desktop.waitToRemoved(widget);
         }
     }
@@ -315,7 +317,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            if (nbt != null ) {
+            if (nbt != null) {
                 tabletNBT.setTag(appName, nbt);
             }
         } else {
@@ -335,7 +337,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
                 List<AbstractApplication> toClosed = new LinkedList<>();
                 for (AbstractApplication openedApp : openedApps) {
                     TerminalRegistry.getAppHardwareDemand(openedApp.getRegistryName(), openedApp.getAppTier()).stream()
-                            .filter(i->i instanceof BatteryHardware).findFirst()
+                            .filter(i -> i instanceof BatteryHardware).findFirst()
                             .ifPresent(x -> toClosed.add(openedApp));
                 }
                 for (AbstractApplication close : toClosed) {
@@ -343,7 +345,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
                 }
                 TerminalDialogWidget.showInfoDialog(this, "terminal.component.warning", "terminal.battery.low_energy").setClientSide().open();
             }
-        } else if(id == -2) { // shutdown
+        } else if (id == -2) { // shutdown
             shutdown(true);
         } else {
             super.readUpdateInfo(id, buffer);
@@ -354,7 +356,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     public void updateScreen() {
         super.updateScreen();
         tickCounter++;
-        if( background != null) {
+        if (background != null) {
             background.updateTick();
         }
     }
@@ -379,9 +381,9 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
             List<AbstractApplication> charged = new ArrayList<>();
             for (AbstractApplication openedApp : openedApps) {
                 TerminalRegistry.getAppHardwareDemand(openedApp.getRegistryName(), openedApp.getAppTier()).stream()
-                        .filter(i->i instanceof BatteryHardware).findFirst()
-                        .ifPresent(battery-> {
-                            costs.addAndGet(((BatteryHardware)battery).getCharge());
+                        .filter(i -> i instanceof BatteryHardware).findFirst()
+                        .ifPresent(battery -> {
+                            costs.addAndGet(((BatteryHardware) battery).getCharge());
                             charged.add(openedApp);
                         });
             }
@@ -391,7 +393,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
                 }
             }
             if (costs.get() > 0 && electricItem.discharge(costs.get(), 999, true, false, false) != costs.get()) {
-                charged.forEach(app->closeApplication(app, false));
+                charged.forEach(app -> closeApplication(app, false));
             } else if (costs.get() < 0) {
                 electricItem.charge(-costs.get(), 999, true, false);
             }
@@ -404,7 +406,19 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
     public void drawInBackground(int mouseX, int mouseY, float partialTicks, IRenderContext context) {
         Position position = getPosition();
         Size size = getSize();
-        if( background != null) {
+
+        // show menu when mouse near the left edge
+        if ((focusApp == null || focusApp.canOpenMenuOnEdge()) && isMouseOver(position.x, position.y, 7, size.height, mouseX, mouseY)) {
+            if (menu.isHide && !showMenuHover) {
+                menu.showMenu();
+                showMenuHover = true;
+            }
+        } else if (!menu.isHide && showMenuHover && !isMouseOver(position.x - 10, position.y, 41, size.height, mouseX, mouseY)) {
+            menu.hideMenu();
+            showMenuHover = false;
+        }
+
+        if (background != null) {
             background.draw(position.x, position.y, size.width, size.height);
         } else {
             drawGradientRect(position.x, position.y, size.width, size.height, -1, -1);
@@ -415,18 +429,19 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
                 menu.drawInBackground(mouseX, mouseY, partialTicks, context);
             }
         } else {
-            RenderUtil.useScissor(position.x, position.y, size.width, size.height, ()-> {
+            RenderUtil.useScissor(position.x, position.y, size.width, size.height, () -> {
                 desktop.drawInBackground(mouseX, mouseY, partialTicks, context);
                 if (menu.isVisible()) {
                     menu.drawInBackground(mouseX, mouseY, partialTicks, context);
                 }
             });
-            TERMINAL_FRAME.draw(position.x-12, position.y-11, 380, 256);
+            TERMINAL_FRAME.draw(position.x - 12, position.y - 11, 380, 256);
         }
         home.drawInBackground(mouseX, mouseY, partialTicks, context);
     }
 
     boolean waitShutdown;
+
     @Override
     public boolean keyTyped(char charTyped, int keyCode) {
         if (waitShutdown && (keyCode == 1 || Minecraft.getMinecraft().gameSettings.keyBindInventory.isActiveAndMatches(keyCode))) {
@@ -442,7 +457,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
                 shutdown(true);
                 return true;
             }
-            TerminalDialogWidget.showConfirmDialog(this, "terminal.component.warning", "terminal.os.shutdown_confirm", result->{
+            TerminalDialogWidget.showConfirmDialog(this, "terminal.component.warning", "terminal.os.shutdown_confirm", result -> {
                 if (result) {
                     shutdown(true);
                 } else {
@@ -465,7 +480,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
         if (this.maximize && (osWidth != gui.getScreenWidth() || osHeight != gui.getScreenHeight())) {
             osWidth = gui.getScreenWidth();
             osHeight = gui.getScreenHeight();
-        } else if (!this.maximize && (osWidth != DEFAULT_WIDTH || osHeight != DEFAULT_HEIGHT)){
+        } else if (!this.maximize && (osWidth != DEFAULT_WIDTH || osHeight != DEFAULT_HEIGHT)) {
             osWidth = DEFAULT_WIDTH;
             osHeight = DEFAULT_HEIGHT;
         } else {

--- a/src/main/java/gregtech/common/terminal/app/appstore/AppCardWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/appstore/AppCardWidget.java
@@ -121,7 +121,7 @@ public class AppCardWidget extends AnimaWidgetGroup {
         int height = getSize().height;
         if (isMouseOverElement(mouseX, mouseY) && store.getOs().desktop.widgets.stream().noneMatch(app->app instanceof  TerminalDialogWidget)) {
             int dur = 7;
-            int maxAlpha = 150; // 0-255!!!!!
+            int maxAlpha = 100; // 0-255!!!!!
             float partialTicks = Minecraft.getMinecraft().getRenderPartialTicks();
             if (alpha != maxAlpha && interpolator == null) {
                 interpolator = new Interpolator(0, maxAlpha, dur, Eases.EaseLinear,

--- a/src/main/java/gregtech/common/terminal/app/game/maze/MazeApp.java
+++ b/src/main/java/gregtech/common/terminal/app/game/maze/MazeApp.java
@@ -101,6 +101,11 @@ public class MazeApp extends AbstractApplication {
     }
 
     @Override
+    public boolean canOpenMenuOnEdge() {
+        return gameState != 1;
+    }
+
+    @Override
     public boolean isClientSideApp() {
         return true;
     }

--- a/src/main/java/gregtech/common/terminal/app/game/minesweeper/MinesweeperApp.java
+++ b/src/main/java/gregtech/common/terminal/app/game/minesweeper/MinesweeperApp.java
@@ -24,6 +24,11 @@ public class MinesweeperApp extends AbstractApplication {
     }
 
     @Override
+    public boolean canOpenMenuOnEdge() {
+        return false;
+    }
+
+    @Override
     public void updateScreen() {
         super.updateScreen();
         if(mineField.hasWon() || mineField.hasLost()) {

--- a/src/main/java/gregtech/common/terminal/app/game/pong/PongApp.java
+++ b/src/main/java/gregtech/common/terminal/app/game/pong/PongApp.java
@@ -50,6 +50,11 @@ public class PongApp extends AbstractApplication {
     }
 
     @Override
+    public boolean canOpenMenuOnEdge() {
+        return false;
+    }
+
+    @Override
     public boolean isClientSideApp() {
         return true;
     }

--- a/src/main/java/gregtech/common/terminal/app/settings/widgets/HomeButtonSettings.java
+++ b/src/main/java/gregtech/common/terminal/app/settings/widgets/HomeButtonSettings.java
@@ -53,13 +53,13 @@ public class HomeButtonSettings extends AbstractWidgetGroup {
                     }
                     TextFieldWidget textFieldWidget = new TextFieldWidget(230, y, 80, 20, TerminalTheme.COLOR_B_3, null, null)
                             .setMaxStringLength(Integer.MAX_VALUE)
-                            .setTextResponder(arg->{
-                                if(arg != null && home.getActions()[i] != null) {
+                            .setTextResponder(arg -> {
+                                if (arg != null && home.getActions()[i] != null) {
                                     home.getActions()[i].setValue(arg);
                                 }
                                 home.saveConfig();
-                            },true)
-                            .setValidator(s->true);
+                            }, true)
+                            .setValidator(s -> true);
                     if (pair != null && pair.getValue() != null) {
                         textFieldWidget.setCurrentString(pair.getValue());
                     } else {
@@ -67,19 +67,19 @@ public class HomeButtonSettings extends AbstractWidgetGroup {
                     }
 
                     this.addWidget(new SelectorWidget(120, y, 100, 20, candidates, -1,
-                            ()->{
+                            () -> {
                                 Pair<SystemCall, String> _pair = home.getActions()[i];
                                 if (_pair != null) {
                                     return _pair.getKey().getTranslateKey();
                                 }
                                 return "terminal.system_call.null";
                             }, true)
-                            .setIsUp(true)
+                            .setIsUp(i > 3)
                             .setHoverText(I18n.format(doubleClick == 1 ? "terminal.settings.home.double_click" : "terminal.settings.home.click") + (ctrl == 1 ? "+Ctrl" : "") + (shift == 1 ? "+Shift" : ""))
-                            .setOnChanged(selected->{
+                            .setOnChanged(selected -> {
                                 SystemCall action = SystemCall.getFromName(selected);
                                 if (action != null) {
-                                    if(home.getActions()[i] == null) {
+                                    if (home.getActions()[i] == null) {
                                         home.getActions()[i] = new MutablePair<>(action, null);
                                     } else {
                                         home.getActions()[i] = new MutablePair<>(action, home.getActions()[i].getValue());
@@ -88,6 +88,15 @@ public class HomeButtonSettings extends AbstractWidgetGroup {
                                     home.getActions()[i] = null;
                                 }
                                 home.saveConfig();
+                            })
+                            .setOnShowChange(isShow -> {
+                                if (isShow) {
+                                    for (Widget widget : widgets) {
+                                        if (widget instanceof SelectorWidget) {
+                                            ((SelectorWidget) widget).hide();
+                                        }
+                                    }
+                                }
                             })
                             .setColors(TerminalTheme.COLOR_B_2.getColor(), TerminalTheme.COLOR_F_1.getColor(), TerminalTheme.COLOR_B_2.getColor())
                             .setBackground(TerminalTheme.COLOR_6));
@@ -102,7 +111,7 @@ public class HomeButtonSettings extends AbstractWidgetGroup {
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
         for (int i = widgets.size() - 1; i >= 0; i--) {
             Widget widget = widgets.get(i);
-            if(widget.isVisible() && widget.isActive() && widget.mouseClicked(mouseX, mouseY, button)) {
+            if (widget.isVisible() && widget.isActive() && widget.mouseClicked(mouseX, mouseY, button)) {
                 mouseX = -10000;
                 mouseY = -10000;
             }

--- a/src/main/java/gregtech/common/terminal/app/settings/widgets/ThemeSettings.java
+++ b/src/main/java/gregtech/common/terminal/app/settings/widgets/ThemeSettings.java
@@ -60,7 +60,7 @@ public class ThemeSettings extends AbstractWidgetGroup {
                     TerminalDialogWidget.showInfoDialog(os, "terminal.component.error", "terminal.component.save_file.error").setClientSide().open();
                 }
             }
-        }).setClientSide().open());
+        }, texture.color).setClientSide().open());
         addWidget(buttonWidget);
     }
 

--- a/src/main/java/gregtech/common/terminal/app/worldprospector/WorldProspectorARApp.java
+++ b/src/main/java/gregtech/common/terminal/app/worldprospector/WorldProspectorARApp.java
@@ -108,7 +108,7 @@ public class WorldProspectorARApp extends ARApplication {
                             buttonWidget.setFill(res | 0xff000000);
                             colors[index] = res | 0xff000000;
                         }
-                    }).open())
+                    }, colors[index]).open())
             );
         }
         addWidget(new CircleButtonWidget(333 / 2, 200)


### PR DESCRIPTION
- When the mouse hovers over the left screen edge the menu appears. This is so you don't have to click the home button every time and then move the mouse back to the other side of the screen. Can be disabled for each app individualy.
- Color settings now will now have set their current color on open. Before it was always set to white.
- The pop up menu list for the buttons in home button settings were all opening to the top. This caused some options to go out of screen when gui scale is set to large or auto. 
- The pop up buttons will now close all other pop up buttons on open in home button settings
- reduce alpha for background in app store when hovering a app