### PR TITLE
TOP Provider Improvements

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -8,7 +8,6 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget.ClickData;
 import gregtech.api.gui.widgets.AdvancedTextWidget;
-import gregtech.api.gui.widgets.CycleButtonWidget;
 import gregtech.api.gui.widgets.ImageCycleButtonWidget;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.pattern.TraceabilityPredicate;
@@ -16,7 +15,6 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.GTUtility;
-import gregtech.api.util.LocalizationUtils;
 import gregtech.common.ConfigHolder;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -151,6 +149,11 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
                 maintenanceHatch.setTaped(false);
                 timeActive = timeActive - minimumMaintenanceTime;
             }
+    }
+
+    @Override
+    public boolean isStructureObstructed() {
+        return hasMufflerMechanics() && !isMufflerFaceFree();
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -564,7 +564,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
         return Textures.VOLTAGE_CASINGS[this.tier].getSpriteOnSide(SimpleSidedCubeRenderer.RenderSide.SIDE);
     }
 
-    public enum ConveyorMode implements IStringSerializable {
+    public enum ConveyorMode implements IStringSerializable, IIOMode {
         IMPORT("cover.conveyor.mode.import"),
         EXPORT("cover.conveyor.mode.export");
 
@@ -578,6 +578,11 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
         @Override
         public String getName() {
             return localeName;
+        }
+
+        @Override
+        public boolean isImport() {
+            return this == IMPORT;
         }
     }
 

--- a/src/main/java/gregtech/common/covers/CoverEnderFluidLink.java
+++ b/src/main/java/gregtech/common/covers/CoverEnderFluidLink.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 
 public class CoverEnderFluidLink extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
 
-    private final int TRANSFER_RATE = 8000; // mB/t
+    public static final int TRANSFER_RATE = 8000; // mB/t
 
     protected CoverPump.PumpMode pumpMode;
     private int color;
@@ -65,6 +65,14 @@ public class CoverEnderFluidLink extends CoverBehavior implements CoverWithUI, I
 
     private UUID getTankUUID() {
         return isPrivate ? playerUUID : null;
+    }
+
+    public FluidFilterContainer getFluidFilterContainer() {
+        return this.fluidFilter;
+    }
+
+    public boolean isIOEnabled() {
+        return this.ioEnabled;
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -58,6 +58,10 @@ public class CoverFluidFilter extends CoverBehavior implements CoverWithUI {
         return filterMode;
     }
 
+    public FluidFilterWrapper getFluidFilter() {
+        return this.fluidFilter;
+    }
+
     public boolean testFluidStack(FluidStack stack) {
         return fluidFilter.testFluidStack(stack);
     }

--- a/src/main/java/gregtech/common/covers/CoverFluidVoidingAdvanced.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidVoidingAdvanced.java
@@ -97,6 +97,10 @@ public class CoverFluidVoidingAdvanced extends CoverFluidVoiding {
         coverHolder.markDirty();
     }
 
+    public int getTransferAmount() {
+        return this.transferAmount;
+    }
+
     public void setVoidingMode(VoidingMode transferMode) {
         this.voidingMode = transferMode;
         this.coverHolder.markDirty();

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -58,6 +58,10 @@ public class CoverItemFilter extends CoverBehavior implements CoverWithUI {
         return filterMode;
     }
 
+    public ItemFilterWrapper getItemFilter() {
+        return this.itemFilter;
+    }
+
     @Override
     public boolean canAttach() {
         return coverHolder.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, attachedSide) != null;

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -354,7 +354,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
         return Textures.VOLTAGE_CASINGS[this.tier].getSpriteOnSide(SimpleSidedCubeRenderer.RenderSide.SIDE);
     }
 
-    public enum PumpMode implements IStringSerializable {
+    public enum PumpMode implements IStringSerializable, IIOMode {
         IMPORT("cover.pump.mode.import"),
         EXPORT("cover.pump.mode.export");
 
@@ -368,6 +368,11 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
         @Override
         public String getName() {
             return localeName;
+        }
+
+        @Override
+        public boolean isImport() {
+            return this == IMPORT;
         }
     }
 

--- a/src/main/java/gregtech/common/covers/FluidFilterMode.java
+++ b/src/main/java/gregtech/common/covers/FluidFilterMode.java
@@ -1,6 +1,6 @@
 package gregtech.common.covers;
 
-public enum FluidFilterMode {
+public enum FluidFilterMode implements IFilterMode {
 
     FILTER_FILL("cover.fluid_filter.mode.filter_fill"),
     FILTER_DRAIN("cover.fluid_filter.mode.filter_drain"),
@@ -10,5 +10,10 @@ public enum FluidFilterMode {
 
     FluidFilterMode(String localeName) {
         this.localeName = localeName;
+    }
+
+    @Override
+    public String getName() {
+        return this.localeName;
     }
 }

--- a/src/main/java/gregtech/common/covers/IFilterMode.java
+++ b/src/main/java/gregtech/common/covers/IFilterMode.java
@@ -1,0 +1,6 @@
+package gregtech.common.covers;
+
+public interface IFilterMode {
+
+    String getName();
+}

--- a/src/main/java/gregtech/common/covers/IIOMode.java
+++ b/src/main/java/gregtech/common/covers/IIOMode.java
@@ -1,0 +1,9 @@
+package gregtech.common.covers;
+
+/**
+ * Interface for combining Robot Arm and Pump I/O modes into one type
+ */
+public interface IIOMode {
+
+    boolean isImport();
+}

--- a/src/main/java/gregtech/common/covers/ItemFilterMode.java
+++ b/src/main/java/gregtech/common/covers/ItemFilterMode.java
@@ -1,6 +1,6 @@
 package gregtech.common.covers;
 
-public enum ItemFilterMode {
+public enum ItemFilterMode implements IFilterMode {
 
     FILTER_INSERT("cover.filter.mode.filter_insert"),
     FILTER_EXTRACT("cover.filter.mode.filter_extract"),
@@ -10,5 +10,10 @@ public enum ItemFilterMode {
 
     ItemFilterMode(String localeName) {
         this.localeName = localeName;
+    }
+
+    @Override
+    public String getName() {
+        return this.localeName;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -165,7 +165,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
 
     @Override
     public boolean isStructureObstructed() {
-        return checkIntakesObstructed();
+        return super.isStructureObstructed() || checkIntakesObstructed();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -193,7 +193,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController impleme
 
     @Override
     public boolean isStructureObstructed() {
-        return !isRotorFaceFree();
+        return super.isStructureObstructed() || !isRotorFaceFree();
     }
 
     @Override

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
@@ -21,5 +21,6 @@ public class TheOneProbeCompatibility {
         oneProbe.registerProvider(new ConverterInfoProvider());
         oneProbe.registerProvider(new RecipeLogicInfoProvider());
         oneProbe.registerProvider(new PrimitivePumpInfoProvider());
+        oneProbe.registerProvider(new CoverProvider());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CapabilityInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CapabilityInfoProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.theoneprobe.provider;
 
-import gregtech.api.util.GTLog;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoProvider;
@@ -8,35 +7,30 @@ import mcjty.theoneprobe.api.ProbeMode;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 
+import javax.annotation.Nonnull;
+
 public abstract class CapabilityInfoProvider<T> implements IProbeInfoProvider {
 
+    @Nonnull
     protected abstract Capability<T> getCapability();
 
-    protected abstract void addProbeInfo(T capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit);
+    protected abstract void addProbeInfo(T capability, IProbeInfo probeInfo, EntityPlayer player, TileEntity tileEntity, IProbeHitData data);
 
     protected boolean allowDisplaying(T capability) {
         return true;
     }
 
     @Override
-    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
+    public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
         if (blockState.getBlock().hasTileEntity(blockState)) {
-            EnumFacing sideHit = data.getSideHit();
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (tileEntity == null) return;
-            try {
-                T resultCapability = tileEntity.getCapability(getCapability(), null);
-                if (resultCapability != null && allowDisplaying(resultCapability)) {
-                    addProbeInfo(resultCapability, probeInfo, tileEntity, sideHit);
-                }
-            } catch (ClassCastException ignored) {
-            } catch (Throwable e) {
-                GTLog.logger.info("Bad One probe Implem: {} {} {}", e.getClass().toGenericString(), e.getMessage(), e.getStackTrace()[0].getClassName());
-                e.printStackTrace();
+            T resultCapability = tileEntity.getCapability(getCapability(), null);
+            if (resultCapability != null && allowDisplaying(resultCapability)) {
+                addProbeInfo(resultCapability, probeInfo, player, tileEntity, data);
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ControllableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ControllableInfoProvider.java
@@ -1,15 +1,20 @@
 package gregtech.integration.theoneprobe.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
 
 public class ControllableInfoProvider extends CapabilityInfoProvider<IControllable> {
 
+    @Nonnull
     @Override
     protected Capability<IControllable> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE;
@@ -17,13 +22,11 @@ public class ControllableInfoProvider extends CapabilityInfoProvider<IControllab
 
     @Override
     public String getID() {
-        return "gregtech:controllable_provider";
+        return GTValues.MODID + ":controllable_provider";
     }
 
     @Override
-    protected void addProbeInfo(IControllable capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
-        if (!capability.isWorkingEnabled()) {
-            probeInfo.text(TextStyleClass.INFOIMP + "{*gregtech.top.working_disabled*}");
-        }
+    protected void addProbeInfo(@Nonnull IControllable capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+        if (!capability.isWorkingEnabled()) probeInfo.text(TextStyleClass.WARNING + "{*gregtech.top.working_disabled*}");
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
@@ -3,56 +3,53 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
-import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.converter.ConverterTrait;
-import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
+import javax.annotation.Nonnull;
+
 public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait> {
 
     @Override
     public String getID() {
-        return "gregtech:converter_info_provider";
+        return GTValues.MODID + ":converter_info_provider";
     }
 
+    @Nonnull
     @Override
     protected Capability<ConverterTrait> getCapability() {
         return GregtechCapabilities.CAPABILITY_CONVERTER;
     }
 
     @Override
-    protected void addProbeInfo(ConverterTrait capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+    protected void addProbeInfo(@Nonnull ConverterTrait capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         // Info on current converter mode
-        IProbeInfo pane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-        if (capability.isFeToEu()) {
-            pane.text(TextStyleClass.INFO + "{*gregtech.top.convert_fe*}");
-        } else {
-            pane.text(TextStyleClass.INFO + "{*gregtech.top.convert_eu*}");
-        }
+        probeInfo.text(TextStyleClass.INFO + ((capability.isFeToEu()) ? "{*gregtech.top.convert_fe*}" : "{*gregtech.top.convert_eu*}"));
 
         // Info on the current side of the converter
-        pane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-        MetaTileEntity mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
+        EnumFacing facing = ((IGregTechTileEntity) tileEntity).getMetaTileEntity().getFrontFacing();
         String voltageN = GTValues.VNF[GTUtility.getTierByVoltage(capability.getVoltage())];
         long amperage = capability.getBaseAmps();
         if (capability.isFeToEu()) {
-            if (sideHit == mte.getFrontFacing()) {
-                pane.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + voltageN + TextFormatting.GREEN + " (" + amperage + "A)");
+            if (data.getSideHit() == facing) {
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + voltageN + TextFormatting.GREEN + " (" + amperage + "A)");
             } else {
-                pane.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage(), FeCompat.ratio(true)) + "FE");
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage(), FeCompat.ratio(true)) + " FE");
             }
         } else {
-            if (sideHit == mte.getFrontFacing()) {
-                pane.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage(), FeCompat.ratio(false)) + "FE");
+            if (data.getSideHit() == facing) {
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage(), FeCompat.ratio(false)) + " FE");
             } else {
-                pane.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + voltageN + TextFormatting.GREEN + " (" + amperage + "A)");
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + voltageN + TextFormatting.GREEN + " (" + amperage + "A)");
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
@@ -42,6 +42,8 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
             itemFilterInfo(probeInfo, (CoverItemFilter) coverBehavior);
         } else if (coverBehavior instanceof CoverFluidFilter) {
             fluidFilterInfo(probeInfo, (CoverFluidFilter) coverBehavior);
+        } else if (coverBehavior instanceof CoverEnderFluidLink) {
+            enderFluidLinkInfo(probeInfo, (CoverEnderFluidLink) coverBehavior);
         }
     }
 
@@ -147,6 +149,21 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
     private static void fluidFilterInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverFluidFilter fluidFilter) {
         filterModeText(probeInfo, fluidFilter.getFilterMode());
         fluidFilterText(probeInfo, fluidFilter.getFluidFilter().getFluidFilter());
+    }
+
+    /**
+     * Displays text for {@link CoverEnderFluidLink} related covers
+     *
+     * @param probeInfo      the info to add the text to
+     * @param enderFluidLink the ender fluid link cover to get data from
+     */
+    private static void enderFluidLinkInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverEnderFluidLink enderFluidLink) {
+        transferRateText(probeInfo, enderFluidLink.getPumpMode(), " {*cover.bucket.mode.milli_bucket*}", enderFluidLink.isIOEnabled() ? CoverEnderFluidLink.TRANSFER_RATE : 0);
+        fluidFilterText(probeInfo, enderFluidLink.getFluidFilterContainer().getFilterWrapper().getFluidFilter());
+
+        if (!enderFluidLink.getColorStr().isEmpty()) {
+            probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.link_cover.color*} " + enderFluidLink.getColorStr());
+        }
     }
 
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
@@ -66,6 +66,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
             CoverRoboticArm roboticArm = (CoverRoboticArm) conveyor;
             transferModeText(probeInfo, roboticArm.getTransferMode(), rateUnit, roboticArm.getItemFilterContainer().getTransferStackSize());
         }
+        itemFilterText(probeInfo, conveyor.getItemFilterContainer().getFilterWrapper().getItemFilter());
     }
 
     /**
@@ -108,6 +109,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
             CoverFluidRegulator regulator = (CoverFluidRegulator) pump;
             transferModeText(probeInfo, regulator.getTransferMode(), rateUnit, regulator.getTransferAmount());
         }
+        fluidFilterText(probeInfo, pump.getFluidFilterContainer().getFilterWrapper().getFluidFilter());
     }
 
     /**

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
@@ -1,0 +1,228 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.cover.CoverBehavior;
+import gregtech.api.cover.ICoverable;
+import gregtech.api.util.GTUtility;
+import gregtech.common.covers.*;
+import gregtech.common.covers.filter.*;
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
+
+public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
+
+    @Nonnull
+    @Override
+    protected Capability<ICoverable> getCapability() {
+        return GregtechTileCapabilities.CAPABILITY_COVERABLE;
+    }
+
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":coverable_provider";
+    }
+
+    @Override
+    protected void addProbeInfo(@Nonnull ICoverable capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+        CoverBehavior coverBehavior = capability.getCoverAtSide(data.getSideHit());
+        if (coverBehavior instanceof CoverConveyor) {
+            conveyorInfo(probeInfo, (CoverConveyor) coverBehavior);
+        } else if (coverBehavior instanceof CoverPump) {
+            pumpInfo(probeInfo, (CoverPump) coverBehavior);
+        } else if (coverBehavior instanceof CoverItemFilter) {
+            itemFilterInfo(probeInfo, (CoverItemFilter) coverBehavior);
+        } else if (coverBehavior instanceof CoverFluidFilter) {
+            fluidFilterInfo(probeInfo, (CoverFluidFilter) coverBehavior);
+        }
+    }
+
+    /**
+     * Displays text for {@link CoverConveyor} related covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param conveyor  the conveyor to get data from
+     */
+    private static void conveyorInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverConveyor conveyor) {
+        String rateUnit = " {*cover.conveyor.transfer_rate*}";
+
+        if (conveyor instanceof CoverItemVoiding) {
+            itemVoidingInfo(probeInfo, (CoverItemVoiding) conveyor);
+        }
+
+        // do not display the regular rate if the cover has a specialized rate
+        if (!(conveyor instanceof CoverItemVoiding) && (!(conveyor instanceof CoverRoboticArm) || ((CoverRoboticArm) conveyor).getTransferMode() == TransferMode.TRANSFER_ANY)) {
+            transferRateText(probeInfo, conveyor.getConveyorMode(), rateUnit, conveyor.getTransferRate());
+        }
+
+        if (conveyor instanceof CoverRoboticArm) {
+            CoverRoboticArm roboticArm = (CoverRoboticArm) conveyor;
+            transferModeText(probeInfo, roboticArm.getTransferMode(), rateUnit, roboticArm.getItemFilterContainer().getTransferStackSize());
+        }
+    }
+
+    /**
+     * Displays info for {@link CoverItemVoiding} related covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param voiding   the voiding cover to get data from
+     */
+    private static void itemVoidingInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverItemVoiding voiding) {
+        String unit = " {*gregtech.top.unit.items*}";
+
+        ItemFilterContainer container = voiding.getItemFilterContainer();
+        if (voiding instanceof CoverItemVoidingAdvanced) {
+            CoverItemVoidingAdvanced advanced = (CoverItemVoidingAdvanced) voiding;
+            VoidingMode mode = advanced.getVoidingMode();
+            voidingText(probeInfo, mode, unit, container.getTransferStackSize());
+        }
+        itemFilterText(probeInfo, container.getFilterWrapper().getItemFilter());
+    }
+
+    /**
+     * Displays text for {@link CoverPump} related covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param pump      the pump to get data from
+     */
+    private static void pumpInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverPump pump) {
+        String rateUnit = IProbeInfo.STARTLOC + pump.getBucketMode().getName() + IProbeInfo.ENDLOC;
+
+        if (pump instanceof CoverFluidVoiding) {
+            fluidVoidingInfo(probeInfo, (CoverFluidVoiding) pump);
+        }
+
+        // do not display the regular rate if the cover has a specialized rate
+        if (!(pump instanceof CoverFluidVoiding) && (!(pump instanceof CoverFluidRegulator) || ((CoverFluidRegulator) pump).getTransferMode() == TransferMode.TRANSFER_ANY)) {
+            transferRateText(probeInfo, pump.getPumpMode(), " " + rateUnit, pump.getBucketMode() == CoverPump.BucketMode.BUCKET ? pump.getTransferRate() / 1000 : pump.getTransferRate());
+        }
+
+        if (pump instanceof CoverFluidRegulator) {
+            CoverFluidRegulator regulator = (CoverFluidRegulator) pump;
+            transferModeText(probeInfo, regulator.getTransferMode(), rateUnit, regulator.getTransferAmount());
+        }
+    }
+
+    /**
+     * Displays info for {@link CoverFluidVoiding} related covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param voiding   the voiding cover to get data from
+     */
+    private static void fluidVoidingInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverFluidVoiding voiding) {
+        String unit = voiding.getBucketMode() == CoverPump.BucketMode.BUCKET ? " {*gregtech.top.unit.fluid_buckets*}" : " {*gregtech.top.unit.fluid_milibuckets*}";
+
+        if (voiding instanceof CoverFluidVoidingAdvanced) {
+            CoverFluidVoidingAdvanced advanced = (CoverFluidVoidingAdvanced) voiding;
+            VoidingMode mode = advanced.getVoidingMode();
+            voidingText(probeInfo, mode, unit, voiding.getBucketMode() == CoverPump.BucketMode.BUCKET ? advanced.getTransferAmount() / 1000 : advanced.getTransferAmount());
+        }
+        fluidFilterText(probeInfo, voiding.getFluidFilterContainer().getFilterWrapper().getFluidFilter());
+    }
+
+    /**
+     * Displays text for {@link CoverItemFilter} related covers
+     *
+     * @param probeInfo  the info to add the text to
+     * @param itemFilter the filter to get data from
+     */
+    private static void itemFilterInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverItemFilter itemFilter) {
+        filterModeText(probeInfo, itemFilter.getFilterMode());
+        itemFilterText(probeInfo, itemFilter.getItemFilter().getItemFilter());
+    }
+
+    /**
+     * Displays text for {@link CoverFluidFilter} related covers
+     *
+     * @param probeInfo   the info to add the text to
+     * @param fluidFilter the filter to get data from
+     */
+    private static void fluidFilterInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverFluidFilter fluidFilter) {
+        filterModeText(probeInfo, fluidFilter.getFilterMode());
+        fluidFilterText(probeInfo, fluidFilter.getFluidFilter().getFluidFilter());
+    }
+
+
+    /**
+     * Displays text for {@link IIOMode} covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param mode      the transfer mode of the cover
+     * @param rateUnit  the unit of what is transferred
+     * @param rate      the transfer rate of the mode
+     */
+    private static void transferRateText(@Nonnull IProbeInfo probeInfo, @Nonnull IIOMode mode, @Nonnull String rateUnit, int rate) {
+        String modeText = mode.isImport() ? "{*gregtech.top.mode.import*} " : "{*gregtech.top.mode.export*} ";
+        probeInfo.text(TextStyleClass.OK + modeText + TextStyleClass.LABEL + GTUtility.formatNumbers(rate) + rateUnit);
+    }
+
+    /**
+     * Displays text for {@link TransferMode} covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param mode      the transfer mode of the cover
+     * @param rateUnit  the unit of what is transferred
+     * @param rate      the transfer rate of the mode
+     */
+    private static void transferModeText(@Nonnull IProbeInfo probeInfo, @Nonnull TransferMode mode, @Nonnull String rateUnit, int rate) {
+        String text = TextStyleClass.OK + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
+        if (mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + rate + rateUnit;
+        probeInfo.text(text);
+    }
+
+    /**
+     * Displays text for {@link VoidingMode} covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param mode      the transfer mode of the cover
+     * @param unit      the unit of what is transferred
+     * @param amount    the transfer rate of the mode
+     */
+    private static void voidingText(@Nonnull IProbeInfo probeInfo, @Nonnull VoidingMode mode, @Nonnull String unit, int amount) {
+        String text = TextFormatting.RED + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
+        if (mode != VoidingMode.VOID_ANY) text += " " + amount + unit;
+        probeInfo.text(text);
+    }
+
+    /**
+     * Displays text for {@link IFilterMode} covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param mode      the filter mode of the cover
+     */
+    private static void filterModeText(@Nonnull IProbeInfo probeInfo, @Nonnull IFilterMode mode) {
+        probeInfo.text(TextStyleClass.WARNING + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC);
+    }
+
+    /**
+     * Displays text for {@link ItemFilter} covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param filter    the filter to display info from
+     */
+    private static void itemFilterText(@Nonnull IProbeInfo probeInfo, @Nonnull ItemFilter filter) {
+        String label = TextStyleClass.INFO + "{*gregtech.top.filter.label*} ";
+        if (filter instanceof OreDictionaryItemFilter) {
+            probeInfo.text(label + ((OreDictionaryItemFilter) filter).getOreDictFilterExpression());
+        } else if (filter instanceof SmartItemFilter) {
+            probeInfo.text(label + IProbeInfo.STARTLOC + ((SmartItemFilter) filter).getFilteringMode().getName() + IProbeInfo.ENDLOC);
+        }
+    }
+
+    /**
+     * Displays text for {@link FluidFilter} covers
+     *
+     * @param probeInfo the info to add the text to
+     * @param filter    the filter to display info from
+     */
+    private static void fluidFilterText(@Nonnull IProbeInfo probeInfo, @Nonnull FluidFilter filter) {
+        // TODO If more unique fluid filtration is added, providers for it go here
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
@@ -62,11 +62,12 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
             transferRateText(probeInfo, conveyor.getConveyorMode(), rateUnit, conveyor.getTransferRate());
         }
 
+        ItemFilterContainer filter = conveyor.getItemFilterContainer();
         if (conveyor instanceof CoverRoboticArm) {
             CoverRoboticArm roboticArm = (CoverRoboticArm) conveyor;
-            transferModeText(probeInfo, roboticArm.getTransferMode(), rateUnit, roboticArm.getItemFilterContainer().getTransferStackSize());
+            transferModeText(probeInfo, roboticArm.getTransferMode(), rateUnit, filter.getTransferStackSize(), filter.getFilterWrapper().getItemFilter() != null);
         }
-        itemFilterText(probeInfo, conveyor.getItemFilterContainer().getFilterWrapper().getItemFilter());
+        itemFilterText(probeInfo, filter.getFilterWrapper().getItemFilter());
     }
 
     /**
@@ -105,11 +106,12 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
             transferRateText(probeInfo, pump.getPumpMode(), " " + rateUnit, pump.getBucketMode() == CoverPump.BucketMode.BUCKET ? pump.getTransferRate() / 1000 : pump.getTransferRate());
         }
 
+        FluidFilterContainer filter = pump.getFluidFilterContainer();
         if (pump instanceof CoverFluidRegulator) {
             CoverFluidRegulator regulator = (CoverFluidRegulator) pump;
-            transferModeText(probeInfo, regulator.getTransferMode(), rateUnit, regulator.getTransferAmount());
+            transferModeText(probeInfo, regulator.getTransferMode(), rateUnit, regulator.getTransferAmount(), filter.getFilterWrapper().getFluidFilter() != null);
         }
-        fluidFilterText(probeInfo, pump.getFluidFilterContainer().getFilterWrapper().getFluidFilter());
+        fluidFilterText(probeInfo, filter.getFilterWrapper().getFluidFilter());
     }
 
     /**
@@ -172,10 +174,11 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param mode      the transfer mode of the cover
      * @param rateUnit  the unit of what is transferred
      * @param rate      the transfer rate of the mode
+     * @param hasFilter whether the cover has a filter installed
      */
-    private static void transferModeText(@Nonnull IProbeInfo probeInfo, @Nonnull TransferMode mode, @Nonnull String rateUnit, int rate) {
+    private static void transferModeText(@Nonnull IProbeInfo probeInfo, @Nonnull TransferMode mode, @Nonnull String rateUnit, int rate, boolean hasFilter) {
         String text = TextStyleClass.OK + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
-        if (mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + rate + rateUnit;
+        if (!hasFilter && mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + rate + rateUnit;
         probeInfo.text(text);
     }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/DebugPipeNetInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/DebugPipeNetInfoProvider.java
@@ -15,11 +15,11 @@ import mcjty.theoneprobe.api.ProbeMode;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Map;
+import java.util.List;
 
 public class DebugPipeNetInfoProvider implements IProbeInfoProvider {
     @Override
@@ -28,16 +28,16 @@ public class DebugPipeNetInfoProvider implements IProbeInfoProvider {
     }
 
     @Override
-    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
+    public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
         if (mode == ProbeMode.DEBUG && ConfigHolder.misc.debug) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (tileEntity instanceof IGregTechTileEntity) {
                 MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
                 if (metaTileEntity != null) {
-                    ArrayList<String> arrayList = new ArrayList<>();
-                    arrayList.add("MetaTileEntity Id: " + metaTileEntity.metaTileEntityId);
-                    metaTileEntity.addDebugInfo(arrayList);
-                    arrayList.forEach(probeInfo::text);
+                    List<String> list = new ArrayList<>();
+                    list.add("MetaTileEntity Id: " + metaTileEntity.metaTileEntityId);
+                    metaTileEntity.addDebugInfo(list);
+                    list.forEach(probeInfo::text);
                 }
             }
             if (tileEntity instanceof TileEntityPipeBase) {
@@ -48,19 +48,20 @@ public class DebugPipeNetInfoProvider implements IProbeInfoProvider {
                     probeInfo.text("Net: " + pipeNet.hashCode());
                     probeInfo.text("Node Info: ");
                     StringBuilder builder = new StringBuilder();
-                    Map<BlockPos, ? extends Node<?>> nodeMap = pipeNet.getAllNodes();
-                    Node<?> node = nodeMap.get(data.getPos());
-                    builder.append("{").append("active: ").append(node.isActive)
+                    Node<?> node = pipeNet.getAllNodes().get(data.getPos());
+                    builder.append("{")
+                            .append("active: ").append(node.isActive)
                             .append(", mark: ").append(node.mark)
-                            .append(", open: ").append(node.openConnections).append("}");
+                            .append(", open: ").append(node.openConnections)
+                            .append("}");
                     probeInfo.text(builder.toString());
                 }
                 probeInfo.text("tile open: " + pipeTile.getConnections());
-                /*if (blockPipe instanceof BlockFluidPipe) {
-                    if (pipeTile instanceof TileEntityFluidPipeTickable) {
-                        probeInfo.text("tile active: " + ((TileEntityFluidPipeTickable) pipeTile).isActive());
-                    }
-                }*/
+//                if (blockPipe instanceof BlockFluidPipe) {
+//                    if (pipeTile instanceof TileEntityFluidPipeTickable) {
+//                        probeInfo.text("tile active: " + ((TileEntityFluidPipeTickable) pipeTile).isActive());
+//                    }
+//                }
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/DiodeInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/DiodeInfoProvider.java
@@ -4,11 +4,13 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.common.metatileentities.electric.MetaTileEntityDiode;
-import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
+
+import javax.annotation.Nonnull;
 
 public class DiodeInfoProvider extends ElectricContainerInfoProvider {
 
@@ -18,20 +20,14 @@ public class DiodeInfoProvider extends ElectricContainerInfoProvider {
     }
 
     @Override
-    protected void addProbeInfo(IEnergyContainer capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+    protected void addProbeInfo(@Nonnull IEnergyContainer capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         if (tileEntity instanceof IGregTechTileEntity) {
             MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity instanceof MetaTileEntityDiode) {
-                long inputAmperage = capability.getInputAmperage();
-                long outputAmperage = capability.getOutputAmperage();
-                IProbeInfo horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-                String transformInfo;
-                if (capability.inputsEnergy(sideHit)) {
-                    transformInfo = "{*gregtech.top.transform_input*} " + inputAmperage + "A";
-                    horizontalPane.text(TextStyleClass.INFO + transformInfo);
-                } else if (capability.outputsEnergy(sideHit)) {
-                    transformInfo = "{*gregtech.top.transform_output*} " + outputAmperage + "A";
-                    horizontalPane.text(TextStyleClass.INFO + transformInfo);
+                if (capability.inputsEnergy(data.getSideHit())) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + capability.getInputAmperage() + " A");
+                } else if (capability.outputsEnergy(data.getSideHit())) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + capability.getOutputAmperage() + " A");
                 }
             }
         }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -1,46 +1,43 @@
 package gregtech.integration.theoneprobe.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
-import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IEnergyContainer;
-import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
-import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
 
 public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnergyContainer> {
 
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":energy_container_provider";
+    }
+
+    @Nonnull
     @Override
     protected Capability<IEnergyContainer> getCapability() {
         return GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER;
     }
 
     @Override
-    public String getID() {
-        return "gregtech:energy_container_provider";
-    }
-
-    @Override
-    protected boolean allowDisplaying(IEnergyContainer capability) {
+    protected boolean allowDisplaying(@Nonnull IEnergyContainer capability) {
         return !capability.isOneProbeHidden();
     }
 
     @Override
-    protected void addProbeInfo(IEnergyContainer capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
-        long energyStored = capability.getEnergyStored();
+    protected void addProbeInfo(@Nonnull IEnergyContainer capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         long maxStorage = capability.getEnergyCapacity();
-        if (maxStorage == 0) return; //do not add empty max storage progress bar
-        IProbeInfo horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-        String additionalSpacing = tileEntity.hasCapability(GregtechTileCapabilities.CAPABILITY_WORKABLE, sideHit) ? "   " : "";
-        horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.energy_stored*} " + additionalSpacing);
-        horizontalPane.progress(energyStored, maxStorage, probeInfo.defaultProgressStyle()
-                .suffix("/" + maxStorage + " EU")
-                .borderColor(0x00000000)
-                .backgroundColor(0x00000000)
-                .filledColor(0xFFFFE000)
-                .alternateFilledColor(0xFFEED000));
+        if (maxStorage == 0) return; // do not add empty max storage progress bar
+        probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
+                .suffix(" / " + maxStorage + " EU")
+                .filledColor(0xFFEEE600)
+                .alternateFilledColor(0xFFEEE600)
+                .borderColor(0xFF555555));
     }
 
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
@@ -1,41 +1,100 @@
 package gregtech.integration.theoneprobe.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.metatileentity.multiblock.IMaintenance;
 import gregtech.common.ConfigHolder;
+import gregtech.common.items.MetaItems;
 import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
 
 public class MaintenanceInfoProvider extends CapabilityInfoProvider<IMaintenance> {
 
+    private static final ItemStack WRENCH = MetaItems.WRENCH.getStackForm();
+    private static final ItemStack SCREWDRIVER = MetaItems.SCREWDRIVER.getStackForm();
+    private static final ItemStack SOFT_MALLET = MetaItems.SOFT_HAMMER.getStackForm();
+    private static final ItemStack HARD_HAMMER = MetaItems.HARD_HAMMER.getStackForm();
+    private static final ItemStack WIRE_CUTTERS = MetaItems.WIRE_CUTTER.getStackForm();
+    private static final ItemStack CROWBAR = MetaItems.CROWBAR.getStackForm();
+
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":multiblock_maintenance_provider";
+    }
+
+    @Nonnull
     @Override
     protected Capability<IMaintenance> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_MAINTENANCE;
     }
 
     @Override
-    protected void addProbeInfo(IMaintenance capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+    protected void addProbeInfo(IMaintenance capability, IProbeInfo probeInfo, EntityPlayer player, TileEntity tileEntity, IProbeHitData data) {
         if (ConfigHolder.machines.enableMaintenance && capability.hasMaintenanceMechanics()) {
-            if(tileEntity.hasCapability(GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER, null)) {
-                if(tileEntity.getCapability(GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER, null).isStructureFormed()) {
-                    IProbeInfo horizontalPaneMaintenance = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+            if (tileEntity.hasCapability(GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER, null)) {
+                //noinspection ConstantConditions
+                if (tileEntity.getCapability(GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER, null).isStructureFormed()) {
                     if (capability.hasMaintenanceProblems()) {
-                        horizontalPaneMaintenance.text(TextStyleClass.INFO + "{*gregtech.top.maintenance_broken*}");
+                        if (player.isSneaking()) {
+                            int problems = capability.getMaintenanceProblems();
+                            for (byte i = 0; i < 6; i++) {
+                                if (((problems >> i) & 1) == 0) {
+                                    IProbeInfo horizontal = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+                                    ItemStack stack = ItemStack.EMPTY;
+                                    String text = "";
+                                    switch (i) {
+                                        case 0: {
+                                            stack = WRENCH;
+                                            text = "gregtech.top.maintenance.wrench";
+                                            break;
+                                        }
+                                        case 1: {
+                                            stack = SCREWDRIVER;
+                                            text = "gregtech.top.maintenance.screwdriver";
+                                            break;
+                                        }
+                                        case 2: {
+                                            stack = SOFT_MALLET;
+                                            text = "gregtech.top.maintenance.soft_mallet";
+                                            break;
+                                        }
+                                        case 3: {
+                                            stack = HARD_HAMMER;
+                                            text = "gregtech.top.maintenance.hard_hammer";
+                                            break;
+                                        }
+                                        case 4: {
+                                            stack = WIRE_CUTTERS;
+                                            text = "gregtech.top.maintenance.wire_cutter";
+                                            break;
+                                        }
+                                        case 5: {
+                                            stack = CROWBAR;
+                                            text = "gregtech.top.maintenance.crowbar";
+                                            break;
+                                        }
+                                    }
+                                    horizontal.item(stack).text(TextFormatting.RED + IProbeInfo.STARTLOC + text + IProbeInfo.ENDLOC);
+                                }
+                            }
+                        } else {
+                            probeInfo.text(TextFormatting.RED + "{*gregtech.top.maintenance_broken*}");
+                        }
                     } else {
-                        horizontalPaneMaintenance.text(TextStyleClass.INFO + "{*gregtech.top.maintenance_fixed*}");
+                        probeInfo.text(TextStyleClass.LABEL + "{*gregtech.top.maintenance_fixed*}");
                     }
                 }
             }
         }
-    }
-
-    @Override
-    public String getID() {
-        return "gregtech:multiblock_maintenance_provider";
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
@@ -91,7 +91,7 @@ public class MaintenanceInfoProvider extends CapabilityInfoProvider<IMaintenance
                             probeInfo.text(TextFormatting.RED + "{*gregtech.top.maintenance_broken*}");
                         }
                     } else {
-                        probeInfo.text(TextStyleClass.LABEL + "{*gregtech.top.maintenance_fixed*}");
+                        probeInfo.text(TextStyleClass.OK + "{*gregtech.top.maintenance_fixed*}");
                     }
                 }
             }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -4,10 +4,11 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMultipleRecipeMaps;
 import gregtech.api.recipes.RecipeMap;
-import mcjty.theoneprobe.api.*;
-import net.minecraft.client.resources.I18n;
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 
 import javax.annotation.Nonnull;
@@ -16,18 +17,20 @@ public class MultiRecipeMapInfoProvider extends CapabilityInfoProvider<IMultiple
 
     @Override
     public String getID() {
-        return String.format("%s:multi_recipemap_provider", GTValues.MODID);
+        return GTValues.MODID + ":multi_recipemap_provider";
     }
 
+    @Nonnull
     @Override
     protected Capability<IMultipleRecipeMaps> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_MULTIPLE_RECIPEMAPS;
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IMultipleRecipeMaps iMultipleRecipeMaps, IProbeInfo iProbeInfo, TileEntity tileEntity, EnumFacing enumFacing) {
+    protected void addProbeInfo(@Nonnull IMultipleRecipeMaps iMultipleRecipeMaps, @Nonnull IProbeInfo iProbeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         if (iMultipleRecipeMaps.getAvailableRecipeMaps().length == 1) return;
-        iProbeInfo.text(TextStyleClass.INFO + I18n.format("gregtech.multiblock.multiple_recipemaps.header"));
+
+        iProbeInfo.text(TextStyleClass.INFO + IProbeInfo.STARTLOC + "gregtech.multiblock.multiple_recipemaps.header" + IProbeInfo.ENDLOC);
         for (RecipeMap<?> recipeMap : iMultipleRecipeMaps.getAvailableRecipeMaps()) {
             if (recipeMap.equals(iMultipleRecipeMaps.getCurrentRecipeMap())) {
                 iProbeInfo.text("   " + TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiblockInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiblockInfoProvider.java
@@ -1,38 +1,40 @@
 package gregtech.integration.theoneprobe.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IMultiblockController;
-import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
 
 public class MultiblockInfoProvider extends CapabilityInfoProvider<IMultiblockController> {
 
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":multiblock_controller_provider";
+    }
+
+    @Nonnull
     @Override
     protected Capability<IMultiblockController> getCapability() {
         return GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER;
     }
 
     @Override
-    protected void addProbeInfo(IMultiblockController capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
-        IProbeInfo horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+    protected void addProbeInfo(@Nonnull IMultiblockController capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         if (capability.isStructureFormed()) {
-            horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.valid_structure*}");
-            if(capability.isStructureObstructed()) {
-                IProbeInfo horizontalPaneObstructed = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-                horizontalPaneObstructed.text(TextStyleClass.INFO + "{*gregtech.top.obstructed_structure*}");
+            probeInfo.text(TextStyleClass.LABEL + "{*gregtech.top.valid_structure*}");
+            if (capability.isStructureObstructed()) {
+                probeInfo.text(TextFormatting.RED + "{*gregtech.top.obstructed_structure*}");
             }
-
+        } else {
+            probeInfo.text(TextFormatting.RED + "{*gregtech.top.invalid_structure*}");
         }
-        else
-            horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.invalid_structure*}");
-    }
-
-    @Override
-    public String getID() {
-        return "gregtech:multiblock_controller_provider";
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiblockInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiblockInfoProvider.java
@@ -29,7 +29,7 @@ public class MultiblockInfoProvider extends CapabilityInfoProvider<IMultiblockCo
     @Override
     protected void addProbeInfo(@Nonnull IMultiblockController capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         if (capability.isStructureFormed()) {
-            probeInfo.text(TextStyleClass.LABEL + "{*gregtech.top.valid_structure*}");
+            probeInfo.text(TextStyleClass.OK + "{*gregtech.top.valid_structure*}");
             if (capability.isStructureObstructed()) {
                 probeInfo.text(TextFormatting.RED + "{*gregtech.top.obstructed_structure*}");
             }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
@@ -17,11 +17,11 @@ public class PrimitivePumpInfoProvider implements IProbeInfoProvider {
 
     @Override
     public String getID() {
-        return String.format("%s:primitive_pump_provider", GTValues.MODID);
+        return GTValues.MODID + ":primitive_pump_provider";
     }
 
     @Override
-    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, @Nonnull IBlockState blockState, IProbeHitData data) {
+    public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
         if (blockState.getBlock().hasTileEntity(blockState)) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (!(tileEntity instanceof IGregTechTileEntity)) return;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -5,10 +5,11 @@ import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.capability.impl.PrimitiveRecipeLogic;
 import gregtech.integration.jei.utils.JEIHelpers;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
@@ -17,26 +18,27 @@ import javax.annotation.Nonnull;
 public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractRecipeLogic> {
 
     @Override
+    public String getID() {
+        return GTValues.MODID + ":recipe_logic_provider";
+    }
+
+    @Nonnull
+    @Override
     protected Capability<AbstractRecipeLogic> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_RECIPE_LOGIC;
     }
 
     @Override
-    public String getID() {
-        return String.format("%s:recipe_logic_provider", GTValues.MODID);
-    }
-
-    @Override
-    protected void addProbeInfo(@Nonnull AbstractRecipeLogic capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+    protected void addProbeInfo(@Nonnull AbstractRecipeLogic capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         // do not show energy usage on machines that do not use energy
         if (capability.isWorking()) {
             if (!(capability instanceof PrimitiveRecipeLogic)) {
                 int EUt = capability.getRecipeEUt();
-                if (EUt > 0) {
-                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + TextFormatting.RED + EUt + TextFormatting.RESET + " EU/t (" + GTValues.VNF[JEIHelpers.getMinTierForVoltage(EUt)] + TextFormatting.RESET + ")");
-                } else if (EUt < 0) {
-                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " + TextFormatting.RED + (EUt * -1) + TextFormatting.RESET + " EU/t (" + GTValues.VNF[JEIHelpers.getMinTierForVoltage(EUt * -1)] + TextFormatting.RESET + ")");
-                }
+                int absEUt = Math.abs(EUt);
+                String text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN + " (" + GTValues.VNF[JEIHelpers.getMinTierForVoltage(absEUt)] + TextFormatting.GREEN + ")";
+
+                if (EUt > 0) probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);
+                else if (EUt < 0) probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " + text);
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -37,8 +37,11 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 int absEUt = Math.abs(EUt);
                 String text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN + " (" + GTValues.VNF[JEIHelpers.getMinTierForVoltage(absEUt)] + TextFormatting.GREEN + ")";
 
-                if (EUt > 0) probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);
-                else if (EUt < 0) probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " + text);
+                if (EUt > 0) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);
+                } else if (EUt < 0) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " + text);
+                }
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
@@ -6,54 +6,49 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.electric.MetaTileEntityTransformer;
-import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
+
+import javax.annotation.Nonnull;
 
 public class TransformerInfoProvider extends ElectricContainerInfoProvider {
 
     @Override
     public String getID() {
-        return "gregtech:transformer_info_provider";
+        return GTValues.MODID + ":transformer_info_provider";
     }
 
     @Override
-    protected void addProbeInfo(IEnergyContainer capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
+    protected void addProbeInfo(@Nonnull IEnergyContainer capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
         if (tileEntity instanceof IGregTechTileEntity) {
             MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity instanceof MetaTileEntityTransformer) {
-                MetaTileEntityTransformer mteTransformer = (MetaTileEntityTransformer) metaTileEntity;
-                String inputVoltageN = GTValues.VNF[GTUtility.getTierByVoltage(capability.getInputVoltage())];
-                String outputVoltageN = GTValues.VNF[GTUtility.getTierByVoltage(capability.getOutputVoltage())];
-                long inputAmperage = capability.getInputAmperage();
-                long outputAmperage = capability.getOutputAmperage();
-                IProbeInfo horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-                String transformInfo;
+                StringBuilder input = new StringBuilder()
+                        .append(GTValues.VNF[GTUtility.getTierByVoltage(capability.getInputVoltage())])
+                        .append(TextFormatting.GREEN)
+                        .append(" (")
+                        .append(capability.getInputAmperage())
+                        .append("A)");
+
+                StringBuilder output = new StringBuilder()
+                        .append(GTValues.VNF[GTUtility.getTierByVoltage(capability.getOutputVoltage())])
+                        .append(TextFormatting.GREEN)
+                        .append(" (")
+                        .append(capability.getOutputAmperage())
+                        .append("A)");
 
                 // Step Up/Step Down line
-                if (mteTransformer.isInverted()) {
-                    transformInfo = "{*gregtech.top.transform_up*} ";
-                } else {
-                    transformInfo = "{*gregtech.top.transform_down*} ";
-                }
-                transformInfo += inputVoltageN + TextFormatting.GREEN + " (" + inputAmperage + "A) -> "
-                        + outputVoltageN + TextFormatting.GREEN + " (" + outputAmperage + "A)";
-                horizontalPane.text(TextStyleClass.INFO + transformInfo);
+                probeInfo.text(TextStyleClass.INFO + (((MetaTileEntityTransformer) metaTileEntity).isInverted() ? "{*gregtech.top.transform_up*} " : "{*gregtech.top.transform_down*} ") + input + " -> " + output);
 
                 // Input/Output side line
-                horizontalPane = probeInfo.vertical(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-                if (capability.inputsEnergy(sideHit)) {
-                    transformInfo = "{*gregtech.top.transform_input*} "
-                            + inputVoltageN + TextFormatting.GREEN + " (" + inputAmperage + "A)";
-                    horizontalPane.text(TextStyleClass.INFO + transformInfo);
-
-                } else if (capability.outputsEnergy(sideHit)) {
-                    transformInfo = "{*gregtech.top.transform_output*} "
-                            + outputVoltageN + TextFormatting.GREEN + " (" + outputAmperage + "A)";
-                    horizontalPane.text(TextStyleClass.INFO + transformInfo);
+                if (capability.inputsEnergy(data.getSideHit())) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + input);
+                } else if (capability.outputsEnergy(data.getSideHit())) {
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + output);
                 }
             }
         }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
@@ -1,51 +1,52 @@
 package gregtech.integration.theoneprobe.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
-import mcjty.theoneprobe.api.ElementAlignment;
+import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
-import mcjty.theoneprobe.api.TextStyleClass;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nonnull;
 
 public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {
 
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":workable_provider";
+    }
+
+    @Nonnull
     @Override
     protected Capability<IWorkable> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_WORKABLE;
     }
 
     @Override
-    public String getID() {
-        return "gregtech:workable_provider";
-    }
+    protected void addProbeInfo(@Nonnull IWorkable capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+        if (!capability.isActive()) return;
 
-    @Override
-    protected void addProbeInfo(IWorkable capability, IProbeInfo probeInfo, TileEntity tileEntity, EnumFacing sideHit) {
         int currentProgress = capability.getProgress();
         int maxProgress = capability.getMaxProgress();
-        String suffix;
+        String text;
 
         if (maxProgress < 20) {
-            currentProgress = capability.getProgress();
-            maxProgress = capability.getMaxProgress();
-            suffix = " t / " + maxProgress + " t";
+            text = " / " + maxProgress + " t";
         } else {
-            currentProgress = (int) Math.round(currentProgress / 20.0);
-            maxProgress = (int) Math.round(maxProgress / 20.0);
-            suffix = " s / " + maxProgress + " s";
+            currentProgress = Math.round(currentProgress / 20.0F);
+            maxProgress = Math.round(maxProgress / 20.0F);
+            text = " / " + maxProgress + " s";
         }
 
         if (maxProgress > 0) {
-            IProbeInfo horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
-            horizontalPane.text(TextStyleClass.INFO + "{*gregtech.top.progress*} ");
-            horizontalPane.progress(currentProgress, maxProgress, probeInfo.defaultProgressStyle()
-                    .suffix(suffix)
-                    .borderColor(0x00000000)
-                    .backgroundColor(0x00000000)
-                    .filledColor(0xFF000099)
-                    .alternateFilledColor(0xFF000077));
+            int color = capability.isWorkingEnabled() ? 0xFF4CBB17 : 0xFFBB1C28;
+            probeInfo.progress(currentProgress, maxProgress, probeInfo.defaultProgressStyle()
+                    .suffix(text)
+                    .filledColor(color)
+                    .alternateFilledColor(color)
+                    .borderColor(0xFF555555));
         }
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -24,32 +24,34 @@ gregtech.machine.steam_oven.name=Steam Oven
 gregtech.machine.steam_oven.tooltip=Smelts up to 8 items per craft. Takes 1.5x base duration to process, not affected by number of items. Requires §eSteam Hatches and Buses
 gregtech.multiblock.steam_oven.description=A Multi Smelter at the Steam Age. Requires at least 6 Bronze Casings to form. Cannot use normal Input/Output busses, nor Fluid Hatches other than the Steam Hatch. Steam Hatch must be on the bottom layer, no more than one.
 
-gregtech.top.energy_stored=Energy:
-gregtech.top.progress=Progress:
 gregtech.top.working_disabled=Working Disabled
 
-gregtech.top.energy_consumption=Usage:
-gregtech.top.energy_production=Output:
+gregtech.top.energy_consumption=Using
+gregtech.top.energy_production=Producing
 
 gregtech.top.transform_up=§cStep Up§r
 gregtech.top.transform_down=§aStep Down§r
 gregtech.top.transform_input=§6Input:§r
 gregtech.top.transform_output=§9Output:§r
 
-gregtech.top.convert_eu=§eConverting EU§r
-gregtech.top.convert_fe=§cConverting FE§r
+gregtech.top.convert_eu=Converting §eEU§r -> §cFE§r
+gregtech.top.convert_fe=Converting §cFE§r -> §eEU§r
 
-gregtech.top.fuel_burn=for
-gregtech.top.fuel_time=secs
-gregtech.top.fuel_min_consume=needs
-gregtech.top.fuel_name=Fuel:
+gregtech.top.fuel_min_consume=Needs
 gregtech.top.fuel_none=No fuel
 
-gregtech.top.invalid_structure=§cStructure Incomplete
-gregtech.top.valid_structure=§aStructure Formed
-gregtech.top.obstructed_structure=§cStructure Obstructed
-gregtech.top.maintenance_fixed=§aMaintenance Fine
-gregtech.top.maintenance_broken=§cNeeds Maintenance
+gregtech.top.invalid_structure=Structure Incomplete
+gregtech.top.valid_structure=Structure Formed
+gregtech.top.obstructed_structure=Structure Obstructed
+
+gregtech.top.maintenance_fixed=Maintenance Fine
+gregtech.top.maintenance_broken=Needs Maintenance
+gregtech.top.maintenance.wrench=Pipe is loose
+gregtech.top.maintenance.screwdriver=Screws are loose
+gregtech.top.maintenance.soft_mallet=Something is stuck
+gregtech.top.maintenance.hard_hammer=Plating is dented
+gregtech.top.maintenance.wire_cutter=Wires burned out
+gregtech.top.maintenance.crowbar=That doesn't belong there
 
 gregtech.top.primitive_pump_production=Production:
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -55,7 +55,7 @@ gregtech.top.maintenance.crowbar=That doesn't belong there
 
 gregtech.top.primitive_pump_production=Production:
 
-gregtech.top.filter.label=Filter
+gregtech.top.filter.label=Filter:
 
 gregtech.top.mode.export=Exporting
 gregtech.top.mode.import=Importing

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -55,6 +55,15 @@ gregtech.top.maintenance.crowbar=That doesn't belong there
 
 gregtech.top.primitive_pump_production=Production:
 
+gregtech.top.filter.label=Filter
+
+gregtech.top.mode.export=Exporting
+gregtech.top.mode.import=Importing
+
+gregtech.top.unit.items=Items
+gregtech.top.unit.fluid_milibuckets=L
+gregtech.top.unit.fluid_buckets=kL
+
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.
 gregtech.multiblock.coke_oven.description=The Coke Oven is a multiblock structure used for getting coke and creosote in the early game. It doesn't require fuel and has an internal tank of 32 buckets for creosote. Its inventory can be accessed via its Coke Oven Hatch.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -56,6 +56,7 @@ gregtech.top.maintenance.crowbar=That doesn't belong there
 gregtech.top.primitive_pump_production=Production:
 
 gregtech.top.filter.label=Filter:
+gregtech.top.link_cover.color=Color:
 
 gregtech.top.mode.export=Exporting
 gregtech.top.mode.import=Importing


### PR DESCRIPTION
**What:**
This PR improves our TOP providers.

Many color and stylistic changes have been made to improve readability and cleanliness. Additionally, much code cleanup was performed on each of the provider classes to remove a lot of extraneous processing. All of our providers also use `GTValues.MODID` for their names instead of hardcoding `gregtech` in some places.

The `FuelableInfoProvider` has been cleaned up significantly, but the underlying system is likely flawed or not entirely functional, and is to be fully fixed up and improved in the future.

This PR also adds a new TOP Provider, CoverInfoProvider, which adds a lot of information concerning covers. For all applicable covers, Transfer Rate and Direction is displayed. Covers with transfer modes display their modes and relevant data. Voiding covers display voiding modes and relevant data. Filters display their direction and relevant data, and this information is also displayed when placed inside of other covers.

This PR also no longer uses `I18n.format()` in any provider, which fixes potential log warning spam on servers.

**Implementation Details:**
`CapabilityInfoProvider` now passes through the `IProbeHitData` instead of the `EnumFacing` side hit, which will allow for more complex future capability provider implementations.

`CoverInfoProvider` has a method `fluidFilterText()` which is intended for future fluid filters with unique attributes to display.

**Outcome:**
Improved TOP providers.

**Additional info:**
Added borders and backgrounds to progress bar style displays for increased readability. The labels for these were also removed along with some strange padding.
![image](https://user-images.githubusercontent.com/37029404/170885222-12b46bc5-95ea-4b14-9749-0c0b9f75b1c9.png)
Pausing machines now changes the progress bar to red.
![image](https://user-images.githubusercontent.com/37029404/170885224-7ffc81b2-7981-408e-bb45-38ef6584ecee.png)
Sneaking while viewing a controller with maintenance problems now shows each problem and associated tool.
![image](https://user-images.githubusercontent.com/37029404/170885253-17277cb4-bba4-4eed-b7b1-b18b105b2355.png)
Filter information is now displayed.
![image](https://user-images.githubusercontent.com/37029404/170890394-142c45c2-0cfc-4188-89a9-0bb3a390c0a4.png)
![image](https://user-images.githubusercontent.com/37029404/170890399-b2b16fbc-bf2d-44ea-9612-a070af9bee6b.png)

Many other minor improvements have been made in addition.
