### PR TITLE
Fix delay with GUI taking too long to open

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
@@ -28,7 +28,10 @@ public class ModularUIGui extends GuiContainer implements IRenderContext {
     public static final float rColorForOverlay = 1;
     public static final float gColorForOverlay = 1;
     public static final float bColorForOverlay = 1;
+
+    public static final float FRAMES_PER_TICK = 1/3f;
     private float lastUpdate;
+
     public int dragSplittingLimit;
     public int dragSplittingButton;
 
@@ -75,11 +78,10 @@ public class ModularUIGui extends GuiContainer implements IRenderContext {
 
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
-        float now = getModularUI().entityPlayer.ticksExisted + partialTicks;
-        int times = (int) ((now - lastUpdate) / 0.333f);
-        for (int i = 0; i < times; i++) {
+        lastUpdate += partialTicks;
+        while (lastUpdate >= FRAMES_PER_TICK) {
+            lastUpdate -= FRAMES_PER_TICK;
             modularUI.guiWidgets.values().forEach(Widget::updateScreenOnFrame);
-            lastUpdate += 0.333f;
         }
         this.hoveredSlot = null;
         drawDefaultBackground();

--- a/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
@@ -79,7 +79,7 @@ public class ModularUIGui extends GuiContainer implements IRenderContext {
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         lastUpdate += partialTicks;
-        while (lastUpdate >= FRAMES_PER_TICK) {
+        while (lastUpdate >= 0) {
             lastUpdate -= FRAMES_PER_TICK;
             modularUI.guiWidgets.values().forEach(Widget::updateScreenOnFrame);
         }


### PR DESCRIPTION
This PR fixes the issue that GUIs took longer and longer to open, which was introduced in the transition to 60FPS widgets in #316.

Using `entityPlayer.ticksExisted` felt unnecessary, but most importantly caused the `for` loop to run for much longer than it should when opening a GUI.