### PR TITLE
Adjust weird Capability issue with worldgen

### DIFF
--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -99,7 +99,9 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
             int masterHeight = world.getHeight(heightSpot).getY();
             int masterBottomHeight = world.getTopSolidOrLiquidBlock(heightSpot).getY();
             this.masterEntry = primerChunk.getCapability(GTWorldGenCapability.CAPABILITY, null);
-            this.masterEntry = new GTWorldGenCapability();
+            if(this.masterEntry == null) {
+                this.masterEntry = new GTWorldGenCapability();
+            }
             this.masterEntry.setMaxHeight(masterHeight, masterBottomHeight);
         }
 


### PR DESCRIPTION
**What:**
Only set `masterEntry` to a new Capability if the capability retrieved from the chunk was null. Otherwise the non-null capability retrieved from the chunk would be ignored.

Not sure if this actually matters or not, because it has been like this since 2019. I wonder if this could possibly be the reason for mismatching stone types in spawn chunks?

**Outcome:**
Fixes a weird issue with world generation capabilities
