### PR TITLE
Fix CycleItemStackHandler

### DIFF
--- a/src/main/java/gregtech/common/inventory/handlers/CycleItemStackHandler.java
+++ b/src/main/java/gregtech/common/inventory/handlers/CycleItemStackHandler.java
@@ -8,20 +8,14 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 
 public class CycleItemStackHandler extends ItemStackHandler {
-    private int index;
 
     public CycleItemStackHandler(NonNullList<ItemStack> stacks) {
         super(stacks);
-        index = 0;
-    }
-
-    public void update(){
-        index = (index + 1) % stacks.size();
     }
 
     @Nonnull
     @Override
     public ItemStack getStackInSlot(int slot) {
-        return super.getStackInSlot(index);
+        return stacks.isEmpty() ? ItemStack.EMPTY : super.getStackInSlot(Math.abs((int)(System.currentTimeMillis() / 1000) % stacks.size()));
     }
 }

--- a/src/main/java/gregtech/common/terminal/app/multiblockhelper/MachineBuilderWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/multiblockhelper/MachineBuilderWidget.java
@@ -86,11 +86,6 @@ public class MachineBuilderWidget extends WidgetGroup {
     }
 
     @Override
-    public void updateScreen() {
-        super.updateScreen();
-    }
-
-    @Override
     public void handleClientAction(int id, PacketBuffer buffer) {
         if (id == -2) { // select
             this.selected = buffer.readVarInt();

--- a/src/main/java/gregtech/common/terminal/app/multiblockhelper/MachineBuilderWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/multiblockhelper/MachineBuilderWidget.java
@@ -88,7 +88,6 @@ public class MachineBuilderWidget extends WidgetGroup {
     @Override
     public void updateScreen() {
         super.updateScreen();
-        if (handlers != null && gui.entityPlayer.ticksExisted % 20 == 0) handlers.forEach(CycleItemStackHandler::update);
     }
 
     @Override


### PR DESCRIPTION
CycleItemStackHandler will crash when pass an empty list.

Remove updates.  Returns the itemstack based on system time.  