### PR TITLE
canInputFluid performance burden alleviation

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
@@ -26,10 +26,7 @@ import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity implements IDataInfoProvider {
@@ -127,28 +124,19 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity 
 
     protected boolean canInputFluid(FluidStack inputFluid) {
         RecipeMap<?> recipeMap = workable.getRecipeMap();
-        if (recipeMap.canInputFluidForce(inputFluid.getFluid()))
-            return true; //if recipe map forces input of given fluid, return true
-        Set<Recipe> matchingRecipes = null;
+        if (recipeMap.canInputFluidForce(inputFluid.getFluid())) {
+            return true; // RecipeMap forces input
+        }
         for (IFluidTank fluidTank : importFluids) {
             FluidStack fluidInTank = fluidTank.getFluid();
             if (fluidInTank != null) {
-                if (matchingRecipes == null) {
-                    //if we didn't have a list of recipes with any fluids, obtain it from first tank with fluid
-                    matchingRecipes = new HashSet<>(recipeMap.getRecipesForFluid(fluidInTank));
-                } else {
-                    //retain recipes which use the fluid in this tank
-                    matchingRecipes.retainAll(recipeMap.getRecipesForFluid(fluidInTank));
+                // Check if both fluids are equal, short-circuit and inform that the fluid can be inputted
+                if (inputFluid.isFluidEqual(fluidInTank)) {
+                    return true;
                 }
             }
         }
-        if (matchingRecipes == null) {
-            //if all tanks are empty, generally fluid can be inserted if there are recipes for it
-            return !recipeMap.getRecipesForFluid(inputFluid).isEmpty();
-        } else {
-            matchingRecipes.retainAll(recipeMap.getRecipesForFluid(inputFluid));
-            return !matchingRecipes.isEmpty();
-        }
+        return !recipeMap.getRecipesForFluid(inputFluid).isEmpty();
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -187,6 +187,10 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return recipeFluidMap.getOrDefault(new FluidKey(fluid), Collections.emptySet());
     }
 
+    public Collection<Recipe> getRecipesForFluid(FluidKey fluidKey) {
+        return recipeFluidMap.getOrDefault(fluidKey, Collections.emptySet());
+    }
+
     private static boolean foundInvalidRecipe = false;
 
     //internal usage only, use buildAndRegister()


### PR DESCRIPTION
This issue spawned from Smudge's spark profiling report: https://spark.lucko.me/Y2pdwRFqgS

The performance burden is alleviated from this hotspot by avoiding:

1. Object creation
2. Vanilla `HashSet` usage (e.g: excessive hashing)
3. `Recipe#equals` checks, since we're essentially only checking for identity equality.
4. `Collection#retainAll` usage, this correlates to the second point, since `retainAll` modifies the first collection, a `HashSet` instantiation was needed.

The logic could be flawed, some initial testing done on my end has shown the same logic however.