### PR TITLE
fix programm circuit added by zs

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -69,7 +69,9 @@ public class CTRecipeBuilder {
 
     @ZenMethod
     public CTRecipeBuilder circuit(int num) {
-        this.backingBuilder.notConsumable(CraftTweakerIngredientWrapper.fromStacks(IntCircuitIngredient.getIntegratedCircuit(num)));
+        if (num < 0 || num > IntCircuitIngredient.CIRCUIT_MAX)
+            throw new IllegalArgumentException("Given configuration number is out of range!");
+        this.backingBuilder.notConsumable(new IntCircuitIngredient(num));
         return this;
     }
 

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes.crafttweaker;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -70,7 +71,7 @@ public class CTRecipeBuilder {
     @ZenMethod
     public CTRecipeBuilder circuit(int num) {
         if (num < 0 || num > IntCircuitIngredient.CIRCUIT_MAX)
-            throw new IllegalArgumentException("Given configuration number is out of range!");
+            CraftTweakerAPI.logError("Given configuration number is out of range!", new IllegalArgumentException());
         this.backingBuilder.notConsumable(new IntCircuitIngredient(num));
         return this;
     }


### PR DESCRIPTION
**What:**
fix the programm cricuit can't be handled properly through `circuit()`
fix https://github.com/GregTechCEu/GregTech/issues/853

**Outcome:**
now the programme circuit added by zs can be actcully distinguished, before any recipe from zs with programme circuit will accept all numbers of them.

