### PR TITLE
Fix #768

### DIFF
--- a/src/main/java/gregtech/api/enchants/EnchantmentHardHammer.java
+++ b/src/main/java/gregtech/api/enchants/EnchantmentHardHammer.java
@@ -43,6 +43,11 @@ public class EnchantmentHardHammer extends Enchantment {
 
     @Override
     public boolean canApply(ItemStack stack) {
+        return this.canApplyAtEnchantingTable(stack);
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack) {
         boolean isPick = false;
 
         if(stack.getItem() instanceof ItemPickaxe) {
@@ -50,13 +55,13 @@ public class EnchantmentHardHammer extends Enchantment {
         }
         else if(stack.getItem() instanceof ToolMetaItem) {
             ToolMetaItem<?> toolMetaItem = (ToolMetaItem<?>) stack.getItem();
-            ToolMetaItem.MetaToolValueItem toolValueItem = toolMetaItem.getItem(stack);
+            ToolMetaItem<?>.MetaToolValueItem toolValueItem = toolMetaItem.getItem(stack);
             if(toolValueItem.getToolStats() instanceof ToolPickaxe) {
                 isPick = true;
             }
         }
 
-        return isPick && super.canApply(stack);
+        return isPick && stack.getItem().canApplyAtEnchantingTable(stack, this);
     }
 
     @Override


### PR DESCRIPTION
**What:**
#475 meant to restrict the hammering enchantment to only be applicable to pickaxes, but overlooked the logic for applying it at an enchanting table meaning that you could still apply it to other things at an enchanting table. This PR changes it so that it can only be applied to pickaxes at enchanting tables and when enchanting with a book or commands. This fixes #768 