### PR TITLE
[update] cannot change nerfed wood plank recipe output via CT

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -139,6 +139,10 @@ public class ConfigHolder {
         @Config.Comment({"Whether to nerf Wood crafting to 2 Planks from 1 Log, and 2 Sticks from 2 Planks.", "Default: false"})
         public boolean nerfWoodCrafting = false;
 
+        @Config.Comment({"Whether the number of wood and sticks crafted should be changed numerically when nerfWoodCrafting is enabled.", "Default: 4"})
+        @Config.RangeInt(min = 2, max = 4)
+        public int nerfWoodCraftingBase = 4;
+
         @Config.Comment({"Whether to nerf the Paper crafting recipe.", "Default: true"})
         public boolean nerfPaperCrafting = true;
 

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -46,6 +46,11 @@ public class WoodMachineRecipes {
 
             //wood nerf
             if (ConfigHolder.recipes.nerfWoodCrafting) {
+                //set custom amount
+                if (ConfigHolder.recipes.nerfWoodCraftingBase != 4) {
+                    originalOutput = ConfigHolder.recipes.nerfWoodCraftingBase;
+                }
+
                 //remove the old recipe
                 ModHandler.removeRecipeByName(outputRecipe.getRegistryName());
 

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -47,7 +47,9 @@ public class WoodMachineRecipes {
             //wood nerf
             if (ConfigHolder.recipes.nerfWoodCrafting) {
                 //set custom amount
-                if (ConfigHolder.recipes.nerfWoodCraftingBase != 4) {
+                if (ConfigHolder.recipes.nerfWoodCraftingBase == 4) {
+                    originalOutput = 4;
+                } else {
                     originalOutput = ConfigHolder.recipes.nerfWoodCraftingBase;
                 }
 


### PR DESCRIPTION
**What:**
[BUG] cannot change nerfed wood plank recipe output via CT (#737)

**Outcome:**
Added a cfg that allows the number of planks created to be changed, as this cannot be changed in CT.
Fixes: #737

**Possible compatibility issue:**
* Add new config
```
# Change how many pieces of wood will be created from a single log when nerfWoodCrafting is enabled.
# Default: 4
# Min: 2
# Max: 4
I:nerfWoodCraftingBase=4
```

