### PR TITLE
Fix Robotic Arm hiding amount config from ore dictionary filters

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -143,6 +143,10 @@ public class CoverRoboticArm extends CoverConveyor {
         return transferMode;
     }
 
+    private boolean shouldDisplayAmountSlider() {
+        return transferMode != TransferMode.TRANSFER_ANY;
+    }
+
     @Override
     protected String getUITitle() {
         return "cover.robotic_arm.title";
@@ -155,7 +159,7 @@ public class CoverRoboticArm extends CoverConveyor {
                 TransferMode.class, this::getTransferMode, this::setTransferMode)
                 .setTooltipHoverString("cover.robotic_arm.transfer_mode.description"));
 
-        ServerWidgetGroup stackSizeGroup = new ServerWidgetGroup(() -> itemFilterContainer.getFilterWrapper().getItemFilter() == null && transferMode != TransferMode.TRANSFER_ANY);
+        ServerWidgetGroup stackSizeGroup = new ServerWidgetGroup(this::shouldDisplayAmountSlider);
         stackSizeGroup.addWidget(new ImageWidget(111, 70, 35, 20, GuiTextures.DISPLAY));
 
         stackSizeGroup.addWidget(new IncrementButtonWidget(146, 70, 20, 20, 1, 8, 64, 512, itemFilterContainer::adjustTransferStackSize)

--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -144,7 +144,10 @@ public class CoverRoboticArm extends CoverConveyor {
     }
 
     private boolean shouldDisplayAmountSlider() {
-        return transferMode != TransferMode.TRANSFER_ANY;
+        if (transferMode == TransferMode.TRANSFER_ANY) {
+            return false;
+        }
+        return itemFilterContainer.showGlobalTransferLimitSlider();
     }
 
     @Override


### PR DESCRIPTION
**What:**
Fixes Robotic Arms with Ore Dictonary Filters having the slider widget disabled

**Outcome:**
Can now again set the amount transfered by arms with ore dict filters