### PR TITLE
Fix CT Gas Collector crash

### DIFF
--- a/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes.builders;
 
+import crafttweaker.CraftTweakerAPI;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
@@ -9,6 +10,7 @@ import gregtech.api.util.ValidationResult;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class GasCollectorRecipeBuilder extends RecipeBuilder<GasCollectorRecipeBuilder> {
@@ -35,7 +37,20 @@ public class GasCollectorRecipeBuilder extends RecipeBuilder<GasCollectorRecipeB
     @Override
     public boolean applyProperty(String key, Object value) {
         if (key.equals(GasCollectorDimensionProperty.KEY)) {
-            this.dimension(((List<Integer>) value).get(0));
+            if (value instanceof Integer) {
+                this.dimension((Integer) value);
+            } else if (value instanceof List && !((List<?>) value).isEmpty() && ((List<?>) value).get(0) instanceof Integer) {
+                if (this.dimensionIDs == null) {
+                    this.dimensionIDs = new ArrayList<>();
+                }
+                this.dimensionIDs.addAll((Collection<? extends Integer>) value);
+            } else {
+                if (isCTRecipe) {
+                    CraftTweakerAPI.logError("Dimension for Gas Collector needs to be a Integer");
+                    return false;
+                }
+                throw new IllegalArgumentException("Invalid Dimension Property Type!");
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
In #808 the `applyProperty` was changed to cast the Object to `List` without a check. CT uses that method to and causes a crash because it passes an `Integer`.
This was fixed by cheching the type and throwing an error if the type is not valid.