### PR TITLE
fix Drums and Rock Breakers tooltips confusing people

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2449,7 +2449,7 @@ gregtech.machine.drum.stainless_steel.name=Stainless Steel Drum
 gregtech.machine.drum.titanium.name=Titanium Drum
 gregtech.machine.drum.tungstensteel.name=Tungstensteel Drum
 
-gregtech.machine.drum.enable_output=Will drain Fluid to vertically adjacent Tanks
+gregtech.machine.drum.enable_output=Will drain Fluid to downward adjacent Tanks
 gregtech.machine.drum.disable_output=Will not drain Fluid
 
 # Crates
@@ -2647,9 +2647,9 @@ gregtech.machine.steam_alloy_smelter_bronze.tooltip=Combination Smelter
 gregtech.machine.steam_alloy_smelter_steel.name=High Pressure Steam Alloy Smelter
 gregtech.machine.steam_alloy_smelter_steel.tooltip=Combination Smelter
 gregtech.machine.steam_rock_breaker_bronze.name=Steam Rock Breaker
-gregtech.machine.steam_rock_breaker_bronze.tooltip=Place Water and Lava adjacent
+gregtech.machine.steam_rock_breaker_bronze.tooltip=Place Water and Lava horizontally adjacent
 gregtech.machine.steam_rock_breaker_steel.name=High Pressure Steam Rock Breaker
-gregtech.machine.steam_rock_breaker_steel.tooltip=Place Water and Lava adjacent
+gregtech.machine.steam_rock_breaker_steel.tooltip=Place Water and Lava horizontally adjacent
 gregtech.machine.steam_miner.name=Steam Miner
 gregtech.machine.steam_miner.tooltip=Mines ores below the miner ONLY!
 gregtech.machine.steam_miner.description=Working Area: §b%dx%d§7 blocks. §b%ds§7 per block. Uses §b16mB/t§7 of steam.
@@ -4068,13 +4068,13 @@ gregtech.machine.gas_collector.opv.tooltip=Collects Gas from the universe depend
 
 #Rock Breakers
 gregtech.machine.rock_breaker.lv.name=Basic Rock Breaker
-gregtech.machine.rock_breaker.lv.tooltip=Place Lava and Water adjacent
+gregtech.machine.rock_breaker.lv.tooltip=Place Water and Lava horizontally adjacent
 gregtech.machine.rock_breaker.mv.name=Advanced Rock Breaker
-gregtech.machine.rock_breaker.mv.tooltip=Place Lava and Water adjacent
+gregtech.machine.rock_breaker.mv.tooltip=Place Water and Lava horizontally adjacent
 gregtech.machine.rock_breaker.hv.name=Advanced Rock Breaker II
-gregtech.machine.rock_breaker.hv.tooltip=Place Lava and Water adjacent
+gregtech.machine.rock_breaker.hv.tooltip=Place Water and Lava horizontally adjacent
 gregtech.machine.rock_breaker.ev.name=Advanced Rock Breaker III
-gregtech.machine.rock_breaker.ev.tooltip=Place Lava and Water adjacent
+gregtech.machine.rock_breaker.ev.tooltip=Place Water and Lava horizontally adjacent
 gregtech.machine.rock_breaker.iv.name=Elite Rock Breaker
 gregtech.machine.rock_breaker.iv.tooltip=Cryogenic Magma Solidifier R-8200
 gregtech.machine.rock_breaker.luv.name=Elite Rock Breaker II

--- a/src/main/resources/assets/gregtech/lang/ja_jp.lang
+++ b/src/main/resources/assets/gregtech/lang/ja_jp.lang
@@ -2409,7 +2409,7 @@ gregtech.machine.drum.stainless_steel.name=ステンレススチール製ドラ�
 gregtech.machine.drum.titanium.name=チタン製ドラム
 gregtech.machine.drum.tungstensteel.name=タングステンスチール製ドラム
 
-gregtech.machine.drum.enable_output=垂直に隣接するタンクに液体を排出.
+gregtech.machine.drum.enable_output=下方向に隣接するタンクに液体を排出.
 gregtech.machine.drum.disable_output=液体を排出しない.
 
 # Crates
@@ -2607,9 +2607,9 @@ gregtech.machine.steam_alloy_smelter_bronze.tooltip=合体製錬
 gregtech.machine.steam_alloy_smelter_steel.name=高圧蒸気式合金精錬機
 gregtech.machine.steam_alloy_smelter_steel.tooltip=合体製錬
 gregtech.machine.steam_rock_breaker_bronze.name=蒸気式破砕機
-gregtech.machine.steam_rock_breaker_bronze.tooltip=水と溶岩に隣接させて
+gregtech.machine.steam_rock_breaker_bronze.tooltip=水と溶岩に水平に隣接させて設置
 gregtech.machine.steam_rock_breaker_steel.name=高圧蒸気式破砕機
-gregtech.machine.steam_rock_breaker_steel.tooltip=水と溶岩に隣接させて
+gregtech.machine.steam_rock_breaker_steel.tooltip=水と溶岩に水平に隣接させて設置
 gregtech.machine.steam_miner.name=蒸気式採掘機
 gregtech.machine.steam_miner.tooltip=採掘機より下§bのみ§7採掘!
 gregtech.machine.steam_miner.description=採掘範囲: §b%dx%d§7 ブロック. 1ブロックにつき§b%d秒§7. 蒸気を §b16mB/t§7消費.
@@ -4028,13 +4028,13 @@ gregtech.machine.gas_collector.opv.tooltip=宇宙からディメンション依�
 
 # Rock Breaker
 gregtech.machine.rock_breaker.lv.name=基本型破砕機
-gregtech.machine.rock_breaker.lv.tooltip=水と溶岩に隣接させて設置
+gregtech.machine.rock_breaker.lv.tooltip=水と溶岩に水平に隣接させて設置
 gregtech.machine.rock_breaker.mv.name=発展型破砕機
-gregtech.machine.rock_breaker.mv.tooltip=水と溶岩に隣接させて設置
+gregtech.machine.rock_breaker.mv.tooltip=水と溶岩に水平に隣接させて設置
 gregtech.machine.rock_breaker.hv.name=発展型破砕機 II
-gregtech.machine.rock_breaker.hv.tooltip=水と溶岩に隣接させて設置
+gregtech.machine.rock_breaker.hv.tooltip=水と溶岩に水平に隣接させて設置
 gregtech.machine.rock_breaker.ev.name=発展型破砕機 III
-gregtech.machine.rock_breaker.ev.tooltip=水と溶岩に隣接させて設置
+gregtech.machine.rock_breaker.ev.tooltip=水と溶岩に水平に隣接させて設置
 gregtech.machine.rock_breaker.iv.name=精鋭型破砕機
 gregtech.machine.rock_breaker.iv.tooltip=極低温マグマ凝固装置 R-8200
 gregtech.machine.rock_breaker.luv.name=精鋭型破砕機 II

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2475,7 +2475,7 @@ gregtech.machine.drum.stainless_steel.name=不锈钢桶
 gregtech.machine.drum.titanium.name=钛桶
 gregtech.machine.drum.tungstensteel.name=钨钢桶
 
-gregtech.machine.drum.enable_output=将液体排到垂直相邻的容器
+gregtech.machine.drum.enable_output=将液体排到下方相邻的容器
 gregtech.machine.drum.disable_output=不会排出液体
 
 # Crates
@@ -2673,9 +2673,9 @@ gregtech.machine.steam_alloy_smelter_bronze.tooltip=融合炉
 gregtech.machine.steam_alloy_smelter_steel.name=高压蒸汽合金炉
 gregtech.machine.steam_alloy_smelter_steel.tooltip=融合炉
 gregtech.machine.steam_rock_breaker_bronze.name=蒸汽碎岩机
-gregtech.machine.steam_rock_breaker_bronze.tooltip=在相邻处放置水和熔岩
+gregtech.machine.steam_rock_breaker_bronze.tooltip=在水平相邻处放置水和熔岩
 gregtech.machine.steam_rock_breaker_steel.name=高压蒸汽碎岩机
-gregtech.machine.steam_rock_breaker_steel.tooltip=在相邻处放置水和熔岩
+gregtech.machine.steam_rock_breaker_steel.tooltip=在水平相邻处放置水和熔岩
 gregtech.machine.steam_miner.name=蒸汽采矿机
 gregtech.machine.steam_miner.tooltip=只开采矿机下面的矿石!
 gregtech.machine.steam_miner.description=工作范围: §b%dx%d§7 方块，挖掘一个方块需要 §b%ds§7。蒸汽消耗速率为 §b16mB/t§7。
@@ -4092,13 +4092,13 @@ gregtech.machine.gas_collector.opv.tooltip=根据尺寸大小，以消耗能量�
 
 # 碎岩机 Rock Breakers
 gregtech.machine.rock_breaker.lv.name=基础碎岩机
-gregtech.machine.rock_breaker.lv.tooltip=在机器相邻处放置熔岩和水
+gregtech.machine.rock_breaker.lv.tooltip=在机器水平相邻处放置熔岩和水
 gregtech.machine.rock_breaker.mv.name=进阶碎岩机
-gregtech.machine.rock_breaker.mv.tooltip=在机器相邻处放置熔岩和水
+gregtech.machine.rock_breaker.mv.tooltip=在机器水平相邻处放置熔岩和水
 gregtech.machine.rock_breaker.hv.name=进阶碎岩机 II
-gregtech.machine.rock_breaker.hv.tooltip=在机器相邻处放置熔岩和水
+gregtech.machine.rock_breaker.hv.tooltip=在机器水平相邻处放置熔岩和水
 gregtech.machine.rock_breaker.ev.name=进阶碎岩机 III
-gregtech.machine.rock_breaker.ev.tooltip=在机器相邻处放置熔岩和水
+gregtech.machine.rock_breaker.ev.tooltip=在机器水平相邻处放置熔岩和水
 gregtech.machine.rock_breaker.iv.name=精英碎岩机
 gregtech.machine.rock_breaker.iv.tooltip=低温岩浆固化器 R-8200
 gregtech.machine.rock_breaker.luv.name=精英碎岩机 II


### PR DESCRIPTION
**What:**
There are a few people asking for help about Drums and Rock Breakers in the discord server
It is because their tooltips are either misleading or insufficient
This PR fixes that

**Implementation Details:**

- Drums only drain fluid to downward adjacent tanks not vertical adjacent tanks

- You have to place Water and Lava horizontally adjacent to the Rock Breaker

**Outcome:**
fixes #897 

**Additional info:**
I did nothing with Russian
