### PR TITLE
Minor chemistry and formula fixes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -75,7 +75,7 @@ public class Material implements Comparable<Material> {
                 }
             }
             if (water != 0 && this.hasFlag(MaterialFlags.HYDRATED_SALT)) {
-                components.append("\u00b7 "); // middle dot
+                components.append("\u2219 "); // middle dot
                 if (water != 1) components.append(water);
                 components.append("H\u2082O"); // subscript 2
             }

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -65,9 +65,20 @@ public class Material implements Comparable<Material> {
             return materialInfo.element.getSymbol();
         }
         if (!materialInfo.componentList.isEmpty()) {
+            long water = 0;
             StringBuilder components = new StringBuilder();
-            for (MaterialStack component : materialInfo.componentList)
-                components.append(component.toString());
+            for (MaterialStack component : materialInfo.componentList) {
+                if (component.material == Materials.Water) {
+                    water += component.amount;
+                } else {
+                    components.append(component.toString());
+                }
+            }
+            if (water != 0) {
+                components.append("\u00b7 "); // middle dot TODO fix edge cases
+                components.append(water);
+                components.append(SmallDigits.toSmallDownNumbers("H2O"));
+            }
             return components.toString();
         }
         return "";

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -68,15 +68,15 @@ public class Material implements Comparable<Material> {
             long water = 0;
             StringBuilder components = new StringBuilder();
             for (MaterialStack component : materialInfo.componentList) {
-                if (component.material == Materials.Water) {
+                if (component.material == Materials.Water && this.hasFlag(MaterialFlags.HYDRATED_SALT)) {
                     water += component.amount;
                 } else {
                     components.append(component.toString());
                 }
             }
-            if (water != 0) {
-                components.append("\u00b7 "); // middle dot TODO fix edge cases
-                components.append(water);
+            if (water != 0 && this.hasFlag(MaterialFlags.HYDRATED_SALT)) {
+                components.append("\u00b7 "); // middle dot
+                if (water != 1) components.append(water);
                 components.append(SmallDigits.toSmallDownNumbers("H2O"));
             }
             return components.toString();

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -77,7 +77,7 @@ public class Material implements Comparable<Material> {
             if (water != 0 && this.hasFlag(MaterialFlags.HYDRATED_SALT)) {
                 components.append("\u00b7 "); // middle dot
                 if (water != 1) components.append(water);
-                components.append(SmallDigits.toSmallDownNumbers("H2O"));
+                components.append("H\u2082O"); // subscript 2
             }
             return components.toString();
         }

--- a/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
@@ -70,6 +70,11 @@ public class MaterialFlags {
      */
     public static final MaterialFlag FLAMMABLE = new MaterialFlag.Builder("flammable").build();
 
+    /**
+     * Add to material if it is some kind of hydrated salt (eg. CuSO4·5H2O)
+     */
+    public static final MaterialFlag HYDRATED_SALT = new MaterialFlag.Builder("hydrated_salt").build();
+
     //////////////////
     //     DUST     //
     //////////////////

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -19,13 +19,13 @@ public class FirstDegreeMaterials {
                 .gem(1).ore(3, 1)
                 .color(0xFF0000)
                 .components(Aluminium, 2, Iron, 3, Silicon, 3, Oxygen, 12)
-                .build();
+                .build().setFormula("Al2Fe3(SiO4)3", true);
 
         Andradite = new Material.Builder(251, "andradite")
                 .gem(1)
                 .color(0x967800).iconSet(RUBY)
                 .components(Calcium, 3, Iron, 2, Silicon, 3, Oxygen, 12)
-                .build();
+                .build().setFormula("Ca3Fe2(SiO4)3", true);
 
         AnnealedCopper = new Material.Builder(252, "annealed_copper")
                 .ingot().fluid()
@@ -40,7 +40,7 @@ public class FirstDegreeMaterials {
                 .dust(1).ore(3, 1)
                 .color(0xE6E6E6)
                 .components(Magnesium, 3, Silicon, 2, Hydrogen, 4, Oxygen, 9)
-                .build();
+                .build().setFormula("Mg3Si2O5(OH)4", true);
 
         Ash = new Material.Builder(254, "ash")
                 .dust(1)
@@ -100,7 +100,7 @@ public class FirstDegreeMaterials {
                 .color(0xC86400).iconSet(METALLIC)
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, BLAST_FURNACE_CALCITE_TRIPLE)
                 .components(Iron, 1, Hydrogen, 1, Oxygen, 2)
-                .build();
+                .build().setFormula("FeO(OH)", true);
 
         Calcite = new Material.Builder(262, "calcite")
                 .dust(1).ore()
@@ -219,7 +219,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GENERATE_LENS)
                 .components(Beryllium, 3, Aluminium, 2, Silicon, 6, Oxygen, 18)
                 .toolStats(10.0f, 2.0f, 368, 15)
-                .build();
+                .build().setFormula("Be3Al2(SiO3)6", true);
 
         Galena = new Material.Builder(279, "galena")
                 .dust(3).ore()
@@ -246,7 +246,7 @@ public class FirstDegreeMaterials {
                 .gem(1).ore(3, 1)
                 .color(0xC86400).iconSet(RUBY)
                 .components(Calcium, 3, Aluminium, 2, Silicon, 3, Oxygen, 12)
-                .build();
+                .build().setFormula("Ca3Al2(SiO4)3", true);
 
         Ice = new Material.Builder(283, "ice")
                 .dust(0).fluid()
@@ -423,7 +423,7 @@ public class FirstDegreeMaterials {
         Biotite = new Material.Builder(304, "biotite")
                 .dust(1)
                 .color(0x141E14).iconSet(METALLIC)
-                .components(Potassium, 1, Magnesium, 3, Aluminium, 3, Fluorine, 2, Silicon, 3, Oxygen, 10)
+                .components(Potassium, 1, Magnesium, 3, Aluminium, 3, Silicon, 3, Oxygen, 10, Fluorine, 2)
                 .build();
 
         Powellite = new Material.Builder(305, "powellite")
@@ -449,7 +449,7 @@ public class FirstDegreeMaterials {
                 .gem().ore(3, 1)
                 .color(0x783264).iconSet(RUBY)
                 .components(Aluminium, 2, Magnesium, 3, Silicon, 3, Oxygen, 12)
-                .build();
+                .build().setFormula("Al2Mg3(SiO4)3", true);
 
         RockSalt = new Material.Builder(309, "rock_salt")
                 .gem(1).ore(2, 1)
@@ -539,7 +539,7 @@ public class FirstDegreeMaterials {
                 .gem().ore(3, 1)
                 .color(0xFF6464).iconSet(RUBY)
                 .components(Aluminium, 2, Manganese, 3, Silicon, 3, Oxygen, 12)
-                .build();
+                .build().setFormula("Al2Mn3(SiO4)3", true);
 
         Sphalerite = new Material.Builder(322, "sphalerite")
                 .dust(1).ore()
@@ -605,7 +605,7 @@ public class FirstDegreeMaterials {
                 .dust(3).ore()
                 .color(0x373223)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(Tungsten, 1, Lithium, 2, Oxygen, 4)
+                .components(Lithium, 2, Tungsten, 1, Oxygen, 4)
                 .build();
 
         Ultimet = new Material.Builder(331, "ultimet")
@@ -630,7 +630,7 @@ public class FirstDegreeMaterials {
                 .gem()
                 .color(0xB4ffB4).iconSet(RUBY)
                 .components(Calcium, 3, Chrome, 2, Silicon, 3, Oxygen, 12)
-                .build();
+                .build().setFormula("Ca3Cr2(SiO4)3", true);
 
         VanadiumGallium = new Material.Builder(334, "vanadium_gallium")
                 .ingot().fluid()
@@ -663,7 +663,7 @@ public class FirstDegreeMaterials {
                 .color(0xC8C800).iconSet(METALLIC)
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, BLAST_FURNACE_CALCITE_DOUBLE)
                 .components(Iron, 1, Hydrogen, 1, Oxygen, 2)
-                .build();
+                .build().setFormula("FeO(OH)", true);
 
         YttriumBariumCuprate = new Material.Builder(338, "yttrium_barium_cuprate")
                 .ingot().fluid()
@@ -948,12 +948,12 @@ public class FirstDegreeMaterials {
                 .dust().ore()
                 .color(0xBEAAAA)
                 .components(Lithium, 1, Aluminium, 1, Silicon, 2, Oxygen, 6)
-                .build();
+                .build().setFormula("LiAl(SiO3)2", true);
 
         Lepidolite = new Material.Builder(382, "lepidolite")
                 .dust().ore(2, 1)
                 .color(0xF0328C).iconSet(FINE)
-                .components(Potassium, 1, Lithium, 3, Aluminium, 4, Fluorine, 2, Oxygen, 10)
+                .components(Potassium, 1, Lithium, 3, Aluminium, 4, Oxygen, 10, Fluorine, 2)
                 .build();
 
         // Free ID 383
@@ -962,18 +962,18 @@ public class FirstDegreeMaterials {
                 .dust().ore(3, 1)
                 .color(0x82B43C).iconSet(SAND)
                 .components(Potassium, 1, Magnesium, 2, Aluminium, 4, Hydrogen, 2, Oxygen, 12)
-                .build();
+                .build().setFormula("KMg2Al4O10(OH)2", true);
 
         Malachite = new Material.Builder(385, "malachite")
                 .gem().ore()
                 .color(0x055F05).iconSet(LAPIS)
                 .components(Copper, 2, Carbon, 1, Hydrogen, 2, Oxygen, 5)
-                .build();
+                .build().setFormula("Cu2CO3(OH)2", true);
 
         Mica = new Material.Builder(386, "mica")
                 .dust().ore(2, 1)
                 .color(0xC3C3CD).iconSet(FINE)
-                .components(Potassium, 1, Aluminium, 3, Silicon, 3, Fluorine, 2, Oxygen, 10)
+                .components(Potassium, 1, Aluminium, 3, Silicon, 3, Oxygen, 10, Fluorine, 2)
                 .build();
 
         Barite = new Material.Builder(387, "barite")
@@ -985,8 +985,8 @@ public class FirstDegreeMaterials {
         Alunite = new Material.Builder(388, "alunite")
                 .dust().ore(3, 1)
                 .color(0xE1B441).iconSet(METALLIC)
-                .components(Potassium, 1, Aluminium, 3, Silicon, 2, Hydrogen, 6, Oxygen, 14)
-                .build();
+                .components(Potassium, 1, Aluminium, 3, Sulfur, 2, Hydrogen, 6, Oxygen, 14)
+                .build().setFormula("KAl3(SO4)2(OH)6", true);
 
         // Free ID 389
 
@@ -998,13 +998,13 @@ public class FirstDegreeMaterials {
                 .dust().ore(2, 1)
                 .color(0x5AB45A).iconSet(FINE)
                 .components(Magnesium, 3, Silicon, 4, Hydrogen, 2, Oxygen, 12)
-                .build();
+                .build().setFormula("Mg3(Si2O5)2(OH)2", true);
 
         Soapstone = new Material.Builder(393, "soapstone")
                 .dust(1).ore(3, 1)
                 .color(0x5F915F)
                 .components(Magnesium, 3, Silicon, 4, Hydrogen, 2, Oxygen, 12)
-                .build();
+                .build().setFormula("Mg3(Si2O5)2(OH)2", true);
 
         Kyanite = new Material.Builder(394, "kyanite")
                 .dust().ore()
@@ -1163,7 +1163,7 @@ public class FirstDegreeMaterials {
         PotassiumFeldspar = new Material.Builder(417, "potassium_feldspar")
                 .dust(1)
                 .color(0x782828).iconSet(FINE)
-                .components(Potassium, 1, Aluminium, 1, Silicon, 1, Oxygen, 8)
+                .components(Potassium, 1, Aluminium, 1, Silicon, 3, Oxygen, 8)
                 .build();
 
         NeodymiumMagnetic = new Material.Builder(418, "neodymium_magnetic")

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -142,7 +142,7 @@ public class FirstDegreeMaterials {
         Cinnabar = new Material.Builder(268, "cinnabar")
                 .gem(1).ore()
                 .color(0x960000).iconSet(EMERALD)
-                .flags(CRYSTALLIZABLE, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(CRYSTALLIZABLE, DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Mercury, 1, Sulfur, 1)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -501,8 +501,7 @@ public class FirstDegreeMaterials {
                 .color(0xC88C14)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Calcium, 1, Tungsten, 1, Oxygen, 4)
-                .build()
-                .setFormula("Ca(WO3)O", true);
+                .build();
 
         Sodalite = new Material.Builder(316, "sodalite")
                 .gem(1).ore(6, 4)
@@ -583,7 +582,7 @@ public class FirstDegreeMaterials {
         Tetrahedrite = new Material.Builder(327, "tetrahedrite")
                 .dust().ore()
                 .color(0xC82000)
-                .components(Copper, 3, Antimony, 1, Sulfur, 3, Iron, 1)
+                .components(Copper, 3, Iron, 1, Antimony, 1, Sulfur, 3)
                 .build();
 
         TinAlloy = new Material.Builder(328, "tin_alloy")
@@ -607,8 +606,7 @@ public class FirstDegreeMaterials {
                 .color(0x373223)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Tungsten, 1, Lithium, 2, Oxygen, 4)
-                .build()
-                .setFormula("Li2(WO3)O", true);
+                .build();
 
         Ultimet = new Material.Builder(331, "ultimet")
                 .ingot(4).fluid()
@@ -761,7 +759,7 @@ public class FirstDegreeMaterials {
                 .ingot(1).fluid()
                 .color(0xA0A0A0)
                 .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING)
-                .components(Arsenic, 1, Gallium, 1)
+                .components(Gallium, 1, Arsenic, 1)
                 .blastTemp(1200, GasTier.LOW, VA[MV], 1200)
                 .build();
 
@@ -937,7 +935,7 @@ public class FirstDegreeMaterials {
         Bastnasite = new Material.Builder(379, "bastnasite")
                 .dust().ore(2, 1)
                 .color(0xC86E2D).iconSet(FINE)
-                .components(Cerium, 1, Carbon, 1, Fluorine, 1, Oxygen, 3)
+                .components(Cerium, 1, Carbon, 1, Oxygen, 3, Fluorine, 1)
                 .build();
 
         Pentlandite = new Material.Builder(380, "pentlandite")

--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -233,7 +233,7 @@ public class OrganicChemistryMaterials {
                 .color(0xDCC8B4)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Calcium, 1, Carbon, 4, Oxygen, 4, Hydrogen, 6, Water, 1)
-                .build();
+                .build().setFormula("Ca(C2H3O2)2(H2O)", true);
 
         VinylAcetate = new Material.Builder(1033, "vinyl_acetate")
                 .fluid()

--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -261,21 +261,22 @@ public class OrganicChemistryMaterials {
                 .color(0x0F2828)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 1, Nitrogen, 4, Oxygen, 8)
-                .build();
+                .build()
+                .setFormula("C(NO2)4", true);
 
         Dimethylamine = new Material.Builder(1037, "dimethylamine")
                 .fluid(FluidTypes.GAS)
                 .color(0x554469)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 7, Nitrogen, 1)
-                .build();
+                .build().setFormula("NH(CH3)2", true);
 
         Dimethylhydrazine = new Material.Builder(1038, "dimethylhydrazine")
                 .fluid()
                 .color(0x000055)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 8, Nitrogen, 2)
-                .build();
+                .build().setFormula("H2N2(CH3)2");
 
         DinitrogenTetroxide = new Material.Builder(1039, "dinitrogen_tetroxide")
                 .fluid(FluidTypes.GAS)
@@ -316,14 +317,14 @@ public class OrganicChemistryMaterials {
                 .color(0xC8B4A0)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 4, Oxygen, 2)
-                .build();
+                .build().setFormula("CH3CO2H", true);
 
         Phenol = new Material.Builder(1045, "phenol")
                 .fluid()
                 .color(0x784421)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 6, Hydrogen, 6, Oxygen, 1)
-                .build();
+                .build().setFormula("C6H5OH", true);
 
         BisphenolA = new Material.Builder(1046, "bisphenol_a")
                 .fluid()
@@ -358,19 +359,19 @@ public class OrganicChemistryMaterials {
                 .color(0xAFAFAF)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 3, Hydrogen, 6, Oxygen, 1)
-                .build();
+                .build().setFormula("(CH3)2CO");
 
         Glycerol = new Material.Builder(1051, "glycerol")
                 .fluid()
                 .color(0x87DE87)
                 .components(Carbon, 3, Hydrogen, 8, Oxygen, 3)
-                .build();
+                .build().setFormula("C3H5(OH)3", true);
 
         Methanol = new Material.Builder(1052, "methanol")
                 .fluid()
                 .color(0xAA8800)
                 .components(Carbon, 1, Hydrogen, 4, Oxygen, 1)
-                .build();
+                .build().setFormula("CH3OH", true);
 
         // FREE ID 1053
 
@@ -378,7 +379,7 @@ public class OrganicChemistryMaterials {
                 .fluid()
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 6, Oxygen, 1)
-                .build();
+                .build().setFormula("C2H5OH", true);
 
         Toluene = new Material.Builder(1055, "toluene")
                 .fluid()

--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -276,7 +276,7 @@ public class OrganicChemistryMaterials {
                 .color(0x000055)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 8, Nitrogen, 2)
-                .build().setFormula("H2N2(CH3)2");
+                .build().setFormula("NH2N(CH3)2", true);
 
         DinitrogenTetroxide = new Material.Builder(1039, "dinitrogen_tetroxide")
                 .fluid(FluidTypes.GAS)
@@ -359,7 +359,7 @@ public class OrganicChemistryMaterials {
                 .color(0xAFAFAF)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 3, Hydrogen, 6, Oxygen, 1)
-                .build().setFormula("(CH3)2CO");
+                .build().setFormula("(CH3)2CO", true);
 
         Glycerol = new Material.Builder(1051, "glycerol")
                 .fluid()

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -31,7 +31,7 @@ public class SecondDegreeMaterials {
         Borax = new Material.Builder(2002, "borax")
                 .dust(1)
                 .color(0xFAFAFA).iconSet(FINE)
-                .components(Sodium, 2, Boron, 4, Water, 10, Oxygen, 7)
+                .components(Sodium, 2, Boron, 4, Oxygen, 7, Water, 10)
                 .build();
 
         SaltWater = new Material.Builder(2003, "salt_water")
@@ -169,7 +169,7 @@ public class SecondDegreeMaterials {
                 .dust(1)
                 .color(0xFF0080).iconSet(ROUGH)
                 .flags(NO_SMASHING)
-                .components(Aluminium, 2, PotassiumFeldspar, 1, Oxygen, 3)
+                .components(Aluminium, 2, Oxygen, 3, PotassiumFeldspar, 1)
                 .build();
 
         // Free ID 2021
@@ -191,7 +191,7 @@ public class SecondDegreeMaterials {
         Pollucite = new Material.Builder(2024, "pollucite")
                 .dust().ore()
                 .color(0xF0D2D2)
-                .components(Caesium, 2, Aluminium, 2, Silicon, 4, Water, 2, Oxygen, 12)
+                .components(Caesium, 2, Silicon, 4, Aluminium, 2, Oxygen, 12, Water, 2)
                 .build();
 
         // Free ID 2025
@@ -200,13 +200,13 @@ public class SecondDegreeMaterials {
                 .dust().ore(3, 1)
                 .color(0xF5D7D2).iconSet(ROUGH)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(Sodium, 1, Magnesium, 6, Silicon, 12, Hydrogen, 4, Water, 5, Oxygen, 36)
+                .components(Sodium, 1, Magnesium, 6, Silicon, 12, Hydrogen, 4, Oxygen, 36, Water, 5)
                 .build();
 
         FullersEarth = new Material.Builder(2027, "fullers_earth")
                 .dust().ore(2, 1)
                 .color(0xA0A078).iconSet(FINE)
-                .components(Magnesium, 1, Silicon, 4, Hydrogen, 1, Water, 4, Oxygen, 11)
+                .components(Magnesium, 1, Silicon, 4, Oxygen, 11, Hydrogen, 1, Water, 4)
                 .build();
 
         Pitchblende = new Material.Builder(2028, "pitchblende")
@@ -227,27 +227,27 @@ public class SecondDegreeMaterials {
         Mirabilite = new Material.Builder(2030, "mirabilite")
                 .dust()
                 .color(0xF0FAD2)
-                .components(Sodium, 2, Sulfur, 1, Water, 10, Oxygen, 4)
+                .components(Sodium, 2, Sulfur, 1, Oxygen, 4, Water, 10)
                 .build();
 
         Trona = new Material.Builder(2031, "trona")
                 .dust(1).ore(2, 1)
                 .color(0x87875F).iconSet(METALLIC)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(Sodium, 3, Carbon, 2, Hydrogen, 1, Water, 2, Oxygen, 6)
+                .components(SodaAsh, 1, SodiumBicarbonate, 1, Water, 2)
                 .build();
 
         Gypsum = new Material.Builder(2032, "gypsum")
                 .dust(1).ore()
                 .color(0xE6E6FA)
-                .components(Calcium, 1, Sulfur, 1, Water, 2, Oxygen, 4)
+                .components(Calcium, 1, Sulfur, 1, Oxygen, 4, Water, 2)
                 .build();
 
         Zeolite = new Material.Builder(2033, "zeolite")
                 .dust().ore(3, 1)
                 .color(0xF0E6E6)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(Sodium, 1, Calcium, 4, Silicon, 27, Aluminium, 9, Water, 28, Oxygen, 72)
+                .components(Sodium, 1, Calcium, 4, Silicon, 27, Aluminium, 9, Oxygen, 72, Water, 28)
                 .build();
 
         Concrete = new Material.Builder(2034, "concrete")

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -372,7 +372,7 @@ public class SecondDegreeMaterials {
                 .fluid(FluidTypes.GAS)
                 .color(0xA9D0F5)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(Nitrogen, 78, Oxygen, 21, Argon, 9)
+                .components(Nitrogen, 70, Oxygen, 22, CarbonDioxide, 5, Helium, 2, Argon, 1, Ice, 1)
                 .build();
 
         LiquidAir = new Material.Builder(2051, "liquid_air")
@@ -386,7 +386,7 @@ public class SecondDegreeMaterials {
                 .fluid(FluidTypes.GAS)
                 .color(0x4C3434)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(CarbonMonoxide, 78, HydrogenSulfide, 21, Neon, 9)
+                .components(CarbonMonoxide, 144, CoalGas, 20, HydrogenSulfide, 15, SulfurDioxide, 15, Helium3, 5, Neon, 1, Ash, 1)
                 .build();
 
         LiquidNetherAir = new Material.Builder(2053, "liquid_nether_air")
@@ -400,7 +400,7 @@ public class SecondDegreeMaterials {
                 .fluid(FluidTypes.GAS)
                 .color(0x283454)
                 .flags(DISABLE_DECOMPOSITION)
-                .components(NitrogenDioxide, 78, Deuterium, 21, Xenon, 9)
+                .components(NitrogenDioxide, 122, Deuterium, 50, Helium, 15, Tritium, 10, Krypton, 1, Xenon, 1, Radon, 1, EnderPearl, 1)
                 .build();
 
         LiquidEnderAir = new Material.Builder(2055, "liquid_ender_air")

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -203,7 +203,7 @@ public class SecondDegreeMaterials {
                 .dust().ore(3, 1)
                 .color(0xF5D7D2).iconSet(ROUGH)
                 .flags(DISABLE_DECOMPOSITION, HYDRATED_SALT)
-                .components(Sodium, 1, Magnesium, 6, Silicon, 12, Hydrogen, 4, Oxygen, 36, Water, 5)
+                .components(Sodium, 1, Magnesium, 6, Silicon, 12, Oxygen, 36, Hydrogen, 4, Water, 5)
                 .build();
 
         FullersEarth = new Material.Builder(2027, "fullers_earth")
@@ -253,7 +253,7 @@ public class SecondDegreeMaterials {
                 .dust().ore(3, 1)
                 .color(0xF0E6E6)
                 .flags(DISABLE_DECOMPOSITION, HYDRATED_SALT)
-                .components(Sodium, 1, Calcium, 4, Silicon, 27, Aluminium, 9, Oxygen, 72, Water, 28)
+                .components(Sodium, 1, Calcium, 4, Aluminium, 9, Silicon, 27, Oxygen, 72, Water, 28)
                 .build();
 
         Concrete = new Material.Builder(2034, "concrete")

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -25,12 +25,14 @@ public class SecondDegreeMaterials {
         Perlite = new Material.Builder(2001, "perlite")
                 .dust(1)
                 .color(0x1E141E)
+                .flags(HYDRATED_SALT)
                 .components(Obsidian, 2, Water, 1)
                 .build();
 
         Borax = new Material.Builder(2002, "borax")
                 .dust(1)
                 .color(0xFAFAFA).iconSet(FINE)
+                .flags(HYDRATED_SALT)
                 .components(Sodium, 2, Boron, 4, Oxygen, 7, Water, 10)
                 .build();
 
@@ -191,6 +193,7 @@ public class SecondDegreeMaterials {
         Pollucite = new Material.Builder(2024, "pollucite")
                 .dust().ore()
                 .color(0xF0D2D2)
+                .flags(HYDRATED_SALT)
                 .components(Caesium, 2, Silicon, 4, Aluminium, 2, Oxygen, 12, Water, 2)
                 .build();
 
@@ -199,13 +202,14 @@ public class SecondDegreeMaterials {
         Bentonite = new Material.Builder(2026, "bentonite")
                 .dust().ore(3, 1)
                 .color(0xF5D7D2).iconSet(ROUGH)
-                .flags(DISABLE_DECOMPOSITION)
+                .flags(DISABLE_DECOMPOSITION, HYDRATED_SALT)
                 .components(Sodium, 1, Magnesium, 6, Silicon, 12, Hydrogen, 4, Oxygen, 36, Water, 5)
                 .build();
 
         FullersEarth = new Material.Builder(2027, "fullers_earth")
                 .dust().ore(2, 1)
                 .color(0xA0A078).iconSet(FINE)
+                .flags(HYDRATED_SALT)
                 .components(Magnesium, 1, Silicon, 4, Oxygen, 11, Hydrogen, 1, Water, 4)
                 .build();
 
@@ -227,26 +231,28 @@ public class SecondDegreeMaterials {
         Mirabilite = new Material.Builder(2030, "mirabilite")
                 .dust()
                 .color(0xF0FAD2)
+                .flags(HYDRATED_SALT)
                 .components(Sodium, 2, Sulfur, 1, Oxygen, 4, Water, 10)
                 .build();
 
         Trona = new Material.Builder(2031, "trona")
                 .dust(1).ore(2, 1)
                 .color(0x87875F).iconSet(METALLIC)
-                .flags(DISABLE_DECOMPOSITION)
+                .flags(DISABLE_DECOMPOSITION, HYDRATED_SALT)
                 .components(SodaAsh, 1, SodiumBicarbonate, 1, Water, 2)
                 .build();
 
         Gypsum = new Material.Builder(2032, "gypsum")
                 .dust(1).ore()
                 .color(0xE6E6FA)
+                .flags(HYDRATED_SALT)
                 .components(Calcium, 1, Sulfur, 1, Oxygen, 4, Water, 2)
                 .build();
 
         Zeolite = new Material.Builder(2033, "zeolite")
                 .dust().ore(3, 1)
                 .color(0xF0E6E6)
-                .flags(DISABLE_DECOMPOSITION)
+                .flags(DISABLE_DECOMPOSITION, HYDRATED_SALT)
                 .components(Sodium, 1, Calcium, 4, Silicon, 27, Aluminium, 9, Oxygen, 72, Water, 28)
                 .build();
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -666,7 +666,7 @@ public class MachineRecipeLoader {
                 .buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder().duration(240).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .input(dust, SiliconDioxide)
+                .input(dust, SiliconDioxide, 3)
                 .input(dust, Carbon, 2)
                 .output(ingot, Silicon)
                 .output(dustTiny, Ash)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -163,7 +163,7 @@ public class ReactorRecipes {
                 .fluidInputs(NitrationMixture.getFluid(3000))
                 .fluidInputs(Glycerol.getFluid(1000))
                 .fluidOutputs(GlycerylTrinitrate.getFluid(1000))
-                .fluidOutputs(DilutedSulfuricAcid.getFluid(3000))
+                .fluidOutputs(DilutedSulfuricAcid.getFluid(2000))
                 .duration(180).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -413,11 +413,11 @@ public class SeparationRecipes {
                 .duration(768).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
-                .input(dust, Trona, 16)
-                .output(dust, SodaAsh, 6)
-                .output(dust, SodiumBicarbonate, 6)
-                .fluidOutputs(Water.getFluid(2000))
-                .duration(784).EUt(VA[LV] * 2).buildAndRegister();
+                .input(dust, Trona, 8)
+                .output(dust, SodaAsh, 3)
+                .output(dust, SodiumBicarbonate, 3)
+                .fluidOutputs(Water.getFluid(1000))
+                .duration(392).EUt(VA[LV] * 2).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .input(dust, Bauxite, 15)


### PR DESCRIPTION
**What:**
Certain formulas of certain materials have various problems, such as:
1. They are displayed in an awkward way: 
![image](https://user-images.githubusercontent.com/61507029/155872377-26a93e9e-a3d3-4d94-9c1e-8d008a797892.png)
![image](https://user-images.githubusercontent.com/61507029/155872411-d98d9b54-7543-40d1-b5ad-afc68c295ba6.png)
![image](https://user-images.githubusercontent.com/61507029/155872512-3eb8c097-966f-4c34-9d23-7d099745a0d4.png)
2. They are simply wrong: 
![image](https://user-images.githubusercontent.com/61507029/155872445-31d9c1af-9952-4e00-931b-76c56cbb3705.png)
![image](https://user-images.githubusercontent.com/61507029/155872465-ca3c898c-f1db-44bc-bc98-f71a34b66c88.png)
![image](https://user-images.githubusercontent.com/61507029/155872531-a3580b54-6fe2-421a-b073-a5dd434ea37b.png)
![image](https://user-images.githubusercontent.com/61507029/155872556-6626f0ae-bcec-45ed-ae6e-2246e4ab298e.png)
3. They are inconsistent with how formulas are displayed:
![image](https://user-images.githubusercontent.com/61507029/155872578-b687bb66-9ccc-4511-b761-7df8451c6e1e.png)

**How solved:**
Fixed offending materials by altering their components, the order of their components, and/or using `setFormula()`.

For hydrated salts, a new material flag `HYDRATED_SALT` was created, which tells the autogen chemical formula to display Water components in hydrated salt form. This is the result:
![image](https://user-images.githubusercontent.com/61507029/155872682-ce3d5f66-4682-4d02-9b4e-26c7cecedc6a.png)
The dot used is the middle dot u+00b7.
**Outcome:**
No more offending formulas

**Additional info:**
Because I am bad at Java, hydrated salt notation is incompatible with `setFormula()`.

In addition to the fixes, 2 minor fixes are bundled:
- Cinnabar decomp changed from Centrifuge to Electrolyzer
- Trona Dust decomp batch size divided by 2, as it was possible
