### PR TITLE
Fix Transparent Blocks Using Wrong Render Layers

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
@@ -38,7 +38,7 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
     @Override
     @Nonnull
     public BlockRenderLayer getRenderLayer() {
-        return BlockRenderLayer.TRANSLUCENT;
+        return BlockRenderLayer.CUTOUT;
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/blockstates/transparent_casing.json
+++ b/src/main/resources/assets/gregtech/blockstates/transparent_casing.json
@@ -3,24 +3,28 @@
   "variants": {
     "active=false,variant=tempered_glass": {
       "model": "minecraft:cube_all",
+      "ambientocclusion": false,
       "textures": {
         "all": "gregtech:blocks/casings/transparent/tempered_glass"
       }
     },
     "active=true,variant=tempered_glass": {
       "model": "minecraft:cube_all",
+      "ambientocclusion": false,
       "textures": {
         "all": "gregtech:blocks/casings/transparent/tempered_glass"
       }
     },
     "active=false,variant=laminated_glass": {
       "model": "minecraft:cube_all",
+      "ambientocclusion": false,
       "textures": {
         "all": "gregtech:blocks/casings/transparent/laminated_glass"
       }
     },
     "active=true,variant=laminated_glass": {
       "model": "minecraft:cube_all",
+      "ambientocclusion": false,
       "textures": {
         "all": "gregtech:blocks/casings/transparent/laminated_glass"
       }

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/transparent/fusion_glass.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/transparent/fusion_glass.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "TRANSLUCENT",
+        "layer": "CUTOUT",
         "textures": [
             "gregtech:blocks/casings/transparent/fusion_glass_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/transparent/laminated_glass.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/transparent/laminated_glass.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "TRANSLUCENT",
+        "layer": "CUTOUT",
         "textures": [
             "gregtech:blocks/casings/transparent/laminated_glass_ctm"
         ],


### PR DESCRIPTION
**What:**
This PR fixes some transparent blocks using the wrong render layers. Blocks that are completely clear like Fusion Glass use the `CUTOUT` render layer, and blocks with semi-transparency like Tempered Glass use `TRANSLUCENT`. This should also improve the performance of the glasses which do not use translucent.

It also fixes the fusion ring's rendering over the edges of the glass.

**Outcome:**
Fixed render layers of transparent blocks
