### PR TITLE
UpdateEntry memory "leak" fix

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -62,7 +62,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
         for (NBTBase entryBase : listTag) {
             NBTTagCompound entryTag = (NBTTagCompound) entryBase;
             for (String discriminatorKey : entryTag.getKeySet()) {
-                ByteBuf backedBuffer = Unpooled.copiedBuffer(updateTag.getByteArray(discriminatorKey));
+                ByteBuf backedBuffer = Unpooled.copiedBuffer(entryTag.getByteArray(discriminatorKey));
                 receiveCustomData(Integer.parseInt(discriminatorKey), new PacketBuffer(backedBuffer));
             }
         }

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -55,7 +55,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         this.paintingColor = tileEntity.getPaintingColor();
         this.connections = tileEntity.getConnections();
         if (tileEntity instanceof TileEntityPipeBase) {
-            this.updateEntries.addAll(((TileEntityPipeBase<?, ?>) tileEntity).updateEntries);
+            this.updates.putAll(((TileEntityPipeBase<?, ?>) tileEntity).updates);
         }
         tileEntity.getCoverableImplementation().transferDataTo(coverableImplementation);
     }


### PR DESCRIPTION
- Allows new data to override old data if they have the same discriminator and if the packet hasn't been sent yet, this normally happens when no players are watching the chunk where the update occurred
- Fix large amounts of memory being occupied and not flushed because of the indefinite queuing of `UpdateEntry`

![image](https://user-images.githubusercontent.com/3684700/162627133-b8ffb572-3677-4f04-87d2-c6f267fa7c58.png)
- Eliminates strain when sending packets as well, the structure has been slightly changed to be tiny bit lighter