### PR TITLE
Fix crash with Crafting Station when player dies

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -203,7 +203,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
     public void discardRecipeResolver(EntityPlayer entityPlayer) {
         this.listeners.remove(entityPlayer);
         if (listeners.isEmpty()) {
-            if (!getWorld().isRemote) {
+            if (!getWorld().isRemote && recipeLogic != null) {
                 itemsCrafted = recipeLogic.getItemsCraftedAmount();
                 this.markDirty();
             }


### PR DESCRIPTION
**What:**
Fixes a crash with the crafting station that occurs when a player dies with the crafting station open. Closes #929 

**Implementation Details:**
This is a bandaid fix for the issue, as we are not quite sure what is causing it. It is theorized that the close listener is being called twice, due to things like `ModularUIContainer#onContainerClosed()` which is not marked client only, or from something else. The close listener being called twice will make the recipelogic null, which will crash when trying to reference it on the server.

**Outcome:**
Fixes a crash with the crafting station when the player dies with the gui open and then respawns
