### PR TITLE
fix Wooden Wall tooltip

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockSteamCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockSteamCasing.java
@@ -38,12 +38,13 @@ public class BlockSteamCasing extends VariantBlock<BlockSteamCasing.SteamCasingT
 
     @Override
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, ITooltipFlag advanced) {
-        if (getState(stack).ordinal() == 4) {
-            super.addInformation(stack, player, tooltip, advanced);
-        } else if (getState(stack).ordinal() < 2) {
+        int ordinal = getState(stack).ordinal();
+        if (ordinal < 2) {
             tooltip.add(I18n.format("tile.steam_casing.bronze.tooltip"));
-        } else {
+        } else if (ordinal < 4) {
             tooltip.add(I18n.format("tile.steam_casing.steel.tooltip"));
+        } else {
+            super.addInformation(stack, player, tooltip, advanced);
         }
     }
 


### PR DESCRIPTION
**What:**
Wooden Wall now displays MetaBlocks default tooltips instead of the Steel Hull tooltip

**Implementation Details:**
rewrote addInformation if logic

**Outcome:**
fix #978

**Possible compatibility issue:**
none
