### PR TITLE
Remove Phenol recipe added by GTCE

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -606,12 +606,6 @@ public class ReactorRecipes {
                 .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .fluidInputs(Benzene.getFluid(1000))
-                .fluidInputs(Oxygen.getFluid(1000))
-                .fluidOutputs(Phenol.getFluid(1000))
-                .duration(400).EUt(2000).buildAndRegister();
-
-        CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(MethylAcetate.getFluid(1000))
                 .fluidInputs(Water.getFluid(1000))
                 .notConsumable(OreDictUnifier.get(dust, SodiumHydroxide))


### PR DESCRIPTION
**What:**
The Phenol quest in GCP says:
`Lore: The Benzene + Oxygen recipe was added in GTCE as part of chemical fixes as the Large Chemical Reactor didn't exist. Now that there are more realistic option, that recipe might go away.`
It is good time to remove it since it causes actual harm in the playthrough

**Implementation Details:**
remove Benzene + Oxygen -> Phenol recipe

**Outcome:**
fix #991 

**Possible compatibility issue:**
none