### PR TITLE
MTE Refactor Pt 1: `IGregTechTileEntity`

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -17,6 +17,7 @@ import gregtech.api.cover.IFacadeCover;
 import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.IBlockAppearance;
 import gregtech.client.renderer.handler.MetaTileEntityRenderer;
 import gregtech.common.ConfigHolder;
@@ -33,16 +34,13 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving.SpawnPlacementType;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.boss.EntityWither;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityWitherSkull;
-import net.minecraft.init.Enchantments;
 import net.minecraft.item.EnumDyeColor;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -53,7 +51,6 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.IWorldNameable;
 import net.minecraft.world.World;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
@@ -150,7 +147,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     public static MetaTileEntity getMetaTileEntity(IBlockAccess blockAccess, BlockPos pos) {
         TileEntity holder = blockAccess.getTileEntity(pos);
-        return holder instanceof MetaTileEntityHolder ? ((MetaTileEntityHolder) holder).getMetaTileEntity() : null;
+        return holder instanceof IGregTechTileEntity ? ((IGregTechTileEntity) holder).getMetaTileEntity() : null;
     }
 
     @Override
@@ -240,11 +237,12 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Override
     public void onBlockPlacedBy(World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull EntityLivingBase placer, ItemStack stack) {
-        MetaTileEntityHolder holder = (MetaTileEntityHolder) worldIn.getTileEntity(pos);
+        IGregTechTileEntity holder = (IGregTechTileEntity) worldIn.getTileEntity(pos);
         MetaTileEntity sampleMetaTileEntity = GregTechAPI.MTE_REGISTRY.getObjectById(stack.getItemDamage());
         if (holder != null && sampleMetaTileEntity != null) {
-            if (stack.hasDisplayName()) {
-                holder.setCustomName(stack.getDisplayName());
+            // TODO Fix this
+            if (stack.hasDisplayName() && holder instanceof MetaTileEntityHolder) {
+                ((MetaTileEntityHolder) holder).setCustomName(stack.getDisplayName());
             }
             MetaTileEntity metaTileEntity = holder.setMetaTileEntity(sampleMetaTileEntity);
             if (stack.hasTagCompound()) {
@@ -290,8 +288,12 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         //only set item tag if it's not empty, so newly created items will stack with dismantled
         if (!tagCompound.isEmpty())
             itemStack.setTagCompound(tagCompound);
-        if (metaTileEntity.getHolder().hasCustomName()) {
-            itemStack.setStackDisplayName(metaTileEntity.getHolder().getName());
+        // TODO Clean this up
+        if (metaTileEntity.getHolder() instanceof MetaTileEntityHolder) {
+            MetaTileEntityHolder holder = (MetaTileEntityHolder) metaTileEntity.getHolder();
+            if (holder.hasCustomName()) {
+                itemStack.setStackDisplayName(holder.getName());
+            }
         }
         drops.add(itemStack);
         metaTileEntity.getDrops(drops, harvesters.get());
@@ -383,7 +385,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Override
     public void harvestBlock(@Nonnull World worldIn, @Nonnull EntityPlayer player, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nullable TileEntity te, @Nonnull ItemStack stack) {
-        tileEntities.set(te == null ? tileEntities.get() : ((MetaTileEntityHolder) te).getMetaTileEntity());
+        tileEntities.set(te == null ? tileEntities.get() : ((IGregTechTileEntity) te).getMetaTileEntity());
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
     }
@@ -395,7 +397,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Nullable
     @Override
-    public MetaTileEntityHolder createNewTileEntity(@Nullable World worldIn, int meta) {
+    public TileEntity createNewTileEntity(@Nullable World worldIn, int meta) {
         return new MetaTileEntityHolder();
     }
 

--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -38,6 +38,7 @@ public class GregtechDataCodes {
     public static final int UPDATE_UI = 0;
     public static final int CREATE_FAKE_UI = 1;
     public static final int MOUSE_POSITION = 2;
+    public static final int INIT_CLIPBOARD_NBT = 3;
 
     // Pump
     public static final int PUMP_HEAD_LEVEL = 200;

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -772,10 +772,10 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         if (dataId == GregtechDataCodes.WORKABLE_ACTIVE) {
             this.isActive = buf.readBoolean();
-            getMetaTileEntity().getHolder().scheduleChunkForRenderUpdate();
+            getMetaTileEntity().scheduleRenderUpdate();
         } else if (dataId == GregtechDataCodes.WORKING_ENABLED) {
             this.workingEnabled = buf.readBoolean();
-            getMetaTileEntity().getHolder().scheduleChunkForRenderUpdate();
+            getMetaTileEntity().scheduleRenderUpdate();
         }
     }
 

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -101,7 +101,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
             this.needsVenting = buf.readBoolean();
         } else if (dataId == GregtechDataCodes.VENTING_SIDE) {
             this.ventingSide = EnumFacing.VALUES[buf.readByte()];
-            getMetaTileEntity().getHolder().scheduleChunkForRenderUpdate();
+            getMetaTileEntity().scheduleRenderUpdate();
         } else if (dataId == GregtechDataCodes.VENTING_STUCK) {
             this.ventingStuck = buf.readBoolean();
         }

--- a/src/main/java/gregtech/api/items/behavior/ProxyHolderPluginBehavior.java
+++ b/src/main/java/gregtech/api/items/behavior/ProxyHolderPluginBehavior.java
@@ -1,6 +1,6 @@
 package gregtech.api.items.behavior;
 
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Objects;
 
 public abstract class ProxyHolderPluginBehavior extends MonitorPluginBaseBehavior {
-    protected MetaTileEntityHolder holder;
+    protected IGregTechTileEntity holder;
     private BlockPos pos;
 
     @Override
@@ -31,14 +31,14 @@ public abstract class ProxyHolderPluginBehavior extends MonitorPluginBaseBehavio
     public void onHolderPosUpdated(BlockPos pos) {
         if (Objects.equals(this.pos, pos)) return;
         this.pos = pos;
-        MetaTileEntityHolder lastHolder = holder;
+        IGregTechTileEntity lastHolder = holder;
         holder = this.screen.getHolderFromPos(pos);
         if (!Objects.equals(lastHolder, holder)) onHolderChanged(lastHolder);
     }
 
-    protected abstract void onHolderChanged(MetaTileEntityHolder lastHolder);
+    protected abstract void onHolderChanged(IGregTechTileEntity lastHolder);
 
-    public MetaTileEntityHolder getHolder() {
+    public IGregTechTileEntity getHolder() {
         return holder;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -5,11 +5,11 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.block.machines.BlockMachine;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.gui.IUIHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.net.NetworkHandler;
 import gregtech.api.net.packets.CPacketRecoverMTE;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
-import gregtech.api.util.TaskScheduler;
 import gregtech.client.particle.GTNameTagParticle;
 import gregtech.client.particle.GTParticleManager;
 import net.minecraft.block.state.IBlockState;
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 
 import static gregtech.api.capability.GregtechDataCodes.INITIALIZE_MTE;
 
-public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIHolder, IWorldNameable {
+public class MetaTileEntityHolder extends TickableTileEntityBase implements IGregTechTileEntity, IUIHolder, IWorldNameable {
 
     MetaTileEntity metaTileEntity;
     private boolean needToUpdateLightning = false;
@@ -48,7 +48,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
     @SideOnly(Side.CLIENT)
     private GTNameTagParticle nameTagParticle;
 
-    private int[] timeStatistics = new int[20];
+    private final int[] timeStatistics = new int[20];
     private int timeStatisticsIndex = 0;
     private int lagWarningCount = 0;
 
@@ -62,13 +62,17 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
      * so it is safe to call it on sample meta tile entities
      * Also can use certain data to preinit the block before data is synced
      */
-    public MetaTileEntity setMetaTileEntity(MetaTileEntity sampleMetaTileEntity, Object... data) {
+    @Override
+    public MetaTileEntity setMetaTileEntity(MetaTileEntity sampleMetaTileEntity) {
         Preconditions.checkNotNull(sampleMetaTileEntity, "metaTileEntity");
         setRawMetaTileEntity(sampleMetaTileEntity.createMetaTileEntity(this));
-        this.metaTileEntity.onAttached(data);
+        this.metaTileEntity.onAttached();
         if (hasWorld() && !getWorld().isRemote) {
             updateBlockOpacity();
-            sendInitialSyncData();
+            writeCustomData(INITIALIZE_MTE, buffer -> {
+                buffer.writeVarInt(GregTechAPI.MTE_REGISTRY.getIdByObjectName(getMetaTileEntity().metaTileEntityId));
+                getMetaTileEntity().writeInitialSyncData(buffer);
+            });
             //just to update neighbours so cables and other things will work properly
             this.needToUpdateLightning = true;
             world.neighborChanged(getPos(), getBlockType(), getPos());
@@ -90,13 +94,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
         }
     }
 
-    public void scheduleChunkForRenderUpdate() {
-        BlockPos pos = getPos();
-        getWorld().markBlockRangeForRenderUpdate(
-                pos.getX() - 1, pos.getY() - 1, pos.getZ() - 1,
-                pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
-    }
-
+    @Override
     public void notifyBlockUpdate() {
         getWorld().notifyNeighborsOfStateChange(pos, getBlockType(), false);
     }
@@ -237,13 +235,6 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
         return list;
     }
 
-    public void sendInitialSyncData() {
-        writeCustomData(INITIALIZE_MTE, buffer -> {
-            buffer.writeVarInt(GregTechAPI.MTE_REGISTRY.getIdByObjectName(metaTileEntity.metaTileEntityId));
-            metaTileEntity.writeInitialSyncData(buffer);
-        });
-    }
-
     @Override
     public void writeInitialSyncData(PacketBuffer buf) {
         buf.writeString(getName());
@@ -261,7 +252,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
             int metaTileEntityId = buf.readVarInt();
             setMetaTileEntity(GregTechAPI.MTE_REGISTRY.getObjectById(metaTileEntityId));
             this.metaTileEntity.receiveInitialSyncData(buf);
-            scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
             this.needToUpdateLightning = true;
         }
     }
@@ -272,7 +263,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
             int metaTileEntityId = buffer.readVarInt();
             setMetaTileEntity(GregTechAPI.MTE_REGISTRY.getObjectById(metaTileEntityId));
             this.metaTileEntity.receiveInitialSyncData(buffer);
-            scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
             this.needToUpdateLightning = true;
         } else if (metaTileEntity != null) {
             metaTileEntity.receiveCustomData(discriminator, buffer);

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityUIFactory.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityUIFactory.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.UIFactory;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.PacketBuffer;
@@ -14,7 +15,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 /**
  * {@link UIFactory} implementation for {@link MetaTileEntity}
  */
-public class MetaTileEntityUIFactory extends UIFactory<MetaTileEntityHolder> {
+public class MetaTileEntityUIFactory extends UIFactory<IGregTechTileEntity> {
 
     public static final MetaTileEntityUIFactory INSTANCE = new MetaTileEntityUIFactory();
 
@@ -26,19 +27,18 @@ public class MetaTileEntityUIFactory extends UIFactory<MetaTileEntityHolder> {
     }
 
     @Override
-    protected ModularUI createUITemplate(MetaTileEntityHolder holder, EntityPlayer entityPlayer) {
-        return holder.getMetaTileEntity().createUI(entityPlayer);
+    protected ModularUI createUITemplate(IGregTechTileEntity tileEntity, EntityPlayer entityPlayer) {
+        return tileEntity.getMetaTileEntity().createUI(entityPlayer);
     }
 
     @Override
     @SideOnly(Side.CLIENT)
-    protected MetaTileEntityHolder readHolderFromSyncData(PacketBuffer syncData) {
-        return (MetaTileEntityHolder) Minecraft.getMinecraft().world.getTileEntity(syncData.readBlockPos());
+    protected IGregTechTileEntity readHolderFromSyncData(PacketBuffer syncData) {
+        return (IGregTechTileEntity) Minecraft.getMinecraft().world.getTileEntity(syncData.readBlockPos());
     }
 
     @Override
-    protected void writeHolderToSyncData(PacketBuffer syncData, MetaTileEntityHolder holder) {
+    protected void writeHolderToSyncData(PacketBuffer syncData, IGregTechTileEntity holder) {
         syncData.writeBlockPos(holder.getPos());
     }
-
 }

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -13,6 +13,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.CycleButtonWidget;
 import gregtech.api.gui.widgets.LabelWidget;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -47,7 +48,7 @@ public class SimpleGeneratorMetaTileEntity extends WorkableTieredMetaTileEntity 
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SimpleGeneratorMetaTileEntity(metaTileEntityId, workable.getRecipeMap(), renderer, getTier(), getTankScalingFunction(), handlesRecipeOutputs);
     }
 

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -16,6 +16,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.gui.widgets.*;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.util.GTUtility;
@@ -79,7 +80,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SimpleMachineMetaTileEntity(metaTileEntityId, workable.getRecipeMap(), renderer, getTier(), hasFrontFacing, getTankScalingFunction());
     }
 
@@ -262,13 +263,13 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacingItems = EnumFacing.VALUES[buf.readByte()];
             this.outputFacingFluids = EnumFacing.VALUES[buf.readByte()];
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         } else if (dataId == UPDATE_AUTO_OUTPUT_ITEMS) {
             this.autoOutputItems = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         } else if (dataId == UPDATE_AUTO_OUTPUT_FLUIDS) {
             this.autoOutputFluids = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 
@@ -284,7 +285,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         this.outputFacingItems = outputFacing;
         this.outputFacingFluids = outputFacing;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_OUTPUT_FACING, buf -> {
                 buf.writeByte(outputFacingItems.getIndex());
                 buf.writeByte(outputFacingFluids.getIndex());
@@ -296,7 +297,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     public void setOutputFacingItems(EnumFacing outputFacing) {
         this.outputFacingItems = outputFacing;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_OUTPUT_FACING, buf -> {
                 buf.writeByte(outputFacingItems.getIndex());
                 buf.writeByte(outputFacingFluids.getIndex());
@@ -308,7 +309,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     public void setOutputFacingFluids(EnumFacing outputFacing) {
         this.outputFacingFluids = outputFacing;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_OUTPUT_FACING, buf -> {
                 buf.writeByte(outputFacingItems.getIndex());
                 buf.writeByte(outputFacingFluids.getIndex());

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
@@ -1,0 +1,30 @@
+package gregtech.api.metatileentity.interfaces;
+
+import gregtech.api.GregTechAPI;
+import gregtech.api.gui.IUIHolder;
+import gregtech.api.metatileentity.MetaTileEntity;
+import net.minecraft.network.PacketBuffer;
+
+import java.util.function.Consumer;
+
+import static gregtech.api.capability.GregtechDataCodes.INITIALIZE_MTE;
+
+/**
+ * A simple compound Interface for all my TileEntities.
+ * <p/>
+ * Also delivers most of the Informations about TileEntities.
+ * <p/>
+ */
+public interface IGregTechTileEntity extends IHasWorldObjectAndCoords, IUIHolder {
+
+    MetaTileEntity getMetaTileEntity();
+
+    MetaTileEntity setMetaTileEntity(MetaTileEntity metaTileEntity);
+
+    void writeCustomData(int discriminator, Consumer<PacketBuffer> dataWriter);
+
+    long getOffsetTimer(); // todo might not keep this one
+
+    @Deprecated
+    boolean isFirstTick();
+}

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IHasWorldObjectAndCoords.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IHasWorldObjectAndCoords.java
@@ -1,0 +1,30 @@
+package gregtech.api.metatileentity.interfaces;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public interface IHasWorldObjectAndCoords {
+
+    World getWorld();
+
+    BlockPos getPos();
+
+    default boolean isServerSide() {
+        return getWorld() != null && !getWorld().isRemote;
+    }
+
+    default boolean isClientSide() {
+        return getWorld() != null && getWorld().isRemote;
+    }
+
+    void markDirty();
+
+    void notifyBlockUpdate();
+
+    default void scheduleRenderUpdate() {
+        BlockPos pos = getPos();
+        getWorld().markBlockRangeForRenderUpdate(
+                pos.getX() - 1, pos.getY() - 1, pos.getZ() - 1,
+                pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
+    }
+}

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -9,6 +9,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IMultiblockController;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pattern.*;
 import gregtech.api.sound.GTSoundManager;
 import gregtech.api.util.world.DummyWorld;
@@ -127,9 +128,9 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     public static TraceabilityPredicate tilePredicate(@Nonnull BiFunction<BlockWorldState, MetaTileEntity, Boolean> predicate, @Nullable Supplier<BlockInfo[]> candidates) {
         return new TraceabilityPredicate(blockWorldState -> {
             TileEntity tileEntity = blockWorldState.getTileEntity();
-            if (!(tileEntity instanceof MetaTileEntityHolder))
+            if (!(tileEntity instanceof IGregTechTileEntity))
                 return false;
-            MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+            MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (predicate.apply(blockWorldState, metaTileEntity)) {
                 if (metaTileEntity instanceof IMultiblockPart) {
                     Set<IMultiblockPart> partsFound = blockWorldState.getMatchContext().getOrCreate("MultiblockParts", HashSet::new);
@@ -148,6 +149,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
 
     private static Supplier<BlockInfo[]> getCandidates(MetaTileEntity... metaTileEntities){
         return ()->Arrays.stream(metaTileEntities).map(tile->{
+            // TODO
             MetaTileEntityHolder holder = new MetaTileEntityHolder();
             holder.setMetaTileEntity(tile);
             holder.getMetaTileEntity().setFrontFacing(EnumFacing.SOUTH);

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -375,8 +375,7 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
         }
         this.getNotifiedItemInputList().addAll(this.getAbilities(MultiblockAbility.IMPORT_ITEMS));
 
-
-        this.getHolder().markDirty();
+        markDirty();
     }
 
     private String getVoidingModeTooltip(int mode) {

--- a/src/main/java/gregtech/api/net/packets/CPacketClipboardUIWidgetUpdate.java
+++ b/src/main/java/gregtech/api/net/packets/CPacketClipboardUIWidgetUpdate.java
@@ -1,6 +1,6 @@
 package gregtech.api.net.packets;
 
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.net.IPacket;
 import gregtech.api.net.NetworkUtils;
 import gregtech.common.metatileentities.MetaTileEntityClipboard;
@@ -45,8 +45,8 @@ public class CPacketClipboardUIWidgetUpdate implements IPacket {
     @Override
     public void executeServer(NetHandlerPlayServer handler) {
         TileEntity te = NetworkUtils.getTileEntityServer(dimension, pos);
-        if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).getMetaTileEntity() instanceof MetaTileEntityClipboard) {
-            ((MetaTileEntityClipboard) ((MetaTileEntityHolder) te).getMetaTileEntity()).readUIAction(handler.player, id, updateData);
+        if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MetaTileEntityClipboard) {
+            ((MetaTileEntityClipboard) ((IGregTechTileEntity) te).getMetaTileEntity()).readUIAction(handler.player, id, updateData);
         }
     }
 }

--- a/src/main/java/gregtech/api/net/packets/CPacketPluginSynced.java
+++ b/src/main/java/gregtech/api/net/packets/CPacketPluginSynced.java
@@ -1,7 +1,7 @@
 package gregtech.api.net.packets;
 
 import gregtech.api.items.behavior.MonitorPluginBaseBehavior;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.net.IPacket;
 import gregtech.api.net.NetworkUtils;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityMonitorScreen;
@@ -46,8 +46,8 @@ public class CPacketPluginSynced implements IPacket {
     @Override
     public void executeServer(NetHandlerPlayServer handler) {
         TileEntity te = NetworkUtils.getTileEntityServer(dimension, pos);
-        if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
-            MonitorPluginBaseBehavior plugin = ((MetaTileEntityMonitorScreen) ((MetaTileEntityHolder) te).getMetaTileEntity()).plugin;
+        if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
+            MonitorPluginBaseBehavior plugin = ((MetaTileEntityMonitorScreen) ((IGregTechTileEntity) te).getMetaTileEntity()).plugin;
             if (plugin != null) {
                 plugin.readPluginAction(handler.player, id, updateData);
             }

--- a/src/main/java/gregtech/api/pattern/BlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/BlockPattern.java
@@ -3,9 +3,9 @@ package gregtech.api.pattern;
 import gregtech.api.GregTechAPI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.util.BlockInfo;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.RelativeDirection;
 import gregtech.common.blocks.MetaBlocks;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
@@ -144,8 +144,8 @@ public class BlockPattern {
                         worldState.update(world, pos, matchContext, globalCount, layerCount, predicate);
                         TileEntity tileEntity = worldState.getTileEntity();
                         if (predicate != TraceabilityPredicate.ANY) {
-                            if (tileEntity instanceof MetaTileEntityHolder) {
-                                if (((MetaTileEntityHolder) tileEntity).isValid()) {
+                            if (tileEntity instanceof IGregTechTileEntity) {
+                                if (((IGregTechTileEntity) tileEntity).isValid()) {
                                     cache.put(pos.toLong(), new BlockInfo(worldState.getBlockState(), tileEntity, predicate));
                                 } else {
                                     cache.put(pos.toLong(), new BlockInfo(worldState.getBlockState(), null, predicate));
@@ -298,7 +298,7 @@ public class BlockPattern {
 
                             List<ItemStack> candidates = Arrays.stream(infos).filter(info -> info.getBlockState().getBlock() != Blocks.AIR).map(info -> {
                                 IBlockState blockState = info.getBlockState();
-                                MetaTileEntity metaTileEntity = info.getTileEntity() instanceof MetaTileEntityHolder ? ((MetaTileEntityHolder) info.getTileEntity()).getMetaTileEntity() : null;
+                                MetaTileEntity metaTileEntity = info.getTileEntity() instanceof IGregTechTileEntity ? ((IGregTechTileEntity) info.getTileEntity()).getMetaTileEntity() : null;
                                 if (metaTileEntity != null) {
                                     return metaTileEntity.getStackForm();
                                 } else {
@@ -332,10 +332,10 @@ public class BlockPattern {
                             blocks.put(pos, state);
                             world.setBlockState(pos, state);
                             TileEntity holder = world.getTileEntity(pos);
-                            if (holder instanceof MetaTileEntityHolder) {
+                            if (holder instanceof IGregTechTileEntity) {
                                 MetaTileEntity sampleMetaTileEntity = GregTechAPI.MTE_REGISTRY.getObjectById(found.getItemDamage());
                                 if (sampleMetaTileEntity != null) {
-                                    MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) holder).setMetaTileEntity(sampleMetaTileEntity);
+                                    MetaTileEntity metaTileEntity = ((IGregTechTileEntity) holder).setMetaTileEntity(sampleMetaTileEntity);
                                     blocks.put(pos, metaTileEntity);
                                     if (found.hasTagCompound()) {
                                         metaTileEntity.initFromItemStackData(found.getTagCompound());
@@ -515,6 +515,7 @@ public class BlockPattern {
                         }
                         BlockInfo info = infos == null || infos.length == 0 ? BlockInfo.EMPTY : infos[0];
                         BlockPos pos = setActualRelativeOffset(z, y, x, EnumFacing.NORTH);
+                        // TODO
                         if (info.getTileEntity() instanceof MetaTileEntityHolder) {
                             MetaTileEntityHolder holder = new MetaTileEntityHolder();
                             holder.setMetaTileEntity(((MetaTileEntityHolder) info.getTileEntity()).getMetaTileEntity());

--- a/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
+++ b/src/main/java/gregtech/api/pattern/TraceabilityPredicate.java
@@ -1,7 +1,7 @@
 package gregtech.api.pattern;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.util.BlockInfo;
 import gregtech.common.blocks.BlockWireCoil;
@@ -324,7 +324,7 @@ public class TraceabilityPredicate {
         public List<ItemStack> getCandidates() {
             return candidates == null ? Collections.emptyList() : Arrays.stream(this.candidates.get()).filter(info -> info.getBlockState().getBlock() != Blocks.AIR).map(info -> {
                 IBlockState blockState = info.getBlockState();
-                MetaTileEntity metaTileEntity = info.getTileEntity() instanceof MetaTileEntityHolder ? ((MetaTileEntityHolder) info.getTileEntity()).getMetaTileEntity() : null;
+                MetaTileEntity metaTileEntity = info.getTileEntity() instanceof IGregTechTileEntity ? ((IGregTechTileEntity) info.getTileEntity()).getMetaTileEntity() : null;
                 if (metaTileEntity != null) {
                     return metaTileEntity.getStackForm();
                 } else {

--- a/src/main/java/gregtech/api/terminal/gui/widgets/MachineSceneWidget.java
+++ b/src/main/java/gregtech/api/terminal/gui/widgets/MachineSceneWidget.java
@@ -5,7 +5,7 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.resources.TextTexture;
 import gregtech.api.gui.widgets.WidgetGroup;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.PatternMatchContext;
@@ -173,8 +173,8 @@ public class MachineSceneWidget extends WidgetGroup {
         if (mte == null) {
             World world = this.gui.entityPlayer.world;
             TileEntity tileEntity = world.getTileEntity(pos);
-            if (tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() != null) {
-                mte = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+            if (tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).getMetaTileEntity() != null) {
+                mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                 updateScene();
             }
         } else if (!mte.isValid()) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -16,8 +16,8 @@ import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.ConfigHolder;
@@ -611,8 +611,8 @@ public class GTUtility {
         for (EntityPlayerMP player : entities) {
             if (player.openContainer instanceof ModularUIContainer) {
                 ModularUI modularUI = ((ModularUIContainer) player.openContainer).getModularUI();
-                if (modularUI.holder instanceof MetaTileEntityHolder &&
-                        ((MetaTileEntityHolder) modularUI.holder).getMetaTileEntity() == metaTileEntity) {
+                if (modularUI.holder instanceof IGregTechTileEntity &&
+                        ((IGregTechTileEntity) modularUI.holder).getMetaTileEntity() == metaTileEntity) {
                     result.add(player);
                 }
             }

--- a/src/main/java/gregtech/client/renderer/handler/MultiblockPreviewRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/MultiblockPreviewRenderer.java
@@ -1,7 +1,7 @@
 package gregtech.client.renderer.handler;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.MultiblockShapeInfo;
 import gregtech.api.util.BlockInfo;
@@ -43,7 +43,7 @@ public class MultiblockPreviewRenderer {
         if (mbpPos != null) {
             Minecraft mc = Minecraft.getMinecraft();
             long time = System.currentTimeMillis();
-            if (opList == -1 || time > mbpEndTime || !(mc.world.getTileEntity(mbpPos) instanceof MetaTileEntityHolder)) {
+            if (opList == -1 || time > mbpEndTime || !(mc.world.getTileEntity(mbpPos) instanceof IGregTechTileEntity)) {
                 resetMultiblockRender();
                 layer = 0;
                 return;
@@ -113,7 +113,7 @@ public class MultiblockPreviewRenderer {
                 BlockInfo[] column = aisle[y];
                 for (int z = 0; z < column.length; z++) {
                     blockMap.put(new BlockPos(x, y, z), column[z]);
-                    MetaTileEntity metaTE = column[z].getTileEntity() instanceof MetaTileEntityHolder ? ((MetaTileEntityHolder) column[z].getTileEntity()).getMetaTileEntity() : null;
+                    MetaTileEntity metaTE = column[z].getTileEntity() instanceof IGregTechTileEntity ? ((IGregTechTileEntity) column[z].getTileEntity()).getMetaTileEntity() : null;
                     if (metaTE instanceof MultiblockControllerBase && metaTE.metaTileEntityId.equals(controllerBase.metaTileEntityId)) {
                         controllerPos = new BlockPos(x, y, z);
                         previewFacing = metaTE.getFrontFacing();

--- a/src/main/java/gregtech/client/renderer/handler/ToolOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/ToolOverlayRenderer.java
@@ -8,7 +8,7 @@ import gregtech.api.cover.ICoverable;
 import gregtech.api.cover.ICoverable.PrimaryBoxData;
 import gregtech.api.items.toolitem.IAOEItem;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.block.BlockPipe;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.util.GTUtility;
@@ -78,8 +78,8 @@ public class ToolOverlayRenderer {
         TileEntity tileEntity = world.getTileEntity(pos);
         ItemStack heldItem = player.getHeldItem(EnumHand.MAIN_HAND);
 
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            if (((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
+        if (tileEntity instanceof IGregTechTileEntity) {
+            if (((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
                 event.setCanceled(true);
                 return;
             }
@@ -104,8 +104,8 @@ public class ToolOverlayRenderer {
                 if (tileEntity instanceof TileEntityPipeBase)
                     drawOverlayLines(facing, box, facing1 -> ((TileEntityPipeBase<?, ?>) tileEntity).isConnected(facing1) ||
                             ((TileEntityPipeBase<?, ?>) tileEntity).getCoverableImplementation().getCoverAtSide(facing1) != null);
-                else if (tileEntity instanceof MetaTileEntityHolder)
-                    drawOverlayLines(facing, box, face -> ((MetaTileEntityHolder) tileEntity).getMetaTileEntity().isSideUsed(face));
+                else if (tileEntity instanceof IGregTechTileEntity)
+                    drawOverlayLines(facing, box, face -> ((IGregTechTileEntity) tileEntity).getMetaTileEntity().isSideUsed(face));
                 else
                     drawOverlayLines(facing, box, ignored -> false);
             }
@@ -135,8 +135,8 @@ public class ToolOverlayRenderer {
 
     public static boolean shouldDrawOverlayForItem(IBlockState state, TileEntity tileEntity, ItemStack itemStack) {
         // MetaTileEntity
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            MetaTileEntity mte = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+        if (tileEntity instanceof IGregTechTileEntity) {
+            MetaTileEntity mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (mte == null || !mte.canRenderMachineGrid())
                 return false;
             if (itemStack.hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null))

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -3,7 +3,7 @@ package gregtech.common;
 import gregtech.api.GTValues;
 import gregtech.api.enchants.EnchantmentHardHammer;
 import gregtech.api.items.armor.ArmorMetaItem;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.CapesRegistry;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
@@ -74,7 +74,7 @@ public class EventHandlers {
 
     @SubscribeEvent
     public static void onPlayerInteractionRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getWorld().getTileEntity(event.getPos()) instanceof MetaTileEntityHolder) {
+        if (event.getWorld().getTileEntity(event.getPos()) instanceof IGregTechTileEntity) {
             event.setUseBlock(Event.Result.ALLOW);
         }
         ItemStack stack = event.getItemStack();
@@ -95,8 +95,8 @@ public class EventHandlers {
     public static void onPlayerInteractionLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
         if (event.getEntityPlayer().isCreative()) {
             TileEntity holder = event.getWorld().getTileEntity(event.getPos());
-            if (holder instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) holder).getMetaTileEntity() instanceof MetaTileEntityCentralMonitor) {
-                ((MetaTileEntityCentralMonitor) ((MetaTileEntityHolder) holder).getMetaTileEntity()).invalidateStructure();
+            if (holder instanceof IGregTechTileEntity && ((IGregTechTileEntity) holder).getMetaTileEntity() instanceof MetaTileEntityCentralMonitor) {
+                ((MetaTileEntityCentralMonitor) ((IGregTechTileEntity) holder).getMetaTileEntity()).invalidateStructure();
             }
         }
     }

--- a/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
@@ -16,7 +16,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.client.renderer.texture.Textures;
@@ -177,8 +177,8 @@ public class CoverDigitalInterface extends CoverBehavior implements IFastRenderM
     }
 
     public TileEntity getCoveredTE() {
-        if (this.coverHolder instanceof MetaTileEntity){
-            return ((MetaTileEntity) this.coverHolder).getHolder();
+        if (this.coverHolder instanceof MetaTileEntity) {
+            return (TileEntity) ((MetaTileEntity) this.coverHolder).getHolder();
         }
         return null;
     }
@@ -908,8 +908,8 @@ public class CoverDigitalInterface extends CoverBehavior implements IFastRenderM
                 TileEntity te = getCoveredTE();
                 if (te != null) {
                     ItemStack itemStack;
-                    if (te instanceof MetaTileEntityHolder) {
-                        itemStack = ((MetaTileEntityHolder) te).getMetaTileEntity().getStackForm();
+                    if (te instanceof IGregTechTileEntity) {
+                        itemStack = ((IGregTechTileEntity) te).getMetaTileEntity().getStackForm();
                     } else {
                         BlockPos pos = te.getPos();
                         itemStack = te.getBlockType().getPickBlock(te.getWorld().getBlockState(pos), new RayTraceResult(new Vec3d(0.5, 0.5, 0.5), getCoveredFacing(), pos), te.getWorld(), pos, Minecraft.getMinecraft().player);

--- a/src/main/java/gregtech/common/covers/CoverDigitalInterfaceWireless.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterfaceWireless.java
@@ -6,7 +6,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.cover.ICoverable;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.BlockPosFace;
 import gregtech.common.items.behaviors.CoverDigitalInterfaceWirelessPlaceBehaviour;
@@ -75,8 +75,8 @@ public class CoverDigitalInterfaceWireless extends CoverDigitalInterface{
         super.update();
         if (remote != null && !isRemote() && coverHolder.getOffsetTimer() % 20 == 0) {
             TileEntity te = coverHolder.getWorld().getTileEntity(remote);
-            if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).getMetaTileEntity() instanceof MetaTileEntityCentralMonitor) {
-                ((MetaTileEntityCentralMonitor) ((MetaTileEntityHolder) te).getMetaTileEntity()).addRemoteCover(new BlockPosFace(coverHolder.getPos(), attachedSide));
+            if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MetaTileEntityCentralMonitor) {
+                ((MetaTileEntityCentralMonitor) ((IGregTechTileEntity) te).getMetaTileEntity()).addRemoteCover(new BlockPosFace(coverHolder.getPos(), attachedSide));
             }
         }
     }

--- a/src/main/java/gregtech/common/items/behaviors/ClipboardBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ClipboardBehavior.java
@@ -10,7 +10,7 @@ import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.items.gui.ItemUIFactory;
 import gregtech.api.items.gui.PlayerInventoryHolder;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.common.items.MetaItems;
 import gregtech.common.metatileentities.MetaTileEntityClipboard;
 import net.minecraft.block.Block;
@@ -256,12 +256,12 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
                     // Get new TE
                     shiftedBlock.createTileEntity(world, state);
                     // And manipulate it to our liking
-                    MetaTileEntityHolder holder = (MetaTileEntityHolder) world.getTileEntity(shiftedPos);
+                    IGregTechTileEntity holder = (IGregTechTileEntity) world.getTileEntity(shiftedPos);
                     if (holder != null) {
-                        MetaTileEntityClipboard clipboard = (MetaTileEntityClipboard) holder.setMetaTileEntity(CLIPBOARD_TILE, heldItem);
+                        MetaTileEntityClipboard clipboard = (MetaTileEntityClipboard) holder.setMetaTileEntity(CLIPBOARD_TILE);
                         if (clipboard != null) {
+                            clipboard.initializeClipboard(heldItem);
                             clipboard.setFrontFacing(facing.getOpposite());
-                            clipboard.setClipboard(heldItem);
                             ItemStack returnedStack = player.getHeldItem(hand);
                             if (!player.isCreative()) {
                                 returnedStack.setCount(player.getHeldItem(hand).getCount() - 1);

--- a/src/main/java/gregtech/common/items/behaviors/ColorSprayBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/ColorSprayBehaviour.java
@@ -4,7 +4,7 @@ import appeng.api.util.AEColor;
 import appeng.tile.networking.TileCableBus;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.sound.GTSounds;
 import net.minecraft.block.Block;
@@ -112,8 +112,8 @@ public class ColorSprayBehaviour extends AbstractUsableBehaviour {
 
         // MTE special case
         TileEntity te = world.getTileEntity(pos);
-        if (te instanceof MetaTileEntityHolder) {
-            MetaTileEntity mte = ((MetaTileEntityHolder) te).getMetaTileEntity();
+        if (te instanceof IGregTechTileEntity) {
+            MetaTileEntity mte = ((IGregTechTileEntity) te).getMetaTileEntity();
             if (mte != null) {
                 if (mte.isPainted()) {
                     mte.setPaintingColor(-1);

--- a/src/main/java/gregtech/common/items/behaviors/CoverDigitalInterfaceWirelessPlaceBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/CoverDigitalInterfaceWirelessPlaceBehaviour.java
@@ -1,7 +1,7 @@
 package gregtech.common.items.behaviors;
 
 import gregtech.api.cover.CoverDefinition;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.handler.BlockPosHighlightRenderer;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
 import net.minecraft.client.resources.I18n;
@@ -49,7 +49,7 @@ public class CoverDigitalInterfaceWirelessPlaceBehaviour extends CoverPlaceBehav
     @Override
     public EnumActionResult onItemUseFirst(EntityPlayer player, World world, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ, EnumHand hand) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityCentralMonitor) {
+        if (tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityCentralMonitor) {
             ItemStack itemStack = player.getHeldItem(hand);
             itemStack.setTagCompound(NBTUtil.createPosTag(pos));
             return EnumActionResult.SUCCESS;

--- a/src/main/java/gregtech/common/items/behaviors/TricorderBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/TricorderBehavior.java
@@ -8,6 +8,7 @@ import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.metatileentity.IDataInfoProvider;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.sound.GTSounds;
 import gregtech.api.util.GTUtility;
@@ -90,8 +91,8 @@ public class TricorderBehavior implements IItemBehaviour {
         ));
 
         MetaTileEntity metaTileEntity;
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+        if (tileEntity instanceof IGregTechTileEntity) {
+            metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity == null)
                 return list;
 
@@ -272,7 +273,7 @@ public class TricorderBehavior implements IItemBehaviour {
 //                list.add(TextFormatting.GREEN + "No Pollution in Chunk! HAYO!" + TextFormatting.RESET);
 //            }
 
-        // debug
+        // debug TODO
         if (tileEntity instanceof MetaTileEntityHolder) {
             list.addAll(((MetaTileEntityHolder) tileEntity).getDebugInfo(player, debugLevel));
         }

--- a/src/main/java/gregtech/common/items/behaviors/WrenchBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/WrenchBehaviour.java
@@ -2,7 +2,7 @@ package gregtech.common.items.behaviors;
 
 import com.google.common.collect.UnmodifiableIterator;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBed;
@@ -38,7 +38,7 @@ public class WrenchBehaviour implements IItemBehaviour {
 
             TileEntity tileEntity = world.getTileEntity(pos);
 
-            if (tileEntity instanceof MetaTileEntityHolder) {
+            if (tileEntity instanceof IGregTechTileEntity) {
                 //machines handle wrench click manually
                 return EnumActionResult.PASS;
             }

--- a/src/main/java/gregtech/common/items/behaviors/monitorplugin/AdvancedMonitorPluginBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/monitorplugin/AdvancedMonitorPluginBehavior.java
@@ -12,7 +12,7 @@ import gregtech.api.gui.widgets.ToggleButtonWidget;
 import gregtech.api.items.behavior.MonitorPluginBaseBehavior;
 import gregtech.api.items.behavior.ProxyHolderPluginBehavior;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.client.renderer.scene.FBOWorldSceneRenderer;
@@ -349,8 +349,8 @@ public class AdvancedMonitorPluginBehavior extends ProxyHolderPluginBehavior {
         if (id == GregtechDataCodes.ACTION_PLUGIN_CONFIG) { //open GUI
             BlockPos pos = buf.readBlockPos();
             TileEntity tileEntity = this.screen.getWorld().getTileEntity(pos);
-            if (tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).isValid()) {
-                ((MetaTileEntityHolder) tileEntity).getMetaTileEntity().onRightClick(player, EnumHand.MAIN_HAND, ((MetaTileEntityHolder) tileEntity).getMetaTileEntity().getFrontFacing(), null);
+            if (tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).isValid()) {
+                ((IGregTechTileEntity) tileEntity).getMetaTileEntity().onRightClick(player, EnumHand.MAIN_HAND, ((IGregTechTileEntity) tileEntity).getMetaTileEntity().getFrontFacing(), null);
             }
         }
     }
@@ -369,7 +369,7 @@ public class AdvancedMonitorPluginBehavior extends ProxyHolderPluginBehavior {
     }
 
     @Override
-    protected void onHolderChanged(MetaTileEntityHolder lastHolder) {
+    protected void onHolderChanged(IGregTechTileEntity lastHolder) {
         if (!this.screen.getWorld().isRemote) {
             validPos = null;
             isValid = false;

--- a/src/main/java/gregtech/common/items/behaviors/monitorplugin/FakeGuiPluginBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/monitorplugin/FakeGuiPluginBehavior.java
@@ -11,7 +11,7 @@ import gregtech.api.gui.widgets.*;
 import gregtech.api.items.behavior.MonitorPluginBaseBehavior;
 import gregtech.api.items.behavior.ProxyHolderPluginBehavior;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.PatternMatchContext;
@@ -67,8 +67,8 @@ public class FakeGuiPluginBehavior extends ProxyHolderPluginBehavior {
         if (target instanceof MultiblockControllerBase && partIndex > 0) {
             if (partPos != null) {
                 TileEntity entity = this.screen.getWorld().getTileEntity(partPos);
-                if (entity instanceof MetaTileEntityHolder) {
-                    return ((MetaTileEntityHolder) entity).getMetaTileEntity();
+                if (entity instanceof IGregTechTileEntity) {
+                    return ((IGregTechTileEntity) entity).getMetaTileEntity();
                 } else {
                     partPos = null;
                     return null;
@@ -163,7 +163,7 @@ public class FakeGuiPluginBehavior extends ProxyHolderPluginBehavior {
     }
 
     @Override
-    public void onHolderChanged(MetaTileEntityHolder lastHolder) {
+    public void onHolderChanged(IGregTechTileEntity lastHolder) {
         if (holder == null) {
             if (this.screen.getWorld() != null && this.screen.getWorld().isRemote) {
                 fakeModularGui = null;

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -16,8 +16,8 @@ import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.GregFakePlayer;
@@ -117,7 +117,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityClipboard(metaTileEntityId);
     }
 
@@ -180,6 +180,13 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
             ((InaccessibleItemStackHandler) this.itemInventory).setStackInSlot(0, CLIPBOARD.getStackForm());
         }
         return this.itemInventory.getStackInSlot(0);
+    }
+
+    public void initializeClipboard(ItemStack stack) {
+        ((InaccessibleItemStackHandler) this.itemInventory).setStackInSlot(0, stack.copy());
+        writeCustomData(INIT_CLIPBOARD_NBT, buf -> {
+            buf.writeCompoundTag(stack.getTagCompound());
+        });
     }
 
     public void setClipboard(ItemStack stack) {
@@ -273,7 +280,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
             CuboidRayTraceResult rayTraceResult = rayTrace(this.getPos(), new Vector3(startVec), new Vector3(endVec), getPageCuboid());
             if (rayTraceResult != null && rayTraceResult.sideHit == this.getFrontFacing().getOpposite()) {
                 TileEntity tileEntity = this.getWorld().getTileEntity(rayTraceResult.getBlockPos());
-                if (tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityClipboard) {
+                if (tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityClipboard) {
                     double[] pos = handleRayTraceResult(rayTraceResult, this.getFrontFacing().getOpposite());
                     if (pos[0] >= 0 && pos[0] <= 1 && pos[1] >= 0 && pos[1] <= 1)
                         return Pair.of(pos[0], pos[1]);
@@ -385,6 +392,17 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
             }
             this.scheduleRenderUpdate();
             this.markDirty();
+        } else if (dataId == INIT_CLIPBOARD_NBT) {
+            try {
+                NBTTagCompound clipboardNBT = buf.readCompoundTag();
+                if (clipboardNBT != NO_CLIPBOARD_SIG) {
+                    ItemStack clipboard = this.getClipboard();
+                    clipboard.setTagCompound(clipboardNBT);
+                    this.setClipboard(clipboard);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
@@ -11,8 +11,8 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.tool.ISoftHammerItem;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
@@ -98,7 +98,7 @@ public class MetaTileEntityConverter extends TieredMetaTileEntity {
         converterTrait.setFeToEu(feToEu);
         if (!getWorld().isRemote) {
             writeCustomData(SYNC_TILE_MODE, b -> b.writeBoolean(converterTrait.isFeToEu()));
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             markDirty();
         }
     }
@@ -111,13 +111,13 @@ public class MetaTileEntityConverter extends TieredMetaTileEntity {
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         if (dataId == SYNC_TILE_MODE) {
             converterTrait.setFeToEu(buf.readBoolean());
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
         super.receiveCustomData(dataId, buf);
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityConverter(metaTileEntityId, getTier(), amps);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAdjustableTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAdjustableTransformer.java
@@ -9,7 +9,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.capability.tool.ISoftHammerItem;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
@@ -44,7 +44,7 @@ public class MetaTileEntityAdjustableTransformer extends MetaTileEntityTransform
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityAdjustableTransformer(metaTileEntityId, getTier());
     }
 
@@ -88,7 +88,7 @@ public class MetaTileEntityAdjustableTransformer extends MetaTileEntityTransform
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
             writeCustomData(AMP_INDEX, b -> b.writeInt(ampIndex));
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             markDirty();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBatteryBuffer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBatteryBuffer.java
@@ -14,6 +14,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.*;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
@@ -53,7 +54,7 @@ public class MetaTileEntityBatteryBuffer extends TieredMetaTileEntity implements
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityBatteryBuffer(metaTileEntityId, getTier(), inventorySize);
     }
 
@@ -89,7 +90,7 @@ public class MetaTileEntityBatteryBuffer extends TieredMetaTileEntity implements
     @Override
     public void setWorkingEnabled(boolean isActivationAllowed) {
         this.allowEnergyOutput = isActivationAllowed;
-        getHolder().notifyBlockUpdate();
+        notifyBlockUpdate();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
@@ -10,8 +10,8 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.BlockUtility;
 import gregtech.api.util.GregFakePlayer;
@@ -54,7 +54,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityBlockBreaker(metaTileEntityId, getTier());
     }
 
@@ -181,7 +181,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
         super.receiveCustomData(dataId, buf);
         if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacing = EnumFacing.VALUES[buf.readByte()];
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 
@@ -199,7 +199,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
     public void setOutputFacing(EnumFacing outputFacing) {
         this.outputFacing = outputFacing;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_OUTPUT_FACING, buf -> buf.writeByte(outputFacing.getIndex()));
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityCharger.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityCharger.java
@@ -9,8 +9,8 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.common.ConfigHolder;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -37,7 +37,7 @@ public class MetaTileEntityCharger extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCharger(metaTileEntityId, getTier(), inventorySize);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -10,8 +10,8 @@ import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.capability.tool.ISoftHammerItem;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
 import gregtech.common.tools.DamageValues;
@@ -44,7 +44,7 @@ public class MetaTileEntityDiode extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityDiode(metaTileEntityId, getTier());
     }
 
@@ -87,7 +87,7 @@ public class MetaTileEntityDiode extends TieredMetaTileEntity {
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
             writeCustomData(AMP_INDEX, b -> b.writeInt(amps));
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             markDirty();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
@@ -8,8 +8,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.unification.OreDictUnifier;
 import net.minecraft.block.BlockLiquid;
@@ -50,7 +50,7 @@ public class MetaTileEntityFisher extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityFisher(metaTileEntityId, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
@@ -3,8 +3,8 @@ package gregtech.common.metatileentities.electric;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.RecipeLogicEnergy;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
@@ -27,7 +27,7 @@ public class MetaTileEntityGasCollector extends SimpleMachineMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityGasCollector(this.metaTileEntityId, RecipeMaps.GAS_COLLECTOR_RECIPES,
                 Textures.GAS_COLLECTOR_OVERLAY, this.getTier(), this.hasFrontFacing(), this.getTankScalingFunction());
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
@@ -7,8 +7,8 @@ import codechicken.lib.vec.Matrix4;
 import gregtech.api.GTValues;
 import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.gui.ModularUI;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
 import net.minecraft.client.resources.I18n;
@@ -29,7 +29,7 @@ public class MetaTileEntityHull extends TieredMetaTileEntity {
     }
 
     @Override
-    public gregtech.api.metatileentity.MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public gregtech.api.metatileentity.MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityHull(metaTileEntityId, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -12,8 +12,8 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SimpleTextWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.covers.filter.ItemFilterContainer;
@@ -63,7 +63,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityItemCollector(metaTileEntityId, getTier(), maxItemSuckingRange);
     }
 
@@ -97,7 +97,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
         super.receiveCustomData(dataId, buf);
         if (dataId == IS_WORKING) {
             this.isWorking = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMacerator.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMacerator.java
@@ -2,8 +2,8 @@ package gregtech.common.metatileentities.electric;
 
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.client.renderer.ICubeRenderer;
 import net.minecraft.util.ResourceLocation;
@@ -25,7 +25,7 @@ public class MetaTileEntityMacerator extends SimpleMachineMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMacerator(metaTileEntityId, workable.getRecipeMap(), outputAmount, renderer, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -9,8 +9,8 @@ import gnu.trove.list.array.TIntArrayList;
 import gregtech.api.GTValues;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
@@ -53,7 +53,7 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMagicEnergyAbsorber(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMiner.java
@@ -17,8 +17,8 @@ import gregtech.api.gui.widgets.AdvancedTextWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.IDataInfoProvider;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.sound.GTSounds;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.resources.I18n;
@@ -60,7 +60,7 @@ public class MetaTileEntityMiner extends TieredMetaTileEntity implements IMiner,
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMiner(metaTileEntityId, getTier(), this.minerLogic.getSpeed(), this.minerLogic.getMaximumRadius(), this.minerLogic.getFortune());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -15,8 +15,8 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
 import net.minecraft.block.BlockLiquid;
@@ -67,7 +67,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityPump(metaTileEntityId, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
@@ -3,8 +3,8 @@ package gregtech.common.metatileentities.electric;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.RecipeLogicEnergy;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.ICubeRenderer;
@@ -26,7 +26,7 @@ public class MetaTileEntityRockBreaker extends SimpleMachineMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityRockBreaker(metaTileEntityId, RecipeMaps.ROCK_BREAKER_RECIPES, Textures.ROCK_BREAKER_OVERLAY, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTransformer.java
@@ -10,8 +10,8 @@ import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.capability.tool.ISoftHammerItem;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
@@ -42,7 +42,7 @@ public class MetaTileEntityTransformer extends TieredMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityTransformer(metaTileEntityId, getTier());
     }
 
@@ -90,7 +90,7 @@ public class MetaTileEntityTransformer extends TieredMetaTileEntity {
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
             writeCustomData(SYNC_TILE_MODE, b -> b.writeBoolean(isTransformUp));
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             markDirty();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
@@ -9,11 +9,10 @@ import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.client.renderer.texture.Textures;
-import gregtech.common.ConfigHolder;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
@@ -44,7 +43,8 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
     private static Class<?> cofhTileClass;
 
     private static boolean considerTile(TileEntity tile) {
-        if (tile instanceof MetaTileEntityHolder || tile instanceof TileEntityPipeBase) {
+        // TODO interface for this?
+        if (tile instanceof IGregTechTileEntity || tile instanceof TileEntityPipeBase) {
             return false;
         }
         if (cofhTileClass == null) {
@@ -74,7 +74,7 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityWorldAccelerator(metaTileEntityId, getTier());
     }
 
@@ -196,7 +196,7 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
         tileMode = inverted;
         if (!getWorld().isRemote) {
             writeCustomData(SYNC_TILE_MODE, b -> b.writeBoolean(tileMode));
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             markDirty();
         }
     }
@@ -263,7 +263,7 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
     @Override
     public void setWorkingEnabled(boolean b) {
         isPaused = !b;
-        getHolder().notifyBlockUpdate();
+        notifyBlockUpdate();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
@@ -1,6 +1,5 @@
 package gregtech.common.metatileentities.multi;
 
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
@@ -8,7 +7,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -21,8 +20,6 @@ import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.MetaTileEntities;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nonnull;
@@ -34,7 +31,7 @@ public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockControll
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCokeOven(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -8,7 +8,7 @@ import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.ItemHandlerProxy;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -72,7 +72,7 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCokeOvenHatch(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -9,7 +9,7 @@ import gregtech.api.capability.impl.*;
 import gregtech.api.gui.Widget.ClickData;
 import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
@@ -61,7 +61,7 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityLargeBoiler(metaTileEntityId, boilerType);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
@@ -12,9 +12,8 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.LabelWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
-import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
@@ -33,7 +32,6 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidTank;
-import org.lwjgl.input.Keyboard;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -68,7 +66,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMultiblockTank(metaTileEntityId, isMetal, capacity);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -1,6 +1,5 @@
 package gregtech.common.metatileentities.multi;
 
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.texture.TextureUtils;
@@ -14,7 +13,7 @@ import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -30,7 +29,6 @@ import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import org.apache.commons.lang3.ArrayUtils;
@@ -44,7 +42,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityPrimitiveBlastFurnace(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveWaterPump.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveWaterPump.java
@@ -5,7 +5,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -44,7 +44,7 @@ public class MetaTileEntityPrimitiveWaterPump extends MultiblockControllerBase {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityPrimitiveWaterPump(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
@@ -11,7 +11,7 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.ICubeRenderer;
@@ -46,7 +46,7 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityPumpHatch(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
@@ -8,7 +8,7 @@ import gregtech.api.capability.impl.FluidHandlerProxy;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -41,7 +41,7 @@ public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityTankValve(metaTileEntityId, isMetal);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
@@ -1,7 +1,7 @@
 package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -27,7 +27,7 @@ public class MetaTileEntityAssemblyLine extends RecipeMapMultiblockController {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityAssemblyLine(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -2,7 +2,7 @@ package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -37,7 +37,7 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCrackingUnit(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -1,7 +1,7 @@
 package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -33,7 +33,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityDistillationTower(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -4,7 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.IHeatingCoil;
 import gregtech.api.capability.impl.HeatingCoilRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -52,7 +52,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityElectricBlastFurnace(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
@@ -11,7 +11,7 @@ import gregtech.api.capability.impl.FluidDrillLogic;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
@@ -60,7 +60,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityFluidDrill(metaTileEntityId, tier);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -6,7 +6,7 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.*;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -46,7 +46,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
@@ -81,7 +80,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityFusionReactor(metaTileEntityId, tier);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
@@ -1,7 +1,7 @@
 package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -23,7 +23,7 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityImplosionCompressor(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
@@ -2,7 +2,7 @@ package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -38,7 +38,7 @@ public class MetaTileEntityLargeChemicalReactor extends RecipeMapMultiblockContr
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityLargeChemicalReactor(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -18,8 +18,8 @@ import gregtech.api.gui.widgets.AdvancedTextWidget;
 import gregtech.api.gui.widgets.ToggleButtonWidget;
 import gregtech.api.metatileentity.IDataInfoProvider;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
@@ -92,7 +92,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityLargeMiner(metaTileEntityId, this.tier, this.minerLogic.getSpeed(), this.minerLogic.getMaximumRadius() / CHUNK_LENGTH, this.minerLogic.getFortune(), getMaterial(), getDrillingFluidConsumePerTick());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
@@ -2,7 +2,7 @@ package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
@@ -36,7 +36,7 @@ public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMultiSmelter(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -7,7 +7,7 @@ import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.IMachineHatchMultiblock;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -54,7 +54,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityProcessingArray(metaTileEntityId, tier);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -2,7 +2,7 @@ package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -37,7 +37,7 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityPyrolyseOven(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityVacuumFreezer.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityVacuumFreezer.java
@@ -1,7 +1,7 @@
 package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -22,7 +22,7 @@ public class MetaTileEntityVacuumFreezer extends RecipeMapMultiblockController {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityVacuumFreezer(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityCentralMonitor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityCentralMonitor.java
@@ -15,7 +15,7 @@ import gregtech.api.gui.widgets.AdvancedTextWidget;
 import gregtech.api.gui.widgets.WidgetGroup;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
@@ -147,8 +147,8 @@ public class MetaTileEntityCentralMonitor extends MultiblockWithDisplayBase impl
             for (EnumFacing facing : EnumFacing.VALUES) {
                 if (((TileEntityPipeBase<?,?>) tileEntityCable).isConnected(facing)) {
                     TileEntity tileEntity = world.getTileEntity(pos.offset(facing));
-                    if (tileEntity instanceof MetaTileEntityHolder) {
-                        MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+                    if (tileEntity instanceof IGregTechTileEntity) {
+                        MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                         if (metaTileEntity != null) {
                             CoverBehavior cover = metaTileEntity.getCoverAtSide(facing.getOpposite());
                             if (cover instanceof CoverDigitalInterface && ((CoverDigitalInterface) cover).isProxy()) {
@@ -163,8 +163,8 @@ public class MetaTileEntityCentralMonitor extends MultiblockWithDisplayBase impl
         while (iterator.hasNext()) {
             BlockPosFace blockPosFace = iterator.next();
             TileEntity tileEntity = world.getTileEntity(blockPosFace.pos);
-            if (tileEntity instanceof MetaTileEntityHolder) {
-                MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+            if (tileEntity instanceof IGregTechTileEntity) {
+                MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                 if (metaTileEntity != null) {
                     CoverBehavior cover = metaTileEntity.getCoverAtSide(blockPosFace.facing);
                     if (cover instanceof CoverDigitalInterface && ((CoverDigitalInterface) cover).isProxy()) {
@@ -356,7 +356,7 @@ public class MetaTileEntityCentralMonitor extends MultiblockWithDisplayBase impl
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
         return new MetaTileEntityCentralMonitor(metaTileEntityId);
     }
 
@@ -521,8 +521,8 @@ public class MetaTileEntityCentralMonitor extends MultiblockWithDisplayBase impl
                     clearScreens();
                     for (BlockPos pos : parts) {
                         TileEntity tileEntity = getWorld().getTileEntity(pos);
-                        if(tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
-                            MetaTileEntityMonitorScreen screen = (MetaTileEntityMonitorScreen) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+                        if(tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
+                            MetaTileEntityMonitorScreen screen = (MetaTileEntityMonitorScreen) ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                             screen.addToMultiBlock(this);
                             int sx = screen.getX(), sy = screen.getY();
                             if (sx < 0 || sx >= width || sy < 0 || sy >= height) {
@@ -575,8 +575,8 @@ public class MetaTileEntityCentralMonitor extends MultiblockWithDisplayBase impl
             } else {
                 parts.forEach(partPos->{
                     TileEntity tileEntity = this.getWorld().getTileEntity(partPos);
-                    if (tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
-                        MetaTileEntityMonitorScreen part = (MetaTileEntityMonitorScreen) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+                    if (tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
+                        MetaTileEntityMonitorScreen part = (MetaTileEntityMonitorScreen) ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                         int x = part.getX();
                         int y = part.getY();
                         screenGrids[x][y].setScreen(part);

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
@@ -11,8 +11,8 @@ import gregtech.api.gui.widgets.*;
 import gregtech.api.items.behavior.MonitorPluginBaseBehavior;
 import gregtech.api.items.behavior.ProxyHolderPluginBehavior;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.util.BlockPosFace;
@@ -115,7 +115,7 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
     public CoverDigitalInterface getCoverFromPosSide(BlockPosFace posFacing) {
         if (posFacing == null) return null;
         ICoverable mte = null;
-        MetaTileEntityHolder holder = getHolderFromPos(posFacing.pos);
+        IGregTechTileEntity holder = getHolderFromPos(posFacing.pos);
         if (holder == null) {
             TileEntity te = this.getWorld() == null ? null : this.getWorld().getTileEntity(posFacing.pos);
             if (te instanceof TileEntityPipeBase) {
@@ -133,10 +133,10 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
         return null;
     }
 
-    public MetaTileEntityHolder getHolderFromPos(BlockPos pos) {
+    public IGregTechTileEntity getHolderFromPos(BlockPos pos) {
         TileEntity te = this.getWorld() == null || pos == null ? null : this.getWorld().getTileEntity(pos);
-        if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).isValid()) {
-            return (MetaTileEntityHolder) te;
+        if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).isValid()) {
+            return (IGregTechTileEntity) te;
         }
         return null;
     }
@@ -279,8 +279,8 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
                 TileEntity te = coverTMP.getCoveredTE();
                 if (te != null) {
                     ItemStack itemStack;
-                    if (te instanceof MetaTileEntityHolder) {
-                        itemStack = ((MetaTileEntityHolder) te).getMetaTileEntity().getStackForm();
+                    if (te instanceof IGregTechTileEntity) {
+                        itemStack = ((IGregTechTileEntity) te).getMetaTileEntity().getStackForm();
                     } else {
                         BlockPos pos = te.getPos();
                         itemStack = te.getBlockType().getPickBlock(te.getWorld().getBlockState(pos), new RayTraceResult(new Vec3d(0.5, 0.5, 0.5), coverTMP.getCoveredFacing(), pos), te.getWorld(), pos, Minecraft.getMinecraft().player);
@@ -458,7 +458,7 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
         return new MetaTileEntityMonitorScreen(this.metaTileEntityId);
     }
 
@@ -680,11 +680,11 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
             if (rayTraceResult != null && rayTraceResult.typeOfHit == RayTraceResult.Type.BLOCK && controller != null && rayTraceResult.sideHit == controller.getFrontFacing()) {
                 int i, j;
                 TileEntity tileEntity = this.getWorld().getTileEntity(rayTraceResult.getBlockPos());
-                if (tileEntity instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
-                    MetaTileEntityMonitorScreen screenHit = (MetaTileEntityMonitorScreen) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+                if (tileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityMonitorScreen) {
+                    MetaTileEntityMonitorScreen screenHit = (MetaTileEntityMonitorScreen) ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                     if (controller == screenHit.getController()) {
-                        i = ((MetaTileEntityMonitorScreen) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()).getX() - this.getX();
-                        j = ((MetaTileEntityMonitorScreen) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()).getY() - this.getY();
+                        i = ((MetaTileEntityMonitorScreen) ((IGregTechTileEntity) tileEntity).getMetaTileEntity()).getX() - this.getX();
+                        j = ((MetaTileEntityMonitorScreen) ((IGregTechTileEntity) tileEntity).getMetaTileEntity()).getY() - this.getY();
                         double[] pos = handleRayTraceResult(rayTraceResult);
                         if ((i >= 0 && j >= 0)) {
                             pos[0] = (pos[0] + i) / this.scale;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -6,7 +6,7 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.MultiblockFuelRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.FuelMultiblockController;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
@@ -55,7 +55,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityLargeCombustionEngine(metaTileEntityId, tier);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -4,9 +4,8 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.IRotorHolder;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
-import gregtech.api.metatileentity.IVoidable;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.FuelMultiblockController;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
@@ -59,7 +58,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController impleme
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityLargeTurbine(metaTileEntityId, recipeMap, tier, casingState, gearboxState, casingRenderer, hasMufflerHatch, frontOverlay);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityAutoMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityAutoMaintenanceHatch.java
@@ -6,7 +6,7 @@ import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.IMaintenanceHatch;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
@@ -27,7 +27,7 @@ public class MetaTileEntityAutoMaintenanceHatch extends MetaTileEntityMultiblock
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
         return new MetaTileEntityAutoMaintenanceHatch(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -8,7 +8,7 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
@@ -46,7 +46,7 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityEnergyHatch(metaTileEntityId, getTier(), amperage, isExportHatch);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -12,7 +12,7 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
@@ -47,7 +47,7 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityFluidHatch(metaTileEntityId, getTier(), isExportHatch);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -8,7 +8,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
@@ -35,7 +35,7 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityItemBus(metaTileEntityId, getTier(), isExportHatch);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -9,7 +9,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.IMachineHatchMultiblock;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -38,7 +38,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMachineHatch(metaTileEntityId, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -16,7 +16,7 @@ import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMaintenance;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
@@ -81,7 +81,7 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
         return new MetaTileEntityMaintenanceHatch(metaTileEntityId, isConfigurable);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
@@ -10,7 +10,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
@@ -49,7 +49,7 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityMufflerHatch(metaTileEntityId, getTier());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -10,7 +10,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -41,7 +41,7 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
         return new MetaTileEntityMultiFluidHatch(metaTileEntityId, this.getTier(), this.isExportHatch);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart.java
@@ -70,7 +70,7 @@ public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity implem
             }
         }
         if (controllerTile != null && (controllerTile.getHolder() == null ||
-                controllerTile.getHolder().isInvalid() || !(getWorld().isRemote || controllerTile.getMultiblockParts().contains(this)))) {
+                !controllerTile.isValid() || !(getWorld().isRemote || controllerTile.getMultiblockParts().contains(this)))) {
             //tile can become invalid for many reasons, and can also forgot to remove us once we aren't in structure anymore
             //so check it here to prevent bugs with dangling controller reference and wrong texture
             this.controllerTile = null;
@@ -132,7 +132,7 @@ public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity implem
                 this.controllerPos = null;
                 this.controllerTile = null;
             }
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -11,7 +11,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
@@ -57,7 +57,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityRotorHolder(metaTileEntityId, getTier());
     }
 
@@ -321,7 +321,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         this.isRotorSpinning = buf.readBoolean();
         this.rotorColor = buf.readInt();
         this.frontFaceFree = buf.readBoolean();
-        getHolder().scheduleChunkForRenderUpdate();
+        scheduleRenderUpdate();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
@@ -2,7 +2,7 @@ package gregtech.common.metatileentities.multi.steam;
 
 import gregtech.api.capability.impl.SteamMultiWorkable;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -30,7 +30,7 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity metaTileEntityHolder) {
         return new MetaTileEntitySteamGrinder(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
@@ -3,7 +3,7 @@ package gregtech.common.metatileentities.multi.steam;
 
 import gregtech.api.capability.impl.SteamMultiWorkable;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.pattern.BlockPattern;
@@ -35,7 +35,7 @@ public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController 
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntitySteamOven(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
@@ -5,8 +5,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,7 +20,7 @@ public class SteamAlloySmelter extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamAlloySmelter(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamCompressor.java
@@ -5,8 +5,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,7 +20,7 @@ public class SteamCompressor extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamCompressor(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
@@ -5,8 +5,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,7 +20,7 @@ public class SteamExtractor extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamExtractor(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
@@ -5,8 +5,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,7 +20,7 @@ public class SteamFurnace extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamFurnace(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
@@ -5,8 +5,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,7 +20,7 @@ public class SteamHammer extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamHammer(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
@@ -5,8 +5,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,7 +20,7 @@ public class SteamMacerator extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamMacerator(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMiner.java
@@ -17,7 +17,7 @@ import gregtech.api.gui.widgets.AdvancedTextWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.IDataInfoProvider;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
@@ -71,7 +71,7 @@ public class SteamMiner extends MetaTileEntity implements IMiner, IControllable,
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamMiner(metaTileEntityId, this.minerLogic.getSpeed(), this.minerLogic.getMaximumRadius(), this.minerLogic.getFortune());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
@@ -6,8 +6,8 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
@@ -34,7 +34,7 @@ public class SteamRockBreaker extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamRockBreaker(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -151,7 +151,7 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
         super.receiveCustomData(dataId, buf);
         if (dataId == IS_WORKING) {
             this.isBurning = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
@@ -8,7 +8,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -32,7 +32,7 @@ public class SteamCoalBoiler extends SteamBoiler implements IFuelable {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamCoalBoiler(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
@@ -10,7 +10,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.material.Materials;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
@@ -35,7 +35,7 @@ public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamLavaBoiler(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamSolarBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamSolarBoiler.java
@@ -4,7 +4,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
@@ -17,7 +17,7 @@ public class SteamSolarBoiler extends SteamBoiler {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SteamSolarBoiler(metaTileEntityId, isHighPressure);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
@@ -12,7 +12,7 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -53,7 +53,7 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntitySteamHatch(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamItemBus.java
@@ -6,7 +6,7 @@ import codechicken.lib.vec.Matrix4;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -35,7 +35,7 @@ public class MetaTileEntitySteamItemBus extends MetaTileEntityItemBus implements
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntitySteamItemBus(metaTileEntityId, isExportHatch);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityBuffer.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityBuffer.java
@@ -11,7 +11,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -55,7 +55,7 @@ public class MetaTileEntityBuffer extends MetaTileEntity implements ITieredMetaT
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityBuffer(metaTileEntityId, tier);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
@@ -8,7 +8,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.unification.material.Material;
@@ -44,7 +44,7 @@ public class MetaTileEntityCrate extends MetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCrate(metaTileEntityId, material, inventorySize);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeChest.java
@@ -10,7 +10,7 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.PhantomSlotWidget;
 import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.cclop.ColourOperation;
 import gregtech.client.renderer.texture.Textures;
@@ -26,8 +26,6 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
-
-import java.util.function.Function;
 
 public class MetaTileEntityCreativeChest extends MetaTileEntityQuantumChest {
 
@@ -64,7 +62,7 @@ public class MetaTileEntityCreativeChest extends MetaTileEntityQuantumChest {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCreativeChest(this.metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -15,7 +15,7 @@ import gregtech.api.gui.widgets.CycleButtonWidget;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -66,7 +66,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEne
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCreativeEnergy();
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -4,7 +4,6 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
-import com.google.common.collect.Lists;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.CycleButtonWidget;
@@ -12,7 +11,7 @@ import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.PhantomFluidWidget;
 import gregtech.api.gui.widgets.TextFieldWidget2;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -28,9 +27,6 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
-
-import java.util.List;
-import java.util.function.Function;
 
 import static net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack.FLUID_NBT_KEY;
 
@@ -56,7 +52,7 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityCreativeTank(this.metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -10,7 +10,7 @@ import gregtech.api.capability.impl.FilteredFluidHandler;
 import gregtech.api.capability.impl.ThermalFluidHandlerItemStack;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.unification.material.Material;
 import gregtech.api.util.GTUtility;
@@ -60,7 +60,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityDrum(metaTileEntityId, material, tankSize);
     }
 
@@ -159,7 +159,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
         super.receiveCustomData(dataId, buf);
         if (dataId == UPDATE_AUTO_OUTPUT) {
             this.isAutoOutput = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 
@@ -195,7 +195,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     private void toggleOutput() {
         isAutoOutput = !isAutoOutput;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_AUTO_OUTPUT, buf -> buf.writeBoolean(isAutoOutput));
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
@@ -17,7 +17,7 @@ import gregtech.api.gui.widgets.ServerWidgetGroup;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.ModHandler;
 import gregtech.client.renderer.texture.Textures;
@@ -103,7 +103,7 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityLockedSafe(metaTileEntityId);
     }
 
@@ -272,7 +272,7 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
         this.isSafeUnlocked = safeUnlocked;
         if (getWorld() != null && !getWorld().isRemote) {
             writeCustomData(UPDATE_LOCKED_STATE, buf -> buf.writeBoolean(safeUnlocked));
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             markDirty();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -17,7 +17,7 @@ import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.ToggleButtonWidget;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -78,7 +78,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityQuantumChest(metaTileEntityId, tier, maxStoredItems);
     }
 
@@ -291,7 +291,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     public void setOutputFacing(EnumFacing outputFacing) {
         this.outputFacing = outputFacing;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_OUTPUT_FACING, buf -> buf.writeByte(outputFacing.getIndex()));
             markDirty();
         }
@@ -337,10 +337,10 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
         super.receiveCustomData(dataId, buf);
         if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacing = EnumFacing.VALUES[buf.readByte()];
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         } else if (dataId == UPDATE_AUTO_OUTPUT_ITEMS) {
             this.autoOutputItems = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -17,7 +17,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
 import gregtech.api.gui.widgets.PhantomTankWidget;
@@ -188,7 +188,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityQuantumTank(metaTileEntityId, tier, maxFluidCapacity);
     }
 
@@ -308,10 +308,10 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         super.receiveCustomData(dataId, buf);
         if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacing = EnumFacing.VALUES[buf.readByte()];
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         } else if (dataId == UPDATE_AUTO_OUTPUT_FLUIDS) {
             this.autoOutputFluids = buf.readBoolean();
-            getHolder().scheduleChunkForRenderUpdate();
+            scheduleRenderUpdate();
         }
     }
 
@@ -339,7 +339,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     public void setOutputFacing(EnumFacing outputFacing) {
         this.outputFacing = outputFacing;
         if (!getWorld().isRemote) {
-            getHolder().notifyBlockUpdate();
+            notifyBlockUpdate();
             writeCustomData(UPDATE_OUTPUT_FACING, buf -> buf.writeByte(outputFacing.getIndex()));
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -14,7 +14,7 @@ import gregtech.api.gui.widgets.*;
 import gregtech.api.gui.widgets.TabGroup.TabLocation;
 import gregtech.api.gui.widgets.tab.ItemTabInfo;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.storage.ICraftingStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.Position;
@@ -92,7 +92,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityWorkbench(metaTileEntityId);
     }
 

--- a/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
+++ b/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
@@ -3,7 +3,7 @@ package gregtech.common.terminal.app.console;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.WidgetGroup;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.terminal.app.AbstractApplication;
 import gregtech.api.terminal.gui.widgets.MachineSceneWidget;
 import gregtech.api.terminal.os.TerminalDialogWidget;
@@ -15,11 +15,11 @@ public class ConsoleApp extends AbstractApplication {
         super("console");
     }
 
-    private MetaTileEntityHolder getMTE() {
+    private IGregTechTileEntity getMTE() {
         if (os.clickPos != null) {
             TileEntity te = os.getModularUI().entityPlayer.world.getTileEntity(os.clickPos);
-            if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).isValid()) {
-                return (MetaTileEntityHolder) te;
+            if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).isValid()) {
+                return (IGregTechTileEntity) te;
             }
         }
         return null;

--- a/src/main/java/gregtech/common/terminal/app/console/MachineConsoleWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/console/MachineConsoleWidget.java
@@ -15,8 +15,8 @@ import gregtech.api.gui.resources.ItemStackTexture;
 import gregtech.api.gui.resources.TextTexture;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.terminal.gui.widgets.RectButtonWidget;
 import gregtech.api.terminal.os.TerminalTheme;
 import gregtech.api.util.Size;
@@ -72,8 +72,8 @@ public class MachineConsoleWidget extends WidgetGroup {
         if (pos != null && facing != null) {
             TileEntity te = gui.entityPlayer.world.getTileEntity(pos);
             clearAllWidgets();
-            if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).isValid()) {
-                mte = ((MetaTileEntityHolder) te).getMetaTileEntity();
+            if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).isValid()) {
+                mte = ((IGregTechTileEntity) te).getMetaTileEntity();
                 initWidgets();
                 if (isRemote()) {
                     writeClientAction(5, buf->{

--- a/src/main/java/gregtech/common/terminal/app/multiblockhelper/MultiBlockPreviewARApp.java
+++ b/src/main/java/gregtech/common/terminal/app/multiblockhelper/MultiBlockPreviewARApp.java
@@ -8,7 +8,7 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.LabelWidget;
 import gregtech.api.gui.widgets.WidgetGroup;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.MultiblockShapeInfo;
 import gregtech.api.terminal.app.ARApplication;
@@ -121,8 +121,8 @@ public class MultiBlockPreviewARApp extends ARApplication {
     private MultiblockControllerBase getController() {
         if (os.clickPos != null) {
             TileEntity te = gui.entityPlayer.world.getTileEntity(os.clickPos);
-            if (te instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) te).getMetaTileEntity() instanceof MultiblockControllerBase) {
-                return (MultiblockControllerBase) ((MetaTileEntityHolder) te).getMetaTileEntity();
+            if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MultiblockControllerBase) {
+                return (MultiblockControllerBase) ((IGregTechTileEntity) te).getMetaTileEntity();
             }
         }
         return null;
@@ -225,9 +225,9 @@ public class MultiBlockPreviewARApp extends ARApplication {
             int y = (i / 30) % 30 - 15;
             int z = (i / 900) - 15;
             TileEntity tileEntity = world.getTileEntity(lastPos.add(x, y, z));
-            if (tileEntity instanceof MetaTileEntityHolder) {
-                if (((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MultiblockControllerBase) {
-                    found.add((MultiblockControllerBase) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity());
+            if (tileEntity instanceof IGregTechTileEntity) {
+                if (((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MultiblockControllerBase) {
+                    found.add((MultiblockControllerBase) ((IGregTechTileEntity) tileEntity).getMetaTileEntity());
                 }
             }
         }

--- a/src/main/java/gregtech/common/tools/HardHammerBehavior.java
+++ b/src/main/java/gregtech/common/tools/HardHammerBehavior.java
@@ -3,7 +3,7 @@ package gregtech.common.tools;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.toolitem.IToolStats;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -33,8 +33,8 @@ public class HardHammerBehavior implements IItemBehaviour {
         ItemStack stack = player.getHeldItem(hand);
 
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+        if (tileEntity instanceof IGregTechTileEntity) {
+            MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             player.sendMessage(metaTileEntity.isMuffled() ?
                     new TextComponentTranslation("gregtech.machine.muffle.off") :
                     new TextComponentTranslation("gregtech.machine.muffle.on"));

--- a/src/main/java/gregtech/core/hooks/RenderChunkHooks.java
+++ b/src/main/java/gregtech/core/hooks/RenderChunkHooks.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 @SuppressWarnings("unused")
 public class RenderChunkHooks {
     public static <T extends TileEntity> TileEntitySpecialRenderer<T> getRenderer(TileEntityRendererDispatcher renderer, @Nullable TileEntity tileEntityIn) {
+        // TODO
         if (tileEntityIn instanceof MetaTileEntityHolder && !((MetaTileEntityHolder) tileEntityIn).hasTESR()) {
             return null;
         }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -7,7 +7,7 @@ import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Translation;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.BlockWorldState;
 import gregtech.api.pattern.MultiblockShapeInfo;
@@ -462,7 +462,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             TileEntity tileEntity = blockInfo.getTileEntity();
             if (tileEntity != null) {
                 this.isTile = true;
-                MetaTileEntity mte = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+                MetaTileEntity mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                 if (mte instanceof MultiblockControllerBase)
                     this.isController = true;
             }
@@ -511,8 +511,8 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             for (int y = 0; y < aisle.length; y++) {
                 BlockInfo[] column = aisle[y];
                 for (int z = 0; z < column.length; z++) {
-                    if (column[z].getTileEntity() instanceof MetaTileEntityHolder && ((MetaTileEntityHolder) column[z].getTileEntity()).getMetaTileEntity() instanceof MultiblockControllerBase) {
-                        controllerBase = (MultiblockControllerBase) ((MetaTileEntityHolder) column[z].getTileEntity()).getMetaTileEntity();
+                    if (column[z].getTileEntity() instanceof IGregTechTileEntity && ((IGregTechTileEntity) column[z].getTileEntity()).getMetaTileEntity() instanceof MultiblockControllerBase) {
+                        controllerBase = (MultiblockControllerBase) ((IGregTechTileEntity) column[z].getTileEntity()).getMetaTileEntity();
                     }
                     blockMap.put(new BlockPos(x, y, z), column[z]);
                 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
@@ -4,7 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.converter.ConverterTrait;
 import mcjty.theoneprobe.api.ElementAlignment;
@@ -39,7 +39,7 @@ public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait
 
         // Info on the current side of the converter
         pane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-        MetaTileEntity mte = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+        MetaTileEntity mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
         String voltageN = GTValues.VNF[GTUtility.getTierByVoltage(capability.getVoltage())];
         long amperage = capability.getBaseAmps();
         if (capability.isFeToEu()) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/DebugPipeNetInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/DebugPipeNetInfoProvider.java
@@ -1,7 +1,7 @@
 package gregtech.integration.theoneprobe.provider;
 
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.Node;
 import gregtech.api.pipenet.PipeNet;
 import gregtech.api.pipenet.block.BlockPipe;
@@ -31,8 +31,8 @@ public class DebugPipeNetInfoProvider implements IProbeInfoProvider {
     public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
         if (mode == ProbeMode.DEBUG && ConfigHolder.misc.debug) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
-            if (tileEntity instanceof MetaTileEntityHolder) {
-                MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+            if (tileEntity instanceof IGregTechTileEntity) {
+                MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                 if (metaTileEntity != null) {
                     ArrayList<String> arrayList = new ArrayList<>();
                     arrayList.add("MetaTileEntity Id: " + metaTileEntity.metaTileEntityId);

--- a/src/main/java/gregtech/integration/theoneprobe/provider/DiodeInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/DiodeInfoProvider.java
@@ -2,7 +2,7 @@ package gregtech.integration.theoneprobe.provider;
 
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.common.metatileentities.electric.MetaTileEntityDiode;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProbeInfo;
@@ -19,8 +19,8 @@ public class DiodeInfoProvider extends ElectricContainerInfoProvider {
 
     @Override
     protected void addProbeInfo(IEnergyContainer capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+        if (tileEntity instanceof IGregTechTileEntity) {
+            MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity instanceof MetaTileEntityDiode) {
                 long inputAmperage = capability.getInputAmperage();
                 long outputAmperage = capability.getOutputAmperage();

--- a/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
@@ -3,7 +3,7 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.electric.MetaTileEntityTransformer;
 import mcjty.theoneprobe.api.ElementAlignment;
@@ -22,8 +22,8 @@ public class TransformerInfoProvider extends ElectricContainerInfoProvider {
 
     @Override
     protected void addProbeInfo(IEnergyContainer capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            MetaTileEntity metaTileEntity = ((MetaTileEntityHolder) tileEntity).getMetaTileEntity();
+        if (tileEntity instanceof IGregTechTileEntity) {
+            MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity instanceof MetaTileEntityTransformer) {
                 MetaTileEntityTransformer mteTransformer = (MetaTileEntityTransformer) metaTileEntity;
                 String inputVoltageN = GTValues.VNF[GTUtility.getTierByVoltage(capability.getInputVoltage())];

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -52,7 +52,7 @@ public class AbstractRecipeLogicTest {
                                 null,
                                 1, false));
         MetaTileEntity atte = new MetaTileEntityHolder().setMetaTileEntity(at);
-        atte.getHolder().setWorld(world);
+        ((MetaTileEntityHolder) atte.getHolder()).setWorld(world);
         map.recipeBuilder()
                 .inputs(new ItemStack(Blocks.COBBLESTONE))
                 .outputs(new ItemStack(Blocks.STONE))

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -119,7 +119,7 @@ public class MultiblockRecipeLogicTest {
             e.printStackTrace();
         }
 
-        mbt.getHolder().setWorld(world);
+        ((MetaTileEntityHolder) mbt.getHolder()).setWorld(world);
 
         //Controller and isAttachedToMultiBlock need the world so we fake it here.
         MetaTileEntityItemBus importItemBus = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, false) {
@@ -354,7 +354,7 @@ public class MultiblockRecipeLogicTest {
             e.printStackTrace();
         }
 
-        mbt.getHolder().setWorld(world);
+        ((MetaTileEntityHolder) mbt.getHolder()).setWorld(world);
 
         try {
             Field field = RecipeMapMultiblockController.class.getDeclaredField("isDistinct");

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -114,7 +114,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
             e.printStackTrace();
         }
 
-        mbt.getHolder().setWorld(world);
+        ((MetaTileEntityHolder) mbt.getHolder()).setWorld(world);
 
         //Controller and isAttachedToMultiBlock need the world so we fake it here.
         importItemBus = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, false) {


### PR DESCRIPTION
Part 1 of the MetaTileEntity refactor work.

With this interface, MetaTileEntities will be able to have a different TileEntity as their "holder." Currently, this is not completely finished, as it depends on many other refactors outside of the scope of this first PR. This is mostly defining a "base set" of methods to be on a TileEntity that holds a MetaTileEntity, and refactors nearly all of our code to take the interface instead of `MetaTileEntityHolder`.