### PR TITLE
Add some new TOP displays

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/IPrimitivePump.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IPrimitivePump.java
@@ -1,0 +1,10 @@
+package gregtech.api.metatileentity.multiblock;
+
+public interface IPrimitivePump {
+
+    /**
+     *
+     * @return the amount of fluid to produce
+     */
+    int getFluidProduction();
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveWaterPump.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveWaterPump.java
@@ -7,14 +7,15 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.IPrimitivePump;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
+import gregtech.api.unification.material.Materials;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
-import gregtech.api.unification.material.Materials;
 import gregtech.common.blocks.BlockSteamCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.MetaTileEntities;
@@ -32,7 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class MetaTileEntityPrimitiveWaterPump extends MultiblockControllerBase {
+public class MetaTileEntityPrimitiveWaterPump extends MultiblockControllerBase implements IPrimitivePump {
 
     private IFluidTank waterTank;
     private int biomeModifier = 0;
@@ -55,7 +56,7 @@ public class MetaTileEntityPrimitiveWaterPump extends MultiblockControllerBase {
             if (biomeModifier == 0) {
                 biomeModifier = getAmount();
             } else if (biomeModifier > 0) {
-                waterTank.fill(Materials.Water.getFluid(biomeModifier * hatchModifier), true);
+                waterTank.fill(Materials.Water.getFluid(getFluidProduction()), true);
             }
         }
     }
@@ -168,5 +169,10 @@ public class MetaTileEntityPrimitiveWaterPump extends MultiblockControllerBase {
                 I18n.format("gregtech.multiblock.primitive_water_pump.extra1").split("/n"),
                 I18n.format("gregtech.multiblock.primitive_water_pump.extra2").split("/n")
         ).flatMap(Stream::of).toArray(String[]::new);
+    }
+
+    @Override
+    public int getFluidProduction() {
+        return biomeModifier * hatchModifier;
     }
 }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -134,7 +134,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         int yPosition = recipeHeight - getPropertyListHeight();
         if (!recipe.hasProperty(PrimitiveProperty.getInstance())) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
-            minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), JEIHelpers.getMinTierForVoltage(recipe.getEUt())), 0, yPosition += LINE_HEIGHT, 0x111111);
+            minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[JEIHelpers.getMinTierForVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);
         } else yPosition -= LINE_HEIGHT * 2;
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += LINE_HEIGHT, 0x111111);
         for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getPropertyValues()) {

--- a/src/main/java/gregtech/integration/jei/utils/JEIHelpers.java
+++ b/src/main/java/gregtech/integration/jei/utils/JEIHelpers.java
@@ -5,15 +5,15 @@ import gregtech.api.GTValues;
 public class JEIHelpers {
 
     /**
-     * Returns the short name for the minimum required power tier for a specified voltage
+     * Returns the int tier for the minimum required power tier for a specified voltage
      */
-    public static String getMinTierForVoltage(long voltage) {
+    public static int getMinTierForVoltage(long voltage) {
         for (int i = 0; i < GTValues.V.length; i++) {
             if (voltage <= GTValues.V[i]) {
-                return GTValues.VN[i];
+                return i;
             }
         }
-        return "";
+        return 0;
     }
 
 }

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
@@ -19,5 +19,7 @@ public class TheOneProbeCompatibility {
         oneProbe.registerProvider(new MaintenanceInfoProvider());
         oneProbe.registerProvider(new MultiRecipeMapInfoProvider());
         oneProbe.registerProvider(new ConverterInfoProvider());
+        oneProbe.registerProvider(new RecipeLogicInfoProvider());
+        oneProbe.registerProvider(new PrimitivePumpInfoProvider());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
@@ -1,0 +1,34 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IPrimitivePump;
+import mcjty.theoneprobe.api.*;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+
+public class PrimitivePumpInfoProvider implements IProbeInfoProvider {
+
+    @Override
+    public String getID() {
+        return String.format("%s:primitive_pump_provider", GTValues.MODID);
+    }
+
+    @Override
+    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, @Nonnull IBlockState blockState, IProbeHitData data) {
+        if (blockState.getBlock().hasTileEntity(blockState)) {
+            TileEntity tileEntity = world.getTileEntity(data.getPos());
+            if (!(tileEntity instanceof IGregTechTileEntity)) return;
+
+            MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
+            if (metaTileEntity instanceof IPrimitivePump) {
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.primitive_pump_production*} §b" + ((IPrimitivePump) metaTileEntity).getFluidProduction() + "§r L/s");
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -1,0 +1,41 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.impl.AbstractRecipeLogic;
+import gregtech.api.capability.impl.PrimitiveRecipeLogic;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
+
+public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractRecipeLogic> {
+
+    @Override
+    protected Capability<AbstractRecipeLogic> getCapability() {
+        return GregtechTileCapabilities.CAPABILITY_RECIPE_LOGIC;
+    }
+
+    @Override
+    public String getID() {
+        return String.format("%s:recipe_logic_provider", GTValues.MODID);
+    }
+
+    @Override
+    protected void addProbeInfo(@Nonnull AbstractRecipeLogic capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+        // do not show energy usage on machines that do not use energy
+        if (capability.isWorking()) {
+            if (!(capability instanceof PrimitiveRecipeLogic)) {
+                int EUt = capability.getRecipeEUt();
+                if (EUt > 0) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} §c" + EUt + "§r EU/t");
+                } else if (EUt < 0) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} §c" + (EUt * -1) + "§r EU/t");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.capability.impl.PrimitiveRecipeLogic;
+import gregtech.integration.jei.utils.JEIHelpers;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
 import net.minecraft.tileentity.TileEntity;
@@ -31,9 +32,9 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             if (!(capability instanceof PrimitiveRecipeLogic)) {
                 int EUt = capability.getRecipeEUt();
                 if (EUt > 0) {
-                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} §c" + EUt + "§r EU/t");
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} §c" + EUt + "§r EU/t (" + GTValues.VNF[JEIHelpers.getMinTierForVoltage(EUt)] + "§r)");
                 } else if (EUt < 0) {
-                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} §c" + (EUt * -1) + "§r EU/t");
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} §c" + (EUt * -1) + "§r EU/t (" + GTValues.VNF[JEIHelpers.getMinTierForVoltage(EUt)] + "§r)");
                 }
             }
         }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -27,6 +27,9 @@ gregtech.top.energy_stored=Energy:
 gregtech.top.progress=Progress:
 gregtech.top.working_disabled=Working Disabled
 
+gregtech.top.energy_consumption=Consumption:
+gregtech.top.energy_production=Production:
+
 gregtech.top.transform_up=§cStep Up§r
 gregtech.top.transform_down=§aStep Down§r
 gregtech.top.transform_input=§6Input:§r
@@ -46,6 +49,8 @@ gregtech.top.valid_structure=§aStructure Formed
 gregtech.top.obstructed_structure=§cStructure Obstructed
 gregtech.top.maintenance_fixed=§aMaintenance Fine
 gregtech.top.maintenance_broken=§cNeeds Maintenance
+
+gregtech.top.primitive_pump_production=Production:
 
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -27,8 +27,8 @@ gregtech.top.energy_stored=Energy:
 gregtech.top.progress=Progress:
 gregtech.top.working_disabled=Working Disabled
 
-gregtech.top.energy_consumption=Consumption:
-gregtech.top.energy_production=Production:
+gregtech.top.energy_consumption=Usage:
+gregtech.top.energy_production=Output:
 
 gregtech.top.transform_up=§cStep Up§r
 gregtech.top.transform_down=§aStep Down§r


### PR DESCRIPTION
**What:**
This PR adds two new TOP displays. 

The first displays the machine's current EU/t usage while running recipes. This value is the value used after overclocking. If the machine produces energy, it displays this value as consumption. If the machine does not use energy, such as the PBF, nothing is displayed.

The second display is for the Primitive Water Pump, which displays its current fluid production rate in L / s. This resulted in the addition of a new interface, `IPrimitivePump`, which may prove useful for addons adding similar machines.

**Outcome:**
Added energy consumption and primitive pump production rate TOP displays