### PR TITLE
Logic hacking for certain contexts to abide to the correct StoneType

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/StoneType.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneType.java
@@ -52,16 +52,40 @@ public class StoneType implements Comparable<StoneType> {
         return STONE_TYPE_REGISTRY.getIDForObject(this) - STONE_TYPE_REGISTRY.getIDForObject(stoneType);
     }
 
+    private static final ThreadLocal<Boolean> hasDummyPredicateRan = ThreadLocal.withInitial(() -> false);
+    private static final com.google.common.base.Predicate<IBlockState> dummyPredicate = state -> {
+        hasDummyPredicateRan.set(true);
+        return false;
+    };
+
     public static void init() {
         //noinspection ResultOfMethodCallIgnored
         StoneTypes.STONE.name.getBytes();
     }
 
-    public static StoneType computeStoneType(IBlockState blockState, IBlockAccess world, BlockPos blockPos) {
-        //TODO ADD CONFIG HOOK HERE FOR MATCHING BLOCKS WITH STONE TYPES
-        for (StoneType stoneType : STONE_TYPE_REGISTRY) {
-            if (blockState.getBlock().isReplaceableOreGen(blockState, world, blockPos, stoneType.predicate))
-                return stoneType;
+    public static StoneType computeStoneType(IBlockState state, IBlockAccess world, BlockPos pos) {
+        // First: check if this Block's isReplaceableOreGen even considers the predicate passed through
+        boolean dummy$isReplaceableOreGen = state.getBlock().isReplaceableOreGen(state, world, pos, dummyPredicate);
+        if (hasDummyPredicateRan.get()) {
+            // Current Block's isReplaceableOreGen does indeed consider the predicate
+            // Reset hasDummyPredicateRan for the next test
+            hasDummyPredicateRan.set(false);
+            // Pass through actual predicates and test for real
+            for (StoneType stoneType : STONE_TYPE_REGISTRY) {
+                if (state.getBlock().isReplaceableOreGen(state, world, pos, stoneType.predicate)) {
+                    // Found suitable match
+                    return stoneType;
+                }
+            }
+        } else if (dummy$isReplaceableOreGen) {
+            // It is not considered, but the test still returned true (this means the impl was probably very lazily done)
+            // We have to test against the IBlockState ourselves to see if there's a suitable StoneType
+            for (StoneType stoneType : STONE_TYPE_REGISTRY) {
+                if (stoneType.predicate.test(state)) {
+                    // Found suitable match
+                    return stoneType;
+                }
+            }
         }
         return null;
     }


### PR DESCRIPTION
Mainly for Galacticraft as it doesn't even consider whatever the predicate is passes through to `isReplaceableOreGen`, assuming some other mods might also do this.

This does NOT fix GalaxySpace/ExtraPlanets not using our generators, this only fixes existing ore veins not using the correct StoneType when generating in base Galacticraft dimensions.