### PR TITLE
Add timer offset method

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -72,7 +72,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
-            if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
+            if (getOffsetTimer() % timerOffsetInTicks() == 0 || isFirstTick()) {
                 checkStructurePattern();
             }
             if (isStructureFormed()) {
@@ -215,6 +215,13 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
      */
     public boolean canShare() {
         return true;
+    }
+
+    /**
+     * Override to change the time in ticks that pattern checker runs
+     */
+    public long timerOffsetInTicks() {
+        return 20L;
     }
 
     /**


### PR DESCRIPTION
**What:**
Adds a method getting the number of ticks to wait for doing structure checks for multiblock controllers

**How solved:**
Added in a method to get the number of ticks for structure checking to occur

**Outcome:**
Allows structure checks to happen at any number of ticks for multiblocks, not just each second