### PR TITLE
Add translation keys for battery charge unit and translate them

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
@@ -131,13 +131,13 @@ public class ElectricStats implements IItemComponent, IItemCapabilityProvider, I
         String unit;
         if (duration.getSeconds() <= 180) {
             chargeTime = duration.getSeconds();
-            unit = "sec";
+            unit = I18n.format("metaitem.battery.charge_unit.second");
         } else if (duration.toMinutes() <= 180) {
             chargeTime = duration.toMinutes();
-            unit = "min";
+            unit = I18n.format("metaitem.battery.charge_unit.minute");
         } else {
             chargeTime = duration.toHours();
-            unit = "hr";
+            unit = I18n.format("metaitem.battery.charge_unit.hour");
         }
         tooltip.add(I18n.format("metaitem.battery.charge_time", chargeTime, unit, GTValues.VNF[tier]));
     }

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -587,13 +587,13 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         String unit;
         if (duration.getSeconds() <= 180) {
             timeRemaining = duration.getSeconds();
-            unit = "sec";
+            unit = I18n.format("metaitem.battery.charge_unit.second");
         } else if (duration.toMinutes() <= 180) {
             timeRemaining = duration.toMinutes();
-            unit = "min";
+            unit = I18n.format("metaitem.battery.charge_unit.minute");
         } else {
             timeRemaining = duration.toHours();
-            unit = "hr";
+            unit = I18n.format("metaitem.battery.charge_unit.hour");
         }
         tooltip.add(I18n.format("metaitem.battery.charge_detailed", currentCharge, maxCharge, GTValues.VNF[tier],
                 percentRemaining < 30 ? 'c' : percentRemaining < 60 ? 'e' : 'a',

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -279,6 +279,9 @@ metaitem.battery.hull.uv.tooltip=An empty §3UV §7Battery Hull
 
 metaitem.battery.charge_time=§aHolds %,d%s of Power
 metaitem.battery.charge_detailed=%,d/%,d EU - Tier %s §7(§%c%,d%s remaining§7)
+metaitem.battery.charge_unit.second=sec
+metaitem.battery.charge_unit.minute=min
+metaitem.battery.charge_unit.hour=hr
 
 metaitem.battery.re.ulv.tantalum.name=Tantalum Capacitor
 metaitem.battery.re.ulv.tantalum.tooltip=Reusable Battery

--- a/src/main/resources/assets/gregtech/lang/ja_jp.lang
+++ b/src/main/resources/assets/gregtech/lang/ja_jp.lang
@@ -277,6 +277,9 @@ metaitem.battery.hull.uv.tooltip=空の§3UV用§7バッテリー筐体
 
 metaitem.battery.charge_time=§a%,d%s放出可能
 metaitem.battery.charge_detailed=%,d/%,d EU - Tier %s §7(§%c%,d%s放出可能§7)
+metaitem.battery.charge_unit.second=秒
+metaitem.battery.charge_unit.minute=分
+metaitem.battery.charge_unit.hour=時間
 
 metaitem.battery.re.ulv.tantalum.name=タンタル製キャパシター
 metaitem.battery.re.ulv.tantalum.tooltip=充電式

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -277,9 +277,6 @@ metaitem.battery.hull.uv.tooltip=Пустой §3UV §7корпус батаре
 
 metaitem.battery.charge_time=§aДержит заряд %,d%s
 metaitem.battery.charge_detailed=%,d/%,d EU– Tier %s §7(§%c%,d%s осталось§7)
-
-metaitem.battery.charge_time=§aHolds %,d%s of Power
-metaitem.battery.charge_detailed=%,d/%,d EU - Tier %s §7(§%c%,d%s remaining§7)
 metaitem.battery.charge_unit.second=sec
 metaitem.battery.charge_unit.minute=min
 metaitem.battery.charge_unit.hour=hr

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -278,6 +278,12 @@ metaitem.battery.hull.uv.tooltip=Пустой §3UV §7корпус батаре
 metaitem.battery.charge_time=§aДержит заряд %,d%s
 metaitem.battery.charge_detailed=%,d/%,d EU– Tier %s §7(§%c%,d%s осталось§7)
 
+metaitem.battery.charge_time=§aHolds %,d%s of Power
+metaitem.battery.charge_detailed=%,d/%,d EU - Tier %s §7(§%c%,d%s remaining§7)
+metaitem.battery.charge_unit.second=sec
+metaitem.battery.charge_unit.minute=min
+metaitem.battery.charge_unit.hour=hr
+
 metaitem.battery.re.ulv.tantalum.name=Танталовый конденсатор
 metaitem.battery.re.ulv.tantalum.tooltip=Аккумулятор
 

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -292,6 +292,9 @@ metaitem.battery.hull.uv.tooltip=一个空的 §3UV §7电池外壳
 
 metaitem.battery.charge_time=§a可以持续供电 %,d%s
 metaitem.battery.charge_detailed=%,d/%,d EU - 等级 %s §7(§%c%,d%s 剩余§7)
+metaitem.battery.charge_unit.second=秒
+metaitem.battery.charge_unit.minute=分钟
+metaitem.battery.charge_unit.hour=小时
 
 metaitem.battery.re.ulv.tantalum.name=钽电容
 metaitem.battery.re.ulv.tantalum.tooltip=可充电电池


### PR DESCRIPTION
**What:**
battery charge unit is hardcoded currently 
![image](https://user-images.githubusercontent.com/39122497/163693929-9ee9dc53-6226-4344-9b5b-60b664a6c086.png)
I added lang key to fix that

**Outcome:**
![キャプチャ1286](https://user-images.githubusercontent.com/39122497/163693936-67f6ae5a-5896-40ee-ad8f-fa195b6c207a.PNG)

**Additional info:**
I can't speak Russian so I did nothing with that