### PR TITLE
Print error when metaitem or material was not found

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/MetaItemBracketHandler.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/MetaItemBracketHandler.java
@@ -87,7 +87,11 @@ public class MetaItemBracketHandler implements IBracketHandler {
         if((item = metaBlockNames.get(name)) != null) {
             return new MCItemStack(item);
         }
-        return MetaTileEntityBracketHandler.getMetaTileEntityItem(name);
+        IItemStack iItemStack = MetaTileEntityBracketHandler.getMetaTileEntityItem(name);
+        if (iItemStack == null) {
+            CraftTweakerAPI.logError("Could not find meta item with name " + name);
+        }
+        return iItemStack;
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialBracketHandler.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialBracketHandler.java
@@ -27,7 +27,11 @@ public class MaterialBracketHandler implements IBracketHandler {
     }
 
     public static Material getMaterial(String name) {
-        return name == null ? null : GregTechAPI.MaterialRegistry.get(name);
+        Material material = name == null ? null : GregTechAPI.MaterialRegistry.get(name);
+        if (material == null) {
+            CraftTweakerAPI.logError("Could not find material with name " + name);
+        }
+        return material;
     }
 
     @Override


### PR DESCRIPTION
**What:**
When a material or meta item is not found with ct it prints the name to the ct log.

**Implementation Details:**
Nothing crazy

**Outcome:**
Users will save 12.6% of their debug time

**Additional info:**
Why was this not a thing?

**Possible compatibility issue:**
No
