### PR TITLE
Fix armor classes not attaching new NBT compounds

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -647,7 +647,11 @@ public class GTUtility {
 
     public static NBTTagCompound getOrCreateNbtCompound(ItemStack stack) {
         NBTTagCompound compound = stack.getTagCompound();
-        return compound == null ? new NBTTagCompound() : compound;
+        if (compound == null) {
+            compound = new NBTTagCompound();
+            stack.setTagCompound(compound);
+        }
+        return compound;
     }
 
     public static NonNullList<ItemStack> copyStackList(List<ItemStack> itemStacks) {


### PR DESCRIPTION
**What:**
I noticed that the armor classes use a function, `GTUtility#getOrCreateNbtCompound()`, that does not actually attach the new NBT compound to the stack if it creates a new one. This resulted in some weird behavior; for instance, before #815, if you did not have enough power and tried to activate sharing on one of the suites then you would constantly get an activated message. This was not because it failed to activate, but because it was creating a new NBT compound, setting canShare to true, but not actually attaching it to the ItemStack. 

**Implementation Details:**
The function `GTUtility#getOrCreateNbtCompound(ItemStack)` now attaches the NBT compound to the item stack if it creates one. 

**Outcome:**
Everything using `GTUtility#getOrCreateNbtCompound()` can now assume the NBT compound is actually attached to the ItemStack. This fixes instances where NBT changes were thrown away due to no pre-existing NBT compound.
