### PR TITLE
Fix height values for layered veins

### DIFF
--- a/src/main/java/gregtech/api/worldgen/shape/LayeredGenerator.java
+++ b/src/main/java/gregtech/api/worldgen/shape/LayeredGenerator.java
@@ -2,6 +2,7 @@ package gregtech.api.worldgen.shape;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import net.minecraft.util.math.Vec3i;
 
 public class LayeredGenerator extends EllipsoidGenerator {
 
@@ -24,6 +25,12 @@ public class LayeredGenerator extends EllipsoidGenerator {
     @Override
     public int getYRadius() {
         return yRadius;
+    }
+
+    @Override
+    public Vec3i getMaxSize() {
+        Vec3i result = super.getMaxSize();
+        return new Vec3i(result.getX(), yRadius, result.getZ());
     }
 
     @Override


### PR DESCRIPTION
**What:**

Fixes the height calculations for layered veins.

When the vein was attempting to generate in `CachedGridEntry#doGenerateVein`, the Y height was taken from the definition's `getMaxSize`, which would be the maximum radius for the layered vein, as it extended the elliptical vein generator.

To solve the issue, I simply overrode `getMaxSize` to return a new max size that takes into account the y height of the vein.

Supersedes #735. Closes #733 