### PR TITLE
Re-add (ItemStack, ItemStack) addSmeltingRecipe

### DIFF
--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -198,6 +198,10 @@ public class ModHandler {
         }
     }
 
+    public static void addSmeltingRecipe(ItemStack input, ItemStack output) {
+        addSmeltingRecipe(input, output, 0);
+    }
+
     ///////////////////////////////////////////////////
     //              Crafting Recipe Helpers          //
     ///////////////////////////////////////////////////


### PR DESCRIPTION
Fixes a compatibility issue with GTFO, which used this particular function.