### PR TITLE
Fix suit charging messages

### DIFF
--- a/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
@@ -60,13 +60,18 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
         if (toggleTimer == 0 && ArmorUtils.isKeyDown(player, EnumKey.SHARE_KEY)) {
             canShare = !canShare;
             toggleTimer = 5;
-            data.setBoolean("canShare", canShare);
             if (!world.isRemote) {
-                if (canShare)
+                if (canShare && cont.getCharge() == 0)
+                    player.sendStatusMessage(new TextComponentTranslation("metaarmor.nms.share.error"), true);
+                else if (canShare)
                     player.sendStatusMessage(new TextComponentTranslation("metaarmor.nms.share.enable"), true);
                 else
                     player.sendStatusMessage(new TextComponentTranslation("metaarmor.nms.share.disable"), true);
             }
+
+            // Only allow for charging to be enabled if charge is nonzero
+            canShare = canShare && (cont.getCharge() != 0);
+            data.setBoolean("canShare", canShare);
         }
 
         performFlying(player, hoverMode, item);

--- a/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
@@ -61,13 +61,18 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
         if (toggleTimer == 0 && ArmorUtils.isKeyDown(player, EnumKey.SHARE_KEY)) {
             canShare = !canShare;
             toggleTimer = 5;
-            data.setBoolean("canShare", canShare);
             if (!world.isRemote) {
-                if (canShare)
+                if (canShare && cont.getCharge() == 0)
+                    player.sendStatusMessage(new TextComponentTranslation("metaarmor.qts.share.error"), true);
+                else if (canShare)
                     player.sendStatusMessage(new TextComponentTranslation("metaarmor.qts.share.enable"), true);
                 else
                     player.sendStatusMessage(new TextComponentTranslation("metaarmor.qts.share.disable"), true);
             }
+
+            // Only allow for charging to be enabled if charge is nonzero
+            canShare = canShare && (cont.getCharge() != 0);
+            data.setBoolean("canShare", canShare);
         }
 
         performFlying(player, hoverMode, item);

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1015,9 +1015,11 @@ metaarmor.jetpack.emergency_hover_mode=Emergency Hover Mode Enabled!
 
 metaarmor.nms.share.enable=NanoMuscle™ Suite: Charging Enabled
 metaarmor.nms.share.disable=NanoMuscle™ Suite: Charging Disabled
+metaarmor.nms.share.error=NanoMuscle™ Suite: §cNot enough power for charging!
 
 metaarmor.qts.share.enable=QuarkTech™ Suite: Charging Enabled
 metaarmor.qts.share.disable=QuarkTech™ Suite: Charging Disabled
+metaarmor.qts.share.error=QuarkTech™ Suite: §cNot enough power for charging!
 
 metaarmor.message.nightvision.enabled=§bNightVision: §aOn
 metaarmor.message.nightvision.disabled=§bNightVision: §cOff


### PR DESCRIPTION
**What:**
Previously, when using the advanced nano muscle suite or the advanced quark tech suite, if you had no charge and tried to activate charging it would say enabled without actually enabling charging. Now, it will prevent you from enabling charging if there is no charge in the suite and show an error message.

**Implementation Details:**
Changes `AdvancedNanoMuscleSuite#onArmorTick` and `AdvancedQuarkTechSuite#onArmorTick` to only enable canShare if there is sufficient power and to show an error message otherwise.

**Outcome:**
Fixes advanced nano muscle suite and advanced quark tech suite saying charging enabled when they have no power.
