### PR TITLE
Check if structure is formed before changing radius

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -351,7 +351,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
 
     @Override
     public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
-        if (getWorld().isRemote)
+        if (getWorld().isRemote || !this.isStructureFormed())
             return true;
 
         if (!this.minerLogic.isActive()) {


### PR DESCRIPTION
**What:**
Checks if the Multiblock Miner is formed before attempting to change its radius when clicked by a screwdriver. Closes #884 

**Outcome:**
Fix Game Hang/Crash when attempting to change radius on an unformed Multiblock Miner
