### PR TITLE
Fixes for 2.2.3

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -131,7 +131,6 @@ public class GregTechMod {
 
         proxy.onPreLoad();
         KeyBind.init();
-        OreByProduct.init();
     }
 
     @Mod.EventHandler

--- a/src/main/java/gregtech/api/pipenet/PipeNetWalker.java
+++ b/src/main/java/gregtech/api/pipenet/PipeNetWalker.java
@@ -147,7 +147,7 @@ public abstract class PipeNetWalker {
         if (pipeTile == null) {
             if (walkedBlocks == 1) {
                 // if it is the first block, it wasn't already checked
-                GTLog.logger.warn("First PipeTile is null during walk");
+                GTLog.logger.error("First PipeTile is null during walk at {}", currentPos);
                 this.failed = true;
                 return;
             } else

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -297,11 +297,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
         EnumFacing coverSide = ICoverable.traceCoverSide(hit);
         if (coverSide == null) {
-            if (pipeTile.getFrameMaterial() != null) {
-                BlockFrame blockFrame = MetaBlocks.FRAMES.get(pipeTile.getFrameMaterial());
-                return blockFrame.onBlockActivated(world, pos, state, entityPlayer, hand, hit.sideHit, (float) hit.hitVec.x, (float) hit.hitVec.y, (float) hit.hitVec.z);
-            }
-            return false;
+            return activateFrame(world, state, pos, entityPlayer, hand, hit, pipeTile);
         }
 
         if (!(hit.cuboid6.data instanceof CoverSideData)) {
@@ -315,11 +311,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
         CoverBehavior coverBehavior = pipeTile.getCoverableImplementation().getCoverAtSide(coverSide);
         if (coverBehavior == null) {
-            if (pipeTile.getFrameMaterial() != null) {
-                BlockFrame blockFrame = MetaBlocks.FRAMES.get(pipeTile.getFrameMaterial());
-                return blockFrame.onBlockActivated(world, pos, state, entityPlayer, hand, hit.sideHit, (float) hit.hitVec.x, (float) hit.hitVec.y, (float) hit.hitVec.z);
-            }
-            return false;
+            return activateFrame(world, state, pos, entityPlayer, hand, hit, pipeTile);
         }
 
         IScrewdriverItem screwdriver = itemStack.getCapability(GregtechCapabilities.CAPABILITY_SCREWDRIVER, null);
@@ -335,13 +327,20 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
         EnumActionResult result = coverBehavior.onRightClick(entityPlayer, hand, hit);
         if (result == EnumActionResult.PASS) {
-            if (pipeTile.getFrameMaterial() != null) {
-                BlockFrame blockFrame = MetaBlocks.FRAMES.get(pipeTile.getFrameMaterial());
-                return blockFrame.onBlockActivated(world, pos, state, entityPlayer, hand, hit.sideHit, (float) hit.hitVec.x, (float) hit.hitVec.y, (float) hit.hitVec.z);
+            if (activateFrame(world, state, pos, entityPlayer, hand, hit, pipeTile)) {
+                return true;
             }
             return entityPlayer.isSneaking() && entityPlayer.getHeldItemMainhand().isEmpty() && coverBehavior.onScrewdriverClick(entityPlayer, hand, hit) != EnumActionResult.PASS;
         }
         return true;
+    }
+
+    private boolean activateFrame(World world, IBlockState state, BlockPos pos, EntityPlayer entityPlayer, EnumHand hand, CuboidRayTraceResult hit, IPipeTile<PipeType, NodeDataType> pipeTile) {
+        if (pipeTile.getFrameMaterial() != null && !(entityPlayer.getHeldItem(hand).getItem() instanceof ItemBlockPipe)) {
+            BlockFrame blockFrame = MetaBlocks.FRAMES.get(pipeTile.getFrameMaterial());
+            return blockFrame.onBlockActivated(world, pos, state, entityPlayer, hand, hit.sideHit, (float) hit.hitVec.x, (float) hit.hitVec.y, (float) hit.hitVec.z);
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -89,6 +89,7 @@ public class Material implements Comparable<Material> {
         return this;
     }
 
+    @ZenGetter("components")
     public ImmutableList<MaterialStack> getMaterialComponents() {
         return materialInfo.componentList;
     }

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProduct.java
@@ -48,19 +48,6 @@ public class OreByProduct implements IRecipeWrapper {
 
     private static ImmutableList<ItemStack> ALWAYS_MACHINES;
 
-    public static void init() {
-        ALWAYS_MACHINES = ImmutableList.of(
-                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-                MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm(),
-                MetaTileEntities.ORE_WASHER[GTValues.LV].getStackForm(),
-                MetaTileEntities.THERMAL_CENTRIFUGE[GTValues.LV].getStackForm(),
-                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-                MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
-                MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm()
-        );
-    }
-
     private final Int2ObjectMap<ChanceEntry> chances = new Int2ObjectOpenHashMap<>();
     private final List<List<ItemStack>> inputs = new ArrayList<>();
     private final List<List<ItemStack>> outputs = new ArrayList<>();
@@ -72,6 +59,18 @@ public class OreByProduct implements IRecipeWrapper {
     private int currentSlot;
 
     public OreByProduct(Material material) {
+        if (ALWAYS_MACHINES == null) {
+            ALWAYS_MACHINES = ImmutableList.of(
+                    MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                    MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                    MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm(),
+                    MetaTileEntities.ORE_WASHER[GTValues.LV].getStackForm(),
+                    MetaTileEntities.THERMAL_CENTRIFUGE[GTValues.LV].getStackForm(),
+                    MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                    MetaTileEntities.MACERATOR[GTValues.LV].getStackForm(),
+                    MetaTileEntities.CENTRIFUGE[GTValues.LV].getStackForm()
+            );
+        }
         OreProperty property = material.getProperty(PropertyKey.ORE);
         int oreMultiplier = property.getOreMultiplier();
         int byproductMultiplier = property.getByProductMultiplier();


### PR DESCRIPTION
- fixes machines not appearing in the jei ore byproduct page
- fixes crash when clicking with a pipe on a framed pipe
- adds a pos to the pipe error log
- exposes material components to ct