### PR TITLE
Adjust some Damage Sources

### DIFF
--- a/src/main/java/gregtech/api/damagesources/DamageSources.java
+++ b/src/main/java/gregtech/api/damagesources/DamageSources.java
@@ -5,9 +5,9 @@ import net.minecraft.util.DamageSource;
 public class DamageSources {
 
     private static final DamageSource EXPLOSION = new DamageSource("explosion").setExplosion();
-    private static final DamageSource HEAT = new DamageSource("heat").setDamageBypassesArmor();
-    private static final DamageSource FROST = new DamageSource("frost").setDamageBypassesArmor();
-    private static final DamageSource ELECTRIC = new DamageSource("electric").setDamageBypassesArmor();
+    private static final DamageSource HEAT = new DamageSource("heat");
+    private static final DamageSource FROST = new DamageSource("frost");
+    private static final DamageSource ELECTRIC = new DamageSource("electric");
     private static final DamageSource RADIATION = new DamageSource("radiation").setDamageBypassesArmor();
     private static final DamageSource TURBINE = new DamageSource("turbine");
 

--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -162,9 +162,9 @@ public class MetaPrefixItem extends StandardMetaItem {
             EntityLivingBase entity = (EntityLivingBase) entityIn;
             if (worldIn.getTotalWorldTime() % 20 == 0) {
                 if (prefix.heatDamage != 0.0 && prefix.heatDamage > 0.0) {
-                    entity.attackEntityFrom(DamageSources.getHeatDamage(), prefix.heatDamage);
+                    entity.attackEntityFrom(DamageSources.getHeatDamage().setDamageBypassesArmor(), prefix.heatDamage);
                 } else if (prefix.heatDamage < 0.0) {
-                    entity.attackEntityFrom(DamageSources.getFrostDamage(), -prefix.heatDamage);
+                    entity.attackEntityFrom(DamageSources.getFrostDamage().setDamageBypassesArmor(), -prefix.heatDamage);
                 }
             }
         }


### PR DESCRIPTION
**What:**

Adjusts the Heat, Frost, and Electric Damage sources to not bypass armor. This is mainly done for pipes and cables.

An exception, Heat and Cold damage from any MetaPrefixItems (Aka Hot Ingots) will still bypass armor