### PR TITLE
Parallel fixes and minor gas collector fixes

### DIFF
--- a/src/main/java/gregtech/api/recipes/FluidKey.java
+++ b/src/main/java/gregtech/api/recipes/FluidKey.java
@@ -10,12 +10,20 @@ import java.util.Objects;
 public class FluidKey {
 
     public final String fluid;
-    public final NBTTagCompound tag;
+    // Don't make this final, so we can clear the NBT if we remove the only key, resulting in an NBT of {}. Thanks Forge
+    public NBTTagCompound tag;
+    private final int amount;
 
     public FluidKey(FluidStack fluidStack) {
         this.fluid = fluidStack.getFluid().getName();
         this.tag = fluidStack.tag;
+        this.amount = fluidStack.amount;
     }
+
+    public FluidKey copy() {
+        return new FluidKey(new FluidStack(getFluid(), this.amount, tag));
+    }
+
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
@@ -35,10 +35,10 @@ public class GasCollectorRecipeBuilder extends RecipeBuilder<GasCollectorRecipeB
     @Override
     public boolean applyProperty(String key, Object value) {
         if (key.equals(GasCollectorDimensionProperty.KEY)) {
-            this.dimension(((Number) value).intValue());
+            this.dimension(((List<Integer>) value).get(0));
             return true;
         }
-        return true;
+        return false;
     }
 
     public GasCollectorRecipeBuilder dimension(int dimensionID) {

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -303,6 +303,12 @@ public class ParallelLogic {
             }
         }
 
+        // Return the maximum parallel limit here if there are only non-consumed inputs, which are all found in the input bus
+        // At this point, we would have already returned 0 if we were missing any non-consumable inputs, so we can omit that check
+        if(countableMap.isEmpty() && !notConsumableMap.isEmpty()) {
+            return parallelAmount;
+        }
+
         // Iterate through the recipe inputs
         for (Map.Entry<Ingredient, Integer> recipeInputEntry : countableMap.entrySet()) {
             int needed = recipeInputEntry.getValue();

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -380,6 +380,12 @@ public class ParallelLogic {
             }
         }
 
+        // Return the maximum parallel limit here if there are only non-consumed inputs, which are all found in the input bus
+        // At this point, we would have already returned 0 if we were missing any non-consumable inputs, so we can omit that check
+        if(fluidCountMap.isEmpty() && !notConsumableMap.isEmpty()) {
+            return parallelAmount;
+        }
+
         // Iterate through the fluid inputs in the recipe
         for (Map.Entry<FluidKey, Integer> fs : fluidCountMap.entrySet()) {
             int needed = fs.getValue();


### PR DESCRIPTION
**What:**
This PR fixes some minor parallel issues and minor gas collector issues, with the eventual aim of fixing #804 

**Implementation Details:**
For the parallel fix, the maximum item ratio was returning `Integer.MAX_VALUE` if the only item inputs of the recipe were not-consumed inputs. Therefore, a check was added to instead return the maximum parallel limit if there were only non-consumable item inputs, which were all found in the input bus of the multiblock.

Edit:
Other Parallel Fixes:
- Properly ensure that there are enough of the non-consumed items/fluids in the input bus to run the recipe in the first place
- Strip the nonConsumable tag from NC fluids before comparing against fluids in the input hatches, as the fluids in the input hatches will not have this tag, and `FluidKey#equals` compares tags, meaning that recipe look ups with non-consumed fluids would always fail.

For the Gas collector fix, the property is a `List`, and not a `Number`, so cast to List to avoid ClassCastExceptions when being used inside the ProcessingArray. (The Exceptions came about because of RecipeBuilder#append, which passes the String key and Object value).

In addition, do not return true if the property was failed to be applied.

**Outcome:**
Minor Parallel and Gas Collector fixes.
