### PR TITLE
Add Actions for Automated Releases

### DIFF
--- a/.github/workflows/release_curseforge.yml
+++ b/.github/workflows/release_curseforge.yml
@@ -1,0 +1,59 @@
+name: Release to CurseForge
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Use Cached Gradle Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+
+      - name: Get Project Version
+        id: project_version
+        run: echo ::set-output name=version::$(./gradlew getVersionFromJava --q)
+
+      - name: Get Project Changelog
+        run: ./gradlew getLatestChangelog --q
+
+      - name: Create CurseForge Release
+        uses: itsmeow/curseforge-upload@v3
+        with:
+          game_versions: "Minecraft 1.12:1.12.2,Java 8,Forge"
+          game_endpoint: "minecraft"
+          release_type: "release"
+          changelog: CHANGELOG-current.md
+          changelog_type: "markdown"
+          relations: "codechicken-lib-1-8:requiredDependency,gregtech-chill-edition:incompatible,gregtechce:incompatible"
+          file_path: build/libs/gregtech-${{ steps.project_version.outputs.version }}.jar
+          project_id: "${{ secrets.CURSEFORGE_PROJECT_ID }}"
+          token: "${{ secrets.CURSEFORGE_API_KEY }}"
+
+      - name: Cleanup Gradle Cache
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -1,0 +1,59 @@
+name: Release to GitHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: 'Release Tag'
+        required: true
+        default: 'v'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Use Cached Gradle Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+
+      - name: Get Project Version
+        id: project_version
+        run: echo ::set-output name=version::$(./gradlew getVersionFromJava --q)
+
+      - name: Get Project Changelog
+        run: ./gradlew getLatestChangelog --q
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.releaseTag }}
+          body_path: CHANGELOG-current.md
+          files: build/libs/gregtech-${{ steps.project_version.outputs.version }}.jar
+          generate_release_notes: false
+
+      - name: Cleanup Gradle Cache
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ local.properties
 run/
 
 logs/
+
+### Other ###
+CHANGELOG-current.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ buildscript {
 
 plugins {
     id("com.matthewprenger.cursegradle") version "1.1.0"
-    id("maven-publish")
 }
 
 apply {
@@ -155,7 +154,7 @@ idea {
     }
 }
 
-fun getVersionFromJava(file: File): String  {
+fun getVersionFromJava(file: File): String {
     var major = "0"
     var minor = "0"
     var revision = "0"
@@ -188,4 +187,17 @@ fun getVersionFromJava(file: File): String  {
         return "$major.$minor.$revision-$extra"
     }
     return "$major.$minor.$revision"
+}
+
+task<Exec>("getVersionFromJava") {
+    commandLine("echo", version)
+}
+
+task("getLatestChangelog") {
+    fun getLatestChangelog(file: File): String {
+        var split = file.readText().split("###")
+        return split[0] + "### " + split[1].trim()
+    }
+
+    File("CHANGELOG-current.md").writeText(getLatestChangelog(file("CHANGELOG.md")))
 }


### PR DESCRIPTION
CurseForge data will need to be set as secrets for use. These tasks are also only run manually from the Actions tab, and are intended to be run after an internal version bump and changelog update.