### PR TITLE
Allow for wrenching hatches & buses without sneaking

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -11,6 +11,7 @@ import codechicken.lib.vec.Matrix4;
 import com.google.common.base.Preconditions;
 import gregtech.api.GregTechAPI;
 import gregtech.api.block.machines.BlockMachine;
+import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
@@ -329,6 +330,14 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     /**
+     * Allow for wrenching of certain machines on right click without sneaking
+     * @return wrench on right click without sneak
+     */
+    protected boolean wrenchOnRightClick() {
+        return false;
+    }
+
+    /**
      * Creates a UI instance for player opening inventory of this meta tile entity
      *
      * @param entityPlayer player opening inventory
@@ -379,7 +388,9 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
      * @return true if something happened, so animation will be played
      */
     public boolean onRightClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
-        if (!playerIn.isSneaking() && openGUIOnRightClick()) {
+        if (wrenchOnRightClick() && playerIn.getHeldItem(EnumHand.MAIN_HAND).hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null)) {
+            return false;
+        } else if (!playerIn.isSneaking() && openGUIOnRightClick()) {
             if (getWorld() != null && !getWorld().isRemote) {
                 MetaTileEntityUIFactory.INSTANCE.openUI(getHolder(), (EntityPlayerMP) playerIn);
             }
@@ -403,7 +414,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
      * @return true if something happened, so wrench will get damaged and animation will be played
      */
     public boolean onWrenchClick(EntityPlayer playerIn, EnumHand hand, EnumFacing wrenchSide, CuboidRayTraceResult hitResult) {
-        if (playerIn.isSneaking()) {
+        if (playerIn.isSneaking() || wrenchOnRightClick()) {
             if (wrenchSide == getFrontFacing() || !isValidFrontFacing(wrenchSide) || !hasFrontFacing()) {
                 return false;
             }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -122,6 +122,11 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     }
 
     @Override
+    protected boolean wrenchOnRightClick() {
+        return true;
+    }
+
+    @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         return createTankUI((isExportHatch ? exportFluids : importFluids).getTankAt(0), containerInventory, getMetaFullName(), entityPlayer)
                 .build(getHolder(), entityPlayer);

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -88,6 +88,12 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     }
 
     @Override
+    protected boolean wrenchOnRightClick() {
+        // Allow for item buses to be wrenched on right click without opening GUI
+        return true;
+    }
+
+    @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         int rowSize = (int) Math.sqrt(getInventorySize());
         return createUITemplate(entityPlayer, rowSize, rowSize == 10 ? 9 : 0)

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -127,6 +127,11 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
     }
 
     @Override
+    protected boolean wrenchOnRightClick() {
+        return true;
+    }
+
+    @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         int rowSize = getTier();
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176,


### PR DESCRIPTION
**What:**
This PR adds functionality to allow for MetaTileEntities to indicate that they can be wrenched without sneaking, in which case the UI will not be opened and the machines will be rotated. It specifically applies this functionality to input buses and fluid hatches

**Implementation Details:**
Adds a new function, `MetaTileEntity#wrenchOnRightClick`. When tile entity is right clicked, if this function returns true and the main hand carries an item with the wrench capability then the UI is not opened. Additionally, `MetaTileEntity#onWrenchClick` now allows for wrenching without sneaking if `MetaTileEntity#wrenchOnRightClick` is true.

**Additional info:**
Per request from todo channel: "allow "hatch" and "bus" type blocks to be rotated with a wrench without holding shift"

**Possible compatibility issue:**
The MetaTileEntity API has been changed by adding `MetaTileEntity#wrenchOnRightClick`, but unless that function is overridden to return true than it should function identically to before.