### PR TITLE
Fix three armor related bugs

### DIFF
--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -10,9 +10,11 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.VirtualTankRegistry;
 import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinSaveData;
 import gregtech.common.items.MetaItems;
+import gregtech.common.items.armor.IStepAssist;
 import gregtech.common.items.behaviors.ToggleEnergyConsumerBehavior;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
 import gregtech.common.tools.ToolUtility;
+import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityEnderman;
@@ -28,6 +30,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.EnumDifficulty;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.living.EnderTeleportEvent;
 import net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
@@ -43,12 +46,16 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 @Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class EventHandlers {
 
     private static final String HAS_TERMINAL = GTValues.MODID + ".terminal";
+    private static ItemStack lastFeetEquip = ItemStack.EMPTY;
 
     @SubscribeEvent
     public static void onEndermanTeleportEvent(EnderTeleportEvent event) {
@@ -162,11 +169,12 @@ public class EventHandlers {
 
     @SubscribeEvent
     public static void onLivingEquipmentChangeEvent(LivingEquipmentChangeEvent event) {
-        if (event.getFrom().isEmpty())
+        EntityEquipmentSlot slot = event.getSlot();
+        if (event.getFrom().isEmpty() || slot == EntityEquipmentSlot.MAINHAND || slot==EntityEquipmentSlot.OFFHAND)
             return;
 
         ItemStack stack = event.getFrom();
-        if (!(stack.getItem() instanceof ArmorMetaItem))
+        if (!(stack.getItem() instanceof ArmorMetaItem) || stack.getItem().equals(event.getTo().getItem()))
             return;
 
         ArmorMetaItem<?> armorMetaItem = (ArmorMetaItem<?>) stack.getItem();
@@ -179,7 +187,23 @@ public class EventHandlers {
                 armorMetaItem.getItem(stack).isItemEqual(MetaItems.QUANTUM_CHESTPLATE_ADVANCED.getStackForm())) {
             event.getEntity().isImmuneToFire = false;
         }
+    }
 
+    @SubscribeEvent
+    @SideOnly(Side.CLIENT)
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase == TickEvent.Phase.START && !event.player.isSpectator() && !(event.player instanceof EntityOtherPlayerMP) && !(event.player instanceof FakePlayer)) {
+            ItemStack feetEquip = event.player.getItemStackFromSlot(EntityEquipmentSlot.FEET);
+            if(lastFeetEquip.getItem().equals(feetEquip.getItem())){
+                return;
+            }
+            else{
+                if ((lastFeetEquip.getItem() instanceof ArmorMetaItem<?>) && ((ArmorMetaItem<?>) lastFeetEquip.getItem()).getItem(lastFeetEquip).getArmorLogic() instanceof IStepAssist)
+                    event.player.stepHeight = 0.6f;
+
+                lastFeetEquip = feetEquip.copy();
+            }
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -170,7 +170,7 @@ public class EventHandlers {
     @SubscribeEvent
     public static void onLivingEquipmentChangeEvent(LivingEquipmentChangeEvent event) {
         EntityEquipmentSlot slot = event.getSlot();
-        if (event.getFrom().isEmpty() || slot == EntityEquipmentSlot.MAINHAND || slot==EntityEquipmentSlot.OFFHAND)
+        if (event.getFrom().isEmpty() || slot == EntityEquipmentSlot.MAINHAND || slot == EntityEquipmentSlot.OFFHAND)
             return;
 
         ItemStack stack = event.getFrom();
@@ -194,10 +194,9 @@ public class EventHandlers {
     public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
         if (event.phase == TickEvent.Phase.START && !event.player.isSpectator() && !(event.player instanceof EntityOtherPlayerMP) && !(event.player instanceof FakePlayer)) {
             ItemStack feetEquip = event.player.getItemStackFromSlot(EntityEquipmentSlot.FEET);
-            if(lastFeetEquip.getItem().equals(feetEquip.getItem())){
+            if (lastFeetEquip.getItem().equals(feetEquip.getItem())) {
                 return;
-            }
-            else{
+            } else {
                 if ((lastFeetEquip.getItem() instanceof ArmorMetaItem<?>) && ((ArmorMetaItem<?>) lastFeetEquip.getItem()).getItem(lastFeetEquip).getArmorLogic() instanceof IStepAssist)
                     event.player.stepHeight = 0.6f;
 


### PR DESCRIPTION
**What:**
this PR fixes recently found armor related bugs

**Implementation Details:**

- I fixed  #952 by simply implementing the main hand and the off hand check
- I found while you are equipping NightVision Goggles the removePotionEffect is called every tick
That's because NightVision Goggles damage itself by consuming power and trigger onLivingEquipmentChangeEvent every tick
I fixed that by adding a same item check
- I fixed #948 by adding onPlayerTick event
player stepHeight is only handled by the client, so adding codes to the onLivingEquipmentChangeEvent which is the server side only event had no effect
Sadly, I could not find any client event that triggers by the armor swap
As a reference, EnderIO is also going the same way
https://github.com/SleepyTrousers/EnderIO/blob/d6dfb9d3964946ceb9fd72a66a3cff197a51a1fe/enderio-base/src/main/java/crazypants/enderio/base/handler/darksteel/DarkSteelController.java#L84

**Outcome:**
closes #952 
a bit of lag is removed
closes #948 

**Possible compatibility issue:**
none