### PR TITLE
Fix monitor screen crash

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
@@ -256,6 +256,7 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
 
     @SideOnly(Side.CLIENT)
     public void renderScreen(float partialTicks, RayTraceResult rayTraceResult) {
+        if (getController() == null) return;
         EnumFacing side = getController().getFrontFacing();
         GlStateManager.translate((scale - 1) * 0.5, (scale - 1) * 0.5, 0);
         GlStateManager.scale(this.scale, this.scale, 1);


### PR DESCRIPTION
breaking screen makes the mte invalid (should not render screens here). But `formed checking per second`  hasn't been triggered. causing the `unformed` is not sync to the client immediately, where the monitor is still trying to render screens.