### PR TITLE
Make covers output strong redstone signals

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -354,14 +354,25 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     @Override
     public boolean shouldCheckWeakPower(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
-        // actually cause getWeakPower to be called, rather than prevent it.
-        return false;
+        // actually cause getWeakPower to be called, rather than prevent it. (i.e. true = getStrongPower(), false = getWeakPower())
+        MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
+        return metaTileEntity != null && metaTileEntity.isOutputtingStrongRedstoneSignal(side.getOpposite())
+                && world.getBlockState(pos.offset(side.getOpposite())).isBlockNormalCube(); //Only output strong power to solid blocks, since strong can only be either 15 or 0
     }
 
     @Override
     public int getWeakPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(blockAccess, pos);
-        return metaTileEntity == null ? 0 : metaTileEntity.getOutputRedstoneSignal(side == null ? null : side.getOpposite());
+        return metaTileEntity == null ? 0 : metaTileEntity.getOutputRedstoneSignal(side.getOpposite());
+    }
+
+    @Override
+    public int getStrongPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+        MetaTileEntity metaTileEntity = getMetaTileEntity(blockAccess, pos);
+        if (metaTileEntity != null && metaTileEntity.getOutputRedstoneSignal(side.getOpposite()) > 0) {
+            return 15; //World::getStrongPower only cares about power level 15 or 0
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -354,10 +354,8 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     @Override
     public boolean shouldCheckWeakPower(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
-        // actually cause getWeakPower to be called, rather than prevent it. (i.e. true = getStrongPower(), false = getWeakPower())
-        MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
-        return metaTileEntity != null && metaTileEntity.isOutputtingStrongRedstoneSignal(side.getOpposite())
-                && world.getBlockState(pos.offset(side.getOpposite())).isBlockNormalCube(); //Only output strong power to solid blocks, since strong can only be either 15 or 0
+        // actually cause getWeakPower to be called, rather than prevent it. (Update: This seems right from the code, but getStrongPower is still called when this is false...)
+        return false;
     }
 
     @Override
@@ -369,8 +367,8 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     @Override
     public int getStrongPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(blockAccess, pos);
-        if (metaTileEntity != null && metaTileEntity.getOutputRedstoneSignal(side.getOpposite()) > 0) {
-            return 15; //World::getStrongPower only cares about power level 15 or 0
+        if (metaTileEntity != null && metaTileEntity.isOutputtingStrongRedstoneSignal(side.getOpposite())) {
+            return getWeakPower(blockState, blockAccess, pos, side);
         }
         return 0;
     }

--- a/src/main/java/gregtech/api/cover/CoverBehavior.java
+++ b/src/main/java/gregtech/api/cover/CoverBehavior.java
@@ -41,6 +41,7 @@ public abstract class CoverBehavior implements IUIHolder {
     public final ICoverable coverHolder;
     public final EnumFacing attachedSide;
     private int redstoneSignalOutput;
+    private boolean isOutputtingStrongRedstone;
 
     public CoverBehavior(ICoverable coverHolder, EnumFacing attachedSide) {
         this.coverHolder = coverHolder;
@@ -55,14 +56,20 @@ public abstract class CoverBehavior implements IUIHolder {
         return coverDefinition;
     }
 
-    public final void setRedstoneSignalOutput(int redstoneSignalOutput) {
+    public final void setRedstoneSignalOutput(int redstoneSignalOutput, boolean isStrong) {
         this.redstoneSignalOutput = redstoneSignalOutput;
+        this.isOutputtingStrongRedstone = isStrong;
         coverHolder.notifyBlockUpdate();
+        coverHolder.notifyNeighborsOfStateChange(attachedSide, false);
         coverHolder.markDirty();
     }
 
     public final int getRedstoneSignalOutput() {
         return redstoneSignalOutput;
+    }
+
+    public final boolean isOutputtingStrongRedstone() {
+        return isOutputtingStrongRedstone;
     }
 
     public final int getRedstoneSignalInput() {
@@ -80,10 +87,12 @@ public abstract class CoverBehavior implements IUIHolder {
         if (redstoneSignalOutput > 0) {
             tagCompound.setInteger("RedstoneSignal", redstoneSignalOutput);
         }
+        tagCompound.setBoolean("StrongSignal", isOutputtingStrongRedstone);
     }
 
     public void readFromNBT(NBTTagCompound tagCompound) {
         this.redstoneSignalOutput = tagCompound.getInteger("RedstoneSignal");
+        this.isOutputtingStrongRedstone = tagCompound.getBoolean("StrongSignal");
     }
 
     public void writeInitialSyncData(PacketBuffer packetBuffer) {

--- a/src/main/java/gregtech/api/cover/CoverBehavior.java
+++ b/src/main/java/gregtech/api/cover/CoverBehavior.java
@@ -60,8 +60,10 @@ public abstract class CoverBehavior implements IUIHolder {
         this.redstoneSignalOutput = redstoneSignalOutput;
         this.isOutputtingStrongRedstone = isStrong;
         coverHolder.notifyBlockUpdate();
-        coverHolder.notifyNeighborsOfStateChange(attachedSide, false);
         coverHolder.markDirty();
+        if (isStrong) {
+            coverHolder.notifyNeighborsOfStateChange(attachedSide, false);
+        }
     }
 
     public final int getRedstoneSignalOutput() {

--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -36,6 +36,8 @@ public interface ICoverable {
 
     BlockPos getPos();
 
+    void notifyNeighborsOfStateChange(EnumFacing offsetSide, boolean updateObservers);
+
     long getOffsetTimer();
 
     void markDirty();

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1138,8 +1138,10 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         this.isOutputtingStrongRedstone[side.getIndex()] = isStrong;
         if (getWorld() != null && !getWorld().isRemote && getCoverAtSide(side) == null) {
             notifyBlockUpdate();
-            notifyNeighborsOfStateChange(side, false);
             markDirty();
+            if (isStrong) {
+                notifyNeighborsOfStateChange(side, false);
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -211,10 +211,8 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     @Override
     public boolean shouldCheckWeakPower(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
-        // actually cause getWeakPower to be called, rather than prevent it. (i.e. true = getStrongPower(), false = getWeakPower())
-        IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(world, pos);
-        return pipeTile != null && pipeTile.getCoverableImplementation().isOutputtingStrongRedstoneSignal(side)
-                && world.getBlockState(pos.offset(side.getOpposite())).isBlockNormalCube(); //Only output strong power to solid blocks, since strong can only be either 15 or 0
+        // actually cause getWeakPower to be called, rather than prevent it. (Update: This seems right from the code, but getStrongPower is still called when this is false...)
+        return false;
     }
 
     @Override
@@ -226,8 +224,8 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     @Override
     public int getStrongPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(blockAccess, pos);
-        if (pipeTile != null && pipeTile.getCoverableImplementation().getOutputRedstoneSignal(side.getOpposite()) > 0) {
-            return 15; //World::getStrongPower only cares about power level 15 or 0
+        if (pipeTile != null && pipeTile.getCoverableImplementation().isOutputtingStrongRedstoneSignal(side.getOpposite())) {
+            return getWeakPower(blockState, blockAccess, pos, side);
         }
         return 0;
     }

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -211,14 +211,25 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     @Override
     public boolean shouldCheckWeakPower(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
-        // actually cause getWeakPower to be called, rather than prevent it.
-        return false;
+        // actually cause getWeakPower to be called, rather than prevent it. (i.e. true = getStrongPower(), false = getWeakPower())
+        IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(world, pos);
+        return pipeTile != null && pipeTile.getCoverableImplementation().isOutputtingStrongRedstoneSignal(side)
+                && world.getBlockState(pos.offset(side.getOpposite())).isBlockNormalCube(); //Only output strong power to solid blocks, since strong can only be either 15 or 0
     }
 
     @Override
     public int getWeakPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(blockAccess, pos);
         return pipeTile == null ? 0 : pipeTile.getCoverableImplementation().getOutputRedstoneSignal(side.getOpposite());
+    }
+
+    @Override
+    public int getStrongPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+        IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(blockAccess, pos);
+        if (pipeTile != null && pipeTile.getCoverableImplementation().getOutputRedstoneSignal(side.getOpposite()) > 0) {
+            return 15; //World::getStrongPower only cares about power level 15 or 0
+        }
+        return 0;
     }
 
     public void updateActiveNodeStatus(World worldIn, BlockPos pos, IPipeTile<PipeType, NodeDataType> pipeTile) {

--- a/src/main/java/gregtech/api/pipenet/tile/IPipeTile.java
+++ b/src/main/java/gregtech/api/pipenet/tile/IPipeTile.java
@@ -16,6 +16,8 @@ public interface IPipeTile<PipeType extends Enum<PipeType> & IPipeType<NodeDataT
 
     BlockPos getPipePos();
 
+    void notifyNeighborsOfStateChange(EnumFacing offsetSide, boolean updateObservers);
+
     default long getTickTimer() {
         return getPipeWorld().getTotalWorldTime();
     }

--- a/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
+++ b/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
@@ -218,6 +218,11 @@ public class PipeCoverableImplementation implements ICoverable {
         return highestSignal;
     }
 
+    public boolean isOutputtingStrongRedstoneSignal(EnumFacing side) {
+        CoverBehavior behavior = getCoverAtSide(side);
+        return behavior != null && behavior.isOutputtingStrongRedstone();
+    }
+
     public void update() {
         if (!getWorld().isRemote) {
             for (CoverBehavior coverBehavior : coverBehaviors) {
@@ -332,6 +337,11 @@ public class PipeCoverableImplementation implements ICoverable {
     @Override
     public BlockPos getPos() {
         return holder.getPipePos();
+    }
+
+    @Override
+    public void notifyNeighborsOfStateChange(EnumFacing offsetSide, boolean updateObservers) {
+        holder.notifyNeighborsOfStateChange(offsetSide, updateObservers);
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -6,7 +6,6 @@ import gregtech.api.metatileentity.SyncedTileEntityBase;
 import gregtech.api.pipenet.WorldPipeNet;
 import gregtech.api.pipenet.block.BlockPipe;
 import gregtech.api.pipenet.block.IPipeType;
-import gregtech.api.util.TaskScheduler;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
@@ -75,6 +74,11 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Override
     public BlockPos getPipePos() {
         return getPos();
+    }
+
+    @Override
+    public void notifyNeighborsOfStateChange(EnumFacing offsetSide, boolean updateObservers) {
+        this.getWorld().notifyNeighborsOfStateChange(getPos().offset(offsetSide), getBlockType(), updateObservers);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/detector/CoverActivityDetector.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverActivityDetector.java
@@ -69,8 +69,8 @@ public class CoverActivityDetector extends CoverBehavior implements ITickable {
         if (workable == null)
             return;
 
-        if (isInverted) setRedstoneSignalOutput(workable.isActive() && workable.isWorkingEnabled() ? 0 : 15);
-        else setRedstoneSignalOutput(workable.isActive() && workable.isWorkingEnabled() ? 15 : 0);
+        if (isInverted) setRedstoneSignalOutput(workable.isActive() && workable.isWorkingEnabled() ? 0 : 15, true);
+        else setRedstoneSignalOutput(workable.isActive() && workable.isWorkingEnabled() ? 15 : 0, true);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/detector/CoverActivityDetectorAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverActivityDetectorAdvanced.java
@@ -59,6 +59,6 @@ public class CoverActivityDetectorAdvanced extends CoverActivityDetector {
         else if (this.isInverted)
             outputAmount = 15 - outputAmount;
 
-        setRedstoneSignalOutput(outputAmount);
+        setRedstoneSignalOutput(outputAmount, true);
     }
 }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
@@ -78,7 +78,7 @@ public class CoverDetectorEnergy extends CoverBehavior implements ITickable {
             if (this.isInverted)
                 outputAmount = 15 - outputAmount;
 
-            setRedstoneSignalOutput(outputAmount);
+            setRedstoneSignalOutput(outputAmount, true);
         }
     }
 

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorFluid.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorFluid.java
@@ -90,7 +90,7 @@ public class CoverDetectorFluid extends CoverBehavior implements ITickable {
         if (this.isInverted)
             outputAmount = 15 - outputAmount;
 
-        setRedstoneSignalOutput(outputAmount);
+        setRedstoneSignalOutput(outputAmount, true);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorItem.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorItem.java
@@ -84,7 +84,7 @@ public class CoverDetectorItem extends CoverBehavior implements ITickable {
         if (this.isInverted)
             outputAmount = 15 - outputAmount;
 
-        setRedstoneSignalOutput(outputAmount);
+        setRedstoneSignalOutput(outputAmount, true);
     }
 
     @Override


### PR DESCRIPTION
**What:**
Covers (and MetaTileEntities) now output strong redstone signals when there is a solid block in their output direction.

**How solved:**
I overwrote Block#getStrongPower and called it only when:
    1. The block should be outputting redstone power, and
    2. There is a solid block in the output direction.
I also implemented notifyNeighborsOfStateChange in ICoverable and IPipeTile, which was needed to get strong power outputs working.
CoverBehavior#setRedstonePower and MetaTileEntity#setRedstonePower were also modified to accept a boolean for whether the power should be strong or not. Currently, all detector covers have this set to true, but we can change that if desired.

**Outcome:**
Now covers will either strongly power blocks with level 15, or weakly power dust/non-solid blocks with the true level.

**Possible compatibility issue:**
Anything that implements ICoverable or IPipeTile will have to implement the new notifyNeighborsOfStateChange method.