### PR TITLE
Fix double fluid tanks showing in TOP

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -52,6 +52,12 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     }
 
     @Override
+    protected void initializeInventory() {
+        super.initializeInventory();
+        this.fluidInventory = isExportHatch ? exportFluids : importFluids;
+    }
+
+    @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
         data.setTag("ContainerInventory", containerInventory.serializeNBT());

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -57,8 +57,8 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
             };
         }
         this.fluidTanks = new FluidTankList(false, fluidsHandlers);
-        this.fluidInventory = fluidTanks;
         super.initializeInventory();
+        this.fluidInventory = fluidTanks;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
@@ -58,6 +58,12 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
     }
 
     @Override
+    protected void initializeInventory() {
+        super.initializeInventory();
+        this.fluidInventory = importFluids;
+    }
+
+    @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
         data.setTag("ContainerInventory", containerInventory.serializeNBT());


### PR DESCRIPTION
**What:**
A reboot of #255 since it has not been updated for a while, and is also out of date with the current state of the mod.

This PR applies to Steam Hatches, Fluid Hatches, and Multifluid Hatches, and fixes showing two sets of tanks in the TOP pane for these blocks

**Outcome:**
Fixes showing double tanks in the TOP pane