### PR TITLE
Fix maintenance never happening after initial fix

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -275,8 +275,8 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
     @Override
     protected void completeRecipe() {
-        super.completeRecipe();
         performMaintenanceMufflerOperations();
+        super.completeRecipe();
     }
 
     protected void performMaintenanceMufflerOperations() {


### PR DESCRIPTION
The method was being called after the internal values were reset, so it was adding a whopping `0` tick to the active value.
This should also "fix" parallel multis with a muffler hatch, so now you should get a proper amount of ashes, how lucky players are gonna be!