### PR TITLE
Moved test bootstrapping to one class + fix I18n being null during tests

### DIFF
--- a/src/test/java/gregtech/Bootstrap.java
+++ b/src/test/java/gregtech/Bootstrap.java
@@ -1,0 +1,35 @@
+package gregtech;
+
+import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.common.MetaFluids;
+import gregtech.common.items.MetaItems;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.resources.Locale;
+
+import java.lang.reflect.Method;
+
+public class Bootstrap {
+
+    private static boolean bootstrapped = false;
+
+    public static void perform() {
+        if (bootstrapped) {
+            return;
+        }
+        try {
+            Method setLocale = I18n.class.getDeclaredMethod("setLocale", Locale.class); // No need to care about obfuscation
+            setLocale.setAccessible(true);
+            setLocale.invoke(null, new Locale());
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+        }
+        net.minecraft.init.Bootstrap.register();
+        Materials.register();
+        OrePrefix.runMaterialHandlers();
+        MetaFluids.init();
+        MetaItems.init();
+        bootstrapped = true;
+    }
+
+}

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.*;
 public class AbstractRecipeLogicTest {
 
     @BeforeClass
-    public static void init() {
+    public static void bootstrap() {
         Bootstrap.perform();
     }
 

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -1,5 +1,6 @@
 package gregtech.api.capability.impl;
 
+import gregtech.Bootstrap;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -10,7 +11,6 @@ import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.metatileentities.MetaTileEntities;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -23,7 +23,7 @@ public class AbstractRecipeLogicTest {
 
     @BeforeClass
     public static void init() {
-        Bootstrap.register();
+        Bootstrap.perform();
     }
 
     @Test

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.*;
 public class MultiblockRecipeLogicTest {
 
     @BeforeClass
-    public static void init() {
+    public static void bootstrap() {
         Bootstrap.perform();
     }
 

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -1,5 +1,6 @@
 package gregtech.api.capability.impl;
 
+import gregtech.Bootstrap;
 import gregtech.api.GTValues;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -10,8 +11,6 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
-import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch;
@@ -19,7 +18,6 @@ import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityItemB
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -38,9 +36,7 @@ public class MultiblockRecipeLogicTest {
 
     @BeforeClass
     public static void init() {
-        Bootstrap.register();
-        Materials.register();
-        OrePrefix.runMaterialHandlers();
+        Bootstrap.perform();
     }
 
     private static ResourceLocation gregtechId(String name) {

--- a/src/test/java/gregtech/api/recipes/RecipeMapTest.java
+++ b/src/test/java/gregtech/api/recipes/RecipeMapTest.java
@@ -1,10 +1,8 @@
 package gregtech.api.recipes;
 
+import gregtech.Bootstrap;
 import gregtech.api.recipes.builders.SimpleRecipeBuilder;
-import gregtech.api.unification.material.Materials;
-import gregtech.common.MetaFluids;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
@@ -22,9 +20,7 @@ public class RecipeMapTest {
 
     @BeforeClass
     public static void init() {
-        Bootstrap.register();
-        Materials.register();
-        MetaFluids.init();
+        Bootstrap.perform();
     }
 
     @Test

--- a/src/test/java/gregtech/api/recipes/RecipeMapTest.java
+++ b/src/test/java/gregtech/api/recipes/RecipeMapTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNotNull;
 public class RecipeMapTest {
 
     @BeforeClass
-    public static void init() {
+    public static void bootstrap() {
         Bootstrap.perform();
     }
 

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -43,7 +43,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
     private static boolean enableBonusOverride = false;
 
     @BeforeClass
-    public static void init() {
+    public static void bootstrap() {
         Bootstrap.perform();
     }
 

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes.logic;
 
+import gregtech.Bootstrap;
 import gregtech.api.GTValues;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -10,18 +11,14 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
-import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.ItemStackHashStrategy;
 import gregtech.api.util.world.DummyWorld;
-import gregtech.common.items.MetaItems;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityItemBus;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -47,10 +44,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
 
     @BeforeClass
     public static void init() {
-        Bootstrap.register();
-        Materials.register();
-        OrePrefix.runMaterialHandlers();
-        MetaItems.init();
+        Bootstrap.perform();
     }
 
     private static ResourceLocation gregtechId(String name) {

--- a/src/test/java/gregtech/api/recipes/logic/ParallelLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/ParallelLogicTest.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes.logic;
 
+import gregtech.Bootstrap;
 import gregtech.api.GTValues;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
@@ -8,11 +9,9 @@ import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTHashMaps;
 import gregtech.api.util.OverlayedFluidHandler;
 import gregtech.api.util.OverlayedItemHandler;
-import gregtech.common.MetaFluids;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityItemBus;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import org.junit.BeforeClass;
@@ -28,10 +27,8 @@ public class ParallelLogicTest {
     MetaTileEntityFluidHatch exportFluidBus = new MetaTileEntityFluidHatch(gregtechId("fluid_hatch.import.lv"), 1, true);
 
     @BeforeClass
-    public static void bootStrap() {
-        Bootstrap.register();
-        Materials.register();
-        MetaFluids.init();
+    public static void bootstrap() {
+        Bootstrap.perform();
     }
 
     private static ResourceLocation gregtechId(String name) {

--- a/src/test/java/gregtech/api/util/InventoryUtilsTest.java
+++ b/src/test/java/gregtech/api/util/InventoryUtilsTest.java
@@ -1,6 +1,6 @@
 package gregtech.api.util;
 
-import net.minecraft.init.Bootstrap;
+import gregtech.Bootstrap;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagString;
@@ -22,8 +22,8 @@ public class InventoryUtilsTest {
      * Required. Without this all item-related operations will fail because registries haven't been initialized.
      */
     @BeforeClass
-    public static void bootStrap() {
-        Bootstrap.register();
+    public static void bootstrap() {
+        Bootstrap.perform();
     }
 
     /**

--- a/src/test/java/gregtech/client/I18nTest.java
+++ b/src/test/java/gregtech/client/I18nTest.java
@@ -1,0 +1,22 @@
+package gregtech.client;
+
+import gregtech.Bootstrap;
+import gregtech.api.util.GTLog;
+import net.minecraft.client.resources.I18n;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class I18nTest {
+
+    @BeforeClass
+    public static void bootstrap() {
+        Bootstrap.perform();
+    }
+
+    @Test
+    public void testI18n() {
+        GTLog.logger.info("Test: {}", I18n.format("sus"));
+        GTLog.logger.info("Test: {}", I18n.format("sus", "Sus"));
+    }
+
+}

--- a/src/test/java/gregtech/common/covers/CoverFluidRegulatorTest.java
+++ b/src/test/java/gregtech/common/covers/CoverFluidRegulatorTest.java
@@ -1,7 +1,7 @@
 package gregtech.common.covers;
 
+import gregtech.Bootstrap;
 import gregtech.api.capability.impl.*;
-import net.minecraft.init.*;
 import net.minecraft.util.*;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.fluids.capability.*;
@@ -18,8 +18,8 @@ public class CoverFluidRegulatorTest {
      * Required. Without this all item-related operations will fail because registries haven't been initialized.
      */
     @BeforeClass
-    public static void bootStrap() {
-        Bootstrap.register();
+    public static void bootstrap() {
+        Bootstrap.perform();
     }
 
     @Test


### PR DESCRIPTION
This PR makes it easier to bootstrap tests by concentrating it in one single class. It also provides a better solution to fix failing `I18n` tests for #542 by passing instantiating a dummy `Locale` instance for `I18n`.