### PR TITLE
Fix Boots fall damage handling

### DIFF
--- a/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
@@ -91,13 +91,8 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
 
     @Override
     public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
-        IElectricItem container = armor.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
-        int damageLimit = Integer.MAX_VALUE;
-        if (source == DamageSource.FALL && this.getEquipmentSlot(armor) == EntityEquipmentSlot.FEET) {
-            if (energyPerUse > 0 && container != null) {
-                damageLimit = (int) Math.min(damageLimit, 25.0 * container.getCharge() / (energyPerUse * 10.0D));
-            }
-            return new ArmorProperties(10, (damage < 8.0) ? 1.0 : 0.875, damageLimit);
+        if (SLOT == EntityEquipmentSlot.FEET && source == DamageSource.FALL) {
+            return new ArmorProperties(10, 1, Integer.MAX_VALUE);
         }
         return super.getProperties(player, armor, source, damage, equipmentSlot);
     }

--- a/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
@@ -221,6 +221,10 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
     @Override
     public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         int damageLimit = Integer.MAX_VALUE;
+        if (SLOT == EntityEquipmentSlot.FEET && source == DamageSource.FALL) {
+            return new ArmorProperties(10, 1, damageLimit);
+        }
+
         IElectricItem item = armor.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (item == null) {
             return new ArmorProperties(0, 0, damageLimit);
@@ -228,22 +232,12 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         if (energyPerUse > 0) {
             damageLimit = (int) Math.min(damageLimit, 25.0D * item.getCharge() / (energyPerUse * 100.0D));
         }
-
-        if (source == DamageSource.FALL) {
-            if (SLOT == EntityEquipmentSlot.FEET) {
-                return new ArmorProperties(10, 1.0D, damageLimit);
-            }
-
-            if (SLOT == EntityEquipmentSlot.LEGS) {
-                return new ArmorProperties(9, 0.8D, damageLimit);
-            }
-        }
         return new ArmorProperties(8, getDamageAbsorption() * getAbsorption(armor), damageLimit);
     }
 
     @Override
     public boolean handleUnblockableDamage(EntityLivingBase entity, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
-        return source != DamageSource.FALL && source != DamageSource.DROWN && source != DamageSource.STARVE && source != DamageSource.OUT_OF_WORLD;
+        return source != DamageSource.DROWN && source != DamageSource.STARVE && source != DamageSource.OUT_OF_WORLD;
     }
 
     @Override


### PR DESCRIPTION
**What:**
Although Nano boots negates all fall event in the Event Handler, They still handles fall damage in their code.
In addition, they only absorbs 87.5 % of fall damages!
That's because the Nano(Quark) Boots codes are copied from NukepoweredUtils.
This PR removes that unnecessary parts from the codes, and negates damages caused by unintentional fall events

This PR **does not** fix randomly happening fall damage sounds, it just disables the actual fall damage of it completely

**Implementation Details:**
ArmorProperties have three variables, first one is the priority, second one is the absorb ratio(max 1), third one is the max damage it absorbs

**Possible compatibility issue:**
none
