### PR TITLE
Crafting tweaks compat

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -507,6 +507,12 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return !ItemStack.areItemStacksEqual(oldStack, newStack);
     }
 
+    @Override
+    public String getTranslationKey(ItemStack stack) {
+        T metaItem = getItem(stack);
+        return metaItem == null ? getTranslationKey() : getTranslationKey() + "." + metaItem.unlocalizedName;
+    }
+
     @Nonnull
     @Override
     public String getItemStackDisplayName(ItemStack stack) {


### PR DESCRIPTION
Crafting tweaks compares items via lang key and meta.
Metaitems all had the same key, causing voiding and duping of items
This simply returns a unique lang key for each meta item