### PR TITLE
Start Prioritized Recipe Lookup at correct position

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -380,7 +380,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     private Recipe prioritizedRecipe(Map<Integer, LinkedList<Recipe>> priorityRecipeMap, HashSet<Recipe> iteratedRecipes, List<ItemStack> inputs, List<FluidStack> fluidInputs) {
-        for (int i = priorityRecipeMap.size(); i >= 0; i--) {
+        for (int i = priorityRecipeMap.size() - 1; i >= 0; i--) {
             if (priorityRecipeMap.containsKey(i)) {
                 for (Recipe tmpRecipe : priorityRecipeMap.get(i)) {
                     if (iteratedRecipes.add(tmpRecipe)) {


### PR DESCRIPTION
**What:**
This PR starts the prioritized recipe lookup at the correct position. Since `priorityRecipeMap` is keyed from 0, starting at the size of the map means that the first key check for `i` will always be one greater than the final key.

**Outcome:**
Start Prioritized recipe lookup at correct position.
