### PR TITLE
Emit warnings in CT log for invalid CT recipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -61,6 +61,11 @@ public class Recipe {
      */
     private final boolean hidden;
 
+    /**
+     * If this Recipe is a Crafttweaker recipe. Used for logging purposes
+     */
+    private final boolean isCTRecipe;
+
     private final RecipePropertyStorage recipePropertyStorage;
 
     private static final ItemStackHashStrategy hashStrategy = ItemStackHashStrategy.comparingAll();
@@ -69,7 +74,7 @@ public class Recipe {
 
     public Recipe(List<CountableIngredient> inputs, List<ItemStack> outputs, List<ChanceEntry> chancedOutputs,
                   List<FluidStack> fluidInputs, List<FluidStack> fluidOutputs,
-                  int duration, int EUt, boolean hidden) {
+                  int duration, int EUt, boolean hidden, boolean isCTRecipe) {
         this.recipePropertyStorage = new RecipePropertyStorage();
         this.inputs = NonNullList.create();
         this.inputs.addAll(inputs);
@@ -81,6 +86,7 @@ public class Recipe {
         this.duration = duration;
         this.EUt = EUt;
         this.hidden = hidden;
+        this.isCTRecipe = isCTRecipe;
 
         //sort not consumables inputs to the end
         this.inputs.sort((ing1, ing2) -> Boolean.compare(ing1.isNonConsumable(), ing2.isNonConsumable()));
@@ -90,7 +96,7 @@ public class Recipe {
     public Recipe copy() {
 
         // Create a new Recipe object
-        Recipe newRecipe =  new Recipe(this.inputs, this.outputs, this.chancedOutputs, this.fluidInputs, this.fluidOutputs, this.duration, this.EUt, this.hidden);
+        Recipe newRecipe =  new Recipe(this.inputs, this.outputs, this.chancedOutputs, this.fluidInputs, this.fluidOutputs, this.duration, this.EUt, this.hidden, this.isCTRecipe);
 
         // Apply Properties from the original recipe onto the new one
         if(this.recipePropertyStorage.getSize() > 0) {
@@ -411,6 +417,7 @@ public class Recipe {
                 .append("duration", duration)
                 .append("EUt", EUt)
                 .append("hidden", hidden)
+                .append("CTRecipe", isCTRecipe)
                 .toString();
     }
 
@@ -570,6 +577,10 @@ public class Recipe {
 
     public boolean isHidden() {
         return hidden;
+    }
+
+    public boolean getIsCTRecipe() {
+        return isCTRecipe;
     }
 
     public boolean hasValidInputsForDisplay() {

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes;
 
+import crafttweaker.CraftTweakerAPI;
 import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -45,6 +46,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     protected int duration, EUt;
     protected boolean hidden = false;
+
+    protected boolean isCTRecipe = false;
 
     protected int parallel = 0;
 
@@ -514,6 +517,11 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
+    public R isCTRecipe() {
+        this.isCTRecipe = true;
+        return (R) this;
+    }
+
     public R setRecipeMap(RecipeMap<R> recipeMap) {
         this.recipeMap = recipeMap;
         return (R) this;
@@ -529,16 +537,22 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe));
     }
 
     protected EnumValidationResult validate() {
         if (EUt == 0) {
             GTLog.logger.error("EU/t cannot be equal to 0", new IllegalArgumentException());
+            if(isCTRecipe) {
+                CraftTweakerAPI.logError("EU/t cannot be equal to 0", new IllegalArgumentException());
+            }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (duration <= 0) {
             GTLog.logger.error("Duration cannot be less or equal to 0", new IllegalArgumentException());
+            if(isCTRecipe) {
+                CraftTweakerAPI.logError("Duration cannot be less or equal to 0", new IllegalArgumentException());
+            }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (recipeStatus == EnumValidationResult.INVALID) {

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes;
 
 import com.google.common.collect.ImmutableList;
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
@@ -229,6 +230,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
             }
         } else if (ConfigHolder.misc.debug) {
             GTLog.logger.warn("Recipe: {} for Recipe Map {} is a duplicate and was not added", recipe.toString(), this.unlocalizedName);
+            if(recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError(String.format("Recipe: %s for Recipe Map %s is a duplicate and was not added", recipe.toString(), this.unlocalizedName));
+            }
         }
     }
 
@@ -251,22 +255,38 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         Recipe recipe = validationResult.getResult();
         if (!GTUtility.isBetweenInclusive(getMinInputs(), getMaxInputs(), recipe.getInputs().size())) {
             GTLog.logger.error("Invalid amount of recipe inputs. Actual: {}. Should be between {} and {} inclusive.", recipe.getInputs().size(), getMinInputs(), getMaxInputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+            if(recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError(String.format("Invalid amount of recipe inputs. Actual: %s. Should be between %s and %s inclusive.", recipe.getInputs().size(), getMinInputs(), getMaxInputs()));
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+            }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (!GTUtility.isBetweenInclusive(getMinOutputs(), getMaxOutputs(), recipe.getOutputs().size() + recipe.getChancedOutputs().size())) {
             GTLog.logger.error("Invalid amount of recipe outputs. Actual: {}. Should be between {} and {} inclusive.", recipe.getOutputs().size() + recipe.getChancedOutputs().size(), getMinOutputs(), getMaxOutputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+            if(recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError(String.format("Invalid amount of recipe outputs. Actual: %s. Should be between %s and %s inclusive.", recipe.getOutputs().size() + recipe.getChancedOutputs().size(), getMinOutputs(), getMaxOutputs()));
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+            }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (!GTUtility.isBetweenInclusive(getMinFluidInputs(), getMaxFluidInputs(), recipe.getFluidInputs().size())) {
             GTLog.logger.error("Invalid amount of recipe fluid inputs. Actual: {}. Should be between {} and {} inclusive.", recipe.getFluidInputs().size(), getMinFluidInputs(), getMaxFluidInputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Inputs"));
+            if(recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError(String.format("Invalid amount of recipe fluid inputs. Actual: %s. Should be between %s and %s inclusive.", recipe.getFluidInputs().size(), getMinFluidInputs(), getMaxFluidInputs()));
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Inputs"));
+            }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (!GTUtility.isBetweenInclusive(getMinFluidOutputs(), getMaxFluidOutputs(), recipe.getFluidOutputs().size())) {
             GTLog.logger.error("Invalid amount of recipe fluid outputs. Actual: {}. Should be between {} and {} inclusive.", recipe.getFluidOutputs().size(), getMinFluidOutputs(), getMaxFluidOutputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Outputs"));
+            if(recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError(String.format("Invalid amount of recipe fluid outputs. Actual: %s. Should be between %s and %s inclusive.", recipe.getFluidOutputs().size(), getMinFluidOutputs(), getMaxFluidOutputs()));
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Outputs"));
+            }
             recipeStatus = EnumValidationResult.INVALID;
         }
         return ValidationResult.newResult(recipeStatus, recipe);

--- a/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
@@ -51,7 +51,7 @@ public class BlastRecipeBuilder extends RecipeBuilder<BlastRecipeBuilder> {
 
     public ValidationResult<Recipe> build() {
         Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                duration, EUt, hidden);
+                duration, EUt, hidden, isCTRecipe);
         if (!recipe.setProperty(TemperatureProperty.getInstance(), blastFurnaceTemp)) {
             return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);
         }

--- a/src/main/java/gregtech/api/recipes/builders/CircuitAssemblerRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/CircuitAssemblerRecipeBuilder.java
@@ -50,6 +50,6 @@ public class CircuitAssemblerRecipeBuilder extends RecipeBuilder<CircuitAssemble
     @Nonnull
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe));
     }
 }

--- a/src/main/java/gregtech/api/recipes/builders/FuelRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FuelRecipeBuilder.java
@@ -31,6 +31,6 @@ public class FuelRecipeBuilder extends RecipeBuilder<FuelRecipeBuilder> {
 
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe));
     }
 }

--- a/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
@@ -50,7 +50,7 @@ public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
 
     public ValidationResult<Recipe> build() {
         Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                duration, EUt, hidden);
+                duration, EUt, hidden, isCTRecipe);
         if (!recipe.setProperty(FusionEUToStartProperty.getInstance(), EUToStart)) {
             return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);
         }

--- a/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
@@ -50,7 +50,7 @@ public class GasCollectorRecipeBuilder extends RecipeBuilder<GasCollectorRecipeB
 
     public ValidationResult<Recipe> build() {
         Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                duration, EUt, hidden);
+                duration, EUt, hidden, isCTRecipe);
         if (!recipe.setProperty(GasCollectorDimensionProperty.getInstance(), dimensionIDs)) {
             return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);
         }

--- a/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
@@ -92,7 +92,7 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
 
 
         Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs,
-                duration, EUt, hidden);
+                duration, EUt, hidden, isCTRecipe);
 
         if (!recipe.setProperty(ImplosionExplosiveProperty.getInstance(), explosivesType)) {
             return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);

--- a/src/main/java/gregtech/api/recipes/builders/IntCircuitRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/IntCircuitRecipeBuilder.java
@@ -59,7 +59,7 @@ public class IntCircuitRecipeBuilder extends RecipeBuilder<IntCircuitRecipeBuild
 
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe));
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/builders/PrimitiveRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/PrimitiveRecipeBuilder.java
@@ -28,7 +28,7 @@ public class PrimitiveRecipeBuilder extends RecipeBuilder<PrimitiveRecipeBuilder
     @Override
     public ValidationResult<Recipe> build() {
         this.EUt(1); // secretly force to 1 to allow recipe matching to work properly
-        Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden);
+        Recipe recipe = new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe);
         if (!recipe.setProperty(PrimitiveProperty.getInstance(), true)) {
             return ValidationResult.newResult(EnumValidationResult.INVALID, recipe);
         }

--- a/src/main/java/gregtech/api/recipes/builders/SimpleRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/SimpleRecipeBuilder.java
@@ -25,6 +25,6 @@ public class SimpleRecipeBuilder extends RecipeBuilder<SimpleRecipeBuilder> {
 
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe));
     }
 }

--- a/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
@@ -85,7 +85,7 @@ public class UniversalDistillationRecipeBuilder extends RecipeBuilder<UniversalD
 
     public ValidationResult<Recipe> build() {
         return ValidationResult.newResult(finalizeAndValidate(),
-                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden));
+                new Recipe(inputs, outputs, chancedOutputs, fluidInputs, fluidOutputs, duration, EUt, hidden, isCTRecipe));
     }
 
     private int getRatioForDistillery(FluidStack fluidInput, FluidStack fluidOutput, ItemStack output) {

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -172,7 +172,7 @@ public class CTRecipeBuilder {
 
     @ZenMethod
     public void buildAndRegister() {
-        this.backingBuilder.buildAndRegister();
+        this.backingBuilder.isCTRecipe().buildAndRegister();
     }
 
     @ZenMethod


### PR DESCRIPTION
**What:**
This PR changes invalid recipe warnings to also be put into the Crafttweaker log if the recipe was created with Crafttweaker. This is done to group all the crafttweaker errors into a single place, and also because many people were unaware that the errors were put into the latest.log

**Implementation Details:**
A new parameter has been added to `Recipe` for if the recipe was created via Crafttweaker, and can be set via `RecipeBuilder`, which is done so automatically for anything created via `CTRecipeBuilder`

**Outcome:**
Adds Logging of invalid Crafttweaker recipes to the Crafttweaker log


**Possible compatibility issue:**
The signature of Recipe has changed, which could be problematic for any addon mods that had created custom RecipeBuilders, but it is an easy fix
