### PR TITLE
Fix Solar Panels not charging batteries in Battery Buffers

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverSolarPanel.java
+++ b/src/main/java/gregtech/common/covers/CoverSolarPanel.java
@@ -6,13 +6,11 @@ import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.capability.impl.EnergyContainerBatteryBuffer;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
-import gregtech.common.pipelike.cable.net.EnergyNetHandler;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
@@ -48,10 +46,8 @@ public class CoverSolarPanel extends CoverBehavior implements ITickable {
         BlockPos blockPos = coverHolder.getPos().up();
         if (canSeeSunClearly(world, blockPos)) {
             IEnergyContainer energyContainer = coverHolder.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);
-            if (energyContainer instanceof EnergyNetHandler || energyContainer instanceof EnergyContainerBatteryBuffer) {
+            if(energyContainer != null) {
                 energyContainer.acceptEnergyFromNetwork(null, EUt, 1);
-            } else if (energyContainer != null) {
-                energyContainer.addEnergy(EUt);
             }
         }
     }

--- a/src/main/java/gregtech/common/covers/CoverSolarPanel.java
+++ b/src/main/java/gregtech/common/covers/CoverSolarPanel.java
@@ -6,6 +6,7 @@ import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.impl.EnergyContainerBatteryBuffer;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.util.GTUtility;
@@ -47,7 +48,7 @@ public class CoverSolarPanel extends CoverBehavior implements ITickable {
         BlockPos blockPos = coverHolder.getPos().up();
         if (canSeeSunClearly(world, blockPos)) {
             IEnergyContainer energyContainer = coverHolder.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);
-            if (energyContainer instanceof EnergyNetHandler) {
+            if (energyContainer instanceof EnergyNetHandler || energyContainer instanceof EnergyContainerBatteryBuffer) {
                 energyContainer.acceptEnergyFromNetwork(null, EUt, 1);
             } else if (energyContainer != null) {
                 energyContainer.addEnergy(EUt);


### PR DESCRIPTION
**What:**
Fixes Solar Panels not charging batteries in battery buffers. Closes #717 

**Implementation Details:**
Adds a specific check for the battery buffer, as the batteries need to be charged via `acceptEnergyFromNetwork`, since the Battery Buffer Energy container is different from the batteries themselves, and so we don't want to hit the else if

**Outcome:**
Fixes Solar Panels not charging batteries in Battery Buffers.
