### PR TITLE
Adjust Overclocking duration bonus to happen once per tier

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -568,10 +568,20 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         int overclockedEUt = recipeEUt;
         double overclockedDuration = recipeDuration;
 
+        int tier, previousTier = 0;
+
         while (overclockedEUt * voltageMultiplier <= GTValues.V[GTUtility.getTierByVoltage(maximumVoltage)] && overclockedDuration / durationDivisor > 0 && maxOverclocks > 0) {
+
+            // Find the tier that the OC result will be run at
+            tier = GTUtility.getTierByVoltage((long) (overclockedEUt * voltageMultiplier));
+
+            // Only allow the duration bonus from the Overclock once per voltage tier
+            if(tier != previousTier) {
+                overclockedDuration /= durationDivisor;
+            }
             overclockedEUt *= voltageMultiplier;
-            overclockedDuration /= durationDivisor;
             maxOverclocks--;
+            previousTier = tier;
         }
         return new int[]{overclockedEUt, (int) Math.ceil(overclockedDuration)};
     }


### PR DESCRIPTION
**What:**
Changes the duration bonus from OC to happen once per tier. This change is mainly aimed at the Fusion Reactor, due to its 2x/2x OC. With this special Overclocking values, the Fusion Reactor was able to overclock multiple times per tier, due to the logic in `AbstractRecipeLogic#standardOverclockingLogic`.

The check of `overclockedEUt * voltageMultiplier <= GTValues.V[GTUtility.getTierByVoltage(maximumVoltage)]` in the while loop of that method would be hit multiple times per tier, as the voltageMultipler was only 2x, instead of the 4x, which guarantees a new energy tier is reached.

The change here is to only apply the duration bonus at most once per tier. This solution is not that ideal in my opinion, because it will add extra energy cost to the Fusion Reactor OCs, as there will be one OC where the voltage required is multiplied, but the duration is not cut. This happens because we need to increase the value of `overclockedEUt` to trigger the while loop to break. I am looking for feedback on this situation.


**Outcome:**
Change Duration Reduction in Overclocking to happen at most once per tier, affects special OC cases like the Fusion Reactor.