### PR TITLE
Auto add stone types to jei ore by product page

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/StoneType.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneType.java
@@ -5,6 +5,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.util.GTControlledRegistry;
 import gregtech.common.ConfigHolder;
+import gregtech.integration.jei.recipe.primitive.OreByProduct;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
@@ -45,6 +46,9 @@ public class StoneType implements Comparable<StoneType> {
         this.predicate = predicate::test;
         this.shouldBeDroppedAsItem = shouldBeDroppedAsItem || ConfigHolder.worldgen.allUniqueStoneTypes;
         STONE_TYPE_REGISTRY.register(id, name, this);
+        if (this.shouldBeDroppedAsItem) {
+            OreByProduct.addOreByProductPrefix(this.processingPrefix);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -11,7 +11,6 @@ import gregtech.api.unification.material.properties.OreProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.GTUtility;
-import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.MetaTileEntities;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -31,25 +30,12 @@ import java.util.List;
 
 public class OreByProduct implements IRecipeWrapper {
 
-    private static final ImmutableList<OrePrefix> ORES;
+    private static final List<OrePrefix> ORES = new ArrayList<>();
 
-    static {
-        List<OrePrefix> prefixes = new ArrayList<>();
-        prefixes.add(OrePrefix.ore);
-        prefixes.add(OrePrefix.oreNetherrack);
-        prefixes.add(OrePrefix.oreEndstone);
-        if (ConfigHolder.worldgen.allUniqueStoneTypes) {
-            prefixes.add(OrePrefix.oreGranite);
-            prefixes.add(OrePrefix.oreDiorite);
-            prefixes.add(OrePrefix.oreAndesite);
-            prefixes.add(OrePrefix.oreBasalt);
-            prefixes.add(OrePrefix.oreBlackgranite);
-            prefixes.add(OrePrefix.oreMarble);
-            prefixes.add(OrePrefix.oreRedgranite);
-            prefixes.add(OrePrefix.oreSand);
-            prefixes.add(OrePrefix.oreRedSand);
+    public static void addOreByProductPrefix(OrePrefix orePrefix) {
+        if (!ORES.contains(orePrefix)) {
+            ORES.add(orePrefix);
         }
-        ORES = ImmutableList.copyOf(prefixes);
     }
 
     private static final ImmutableList<OrePrefix> IN_PROCESSING_STEPS = ImmutableList.of(
@@ -296,7 +282,7 @@ public class OreByProduct implements IRecipeWrapper {
         ingredients.setInputLists(VanillaTypes.FLUID, fluidInputs);
         ingredients.setOutputLists(VanillaTypes.ITEM, outputs);
     }
-    
+
     public void addTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
         if (chances.containsKey(slotIndex)) {
             ChanceEntry entry = chances.get(slotIndex);


### PR DESCRIPTION
**What:**
Auto add stone type ore prefixes to JEI ore byproduct page

**Implementation Details:**
List is no longer immutable and stone types add their prefix in the constructor

**Outcome:**
Stone types added with devtech will no automatically show in jei

**Possible compatibility issue:**
Stupid people
