### PR TITLE
Fix the AbstractMethodError of the build JAR

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -20,9 +20,7 @@ import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.sound.GTSoundManager;
-import gregtech.api.recipes.FluidKey;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.sound.GTSoundManager;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
@@ -131,16 +129,16 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     public abstract MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity);
 
     public World getWorld() {
-        return holder == null ? null : holder.getWorld();
+        return holder == null ? null : holder.world();
     }
 
     public BlockPos getPos() {
-        return holder == null ? null : holder.getPos();
+        return holder == null ? null : holder.pos();
     }
 
     public void markDirty() {
         if (holder != null) {
-            holder.markDirty();
+            holder.markAsDirty();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -281,6 +281,16 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
+    public World world() {
+        return getWorld();
+    }
+
+    @Override
+    public BlockPos pos() {
+        return getPos();
+    }
+
+    @Override
     public void markAsDirty() {
         markDirty();
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityUIFactory.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityUIFactory.java
@@ -39,6 +39,6 @@ public class MetaTileEntityUIFactory extends UIFactory<IGregTechTileEntity> {
 
     @Override
     protected void writeHolderToSyncData(PacketBuffer syncData, IGregTechTileEntity holder) {
-        syncData.writeBlockPos(holder.getPos());
+        syncData.writeBlockPos(holder.pos());
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
@@ -1,13 +1,10 @@
 package gregtech.api.metatileentity.interfaces;
 
-import gregtech.api.GregTechAPI;
 import gregtech.api.gui.IUIHolder;
 import gregtech.api.metatileentity.MetaTileEntity;
 import net.minecraft.network.PacketBuffer;
 
 import java.util.function.Consumer;
-
-import static gregtech.api.capability.GregtechDataCodes.INITIALIZE_MTE;
 
 /**
  * A simple compound Interface for all my TileEntities.

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IHasWorldObjectAndCoords.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IHasWorldObjectAndCoords.java
@@ -1,29 +1,28 @@
 package gregtech.api.metatileentity.interfaces;
 
+import gregtech.api.util.IDirtyNotifiable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-public interface IHasWorldObjectAndCoords {
+public interface IHasWorldObjectAndCoords extends IDirtyNotifiable {
 
-    World getWorld();
+    World world();
 
-    BlockPos getPos();
+    BlockPos pos();
 
     default boolean isServerSide() {
-        return getWorld() != null && !getWorld().isRemote;
+        return world() != null && !world().isRemote;
     }
 
     default boolean isClientSide() {
-        return getWorld() != null && getWorld().isRemote;
+        return world() != null && world().isRemote;
     }
-
-    void markDirty();
 
     void notifyBlockUpdate();
 
     default void scheduleRenderUpdate() {
-        BlockPos pos = getPos();
-        getWorld().markBlockRangeForRenderUpdate(
+        BlockPos pos = pos();
+        world().markBlockRangeForRenderUpdate(
                 pos.getX() - 1, pos.getY() - 1, pos.getZ() - 1,
                 pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
     }


### PR DESCRIPTION
**What:**
the `getWorld()` of  the `IHasWorldObjectAndCoords` conflicts with the `getWorld()` of  the `TileEntity`, which will be remapped to a SRG name (`TileEntity`). Causing an issue with the identification of abstract methods.

This also happens with `getPos()` and `markDirty()`.

I honestly don't know what the abstract of `IHasWorldObjectAndCoords` is, since so far it has only one implementation.
So this PR provides a very simple fix, It might end up being fixed in other better way.

