### PR TITLE
Fix Enchantment glint coloring entire slot in Workbench storage

### DIFF
--- a/src/main/java/gregtech/api/gui/Widget.java
+++ b/src/main/java/gregtech/api/gui/Widget.java
@@ -322,6 +322,7 @@ public abstract class Widget {
         GlStateManager.pushMatrix();
         GlStateManager.translate(0.0F, 0.0F, 32.0F);
         GlStateManager.color(1F, 1F, 1F, 1F);
+        GlStateManager.enableDepth();
         GlStateManager.enableRescaleNormal();
         GlStateManager.enableLighting();
         RenderHelper.enableGUIStandardItemLighting();


### PR DESCRIPTION
**What:**

Fixes enchantment glints from coloring the entire slot when in the storage section of the Crafting Station/Workbench.

Before:
![2022-02-22_12-29](https://user-images.githubusercontent.com/31759736/155241738-4b40cf78-6f49-4f1d-9ea3-a599642c2405.png)

After:
![2022-02-22_17-17](https://user-images.githubusercontent.com/31759736/155241827-40032bd8-822c-47dd-b0ac-4a85d3422cfd.png)

