### PR TITLE
Item handling for tanks

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FilteredItemHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/FilteredItemHandler.java
@@ -1,0 +1,40 @@
+package gregtech.api.capability.impl;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.items.ItemStackHandler;
+
+import javax.annotation.Nonnull;
+import java.util.function.Predicate;
+
+public class FilteredItemHandler extends ItemStackHandler {
+
+    public static Predicate<ItemStack> getCapabilityFilter(Capability<?> cap) {
+        return stack -> stack.hasCapability(cap, null);
+    }
+
+    private Predicate<ItemStack> fillPredicate;
+
+    public FilteredItemHandler() {
+        super(1);
+    }
+
+    public FilteredItemHandler(int size) {
+        super(size);
+    }
+
+    public FilteredItemHandler(NonNullList<ItemStack> stacks) {
+        super(stacks);
+    }
+
+    public FilteredItemHandler setFillPredicate(Predicate<ItemStack> fillPredicate) {
+        this.fillPredicate = fillPredicate;
+        return this;
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+        return fillPredicate == null || fillPredicate.test(stack);
+    }
+}

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -19,8 +19,8 @@ import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.sound.GTSoundManager;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.sound.GTSoundManager;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
@@ -930,6 +930,38 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
             return true;
         }
         return false;
+    }
+
+    public void fillInternalTankFromFluidContainer() {
+        for (int i = 0; i < importItems.getSlots(); i++) {
+            ItemStack inputContainerStack = importItems.extractItem(i, 1, true);
+            FluidActionResult result = FluidUtil.tryEmptyContainer(inputContainerStack, importFluids, Integer.MAX_VALUE, null, false);
+            if (result.isSuccess()) {
+                ItemStack remainingItem = result.getResult();
+                if (ItemStack.areItemStacksEqual(inputContainerStack, remainingItem))
+                    continue; //do not fill if item stacks match
+                if (!remainingItem.isEmpty() && !GTTransferUtils.insertItem(exportItems, remainingItem, true).isEmpty())
+                    continue; //do not fill if can't put remaining item
+                FluidUtil.tryEmptyContainer(inputContainerStack, importFluids, Integer.MAX_VALUE, null, true);
+                importItems.extractItem(i, 1, false);
+                GTTransferUtils.insertItem(exportItems, remainingItem, false);
+            }
+        }
+    }
+
+    public void fillContainerFromInternalTank() {
+        for (int i = 0; i < importItems.getSlots(); i++) {
+            ItemStack emptyContainer = importItems.extractItem(i, 1, true);
+            FluidActionResult result = FluidUtil.tryFillContainer(emptyContainer, exportFluids, Integer.MAX_VALUE, null, false);
+            if (result.isSuccess()) {
+                ItemStack remainingItem = result.getResult();
+                if (!remainingItem.isEmpty() && !GTTransferUtils.insertItem(exportItems, remainingItem, true).isEmpty())
+                    continue;
+                FluidUtil.tryFillContainer(emptyContainer, exportFluids, Integer.MAX_VALUE, null, true);
+                importItems.extractItem(i, 1, false);
+                GTTransferUtils.insertItem(exportItems, remainingItem, false);
+            }
+        }
     }
 
     public void pushFluidsIntoNearbyHandlers(EnumFacing... allowedFaces) {

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -431,6 +431,9 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
     @Override
     public <T> T getCapability(Capability<T> capability, T defaultValue) {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            if (defaultValue == null) {
+                return null;
+            }
             IItemHandler delegate = (IItemHandler) defaultValue;
             if (itemHandlerWrapper == null || itemHandlerWrapper.delegate != delegate) {
                 this.itemHandlerWrapper = new CoverableItemHandlerWrapper(delegate);

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -297,6 +297,9 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
     @Override
     public <T> T getCapability(Capability<T> capability, T defaultValue) {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+            if (defaultValue == null) {
+                return null;
+            }
             IFluidHandler delegate = (IFluidHandler) defaultValue;
             if (fluidHandlerWrapper == null || fluidHandlerWrapper.delegate != delegate) {
                 this.fluidHandlerWrapper = new CoverableFluidHandlerWrapper(delegate);

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -17,8 +17,8 @@ import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
+import gregtech.client.renderer.texture.Textures;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
@@ -267,7 +267,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
             return;
         }
         pushFluidsIntoNearbyHandlers(getFrontFacing());
-        fillContainerFromInternalTank(importItems, exportItems, 0, 0);
+        fillContainerFromInternalTank();
 
         //do not do anything without enough energy supplied
         if (energyContainer.getEnergyStored() < GTValues.V[getTier()] * 2) {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.multi;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.capability.impl.FilteredItemHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -17,15 +18,16 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
+import gregtech.common.metatileentities.storage.MetaTileEntityQuantumTank;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
@@ -36,12 +38,10 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
 
     private static final int FLUID_TANK_SIZE = 1000;
     private final FluidTank waterTank;
-    private final ItemStackHandler containerInventory;
 
     public MetaTileEntityPumpHatch(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, 0);
         this.waterTank = new FluidTank(FLUID_TANK_SIZE);
-        this.containerInventory = new ItemStackHandler(2);
         initializeInventory();
     }
 
@@ -51,22 +51,11 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        super.writeToNBT(data);
-        data.setTag("ContainerInventory", containerInventory.serializeNBT());
-        return data;
-    }
-
-    @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
-        this.containerInventory.deserializeNBT(data.getCompoundTag("ContainerInventory"));
-    }
-
-    @Override
-    public void clearMachineInventory(NonNullList<ItemStack> itemBuffer) {
-        super.clearMachineInventory(itemBuffer);
-        clearInventory(itemBuffer, containerInventory);
+        if (data.hasKey("ContainerInventory")) {
+            MetaTileEntityQuantumTank.legacyTankItemHandlerNBTReading(this, data.getCompoundTag("ContainerInventory"), 0, 1);
+        }
     }
 
     @Override
@@ -74,7 +63,7 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
         super.update();
         if (!getWorld().isRemote) {
             pushFluidsIntoNearbyHandlers(getFrontFacing());
-            fillContainerFromInternalTank(containerInventory, containerInventory, 0, 1);
+            fillContainerFromInternalTank();
         }
     }
 
@@ -96,6 +85,16 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
+    protected IItemHandlerModifiable createImportItemHandler() {
+        return new FilteredItemHandler(1).setFillPredicate(FilteredItemHandler.getCapabilityFilter(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY));
+    }
+
+    @Override
+    protected IItemHandlerModifiable createExportItemHandler() {
+        return new ItemStackHandler(1);
+    }
+
+    @Override
     public MultiblockAbility<IFluidTank> getAbility() {
         return MultiblockAbility.PUMP_FLUID_HATCH;
     }
@@ -112,11 +111,11 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
-        return createTankUI(waterTank, containerInventory, getMetaFullName(), entityPlayer)
+        return createTankUI(waterTank, getMetaFullName(), entityPlayer)
                 .build(getHolder(), entityPlayer);
     }
 
-    public ModularUI.Builder createTankUI(IFluidTank fluidTank, IItemHandlerModifiable containerInventory, String title, EntityPlayer entityPlayer) {
+    public ModularUI.Builder createTankUI(IFluidTank fluidTank, String title, EntityPlayer entityPlayer) {
         ModularUI.Builder builder = ModularUI.defaultBuilder();
         builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
         TankWidget tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
@@ -126,10 +125,10 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
         builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
         builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
         return builder.label(6, 6, title)
-                .widget(new FluidContainerSlotWidget(containerInventory, 0, 90, 17, false)
+                .widget(new FluidContainerSlotWidget(importItems, 0, 90, 17, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))
                 .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
-                .widget(new SlotWidget(containerInventory, 1, 90, 54, true, false)
+                .widget(new SlotWidget(exportItems, 0, 90, 54, true, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY))
                 .bindPlayerInventory(entityPlayer.inventory);
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -3,7 +3,9 @@ package gregtech.common.metatileentities.multi.multiblockpart;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.capability.impl.FilteredItemHandler;
 import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.capability.impl.NotifiableFluidTank;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
@@ -15,18 +17,18 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
 import gregtech.client.renderer.texture.Textures;
-import gregtech.api.capability.impl.NotifiableFluidTank;
+import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
+import gregtech.common.metatileentities.storage.MetaTileEntityQuantumTank;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
@@ -36,12 +38,10 @@ import java.util.List;
 public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank> {
 
     private static final int INITIAL_INVENTORY_SIZE = 8000;
-    private final ItemStackHandler containerInventory;
     private final FluidTank fluidTank;
 
     public MetaTileEntityFluidHatch(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {
         super(metaTileEntityId, tier, isExportHatch);
-        this.containerInventory = new ItemStackHandler(2);
         this.fluidTank = new NotifiableFluidTank(getInventorySize(), this, isExportHatch);
         initializeInventory();
     }
@@ -54,33 +54,26 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
-        data.setTag("ContainerInventory", containerInventory.serializeNBT());
-        //fluidTank.writeToNBT(data);
         return data;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
-        containerInventory.deserializeNBT(data.getCompoundTag("ContainerInventory"));
-        //fluidTank.readFromNBT(data);
-    }
-
-    @Override
-    public void clearMachineInventory(NonNullList<ItemStack> itemBuffer) {
-        super.clearMachineInventory(itemBuffer);
-        clearInventory(itemBuffer, containerInventory);
+        if (data.hasKey("ContainerInventory")) {
+            MetaTileEntityQuantumTank.legacyTankItemHandlerNBTReading(this, data.getCompoundTag("ContainerInventory"), 0, 1);
+        }
     }
 
     @Override
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
-            fillContainerFromInternalTank(containerInventory, containerInventory, 0, 1);
+            fillContainerFromInternalTank();
             if (isExportHatch) {
                 pushFluidsIntoNearbyHandlers(getFrontFacing());
             } else {
-                fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
+                fillInternalTankFromFluidContainer();
                 pullFluidsFromNearbyHandlers(getFrontFacing());
             }
         }
@@ -112,6 +105,16 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     }
 
     @Override
+    protected IItemHandlerModifiable createImportItemHandler() {
+        return new FilteredItemHandler(1).setFillPredicate(FilteredItemHandler.getCapabilityFilter(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY));
+    }
+
+    @Override
+    protected IItemHandlerModifiable createExportItemHandler() {
+        return new ItemStackHandler(1);
+    }
+
+    @Override
     public MultiblockAbility<IFluidTank> getAbility() {
         return isExportHatch ? MultiblockAbility.EXPORT_FLUIDS : MultiblockAbility.IMPORT_FLUIDS;
     }
@@ -123,11 +126,11 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
-        return createTankUI((isExportHatch ? exportFluids : importFluids).getTankAt(0), containerInventory, getMetaFullName(), entityPlayer)
+        return createTankUI((isExportHatch ? exportFluids : importFluids).getTankAt(0), getMetaFullName(), entityPlayer)
                 .build(getHolder(), entityPlayer);
     }
 
-    public ModularUI.Builder createTankUI(IFluidTank fluidTank, IItemHandlerModifiable containerInventory, String title, EntityPlayer entityPlayer) {
+    public ModularUI.Builder createTankUI(IFluidTank fluidTank, String title, EntityPlayer entityPlayer) {
         Builder builder = ModularUI.defaultBuilder();
         builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
         TankWidget tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
@@ -137,10 +140,10 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
         builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
         return builder.label(6, 6, title)
-                .widget(new FluidContainerSlotWidget(containerInventory, 0, 90, 16, false)
+                .widget(new FluidContainerSlotWidget(importItems, 0, 90, 16, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))
                 .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
-                .widget(new SlotWidget(containerInventory, 1, 90, 53, true, false)
+                .widget(new SlotWidget(exportItems, 0, 90, 53, true, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY))
                 .bindPlayerInventory(entityPlayer.inventory);
     }


### PR DESCRIPTION
Exposes item handler capability for Super/Quantum tank, (Steam) Fluid Input/Output Hatch and Pump Hatch.
It uses the import and export handlers from `MetaTileEntity`.

Superseeds #827 
