### PR TITLE
Allow Robot Arms to Supply Exact more than 1 stack

### DIFF
--- a/src/main/java/gregtech/common/covers/TransferMode.java
+++ b/src/main/java/gregtech/common/covers/TransferMode.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 
 public enum TransferMode implements IStringSerializable {
     TRANSFER_ANY("cover.robotic_arm.transfer_mode.transfer_any", Integer.MAX_VALUE),
-    TRANSFER_EXACT("cover.robotic_arm.transfer_mode.transfer_exact", 64),
+    TRANSFER_EXACT("cover.robotic_arm.transfer_mode.transfer_exact", 1024),
     KEEP_EXACT("cover.robotic_arm.transfer_mode.keep_exact", 1024);
 
     public final String localeName;


### PR DESCRIPTION
**What:**

Allows the Robot Arm to Supply Exact more than 1 stack. I set it to the same amount as the Keep Exact value