### PR TITLE
Fix Block Breaker spawning drops in wrong location

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
@@ -109,8 +109,8 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
     private void addToInventoryOrDropItems(List<ItemStack> drops) {
         EnumFacing outputFacing = getOutputFacing();
         double itemSpawnX = getPos().getX() + 0.5 + outputFacing.getXOffset();
-        double itemSpawnY = getPos().getX() + 0.5 + outputFacing.getYOffset();
-        double itemSpawnZ = getPos().getX() + 0.5 + outputFacing.getZOffset();
+        double itemSpawnY = getPos().getY() + 0.5 + outputFacing.getYOffset();
+        double itemSpawnZ = getPos().getZ() + 0.5 + outputFacing.getZOffset();
         for (ItemStack itemStack : drops) {
             ItemStack remainStack = ItemHandlerHelper.insertItemStacked(exportItems, itemStack, false);
             if (!remainStack.isEmpty()) {


### PR DESCRIPTION
**What:**
Fixes the Block Breaker spawning drops in the wrong location when the inventory was full. Addresses one point in #786 


**Outcome:**
Block Breaker spawns drops in correct location when its inventory is full
