### PR TITLE
Open up cover methods for addons

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -67,7 +67,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
         this.itemFilterContainer = new ItemFilterContainer(this);
     }
 
-    protected void setTransferRate(int transferRate) {
+    public void setTransferRate(int transferRate) {
         this.transferRate = transferRate;
         coverHolder.markDirty();
 
@@ -85,11 +85,15 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
         }
     }
 
+    public int getTransferRate() {
+        return transferRate;
+    }
+
     protected void adjustTransferRate(int amount) {
         setTransferRate(MathHelper.clamp(transferRate + amount, 1, maxItemTransferRate));
     }
 
-    protected void setConveyorMode(ConveyorMode conveyorMode) {
+    public void setConveyorMode(ConveyorMode conveyorMode) {
         this.conveyorMode = conveyorMode;
         writeUpdateData(1, buf -> buf.writeEnumValue(conveyorMode));
         coverHolder.markDirty();

--- a/src/main/java/gregtech/common/covers/CoverEnderFluidLink.java
+++ b/src/main/java/gregtech/common/covers/CoverEnderFluidLink.java
@@ -165,7 +165,7 @@ public class CoverEnderFluidLink extends CoverBehavior implements CoverWithUI, I
                 .build(this, player);
     }
 
-    private void updateColor(String str) {
+    public void updateColor(String str) {
         if (str.length() == 8) {
             isColorTemp = false;
             // stupid java not having actual unsigned ints
@@ -181,7 +181,7 @@ public class CoverEnderFluidLink extends CoverBehavior implements CoverWithUI, I
         }
     }
 
-    private String getColorStr() {
+    public String getColorStr() {
         return isColorTemp ? tempColorStr : Integer.toHexString(this.color).toUpperCase();
     }
 

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -49,7 +49,7 @@ public class CoverFluidFilter extends CoverBehavior implements CoverWithUI {
         this.fluidFilter.setFluidFilter(fluidFilter);
     }
 
-    protected void setFilterMode(FluidFilterMode filterMode) {
+    public void setFilterMode(FluidFilterMode filterMode) {
         this.filterMode = filterMode;
         this.coverHolder.markDirty();
     }

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -49,7 +49,7 @@ public class CoverItemFilter extends CoverBehavior implements CoverWithUI {
         this.itemFilter.setMaxStackSize(1);
     }
 
-    protected void setFilterMode(ItemFilterMode filterMode) {
+    public void setFilterMode(ItemFilterMode filterMode) {
         this.filterMode = filterMode;
         coverHolder.markDirty();
     }

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -74,9 +74,13 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
         return false;
     }
 
-    protected void setTransferRate(int transferRate) {
+    public void setTransferRate(int transferRate) {
         this.transferRate = transferRate;
         coverHolder.markDirty();
+    }
+
+    public int getTransferRate() {
+        return transferRate;
     }
 
     protected void adjustTransferRate(int amount) {


### PR DESCRIPTION
Makes some formerly private/protected methods to public to avoid:
```java
Method setFilterMode = ReflectionHelper.findMethod(CoverFluidFilter.class, "setFilterMode", null, FluidFilterMode.class);
try {
    setFilterMode.invoke(coverBehavior, FluidFilterMode.values()[mode]);
} catch (IllegalAccessException | InvocationTargetException e) {
    e.printStackTrace();
}
```
in Gregification for the OC compat.