### PR TITLE
Fixes #757

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -130,7 +130,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
                 return null;
             if (clipboardBehaviour.get() instanceof ClipboardBehavior) {
                 PlayerInventoryHolder holder = new PlayerInventoryHolder(new GregFakePlayer(entityPlayer.world), EnumHand.MAIN_HAND); // We can't have this actually set the player's hand
-                holder.setCurrentItem(this.getClipboard());
+                holder.setCustomValidityCheck(this::isValid).setCurrentItem(this.getClipboard());
                 if (entityPlayer instanceof GregFakePlayer) { // This is how to tell if this is being called in-world or not
                     return ((ClipboardBehavior) clipboardBehaviour.get()).createMTEUI(holder, entityPlayer);
                 } else {


### PR DESCRIPTION
- A taped-over solution over the current awful implementation
- Allows even `PlayerInventoryHolder` to have custom validity checks and not just the default which checks if stored stack equals held stack.