### PR TITLE
Add a warning when attempting to add a byproduct of a hidden material

### DIFF
--- a/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
@@ -174,6 +174,11 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
                     GTLog.logger.error("Attempted to add Ore Byproduct of hidden material {} for material {}", material, properties.getMaterial());
                 }
             }
+            else if(material.hasProperty(PropertyKey.FLUID) && !material.hasProperty(PropertyKey.DUST)) {
+                if(ConfigHolder.misc.debug) {
+                    GTLog.logger.error("Attempted to add a Ore Byproduct of material with only fluid property {} for material {}. Things might not behave correctly", material, properties.getMaterial());
+                }
+            }
         }
 
         properties.ensureSet(PropertyKey.DUST, true);

--- a/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
@@ -1,6 +1,8 @@
 package gregtech.api.unification.material.properties;
 
 import gregtech.api.unification.material.Material;
+import gregtech.api.util.GTLog;
+import gregtech.common.ConfigHolder;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
@@ -165,6 +167,15 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
 
     @Override
     public void verifyProperty(MaterialProperties properties) {
+
+        for(Material material : oreByProducts) {
+            if (!material.hasProperty(PropertyKey.DUST) && !material.hasProperty(PropertyKey.FLUID)) {
+                if (ConfigHolder.misc.debug) {
+                    GTLog.logger.error("Attempted to add Ore Byproduct of hidden material {} for material {}", material, properties.getMaterial());
+                }
+            }
+        }
+
         properties.ensureSet(PropertyKey.DUST, true);
 
         if (directSmeltResult != null) directSmeltResult.getProperties().ensureSet(PropertyKey.DUST, true);


### PR DESCRIPTION
**What:**
Adds a warning when a byproduct is attempted to be added for ore Processing when the material the byproduct is from is a hidden material (ie does not have any generation flags).

This currently only happens for Pollucite, which has a declared byproduct of Rubidium, which does not generate in game


**Outcome:**
Adds a warning when attempting to generate byproducts from invalid materials
