### PR TITLE
Fix crash with devtech

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -34,6 +34,7 @@ import gregtech.common.covers.filter.FilterTypeRegistry;
 import gregtech.common.items.MetaItems;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.worldgen.LootTableHelper;
+import gregtech.integration.jei.recipe.primitive.OreByProduct;
 import gregtech.integration.theoneprobe.TheOneProbeCompatibility;
 import gregtech.loaders.dungeon.DungeonLootLoader;
 import net.minecraft.world.World;
@@ -130,6 +131,7 @@ public class GregTechMod {
 
         proxy.onPreLoad();
         KeyBind.init();
+        OreByProduct.init();
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -46,16 +46,20 @@ public class OreByProduct implements IRecipeWrapper {
             OrePrefix.crushedCentrifuged
     );
 
-    private static final ImmutableList<ItemStack> ALWAYS_MACHINES = ImmutableList.of(
-            MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-            MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-            MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm(),
-            MetaTileEntities.ORE_WASHER[GTValues.LV].getStackForm(),
-            MetaTileEntities.THERMAL_CENTRIFUGE[GTValues.LV].getStackForm(),
-            MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-            MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-            MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm()
-    );
+    private static ImmutableList<ItemStack> ALWAYS_MACHINES;
+
+    public static void init() {
+        ALWAYS_MACHINES = ImmutableList.of(
+                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm(),
+                MetaTileEntities.ORE_WASHER[GTValues.LV].getStackForm(),
+                MetaTileEntities.THERMAL_CENTRIFUGE[GTValues.LV].getStackForm(),
+                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm()
+        );
+    }
 
     private final Int2ObjectMap<ChanceEntry> chances = new Int2ObjectOpenHashMap<>();
     private final List<List<ItemStack>> inputs = new ArrayList<>();


### PR DESCRIPTION
This is because the OreByProduct class is initialised earlier and it accesses mtes which are null at the time of initialisation.
This manually inits the list of mtes