### PR TITLE
Change accessibility of getMaxVoltage() to protected

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -92,7 +92,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
 
     protected abstract boolean drawEnergy(int recipeEUt, boolean simulate);
 
-    abstract long getMaxVoltage();
+    protected abstract long getMaxVoltage();
 
     protected IItemHandlerModifiable getInputInventory() {
         return metaTileEntity.getImportItems();


### PR DESCRIPTION
**What:**
This PR changes access modifier of `AbstractRecipeLogic#getMaxVoltage()` to `protected`, to allow addons to implement the class directly.
