### PR TITLE
Recipe logic fix/clean-ups

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -251,6 +251,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * use sparingly
      */
     public void forceRecipeRecheck() {
+        this.previousRecipe = null;
         trySearchNewRecipe();
     }
 

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -278,9 +278,6 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (currentRecipe != null && checkRecipe(currentRecipe)) {
             prepareRecipe(currentRecipe);
         }
-        // Inputs have been inspected.
-        metaTileEntity.getNotifiedItemInputList().clear();
-        metaTileEntity.getNotifiedFluidInputList().clear();
     }
 
     /**
@@ -410,13 +407,17 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         }
 
         // We have already trimmed fluid outputs at this time
-        if(!metaTileEntity.canVoidRecipeFluidOutputs() && !GTTransferUtils.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs())) {
+        if (!metaTileEntity.canVoidRecipeFluidOutputs() && !GTTransferUtils.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs())) {
             this.isOutputsFull = true;
             return false;
         }
 
         this.isOutputsFull = false;
-        return recipe.matches(true, importInventory, importFluids);
+        if (recipe.matches(true, importInventory, importFluids)) {
+            this.metaTileEntity.addNotifiedInput(importInventory);
+            return true;
+        }
+        return false;
     }
 
     protected boolean hasEnoughPower(@Nonnull int[] resultOverclock) {

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -200,7 +200,8 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                     lastRecipeIndex = i;
                     return;
                 }
-            } else {
+            }
+            if (currentRecipe == null) {
                 invalidatedInputList.add(bus);
             }
         }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -112,9 +112,6 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
             if (distinctController.canBeDistinct() && distinctController.isDistinct()) {
                 boolean canWork = false;
-                if (!hasNotifiedInputs() && !hasNotifiedOutputs()) {
-                    return false;
-                }
                 if (invalidatedInputList.isEmpty()) {
                     return true;
                 }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -119,6 +119,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                     canWork = true;
                     invalidatedInputList.clear();
                     metaTileEntity.getNotifiedFluidInputList().clear();
+                    metaTileEntity.getNotifiedItemInputList().clear();
                 } else {
                     Iterator<IItemHandlerModifiable> iterator = metaTileEntity.getNotifiedItemInputList().iterator();
                     while (iterator.hasNext()) {

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -112,6 +112,9 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
             if (distinctController.canBeDistinct() && distinctController.isDistinct()) {
                 boolean canWork = false;
+                if (!hasNotifiedInputs() && !hasNotifiedOutputs()) {
+                    return false;
+                }
                 if (invalidatedInputList.isEmpty()) {
                     return true;
                 }
@@ -179,7 +182,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         if (checkPreviousRecipeDistinct(importInventory.get(lastRecipeIndex)) && checkRecipe(previousRecipe)) {
             currentRecipe = previousRecipe;
             currentDistinctInputBus = importInventory.get(lastRecipeIndex);
-            if(prepareRecipeDistinct(currentRecipe)) {
+            if (prepareRecipeDistinct(currentRecipe)) {
                 // No need to cache the previous recipe here, as it is not null and matched by the current recipe,
                 // so it will always be the same
                 return;
@@ -191,7 +194,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         for (int i = 0; i < importInventory.size(); i++) {
             IItemHandlerModifiable bus = importInventory.get(i);
             // Skip this bus if no recipe was found last time
-            if (invalidatedInputList.contains(bus) ) {
+            if (invalidatedInputList.contains(bus)) {
                 continue;
             }
             // Look for a new recipe after a cache miss
@@ -200,7 +203,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
             if (currentRecipe != null && checkRecipe(currentRecipe)) {
                 this.previousRecipe = currentRecipe;
                 currentDistinctInputBus = bus;
-                if(prepareRecipeDistinct(currentRecipe)) {
+                if (prepareRecipeDistinct(currentRecipe)) {
                     lastRecipeIndex = i;
                     return;
                 }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -110,7 +110,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
             RecipeMapMultiblockController distinctController = (RecipeMapMultiblockController) controller;
 
             if (distinctController.canBeDistinct() && distinctController.isDistinct()) {
-                if (invalidatedInputList.isEmpty()) return true;
+                if (invalidatedInputList.isEmpty() || !metaTileEntity.getNotifiedFluidInputList().isEmpty()) return true;
                 for (IItemHandlerModifiable bus : metaTileEntity.getNotifiedItemInputList()) {
                     if (invalidatedInputList.contains(bus)) {
                         return true;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -104,6 +104,25 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
+    protected boolean canWorkWithInputs() {
+        MultiblockWithDisplayBase controller = (MultiblockWithDisplayBase) metaTileEntity;
+        if (controller instanceof RecipeMapMultiblockController) {
+            RecipeMapMultiblockController distinctController = (RecipeMapMultiblockController) controller;
+
+            if (distinctController.canBeDistinct() && distinctController.isDistinct()) {
+                if (invalidatedInputList.isEmpty()) return true;
+                for (IItemHandlerModifiable bus : metaTileEntity.getNotifiedItemInputList()) {
+                    if (invalidatedInputList.contains(bus)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+        return super.canWorkWithInputs();
+    }
+
+    @Override
     protected void trySearchNewRecipe() {
         // do not run recipes when there are more than 5 maintenance problems
         // Maintenance can apply to all multiblocks, so cast to a base multiblock class

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -128,6 +128,9 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                     }
                     iterator.remove();
                 }
+                if (!invalidatedInputList.containsAll(getInputBuses())) {
+                    canWork = true;
+                }
                 return canWork;
             }
         }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -119,14 +119,15 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                     canWork = true;
                     invalidatedInputList.clear();
                     metaTileEntity.getNotifiedFluidInputList().clear();
-                }
-                Iterator<IItemHandlerModifiable> iterator = metaTileEntity.getNotifiedItemInputList().iterator();
-                while (iterator.hasNext()) {
-                    IItemHandlerModifiable bus = iterator.next();
-                    if (invalidatedInputList.remove(bus)) {
-                        canWork = true;
+                } else {
+                    Iterator<IItemHandlerModifiable> iterator = metaTileEntity.getNotifiedItemInputList().iterator();
+                    while (iterator.hasNext()) {
+                        IItemHandlerModifiable bus = iterator.next();
+                        if (invalidatedInputList.remove(bus)) {
+                            canWork = true;
+                        }
+                        iterator.remove();
                     }
-                    iterator.remove();
                 }
                 if (!invalidatedInputList.containsAll(getInputBuses())) {
                     canWork = true;
@@ -189,7 +190,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         // each bus individually instead of the combined inventory all at once.
         for (int i = 0; i < importInventory.size(); i++) {
             IItemHandlerModifiable bus = importInventory.get(i);
-            // Skip this bus if no recipe was found last time and the inventory did not change
+            // Skip this bus if no recipe was found last time
             if (invalidatedInputList.contains(bus) ) {
                 continue;
             }
@@ -205,6 +206,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                 }
             }
             if (currentRecipe == null) {
+                //no valid recipe found, invalidate this bus
                 invalidatedInputList.add(bus);
             }
         }

--- a/src/main/java/gregtech/api/capability/impl/NotifiableItemStackHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/NotifiableItemStackHandler.java
@@ -15,7 +15,9 @@ public class NotifiableItemStackHandler extends ItemStackHandler implements IIte
 
     public NotifiableItemStackHandler(int slots, MetaTileEntity entityToNotify, boolean isExport) {
         super(slots);
-        this.notifiableEntities.add(entityToNotify);
+        if (entityToNotify != null) {
+            this.notifiableEntities.add(entityToNotify);
+        }
         this.isExport = isExport;
     }
 
@@ -31,6 +33,7 @@ public class NotifiableItemStackHandler extends ItemStackHandler implements IIte
 
     @Override
     public void addNotifiableMetaTileEntity(MetaTileEntity metaTileEntity) {
+        if (metaTileEntity == null) return;
         this.notifiableEntities.add(metaTileEntity);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
@@ -77,7 +77,7 @@ public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEnt
         super.removeFromMultiBlock(controllerBase);
         List<INotifiableHandler> handlerList = getPartHandlers();
         for (INotifiableHandler handler : handlerList) {
-            handler.removeNotifiableMetaTileEntity(this);
+            handler.removeNotifiableMetaTileEntity(controllerBase);
         }
     }
 }

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -104,8 +104,6 @@ public class AbstractRecipeLogicTest {
         assertNotNull(arl.previousRecipe);
         assertTrue(arl.isActive);
         assertEquals(15, arl.getInputInventory().getStackInSlot(0).getCount());
-        //assert the consumption of the inputs did not mark the arl to look for a new recipe
-        assertFalse(arl.hasNotifiedInputs());
 
         // Save a reference to the old recipe so we can make sure it's getting reused
         Recipe prev = arl.previousRecipe;

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -509,6 +509,7 @@ public class MultiblockRecipeLogicTest {
         // Inputs change. did we detect it ?
         assertTrue(mbl.hasNotifiedInputs());
         assertTrue(mbl.getMetaTileEntity().getNotifiedItemInputList().contains(firstBus));
+        assertTrue(mbl.canWorkWithInputs());
         mbl.trySearchNewRecipe();
         assertFalse(mbl.invalidatedInputList.contains(firstBus));
         assertNotNull(mbl.previousRecipe);

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -13,10 +13,10 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.metatileentities.MetaTileEntities;
+import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityItemBus;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
-import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -244,8 +244,6 @@ public class MultiblockRecipeLogicTest {
         assertNotNull(mbl.previousRecipe);
         assertTrue(mbl.isActive);
         assertEquals(15, mbl.getInputInventory().getStackInSlot(0).getCount());
-        //assert the consumption of the inputs did not mark the arl to look for a new recipe
-        assertFalse(mbl.hasNotifiedInputs());
 
         // Save a reference to the old recipe so we can make sure it's getting reused
         Recipe prev = mbl.previousRecipe;
@@ -515,8 +513,6 @@ public class MultiblockRecipeLogicTest {
         assertNotNull(mbl.previousRecipe);
         assertTrue(mbl.isActive);
         assertEquals(15, firstBus.getStackInSlot(0).getCount());
-        //assert the consumption of the inputs did not mark the arl to look for a new recipe
-        assertFalse(mbl.hasNotifiedInputs());
 
         // Save a reference to the old recipe so we can make sure it's getting reused
         Recipe prev = mbl.previousRecipe;


### PR DESCRIPTION
**What:**
This is an attempt to fix a issue with multiblocks apparently stopping running recipes with ingredients enough for a recipe to run idling on their input busses

**Implementation Details:**
Made the forceRecipeRecheck in AbstractRecipeLogic also reset the previouly cached recipe
Fix busses not removing the previous controller object properly on multiblock invalidatio (memory leak)
Extra null checks to avoid null entries in the notifiables list

**Outcome:**
Hopefully fixes the issues reported. *crosses fingers,hands,arms and legs*