### PR TITLE
Fix Prospector App sticking on modes when minimized

### DIFF
--- a/src/main/java/gregtech/api/terminal/app/AbstractApplication.java
+++ b/src/main/java/gregtech/api/terminal/app/AbstractApplication.java
@@ -247,4 +247,8 @@ public abstract class AbstractApplication extends AnimaWidgetGroup {
     public void onOSSizeUpdate(int width, int height) {
         setSelfPosition(Position.ORIGIN.add(new Position((width - getSize().width) / 2, (height - getSize().height) / 2)));
     }
+
+    public boolean canLaunchConcurrently(AbstractApplication application) {
+        return true;
+    }
 }

--- a/src/main/java/gregtech/api/terminal/os/TerminalOSWidget.java
+++ b/src/main/java/gregtech/api/terminal/os/TerminalOSWidget.java
@@ -163,7 +163,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
             closeApplication(focusApp, isClient);
         }
         for (AbstractApplication app : openedApps) {
-            if (app.getClass() == application.getClass() && application.canLaunchConcurrently(app)) {
+            if (app.getRegistryName().equals(application.getRegistryName()) && application.canLaunchConcurrently(app)) {
                 app.onOSSizeUpdate(this.getSize().width, this.getSize().height);
                 maximizeApplication(app, isClient);
                 return;

--- a/src/main/java/gregtech/api/terminal/os/TerminalOSWidget.java
+++ b/src/main/java/gregtech/api/terminal/os/TerminalOSWidget.java
@@ -163,7 +163,7 @@ public class TerminalOSWidget extends AbstractWidgetGroup {
             closeApplication(focusApp, isClient);
         }
         for (AbstractApplication app : openedApps) {
-            if (app.getClass() == application.getClass()) {
+            if (app.getClass() == application.getClass() && application.canLaunchConcurrently(app)) {
                 app.onOSSizeUpdate(this.getSize().width, this.getSize().height);
                 maximizeApplication(app, isClient);
                 return;

--- a/src/main/java/gregtech/common/terminal/app/prospector/ProspectorApp.java
+++ b/src/main/java/gregtech/common/terminal/app/prospector/ProspectorApp.java
@@ -181,13 +181,4 @@ public class ProspectorApp extends AbstractApplication implements SearchComponen
             }
         }
     }
-
-    @Override
-    public boolean canLaunchConcurrently(AbstractApplication application) {
-        if(application instanceof ProspectorApp) {
-            return ((ProspectorApp) application).mode == mode;
-        }
-
-        return super.canLaunchConcurrently(application);
-    }
 }

--- a/src/main/java/gregtech/common/terminal/app/prospector/ProspectorApp.java
+++ b/src/main/java/gregtech/common/terminal/app/prospector/ProspectorApp.java
@@ -181,4 +181,13 @@ public class ProspectorApp extends AbstractApplication implements SearchComponen
             }
         }
     }
+
+    @Override
+    public boolean canLaunchConcurrently(AbstractApplication application) {
+        if(application instanceof ProspectorApp) {
+            return ((ProspectorApp) application).mode == mode;
+        }
+
+        return super.canLaunchConcurrently(application);
+    }
 }


### PR DESCRIPTION
**What:**
Fixes the Prospector Apps in the terminal getting stuck on a single mode when they were minimized, instead of all the way closed.

This issue occurred because `TerminalOSWidget#openApplication` checked for if the class of the application matched the class of any already opened but minimized apps. This was the case for the prospector app, because it created two different apps from the same class, depending on the passed in mode of the app. (I believe this was the only app like this).

To get around this issue, I added a method called `canLaunchConcurrently` to `AbstractApplication`, for which applications can override if they, for some reason, cannot be launched at the same time as other applications. I then made the Prospector App check if the mode of the app was the same as the already open app.


**Outcome:**
Fixes Prospector Apps getting stuck to a single mode when they were minimized instead of closed.
