### PR TITLE
Make manganese veins spawnable

### DIFF
--- a/src/main/resources/assets/gregtech/worldgen/vein/nether/manganese_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/vein/nether/manganese_vein.json
@@ -1,7 +1,7 @@
 {
   "weight": 20,
   "density": 0.25,
-  "min_height": 20,
+  "min_height": 10,
   "max_height": 30,
   "vein_populator": {
     "type": "surface_rock",

--- a/src/main/resources/assets/gregtech/worldgen/vein/overworld/manganese_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/vein/overworld/manganese_vein.json
@@ -1,7 +1,7 @@
 {
   "weight": 20,
   "density": 0.25,
-  "max_height": 30,
+  "max_height": 50,
   "min_height": 20,
   "vein_populator": {
     "type": "surface_rock",


### PR DESCRIPTION
**What:**
Due to a bug I'm not willing to investigate into, veins with a low range between min and max spawn height do not generate. This caused both manganese veins to not spawn with default config.

**How solved:**
Adjusted min and max height for both manganese veins.

**Outcome:**
Closes #733.