### PR TITLE
Crafting station fixes

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
@@ -2,10 +2,8 @@ package gregtech.api.gui.widgets;
 
 import com.google.common.collect.Lists;
 import gregtech.api.gui.ingredient.IGhostIngredientTarget;
-import gregtech.api.util.GTLog;
 import gregtech.api.util.SlotUtil;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.item.ItemStack;
@@ -43,6 +41,24 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
             } else {
                 gui.getModularUIGui().superMouseClicked(mouseX, mouseY, button);
             }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean mouseDragged(int mouseX, int mouseY, int button, long timeDragged) {
+        if (isMouseOverElement(mouseX, mouseY) && gui != null) {
+            ItemStack is = gui.entityPlayer.inventory.getItemStack().copy();
+            is.setCount(1);
+            slotReference.putStack(is);
+            writeClientAction(1, buffer -> {
+                buffer.writeItemStack(slotReference.getStack());
+                int mouseButton = Mouse.getEventButton();
+                boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+                buffer.writeVarInt(mouseButton);
+                buffer.writeBoolean(shiftDown);
+            });
             return true;
         }
         return false;

--- a/src/main/java/gregtech/api/util/SlotUtil.java
+++ b/src/main/java/gregtech/api/util/SlotUtil.java
@@ -19,18 +19,18 @@ public class SlotUtil {
         } else if (mouseButton == 0 || mouseButton == 1) {
 
             if (stackSlot.isEmpty()) {
-                if (!stackHeld.isEmpty() ) {
+                if (!stackHeld.isEmpty()) {
                     fillPhantomSlot(slot, stackHeld, mouseButton);
                 }
             } else if (stackHeld.isEmpty()) {
                 adjustPhantomSlot(slot, mouseButton, clickTypeIn);
-            } else  {
+            } else {
                 if (areItemsEqual(stackSlot, stackHeld)) {
                     adjustPhantomSlot(slot, mouseButton, clickTypeIn);
                 }
                 fillPhantomSlot(slot, stackHeld, mouseButton);
             }
-        } else if (mouseButton == 5) {
+        } else if (mouseButton == 5 || mouseButton == -1) {
             if (!slot.getHasStack()) {
                 fillPhantomSlot(slot, stackHeld, mouseButton);
             }

--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSources.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSources.java
@@ -86,17 +86,20 @@ public class ItemSources implements IItemList {
     @Override
     public int extractItem(ItemStackKey itemStack, int amount, boolean simulate) {
         Object2IntMap<ItemSource> itemSourceMap = new Object2IntOpenHashMap<>();
-        int extracted = 0;
+        int totalExtracted = 0;
         for (ItemSource itemSource : handlerInfoList) {
+            int extractedAmount = 0;
             if (itemInfoMap.get(itemStack) != null && itemInfoMap.get(itemStack).getTotalItemAmount() > 0) {
-                extracted += itemSource.extractItem(itemStack, amount, simulate, itemSourceMap);
-                if (!simulate && extracted > 0) {
-                    itemInfoMap.get(itemStack).removeFromSource(itemSource, extracted);
+                extractedAmount += itemSource.extractItem(itemStack, amount, simulate, itemSourceMap);
+                amount -= extractedAmount;
+                totalExtracted += extractedAmount;
+                if (!simulate && extractedAmount > 0) {
+                    itemInfoMap.get(itemStack).removeFromSource(itemSource, extractedAmount);
                 }
             }
-            if (extracted == amount) break;
+            if (amount == 0) break;
         }
-        return extracted;
+        return totalExtracted;
     }
 
     public void notifyPriorityUpdated() {

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeLogic.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeLogic.java
@@ -133,21 +133,19 @@ public class CraftingRecipeLogic {
         return true;
     }
 
-    public void handleItemCraft(ItemStack itemStack, EntityPlayer player, boolean simulate) {
+    public void handleItemCraft(ItemStack itemStack, EntityPlayer player) {
         itemStack.onCrafting(world, player, 1);
         itemStack.getItem().onCreated(itemStack, world, player);
-        if (!simulate) {
-            //if we're not simulated, fire the event, unlock recipe and add crafted items, and play sounds
-            FMLCommonHandler.instance().firePlayerCraftingEvent(player, itemStack, inventoryCrafting);
+        //if we're not simulated, fire the event, unlock recipe and add crafted items, and play sounds
+        FMLCommonHandler.instance().firePlayerCraftingEvent(player, itemStack, inventoryCrafting);
 
-            if (cachedRecipe != null && !cachedRecipe.isDynamic()) {
-                player.unlockRecipes(Lists.newArrayList(cachedRecipe));
-            }
-            if (cachedRecipe != null) {
-                ItemStack resultStack = cachedRecipe.getCraftingResult(inventoryCrafting);
-                this.itemsCrafted += resultStack.getCount();
-                recipeMemory.notifyRecipePerformed(craftingGrid, resultStack);
-            }
+        if (cachedRecipe != null && !cachedRecipe.isDynamic()) {
+            player.unlockRecipes(Lists.newArrayList(cachedRecipe));
+        }
+        if (cachedRecipe != null) {
+            ItemStack resultStack = cachedRecipe.getCraftingResult(inventoryCrafting);
+            this.itemsCrafted += resultStack.getCount();
+            recipeMemory.notifyRecipePerformed(craftingGrid, resultStack);
         }
     }
 


### PR DESCRIPTION
Actually fixes the issue described in #771.

Replaced slot interaction determing crafting behaviour with packets sent to the server when clicking with the "slot"

Implemented GT6 advanced crafting table behavior
 LClick = 1 craft and add to mouse (adds one if the mouse item matches too)
 RClick = fill mouse
 Shift + LClick = craft 64 and put in inventory
 Shift + RClick = craft everything it can and put in inventory 

Adds dragging support on crafting grid