### PR TITLE
Fix various issues with things going in machine hatch

### DIFF
--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -35,7 +35,13 @@ public class MachineItemBlock extends ItemBlock {
     }
 
     public static MetaTileEntity getMetaTileEntity(ItemStack itemStack) {
-        return GregTechAPI.MTE_REGISTRY.getObjectById(itemStack.getItemDamage());
+        MetaTileEntity mte = GregTechAPI.MTE_REGISTRY.getObjectById(itemStack.getItemDamage());
+        // Guard against passing random ItemStacks with damage into the method and getting an MTE out based on the item damage
+        if(mte == null || !(itemStack.getItem() instanceof MachineItemBlock)) {
+            return null;
+        }
+
+        return mte;
     }
 
     @Nonnull

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -17,6 +17,7 @@ import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
+import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
@@ -938,7 +939,7 @@ public class GTUtility {
         }
 
         MetaTileEntity machine = MachineItemBlock.getMetaTileEntity(machineStack);
-        if (machine instanceof WorkableTieredMetaTileEntity)
+        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity))
             return !findMachineInBlacklist(machine.getRecipeMap().getUnlocalizedName(), recipeMapBlacklist);
 
         return false;

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -24,6 +24,7 @@ import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.ConfigHolder;
 import gregtech.common.items.behaviors.CoverPlaceBehavior;
 import gregtech.common.items.behaviors.CrowbarBehaviour;
+import gregtech.common.metatileentities.electric.MetaTileEntityRockBreaker;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRedstoneWire;
 import net.minecraft.block.properties.IProperty;
@@ -939,7 +940,9 @@ public class GTUtility {
         }
 
         MetaTileEntity machine = MachineItemBlock.getMetaTileEntity(machineStack);
-        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity))
+        // Blacklist the Rock Breaker here instead of through the config option so we don't get people removing the config entry and then
+        // complaining it does not work. Remove from here if we ever decide to implement PA Rock Breaker
+        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity || machine instanceof MetaTileEntityRockBreaker))
             return !findMachineInBlacklist(machine.getRecipeMap().getUnlocalizedName(), recipeMapBlacklist);
 
         return false;

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -94,7 +94,7 @@ public class ConfigHolder {
         @Config.Comment({"Blacklist of machines for the Processing Array.",
                 "Add the unlocalized Recipe Map name to blacklist the machine.",
                 "Default: All machines allowed"})
-        public String[] processingArrayBlacklist = new String[] {"rock_breaker"};
+        public String[] processingArrayBlacklist = new String[0];
     }
 
     public static class WorldGenOptions {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -94,7 +94,7 @@ public class ConfigHolder {
         @Config.Comment({"Blacklist of machines for the Processing Array.",
                 "Add the unlocalized Recipe Map name to blacklist the machine.",
                 "Default: All machines allowed"})
-        public String[] processingArrayBlacklist = new String[0];
+        public String[] processingArrayBlacklist = new String[] {"rock_breaker"};
     }
 
     public static class WorldGenOptions {


### PR DESCRIPTION
**What:**
Fixes invalid items being able to go into a Machine Hatch on a formed Processing Array. Closes #805

**Implementation Details:**
Changes `MachineItemBlock#getMetaTileEntity` to check if the itemstack's item is an instance of `MachineItemBlock`. This should hopefully prevent passing random items with damage into the method and getting an MTE. 

Adds Rock Breaker to the PA blacklist, it should not really work in the PA at all.

Blacklists Generators from the PA, I don't really want to figure out supporting them

**Outcome:**
Fix various issues where unintended items could go in the Machine Hatch attached to a formed Processing Array
