### PR TITLE
Fix Problems with FluidStats

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java
@@ -1,0 +1,38 @@
+package gregtech.api.capability.impl;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
+
+import javax.annotation.Nonnull;
+
+public class GTFluidHandlerItemStack extends FluidHandlerItemStack {
+
+    /**
+     * @param container The container itemStack, data is stored on it directly as NBT.
+     * @param capacity  The maximum capacity of this fluid tank.
+     */
+    public GTFluidHandlerItemStack(@Nonnull ItemStack container, int capacity) {
+        super(container, capacity);
+    }
+
+    @Override
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        FluidStack drained = super.drain(resource, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    @Override
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        FluidStack drained = super.drain(maxDrain, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    private void removeTagWhenEmpty(Boolean doDrain) {
+        if (doDrain && this.getFluid() == null) {
+            this.container.setTagCompound(null);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/capability/impl/GTSimpleFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/GTSimpleFluidHandlerItemStack.java
@@ -1,0 +1,38 @@
+package gregtech.api.capability.impl;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStackSimple;
+
+import javax.annotation.Nonnull;
+
+public class GTSimpleFluidHandlerItemStack extends FluidHandlerItemStackSimple {
+
+    /**
+     * @param container The container itemStack, data is stored on it directly as NBT.
+     * @param capacity  The maximum capacity of this fluid tank.
+     */
+    public GTSimpleFluidHandlerItemStack(@Nonnull ItemStack container, int capacity) {
+        super(container, capacity);
+    }
+
+    @Override
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        FluidStack drained = super.drain(resource, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    @Override
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        FluidStack drained = super.drain(maxDrain, doDrain);
+        this.removeTagWhenEmpty(doDrain);
+        return drained;
+    }
+
+    private void removeTagWhenEmpty(Boolean doDrain) {
+        if (doDrain && this.getFluid() == null) {
+            this.container.setTagCompound(null);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/capability/impl/SimpleThermalFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/SimpleThermalFluidHandlerItemStack.java
@@ -3,11 +3,10 @@ package gregtech.api.capability.impl;
 import gregtech.api.capability.IThermalFluidHandlerItemStack;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStackSimple;
 
 import javax.annotation.Nonnull;
 
-public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStackSimple implements IThermalFluidHandlerItemStack {
+public class SimpleThermalFluidHandlerItemStack extends GTSimpleFluidHandlerItemStack implements IThermalFluidHandlerItemStack {
 
     public final int maxFluidTemperature;
     private final boolean gasProof;
@@ -26,6 +25,11 @@ public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStackSim
         this.acidProof = acidProof;
         this.cryoProof = cryoProof;
         this.plasmaProof = plasmaProof;
+    }
+
+    @Override
+    public boolean canFillFluidType(FluidStack fluid) {
+        return IThermalFluidHandlerItemStack.super.canFillFluidType(fluid);
     }
 
     @Override
@@ -51,25 +55,5 @@ public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStackSim
     @Override
     public boolean isPlasmaProof() {
         return plasmaProof;
-    }
-
-    @Override
-    public FluidStack drain(FluidStack resource, boolean doDrain) {
-        FluidStack drained = super.drain(resource, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    @Override
-    public FluidStack drain(int maxDrain, boolean doDrain) {
-        FluidStack drained = super.drain(maxDrain, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(Boolean doDrain) {
-        if (doDrain && this.getFluid() == null) {
-            this.container.setTagCompound(null);
-        }
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/ThermalFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/ThermalFluidHandlerItemStack.java
@@ -3,11 +3,10 @@ package gregtech.api.capability.impl;
 import gregtech.api.capability.IThermalFluidHandlerItemStack;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
 
 import javax.annotation.Nonnull;
 
-public class ThermalFluidHandlerItemStack extends FluidHandlerItemStack implements IThermalFluidHandlerItemStack {
+public class ThermalFluidHandlerItemStack extends GTFluidHandlerItemStack implements IThermalFluidHandlerItemStack {
 
     private final int maxFluidTemperature;
     private final boolean gasProof;
@@ -29,23 +28,8 @@ public class ThermalFluidHandlerItemStack extends FluidHandlerItemStack implemen
     }
 
     @Override
-    public FluidStack drain(FluidStack resource, boolean doDrain) {
-        FluidStack drained = super.drain(resource, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    @Override
-    public FluidStack drain(int maxDrain, boolean doDrain) {
-        FluidStack drained = super.drain(maxDrain, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(Boolean doDrain) {
-        if (doDrain && this.getFluid() == null) {
-            this.container.setTagCompound(null);
-        }
+    public boolean canFillFluidType(FluidStack fluid) {
+        return IThermalFluidHandlerItemStack.super.canFillFluidType(fluid);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/metaitem/FilteredFluidStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/FilteredFluidStats.java
@@ -1,7 +1,7 @@
 package gregtech.api.items.metaitem;
 
-import gregtech.api.capability.impl.SimpleThermalFluidHandlerItemStack;
-import gregtech.api.capability.impl.ThermalFluidHandlerItemStack;
+import gregtech.api.capability.impl.GTFluidHandlerItemStack;
+import gregtech.api.capability.impl.GTSimpleFluidHandlerItemStack;
 import gregtech.api.items.metaitem.stats.IItemCapabilityProvider;
 import gregtech.api.items.metaitem.stats.IItemComponent;
 import net.minecraft.item.ItemStack;
@@ -25,14 +25,14 @@ public class FilteredFluidStats implements IItemComponent, IItemCapabilityProvid
     @Override
     public ICapabilityProvider createProvider(ItemStack itemStack) {
         if (allowPartialFill) {
-            return new ThermalFluidHandlerItemStack(itemStack, capacity, Integer.MAX_VALUE, true, true, true, true) {
+            return new GTFluidHandlerItemStack(itemStack, capacity) {
                 @Override
                 public boolean canFillFluidType(FluidStack fluid) {
                     return super.canFillFluidType(fluid) && fillPredicate.apply(fluid);
                 }
             };
         }
-        return new SimpleThermalFluidHandlerItemStack(itemStack, capacity, Integer.MAX_VALUE, true, true, true, true) {
+        return new GTSimpleFluidHandlerItemStack(itemStack, capacity) {
             @Override
             public boolean canFillFluidType(FluidStack fluid) {
                 return super.canFillFluidType(fluid) && fillPredicate.apply(fluid);

--- a/src/main/java/gregtech/api/items/metaitem/ThermalFluidStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/ThermalFluidStats.java
@@ -7,7 +7,7 @@ import gregtech.api.items.metaitem.stats.IItemComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
-public class FluidStats implements IItemComponent, IItemCapabilityProvider {
+public class ThermalFluidStats implements IItemComponent, IItemCapabilityProvider {
 
     public final int capacity;
     public final int maxFluidTemperature;
@@ -17,7 +17,7 @@ public class FluidStats implements IItemComponent, IItemCapabilityProvider {
     private final boolean plasmaProof;
     public final boolean allowPartialFill;
 
-    public FluidStats(int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof, boolean allowPartialFill) {
+    public ThermalFluidStats(int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof, boolean allowPartialFill) {
         this.capacity = capacity;
         this.maxFluidTemperature = maxFluidTemperature;
         this.gasProof = gasProof;

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -120,33 +120,33 @@ public class MetaItem1 extends StandardMetaItem {
         }
 
         // Fluid Cells: ID 78-88
-        FLUID_CELL = addItem(78, "fluid_cell").addComponents(new FluidStats(1000, 1800, true, false, false, false, false));
+        FLUID_CELL = addItem(78, "fluid_cell").addComponents(new ThermalFluidStats(1000, 1800, true, false, false, false, false));
 
-        FLUID_CELL_UNIVERSAL = addItem(79, "fluid_cell.universal").addComponents(new FluidStats(1000, 1800, true, false, false, false, false));
+        FLUID_CELL_UNIVERSAL = addItem(79, "fluid_cell.universal").addComponents(new ThermalFluidStats(1000, 1800, true, false, false, false, true));
 
         FLUID_CELL_LARGE_STEEL = addItem(80, "large_fluid_cell.steel")
-                .addComponents(new FluidStats(8000, Materials.Steel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(8000, Materials.Steel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4))); // ingot * 4
 
         FLUID_CELL_LARGE_ALUMINIUM = addItem(81, "large_fluid_cell.aluminium")
-                .addComponents(new FluidStats(32000, Materials.Aluminium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(32000, Materials.Aluminium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Aluminium, M * 4))); // ingot * 4
 
         FLUID_CELL_LARGE_STAINLESS_STEEL = addItem(82, "large_fluid_cell.stainless_steel")
-                .addComponents(new FluidStats(64000, Materials.StainlessSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, true, true, false, true))
+                .addComponents(new ThermalFluidStats(64000, Materials.StainlessSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, true, true, false, true))
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, M * 6))); // ingot * 6
 
         FLUID_CELL_LARGE_TITANIUM = addItem(83, "large_fluid_cell.titanium")
-                .addComponents(new FluidStats(128000, Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(128000, Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Titanium, M * 6))); // ingot * 6
 
         FLUID_CELL_LARGE_TUNGSTEN_STEEL = addItem(84, "large_fluid_cell.tungstensteel")
-                .addComponents(new FluidStats(512000, Materials.TungstenSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(512000, Materials.TungstenSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
                 .setMaxStackSize(32)
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.TungstenSteel, M * 8))); // ingot * 8
 
         FLUID_CELL_GLASS_VIAL = addItem(85, "fluid_cell.glass_vial")
-                .addComponents(new FluidStats(1000, 1200, false, true, false, false, true))
+                .addComponents(new ThermalFluidStats(1000, 1200, false, true, false, false, true))
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 4))); // small dust
 
         // Limited-Use Items: ID 89-95
@@ -158,14 +158,12 @@ public class MetaItem1 extends StandardMetaItem {
         TOOL_LIGHTER_INVAR = addItem(91, "tool.lighter.invar")
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Invar, M * 2)))
                 .addComponents(new LighterBehaviour(new ResourceLocation(GTValues.MODID, "lighter_open"), true, true, true))
-                .addComponents(new FilteredFluidStats(100, true,
-                        fs -> fs.getFluid().equals(Materials.Butane.getFluid()) || fs.getFluid().equals(Materials.Propane.getFluid())))
+                .addComponents(new FilteredFluidStats(100, true, fs -> fs.getFluid().equals(Materials.Butane.getFluid()) || fs.getFluid().equals(Materials.Propane.getFluid())))
                 .setMaxStackSize(1);
         TOOL_LIGHTER_PLATINUM = addItem(92, "tool.lighter.platinum")
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Platinum, M * 2)))
                 .addComponents(new LighterBehaviour(new ResourceLocation(GTValues.MODID, "lighter_open"), true, true, true))
-                .addComponents(new FilteredFluidStats(1000, true,
-                        fs -> fs.getFluid().equals(Materials.Butane.getFluid()) || fs.getFluid().equals(Materials.Propane.getFluid())))
+                .addComponents(new FilteredFluidStats(1000, true, fs -> fs.getFluid().equals(Materials.Butane.getFluid()) || fs.getFluid().equals(Materials.Propane.getFluid())))
                 .setMaxStackSize(1)
                 .setRarity(EnumRarity.UNCOMMON);
 


### PR DESCRIPTION
**What:**
This PR fixes problems with fluid stats. Filtered Fluid Stats are no longer forced to use Thermal Fluid Handlers, which fixes the  tooltips appearing on the lights. This closes #945. 

Additionally, this PR fixes the filtering of fluid cells and other FluidStats items not always applying, due to conflicting overrides with the `IThermalFluidHandlerItemStack` interface.


**Outcome:**
Fixes item fluid container filtering and lighter tooltips.
