### PR TITLE
Rewrite Quantum Chest Item insertion.

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -248,7 +248,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
         super.writeItemStackData(itemStack);
         if (!this.itemStack.isEmpty()) {
             itemStack.setTag(NBT_ITEMSTACK, this.itemStack.writeToNBT(new NBTTagCompound()));
-            itemStack.setLong(NBT_ITEMCOUNT, itemsStoredInside + this.itemStack.getMaxStackSize());
+            itemStack.setLong(NBT_ITEMCOUNT, itemsStoredInside + this.exportItems.getStackInSlot(0).getCount());
         } else {
             ItemStack partialStack = exportItems.extractItem(0, 64, false);
             if (!partialStack.isEmpty()) {


### PR DESCRIPTION
**What:**
Rewrite Quantum Chest Item Insertion. Closes #749 

Specifically, this PR changes insertion to first attempt to be put into the export slot, since the quantum chest moves items to the export slot anyway, and then virtualizes any items that cannot fit into the export slot (but still match). Any non-matching items attempt to get inserted into the input slot.


**Outcome:**
Rewrites Quantum Chest Item Insertion. Closes #749 
