### PR TITLE
Reset children nodes when item selected from inventory

### DIFF
--- a/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
@@ -94,6 +94,17 @@ public class RGNode extends WidgetGroup implements IDraggable {
                                     }
                                 }
                                 phantom.setObject(itemStack);
+
+                                // Reset any children nodes, now that the parent has changed
+                                for (Set<RGNode> childs : children.values()) {
+                                    for (RGNode child : childs) {
+                                        child.removeParent(this);
+                                    }
+                                }
+                                children.clear();
+
+                                // Clear the Inputs for the replaced parent
+                                this.inputsGroup.widgets.clear();
                             }
                         }).setClientSide().open()));
         } else {

--- a/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
@@ -61,7 +61,20 @@ public class RGNode extends WidgetGroup implements IDraggable {
         init(container);
         this.head = head;
         if (isPhantom) {
-            PhantomWidget phantom = new PhantomWidget(0, 0, head).setChangeListener(object -> RGNode.this.head = object);
+            PhantomWidget phantom = new PhantomWidget(0, 0, head).setChangeListener(object -> {
+                RGNode.this.head = object;
+                // Reset any children nodes, now that the parent has changed
+                for (Set<RGNode> childs : children.values()) {
+                    for (RGNode child : childs) {
+                        child.removeParent(this);
+                    }
+                }
+                children.clear();
+
+                // Clear the Inputs for the replaced parent
+                this.inputsGroup.widgets.clear();
+
+            });
             this.addWidget(phantom);
             toolGroup.addWidget(new CircleButtonWidget(-11, 49, 8, 1, 12)
                     .setColors(0, TerminalTheme.COLOR_7.getColor(), 0)


### PR DESCRIPTION
**What:**
Resets any children nodes and saved Inputs when the parent node is changed via the "Select item from inventory" option.

Closes #900 

**Implementation Details:**
As far as I am aware, this function can only be used on the root node, so we should not have to worry about parent nodes at all. But also, I could be missing something that needs to be reset in this class.

**Outcome:**
Clears recipe tree in Recipe Chart terminal app when changing root node via "Select item from inventory" or when dragging from JEI.