### PR TITLE
Make doExplosions to explosionMode and make them more configuratable

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -130,7 +130,7 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
             excessWater %= STEAM_PER_WATER;
 
             FluidStack drainedWater = ModHandler.getBoilerFluidFromContainer(getInputTank(), (int) amount, true);
-            if (amount != 0 && (drainedWater == null || drainedWater.amount < amount)) {
+            if (ConfigHolder.machines.explosionMode != 0 && amount != 0 && (drainedWater == null || drainedWater.amount < amount)) {
                 getMetaTileEntity().explodeMultiblock();
             } else {
                 setLastTickSteam(generatedSteam);

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryBuffer.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryBuffer.java
@@ -41,7 +41,7 @@ public class EnergyContainerBatteryBuffer extends EnergyContainerHandler {
             return 0;
 
         if (side == null || inputsEnergy(side)) {
-            if (voltage > getInputVoltage()) {
+            if (ConfigHolder.machines.explosionMode != 0 && voltage > getInputVoltage()) {
                 metaTileEntity.doExplosion(GTUtility.getExplosionPower(voltage));
                 return usedAmps;
             }

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryCharger.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryCharger.java
@@ -39,7 +39,7 @@ public class EnergyContainerBatteryCharger extends EnergyContainerHandler {
             return 0;
 
         if (side == null || inputsEnergy(side)) {
-            if (voltage > getInputVoltage()) {
+            if (ConfigHolder.machines.explosionMode != 0 && voltage > getInputVoltage()) {
                 metaTileEntity.doExplosion(GTUtility.getExplosionPower(voltage));
             }
 

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
@@ -224,7 +224,7 @@ public class EnergyContainerHandler extends MTETrait implements IEnergyContainer
         if(amps >= getInputAmperage()) return 0;
         long canAccept = getEnergyCapacity() - getEnergyStored();
         if (voltage > 0L && (side == null || inputsEnergy(side))) {
-            if (voltage > getInputVoltage()) {
+            if (ConfigHolder.machines.explosionMode != 0 && voltage > getInputVoltage()) {
                 metaTileEntity.doExplosion(GTUtility.getExplosionPower(voltage));
                 return Math.min(amperage, getInputAmperage() - amps);
             }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1326,9 +1326,10 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public void doExplosion(float explosionPower) {
+        if (ConfigHolder.machines.explosionMode == 0) return;
         getWorld().setBlockToAir(getPos());
         getWorld().createExplosion(null, getPos().getX() + 0.5, getPos().getY() + 0.5, getPos().getZ() + 0.5,
-                explosionPower, ConfigHolder.machines.doExplosions);
+                explosionPower, ConfigHolder.machines.explosionMode == 2);
     }
 
     public boolean doTickProfileMessage() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -18,6 +18,7 @@ import gregtech.client.renderer.handler.MultiblockPreviewRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.BlockInfo;
 import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.blocks.VariantActiveBlock;
 import net.minecraft.block.Block;
@@ -401,6 +402,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     }
 
     public void explodeMultiblock() {
+        if (ConfigHolder.machines.explosionMode == 0) return;
         List<IMultiblockPart> parts = new ArrayList<>(getMultiblockParts());
         parts.forEach(p -> ((MetaTileEntity) p).doExplosion(8));
         doExplosion(8);

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -74,8 +74,10 @@ public class ConfigHolder {
         @Config.Comment({"Steam to EU multiplier for Steam Multiblocks.", "1.0 means 1L Steam -> 1 EU. 0.5 means 2L Steam -> 1 EU.", "Default: 0.5"})
         public double multiblockSteamToEU = 0.5;
 
-        @Config.Comment({"Whether machines should explode when overloaded with power.", "Default: true"})
-        public boolean doExplosions = true;
+        @Config.Comment({"Whether machines how explode when overloaded with power.", "0 - Disable Explosion", "1 - Explode without Destroy", "2 - Enable Explosion", "Default: 2"})
+        @Config.RangeInt(min = 0, max = 2)
+        @Config.SlidingOption
+        public int explosionMode = 2;
 
         @Config.Comment({"Energy use multiplier for electric items.", "Default: 100"})
         public int energyUsageMultiplier = 100;

--- a/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
@@ -6,6 +6,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.util.GTUtility;
+import gregtech.common.ConfigHolder;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -158,7 +159,7 @@ public class ConverterTrait extends MTETrait {
             if (amperage <= 0 || voltage <= 0 || feToEu || side == metaTileEntity.getFrontFacing())
                 return 0;
             if (usedAmps >= amps) return 0;
-            if (voltage > getInputVoltage()) {
+            if (ConfigHolder.machines.explosionMode != 0 && voltage > getInputVoltage()) {
                 metaTileEntity.doExplosion(GTUtility.getExplosionPower(voltage));
                 return Math.min(amperage, amps - usedAmps);
             }

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -225,7 +225,7 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
             if (hasDrainedWater) {
                 filledSteam = steamFluidTank.fill(ModHandler.getSteam(fillAmount), true);
             }
-            if (this.hasNoWater && hasDrainedWater) {
+            if (ConfigHolder.machines.explosionMode != 0 && this.hasNoWater && hasDrainedWater) {
                 doExplosion(2.0f);
             } else this.hasNoWater = !hasDrainedWater;
             if (filledSteam == 0 && hasDrainedWater) {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -18,6 +18,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -139,7 +140,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEne
             lastEnergyInputPerSec = energyInputPerSec;
             energyOutputPerSec = 0;
             energyInputPerSec = 0;
-            if (doExplosion) {
+            if (ConfigHolder.machines.explosionMode != 0 && doExplosion) {
                 getWorld().createExplosion(null, getPos().getX() + 0.5, getPos().getY() + 0.5, getPos().getZ() + 0.5,
                         1, false);
                 doExplosion = false;

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipe.java
@@ -3,6 +3,7 @@ package gregtech.common.pipelike.fluidpipe.tile;
 import gregtech.api.GTValues;
 import gregtech.api.pipenet.block.material.TileEntityMaterialPipeBase;
 import gregtech.api.unification.material.properties.FluidPipeProperties;
+import gregtech.common.ConfigHolder;
 import gregtech.common.pipelike.fluidpipe.FluidPipeType;
 import gregtech.common.pipelike.fluidpipe.net.FluidPipeNet;
 import gregtech.common.pipelike.fluidpipe.net.WorldFluidPipeNet;
@@ -52,7 +53,7 @@ public class TileEntityFluidPipe extends TileEntityMaterialPipeBase<FluidPipeTyp
                 TileEntityFluidPipe.setNeighboursToFire(world, pos);
         } else
             world.setBlockToAir(pos);
-        if (isLeaking && world.rand.nextInt(isBurning ? 3 : 7) == 0) {
+        if (ConfigHolder.machines.explosionMode != 0 && isLeaking && world.rand.nextInt(isBurning ? 3 : 7) == 0) {
             this.doExplosion(1.0f + GTValues.RNG.nextFloat());
         }
     }


### PR DESCRIPTION
**What:**
Implement idea from #879

**Outcome:**
`doExplosions` from Machine Config is now `explosionMode` and more configuratable.
Allowed Values : 0, 1, 2 (Default : 2)
0 - Disable Explosion
1 - Explode without Destroy
2 - Enable Explosion

**Possible compatibility issue:**
I just hope addons doesn't have any references to doExplosions config.