### PR TITLE
Add item handling to fluid hatches & super tanks

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/SimpleFluidItemHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/SimpleFluidItemHandler.java
@@ -1,0 +1,80 @@
+package gregtech.api.capability.impl;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemStackHandler;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Simple item handler to allow for fluid capable items to be inserted / extracted from blocks such as tanks.
+ * See {@link gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch} for usage example.
+ */
+public class SimpleFluidItemHandler implements IItemHandler {
+    private final ItemStackHandler inventory;
+
+    private final int inputSlot;
+    private final int outputSlot;
+
+    public SimpleFluidItemHandler(ItemStackHandler inventory, int inputSlot, int outputSlot) {
+        this.inventory = inventory;
+        this.inputSlot = inputSlot;
+        this.outputSlot = outputSlot;
+    }
+
+    @Override
+    public int getSlots() {
+        return 1;
+    }
+
+    @Override
+    public int getSlotLimit(int i) {
+        return inventory.getSlotLimit(inputSlot);
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack getStackInSlot(int i) {
+        return inventory.getStackInSlot(outputSlot);
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack insertItem(int i, @Nonnull ItemStack stack, boolean simulate) {
+        if (stack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+
+        // Verify that item has a fluid handler and can fit
+        IFluidHandlerItem fluidHandlerItem = FluidUtil.getFluidHandler(stack);
+        if (fluidHandlerItem == null
+                || !inventory.isItemValid(inputSlot, stack)) {
+            return stack;
+        }
+
+        return inventory.insertItem(0, stack, simulate);
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack extractItem(int slot, int amount, boolean simulate) {
+        ItemStack stack = inventory.getStackInSlot(outputSlot);
+        if (stack.isEmpty() || amount == 0) {
+            return ItemStack.EMPTY;
+        }
+
+        ItemStack extractedStack = stack.copy();
+        extractedStack.setCount(Math.min(amount, stack.getCount()));
+        if (!simulate) {
+            if (stack.getCount() <= amount) {
+                inventory.setStackInSlot(outputSlot, ItemStack.EMPTY);
+            } else {
+                stack.setCount(stack.getCount() - amount);
+            }
+        }
+
+        return extractedStack;
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -4,6 +4,8 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.capability.impl.NotifiableFluidTank;
+import gregtech.api.capability.impl.SimpleFluidItemHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
@@ -15,18 +17,21 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import gregtech.client.renderer.texture.Textures;
-import gregtech.api.capability.impl.NotifiableFluidTank;
+import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
@@ -64,6 +69,12 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         super.readFromNBT(data);
         containerInventory.deserializeNBT(data.getCompoundTag("ContainerInventory"));
         //fluidTank.readFromNBT(data);
+    }
+
+    @Override
+    protected void initializeInventory() {
+        super.initializeInventory();
+        this.itemInventory = new SimpleFluidItemHandler(containerInventory, 0, 1);
     }
 
     @Override
@@ -119,6 +130,19 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     @Override
     public void registerAbilities(List<IFluidTank> abilityList) {
         abilityList.addAll(isExportHatch ? this.exportFluids.getFluidTanks() : this.importFluids.getFluidTanks());
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            IItemHandler itemHandler = itemInventory;
+            if (itemHandler.getSlots() > 0) {
+                return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(itemHandler);
+            }
+            return null;
+        }
+
+        return super.getCapability(capability, side);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -7,10 +7,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IActiveOutputSide;
-import gregtech.api.capability.impl.FilteredFluidHandler;
-import gregtech.api.capability.impl.FluidHandlerProxy;
-import gregtech.api.capability.impl.FluidTankList;
-import gregtech.api.capability.impl.ThermalFluidHandlerItemStack;
+import gregtech.api.capability.impl.*;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -41,6 +38,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -95,6 +94,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         this.importFluids = new FluidTankList(false, fluidTank);
         this.exportFluids = new FluidTankList(false, fluidTank);
         this.outputFluidInventory = new FluidHandlerProxy(new FluidTankList(false), exportFluids);
+        this.itemInventory = new SimpleFluidItemHandler(containerInventory, 0, 1);
     }
 
     @Override
@@ -347,7 +347,14 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
 
     @Override
     public <T> T getCapability(Capability<T> capability, EnumFacing side) {
-        if (capability == GregtechTileCapabilities.CAPABILITY_ACTIVE_OUTPUT_SIDE) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            IItemHandler itemHandler = itemInventory;
+            if (itemHandler.getSlots() > 0) {
+                return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(itemHandler);
+            }
+            return null;
+        }
+        else if (capability == GregtechTileCapabilities.CAPABILITY_ACTIVE_OUTPUT_SIDE) {
             if (side == getOutputFacing()) {
                 return GregtechTileCapabilities.CAPABILITY_ACTIVE_OUTPUT_SIDE.cast(this);
             }


### PR DESCRIPTION
**What:**
This PR adds an item handler to fluid hatches and super tanks so that they can now accept fluid handling items being piped into and out of them.

**Implementation Details:**
The item handler might be slightly sketchy, it just pretends it's a single slot and uses the input slot for inserting and the output slot for extracting. This solution seemed to work fine from my testing though.

**Outcome:**
Fluid handling items (buckets, cells, etc.) can now be piped into / out of fluid hatches and super tanks.

**Additional info:**
Per note in the todo channel: expose item handler capabilities for Super Tanks, singleblock generators, Fluid Hatches, etc so that things like buckets or cells could be piped in/out.
I did not add a similar capability for single block generators in this PR as they do not currently have an inventory to hold the items, that could relatively easily be added in the future though.

**Possible compatibility issue:**
This PR adds an API class, SimpleFluidItemHandler, but does not make any changes to existing parts of the API.