### PR TITLE
More Overclocking Cleanups

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -437,7 +437,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
                 capacity = totalEUt;
             }
 
-            // Return true if we have energy energy stored to progress the recipe, either 1A or the whole amount
+            // Return true if we have enough energy stored to progress the recipe, either 1A or the whole amount
             return getEnergyStored() >= capacity;
         }
         // Power Generation case
@@ -486,13 +486,19 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (!isAllowOverclocking())
             return false;
 
-        // check if the voltage to run at is higher than the recipe, and that it is not ULV tier
-        int overclockTier = getOverclockingTier(getOverclockVoltage());
+        // Check if the voltage to run at is higher than the recipe, and that it is not ULV tier
+
+        // The maximum tier that the machine can overclock to
+        int overclockTier = getOverclockForTier(getMaximumOverclockVoltage());
+        // If the maximum tier that the machine can overclock to is ULV, return false.
+        // There is no overclocking allowed in ULV
+        if(overclockTier == GTValues.ULV) {
+            return false;
+        }
         int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
 
-        // Don't overclock if the machine is ULV.
         // Do overclock if the overclock tier is greater than the recipe tier
-        return overclockTier != 0 && overclockTier > recipeTier;
+        return overclockTier > recipeTier;
     }
 
     /**
@@ -504,9 +510,16 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
     protected int[] performOverclocking(Recipe recipe) {
-        int maxOverclocks = getOverclockingTier(getOverclockVoltage()) - 1; // exclude ULV overclocking
 
-        return runOverclockingLogic(recipe.getRecipePropertyStorage(), recipe.getEUt(), getMaxVoltage(), recipe.getDuration(), maxOverclocks);
+        // The maximum number of overclocks is determined by the difference between the tier the recipe is running at,
+        // and the maximum tier that the machine can overclock to.
+        int recipeTier = GTUtility.getTierByVoltage(recipe.getEUt());
+        int maximumOverclockTier = getOverclockForTier(getMaximumOverclockVoltage());
+
+        // At this point, this value should not be negative or zero, as that is filtered out in CheckCanOverclock
+        int maxOverclocks = maximumOverclockTier - recipeTier;
+
+        return runOverclockingLogic(recipe.getRecipePropertyStorage(), recipe.getEUt(), getMaximumOverclockVoltage(), recipe.getDuration(), maxOverclocks);
     }
 
     /**
@@ -547,18 +560,25 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * @param voltage the maximum voltage the recipe is allowed to run at
+     * Finds the maximum tier that a recipe can overclock to, when provided the maximum voltage a recipe can overclock to.
+     *
+     * @param voltage The maximum voltage the recipe is allowed to overclock to.
+     *
      * @return the highest voltage tier the machine should use to overclock with
      */
-    protected int getOverclockingTier(long voltage) {
+    protected int getOverclockForTier(long voltage) {
         return GTUtility.getTierByVoltage(voltage);
     }
 
     /**
+     * Creates an array of Voltage Names that the machine/multiblock can overclock to.
+     * Since this is for use with the customizable overclock button, all tiers up to {@link AbstractRecipeLogic#getMaxVoltage()}
+     * are allowed, since the button is initialized to this value.
+     *
      * @return a String array of the voltage names allowed to be used for overclocking
      */
     public String[] getAvailableOverclockingTiers() {
-        final int maxTier = getOverclockingTier(getMaxVoltage());
+        final int maxTier = getOverclockForTier(getMaxVoltage());
         final String[] result = new String[maxTier + 1];
         result[0] = "gregtech.gui.overclock.off";
         if (maxTier >= 0) System.arraycopy(GTValues.VNF, 1, result, 1, maxTier);
@@ -650,12 +670,6 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         }
     }
 
-    public void setAllowOverclocking(boolean allowOverclocking) {
-        this.allowOverclocking = allowOverclocking;
-        this.overclockVoltage = allowOverclocking ? getOverclockVoltage() : 0;
-        metaTileEntity.markDirty();
-    }
-
     public boolean isHasNotEnoughEnergy() {
         return hasNotEnoughEnergy;
     }
@@ -674,44 +688,70 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         return isActive && !hasNotEnoughEnergy && workingEnabled;
     }
 
-    public boolean isAllowOverclocking() {
-        return allowOverclocking;
-    }
-
-    public long getOverclockVoltage() {
-        return overclockVoltage;
-    }
-
-    public void setOverclockVoltage(final long overclockVoltage) {
-        this.overclockVoltage = overclockVoltage;
-        this.allowOverclocking = (overclockVoltage != 0);
+    /**
+     * Toggles if the Machine/Multiblock is allowed to overclock.
+     *
+     * @param allowOverclocking If overclocking is allowed
+     */
+    public void setAllowOverclocking(boolean allowOverclocking) {
+        this.allowOverclocking = allowOverclocking;
+        this.overclockVoltage = allowOverclocking ? getMaximumOverclockVoltage() : GTValues.V[GTValues.ULV];
         metaTileEntity.markDirty();
     }
 
     /**
-     * Sets the overclocking policy to use getOverclockVoltage() instead of getMaxVoltage()
-     * and initialises the overclock voltage to max voltage.
-     * The actual value will come from the saved tag when the tile is loaded for pre-existing machines.
-     * <p>
-     * NOTE: This should only be used directly after construction of the workable.
+     * @return Whether Overclocking is allowed for the current machine/multiblock
      */
-    public void enableOverclockVoltage() {
-        setOverclockVoltage(getMaxVoltage());
+    public boolean isAllowOverclocking() {
+        return allowOverclocking;
     }
 
+    /**
+     * Sets the maximum voltage that the machine is allowed to overclock to.
+     * If the passed tier is ULV, overclocking for this machine is disabled.
+     *
+     * @param overclockVoltage The maximum voltage that the machine can overclock to. This must correspond to a
+     *                         voltage tier in <B>GTValues.V</>
+     */
+    public void setMaximumOverclockVoltage(final long overclockVoltage) {
+        this.overclockVoltage = overclockVoltage;
+        // Overclocking is not allowed if the passed voltage is ULV
+        this.allowOverclocking = (overclockVoltage != GTValues.V[GTValues.ULV]);
+        metaTileEntity.markDirty();
+    }
+
+    /**
+     * @return The maximum voltage the machine/multiblock can overclock to
+     */
+    public long getMaximumOverclockVoltage() {
+        return overclockVoltage;
+    }
+
+    /**
+     * This is needed as CycleButtonWidget requires an IntSupplier, without making an Enum of tiers.
+     *
+     * @return The current Tier for the voltage the machine is allowed to overclock to
+     */
     public int getOverclockTier() {
-        if (this.overclockVoltage == 0) {
-            return 0;
+
+        // If we do not allow overclocking, return ULV tier
+        if (!isAllowOverclocking()) {
+            return GTValues.ULV;
         }
-        return getOverclockingTier(this.overclockVoltage);
+
+        // This will automatically handle ULV, and return 0
+        return getOverclockForTier(this.overclockVoltage);
     }
 
+    /**
+     * Sets the maximum Tier that the machine/multiblock is allowed to overclock to.
+     * This is used for the Overclock button in Machine GUIs.
+     * This is needed as CycleButtonWidget requires an Int Supplier, without making an Enum of tiers.
+     *
+     * @param tier The maximum tier the multiblock/machine can overclock to
+     */
     public void setOverclockTier(final int tier) {
-        if (tier == 0) {
-            setOverclockVoltage(0);
-            return;
-        }
-        setOverclockVoltage(GTValues.V[tier]);
+        setMaximumOverclockVoltage(GTValues.V[tier]);
     }
 
     @Override
@@ -767,15 +807,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.workingEnabled = compound.getBoolean("WorkEnabled");
         this.canRecipeProgress = compound.getBoolean("CanRecipeProgress");
         this.progressTime = compound.getInteger("Progress");
-        if (compound.hasKey(ALLOW_OVERCLOCKING)) {
-            this.allowOverclocking = compound.getBoolean(ALLOW_OVERCLOCKING);
-        }
-        if (compound.hasKey(OVERCLOCK_VOLTAGE)) {
-            this.overclockVoltage = compound.getLong(OVERCLOCK_VOLTAGE);
-        } else {
-            // Calculate overclock voltage based on old allow flag
-            this.overclockVoltage = this.allowOverclocking ? getOverclockVoltage() : 0;
-        }
+        this.allowOverclocking = compound.getBoolean(ALLOW_OVERCLOCKING);
+        this.overclockVoltage = compound.getLong(OVERCLOCK_VOLTAGE);
         this.isActive = false;
         if (progressTime > 0) {
             this.isActive = true;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -1,10 +1,6 @@
 package gregtech.api.capability.impl;
 
-import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.capability.IMaintenanceHatch;
-import gregtech.api.capability.IMultiblockController;
-import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.IMultipleRecipeMaps;
+import gregtech.api.capability.*;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -15,7 +11,6 @@ import gregtech.common.ConfigHolder;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -284,7 +279,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public long getOverclockVoltage() {
+    public long getMaximumOverclockVoltage() {
         return getMaxVoltage();
     }
 

--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -2,11 +2,8 @@ package gregtech.api.capability.impl;
 
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
-
-import javax.annotation.Nonnull;
 
 import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
 
@@ -56,7 +53,7 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public long getOverclockVoltage() {
+    public long getMaximumOverclockVoltage() {
         return GTValues.V[GTValues.LV];
     }
 

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicEnergy.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicEnergy.java
@@ -13,6 +13,7 @@ public class RecipeLogicEnergy extends AbstractRecipeLogic {
     public RecipeLogicEnergy(MetaTileEntity tileEntity, RecipeMap<?> recipeMap, Supplier<IEnergyContainer> energyContainer) {
         super(tileEntity, recipeMap);
         this.energyContainer = energyContainer;
+        setMaximumOverclockVoltage(getMaxVoltage());
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
@@ -114,8 +114,8 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public long getOverclockVoltage() {
-        return 0;
+    public boolean isAllowOverclocking() {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -54,9 +54,7 @@ public class SimpleGeneratorMetaTileEntity extends WorkableTieredMetaTileEntity 
 
     @Override
     protected RecipeLogicEnergy createWorkable(RecipeMap<?> recipeMap) {
-        final FuelRecipeLogic result = new FuelRecipeLogic(this, recipeMap, () -> energyContainer);
-        result.enableOverclockVoltage();
-        return result;
+        return new FuelRecipeLogic(this, recipeMap, () -> energyContainer);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -7,7 +7,10 @@ import codechicken.lib.vec.Matrix4;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IActiveOutputSide;
-import gregtech.api.capability.impl.*;
+import gregtech.api.capability.impl.EnergyContainerHandler;
+import gregtech.api.capability.impl.FluidHandlerProxy;
+import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.capability.impl.ItemHandlerProxy;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.ICoverable;
@@ -391,13 +394,6 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         super.clearMachineInventory(itemBuffer);
         clearInventory(itemBuffer, chargerInventory);
         clearInventory(itemBuffer, circuitInventory);
-    }
-
-    @Override
-    protected RecipeLogicEnergy createWorkable(RecipeMap<?> recipeMap) {
-        final RecipeLogicEnergy result = super.createWorkable(recipeMap);
-        result.enableOverclockVoltage();
-        return result;
     }
 
     protected ModularUI.Builder createGuiTemplate(EntityPlayer player) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -23,8 +23,7 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
     public FuelMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, int tier) {
         super(metaTileEntityId, recipeMap);
         this.recipeMapWorkable = new MultiblockFuelRecipeLogic(this);
-        this.recipeMapWorkable.enableOverclockVoltage();
-        this.recipeMapWorkable.setOverclockTier(tier);
+        this.recipeMapWorkable.setMaximumOverclockVoltage(GTValues.V[tier]);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
@@ -34,9 +34,7 @@ public class MetaTileEntityGasCollector extends SimpleMachineMetaTileEntity {
 
     @Override
     protected RecipeLogicEnergy createWorkable(RecipeMap<?> recipeMap) {
-        final RecipeLogicEnergy result = new GasCollectorRecipeLogic(this, recipeMap, () -> energyContainer);
-        result.enableOverclockVoltage();
-        return result;
+        return new GasCollectorRecipeLogic(this, recipeMap, () -> energyContainer);
     }
 
     protected boolean checkRecipe(@Nonnull Recipe recipe) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
@@ -32,9 +32,7 @@ public class MetaTileEntityRockBreaker extends SimpleMachineMetaTileEntity {
 
     @Override
     protected RecipeLogicEnergy createWorkable(RecipeMap<?> recipeMap) {
-        final RecipeLogicEnergy result = new RockBreakerRecipeLogic(this, RecipeMaps.ROCK_BREAKER_RECIPES, () -> energyContainer);
-        result.enableOverclockVoltage();
-        return result;
+        return new RockBreakerRecipeLogic(this, RecipeMaps.ROCK_BREAKER_RECIPES, () -> energyContainer);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -48,8 +48,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
     public MetaTileEntityLargeCombustionEngine(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, RecipeMaps.COMBUSTION_GENERATOR_FUELS, tier);
         this.recipeMapWorkable = new LargeCombustionEngineWorkableHandler(this, tier > GTValues.EV);
-        this.recipeMapWorkable.enableOverclockVoltage();
-        this.recipeMapWorkable.setOverclockTier(tier);
+        this.recipeMapWorkable.setMaximumOverclockVoltage(GTValues.V[tier]);
         this.tier = tier;
         this.isExtreme = tier > GTValues.EV;
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -53,8 +53,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController impleme
         this.frontOverlay = frontOverlay;
         this.tier = tier;
         this.recipeMapWorkable = new LargeTurbineWorkableHandler(this, tier);
-        this.recipeMapWorkable.enableOverclockVoltage();
-        this.recipeMapWorkable.setOverclockTier(tier);
+        this.recipeMapWorkable.setMaximumOverclockVoltage(GTValues.V[tier]);
     }
 
     @Override


### PR DESCRIPTION
**What:**
This PR makes more cleanups to overclocking, refactoring method names for clarity, removes some redundant methods and method calls, and also fixes the maximum amount of overclocks. Supersedes #917 

**Implementation Details:**
This PR renames a bunch of methods related to overclocking to hopefully make what is going on clearer.

In addition, passing 0 as the overclocking tier for disabling overclocking is now no longer correct, rather passing V[ULV] is.

Removes `enableOverclockVoltage`, as all this did was initialize the overclocking voltage to the maximum voltage, and was used in conjunction with the overclock button. This was redundant, as the overclocking voltage was already initialized to the max voltage.

Removes some redundant NBT checks that were introduced in GTCE with the introduction of the overclock button. All GTCEu machines will have these NBT tags.

**Outcome:**
Cleans up overclocking logic, and fixes the maximum number of overclocks a machine/multiblock could have

**Possible compatibility issue:**
Method renames and removals
