### PR TITLE
Fix Missing Texture Running Particle on Multiplayer

### DIFF
--- a/src/main/java/gregtech/api/block/BlockCustomParticle.java
+++ b/src/main/java/gregtech/api/block/BlockCustomParticle.java
@@ -2,8 +2,8 @@ package gregtech.api.block;
 
 import codechicken.lib.vec.Vector3;
 import gregtech.api.net.NetworkHandler;
-import gregtech.api.net.packets.SPacketBlockParticle;
 import gregtech.api.net.NetworkUtils;
+import gregtech.api.net.packets.SPacketBlockParticle;
 import gregtech.api.util.ParticleHandlerUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.MapColor;
@@ -60,7 +60,6 @@ public abstract class BlockCustomParticle extends Block implements ICustomPartic
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public boolean addRunningEffects(@Nonnull IBlockState state, World world, @Nonnull BlockPos pos, @Nonnull Entity entity) {
         if (world.isRemote) {
             Pair<TextureAtlasSprite, Integer> atlasSprite = getParticleTexture(world, pos);


### PR DESCRIPTION
**What:**
This PR fixes the missing texture running particle which appeared on cables among other blocks on multiplayer.

**Implementation Details:**
This PR resolves this issue by removing the Client Side Only annotation on `BlockCustomParticle`'s `addRunningEffects()` method, which is not present in the `Block` superclass.

**Outcome:**
Fixed missing texture running particle on multiplayer. Closes #940.
