### PR TITLE
Fix crash when other mods register fluids with negative temperatures

### DIFF
--- a/src/main/java/gregtech/api/fluids/MetaFluids.java
+++ b/src/main/java/gregtech/api/fluids/MetaFluids.java
@@ -69,7 +69,7 @@ public class MetaFluids {
                 int temperature = Math.max(material.getBlastTemperature(), fluidProperty.getFluidTemperature());
                 Fluid fluid = registerFluid(material, fluidProperty.getFluidType(), temperature, fluidProperty.hasBlock());
                 fluidProperty.setFluid(fluid);
-                fluidProperty.setFluidTemperature(fluid.getTemperature());
+                fluidProperty.setFluidTemperature(fluid.getTemperature(), fluid.getTemperature() >= 0);
             }
 
             PlasmaProperty plasmaProperty = material.getProperty(PropertyKey.PLASMA);

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -70,7 +70,12 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
     }
 
     public void setFluidTemperature(int fluidTemperature) {
-        Preconditions.checkArgument(fluidTemperature > 0, "Invalid temperature");
+        setFluidTemperature(fluidTemperature, true);
+    }
+
+    public void setFluidTemperature(int fluidTemperature, boolean isKelvin) {
+        if (isKelvin) Preconditions.checkArgument(fluidTemperature > 0, "Invalid temperature");
+        else setFluidTemperature(fluidTemperature += 273, false);
         this.fluidTemperature = fluidTemperature;
         if (fluid != null)
             fluid.setTemperature(fluidTemperature);

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -74,7 +74,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
     }
 
     public void setFluidTemperature(int fluidTemperature, boolean isKelvin) {
-        if (isKelvin) Preconditions.checkArgument(fluidTemperature > 0, "Invalid temperature");
+        if (isKelvin) Preconditions.checkArgument(fluidTemperature >= 0, "Invalid temperature");
         else fluidTemperature += 273;
         this.fluidTemperature = fluidTemperature;
         if (fluid != null)

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -75,7 +75,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
 
     public void setFluidTemperature(int fluidTemperature, boolean isKelvin) {
         if (isKelvin) Preconditions.checkArgument(fluidTemperature > 0, "Invalid temperature");
-        else setFluidTemperature(fluidTemperature += 273, false);
+        else fluidTemperature += 273;
         this.fluidTemperature = fluidTemperature;
         if (fluid != null)
             fluid.setTemperature(fluidTemperature);


### PR DESCRIPTION
**What:**
Fixes crashes when other mods register fluids with the same name as GT's, but have negative temperatures.

**Outcome:**
Fixes #744.