### PR TITLE
Add Material Rebuilder

### DIFF
--- a/src/main/java/gregtech/api/unification/material/IMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/material/IMaterialBuilder.java
@@ -1,84 +1,74 @@
 package gregtech.api.unification.material;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import gregtech.api.fluids.fluidType.FluidType;
 import gregtech.api.fluids.fluidType.FluidTypes;
 import gregtech.api.unification.Element;
-import gregtech.api.unification.material.info.MaterialFlag;
-import gregtech.api.unification.material.info.MaterialFlags;
-import gregtech.api.unification.material.info.MaterialIconSet;
+import gregtech.api.unification.material.info.*;
 import gregtech.api.unification.material.properties.*;
 import gregtech.api.unification.stack.MaterialStack;
 import net.minecraft.enchantment.Enchantment;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 /** Common interface for various implementations of Material Builders */
 public interface IMaterialBuilder {
 
-    /**
-     * Add a {@link FluidProperty} to this Material.<br>
-     * Will be created as a {@link FluidTypes#LIQUID}, without a Fluid Block.
-     *
-     * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
-     */
-    default IMaterialBuilder fluid() {
-        return fluid(FluidTypes.LIQUID);
-    }
+    // FLUID
 
     /**
-     * Add a {@link FluidProperty} to this Material.<br>
-     * Will be created without a Fluid Block.
+     * Add a {@link FluidProperty} to this Material.<br><br>
+     * Sets Fluid Type to {@link FluidTypes#LIQUID} if not already set.<br>
+     * Created without a Fluid Block unless already set.
+     * <br><br>
+     * See {@link #fluid(FluidType, boolean)} for setting your own value(s).
+     */
+    IMaterialBuilder fluid();
+
+    /**
+     * Add a {@link FluidProperty} to this Material.<br><br>
+     * Created without a Fluid Block unless already set.
+     * <br><br>
+     * See {@link #fluid(FluidType, boolean)} for setting your own value(s).
      *
      * @param type The {@link FluidType} of this Material, either Fluid or Gas.
-     * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
      */
-    default IMaterialBuilder fluid(FluidType type) {
-        return fluid(type, false);
-    }
+    IMaterialBuilder fluid(FluidType type);
 
     /**
      * Add a {@link FluidProperty} to this Material.
      *
      * @param type     The {@link FluidType} of this Material.
      * @param hasBlock If true, create a Fluid Block for this Material.
-     * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
      */
     IMaterialBuilder fluid(FluidType type, boolean hasBlock);
 
     /**
      * Add a {@link PlasmaProperty} to this Material.<br>
      * Is not required to have a {@link FluidProperty}, and will not automatically apply one.
-     *
-     * @throws IllegalArgumentException If a {@link PlasmaProperty} has already been added to this Material.
      */
     IMaterialBuilder plasma();
 
     /**
-     * Add a {@link DustProperty} to this Material.<br>
-     * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).
-     *
-     * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
+     * Add a {@link DustProperty} to this Material.<br><br>
+     * Sets Harvest Level to 2 if not already set.<br>
+     * Sets Burn Time (Furnace Fuel) to 0 if not already set.
+     * <br><br>
+     * See {@link #dust(int, int)} for setting your own value(s).
      */
-    default IMaterialBuilder dust() {
-        return dust(2, 0);
-    }
+    IMaterialBuilder dust();
 
     /**
-     * Add a {@link DustProperty} to this Material.<br>
-     * Will be created with no Burn Time (Furnace Fuel).
+     * Add a {@link DustProperty} to this Material.<br><br>
+     * Sets Burn Time (Furnace Fuel) to 0 if not already set.
+     * <br><br>
+     * See {@link #dust(int, int)} for setting your own value(s).
      *
      * @param harvestLevel The Harvest Level of this block for Mining.<br>
      *                     If this Material also has a {@link ToolProperty}, this value will
      *                     also be used to determine the tool's Mining Level.
-     * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
      */
-    default IMaterialBuilder dust(int harvestLevel) {
-        return dust(harvestLevel, 0);
-    }
+    IMaterialBuilder dust(int harvestLevel);
 
     /**
      * Add a {@link DustProperty} to this Material.
@@ -87,35 +77,34 @@ public interface IMaterialBuilder {
      *                     If this Material also has a {@link ToolProperty}, this value will
      *                     also be used to determine the tool's Mining Level.
      * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.
-     * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
      */
     IMaterialBuilder dust(int harvestLevel, int burnTime);
 
     /**
      * Add an {@link IngotProperty} to this Material.<br>
-     * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).<br>
-     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-     *
-     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.<br><br>
+     * Sets Harvest Level to 2 if not already set.<br>
+     * Sets Burn Time (Furnace Fuel) to 0 if not already set.
+     * <br><br>
+     * See {@link #ingot(int, int)} for setting your own value(s).
+     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
      */
-    default IMaterialBuilder ingot() {
-        return ingot(2, 0);
-    }
+    IMaterialBuilder ingot();
 
     /**
      * Add an {@link IngotProperty} to this Material.<br>
-     * Will be created with no Burn Time (Furnace Fuel).<br>
-     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.<br><br>
+     * Sets Burn Time (Furnace Fuel) to 0 if not already set.
+     * <br><br>
+     * See {@link #ingot(int, int)} for setting your own value(s).
      *
      * @param harvestLevel The Harvest Level of this block for Mining. 2 will make it require a iron tool.<br>
      *                     If this Material also has a {@link ToolProperty}, this value will
      *                     also be used to determine the tool's Mining level (-1). So 2 will make the tool harvest diamonds.<br>
      *                     If this Material already had a Harvest Level defined, it will be overridden.
-     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
+     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
      */
-    default IMaterialBuilder ingot(int harvestLevel) {
-        return ingot(harvestLevel, 0);
-    }
+    IMaterialBuilder ingot(int harvestLevel);
 
     /**
      * Add an {@link IngotProperty} to this Material.<br>
@@ -127,35 +116,35 @@ public interface IMaterialBuilder {
      *                     If this Material already had a Harvest Level defined, it will be overridden.
      * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
      *                     If this Material already had a Burn Time defined, it will be overridden.
-     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
+     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
      */
     IMaterialBuilder ingot(int harvestLevel, int burnTime);
 
     /**
      * Add a {@link GemProperty} to this Material.<br>
-     * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).<br>
-     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-     *
-     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.<br><br>
+     * Sets Harvest Level to 2 if not already set.<br>
+     * Sets Burn Time (Furnace Fuel) to 0 if not already set.
+     * <br><br>
+     * See {@link #gem(int, int)} for setting your own value(s).
+     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
      */
-    default IMaterialBuilder gem() {
-        return gem(2, 0);
-    }
+    IMaterialBuilder gem();
 
     /**
      * Add a {@link GemProperty} to this Material.<br>
-     * Will be created with no Burn Time (Furnace Fuel).<br>
-     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.<br><br>
+     * Sets Burn Time (Furnace Fuel) to 0 if not already set.
+     * <br><br>
+     * See {@link #gem(int, int)} for setting your own value(s).
      *
      * @param harvestLevel The Harvest Level of this block for Mining.<br>
      *                     If this Material also has a {@link ToolProperty}, this value will
      *                     also be used to determine the tool's Mining level.<br>
      *                     If this Material already had a Harvest Level defined, it will be overridden.
-     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
+     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
      */
-    default IMaterialBuilder gem(int harvestLevel) {
-        return gem(harvestLevel, 0);
-    }
+    IMaterialBuilder gem(int harvestLevel);
 
     /**
      * Add a {@link GemProperty} to this Material.<br>
@@ -167,6 +156,7 @@ public interface IMaterialBuilder {
      *                     If this Material already had a Harvest Level defined, it will be overridden.
      * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
      *                     If this Material already had a Burn Time defined, it will be overridden.
+     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
      */
     IMaterialBuilder gem(int harvestLevel, int burnTime);
 
@@ -182,13 +172,14 @@ public interface IMaterialBuilder {
     /**
      * Set the Color of this Material.<br>
      * Defaults to 0xFFFFFF unless {@link IMaterialBuilder#colorAverage()} was called, where
-     * it will be a weighted average of the components of the Material.
+     * it will be a weighted average of the components of the Material.<br>
+     * Will automatically color the Fluid of the Material.
+     * <br><br>
+     * See {@link #color(int, boolean)} to set an override of the Fluid's color.
      *
      * @param color The RGB-formatted Color.
      */
-    default IMaterialBuilder color(int color) {
-        return color(color, true);
-    }
+    IMaterialBuilder color(int color);
 
     /**
      * Set the Color of this Material.<br>
@@ -230,24 +221,7 @@ public interface IMaterialBuilder {
      *                   Material and the amount of said Material in this Material's composition.
      * @throws IllegalArgumentException if the Object array is malformed.
      */
-    default IMaterialBuilder components(Object... components) {
-        Preconditions.checkArgument(
-                components.length % 2 == 0,
-                "Material Components list malformed!"
-        );
-        ImmutableList.Builder<MaterialStack> builder = ImmutableList.builder();
-
-        for (int i = 0; i < components.length; i += 2) {
-            if (components[i] == null) {
-                throw new IllegalArgumentException();
-            }
-            builder.add(new MaterialStack(
-                    (Material) components[i],
-                    (Integer) components[i + 1]
-            ));
-        }
-        return components(builder.build());
-    }
+    IMaterialBuilder components(Object... components);
 
     /**
      * Set the components that make up this Material.<br>
@@ -266,11 +240,7 @@ public interface IMaterialBuilder {
      * @param f1 A {@link Collection} of {@link MaterialFlag}. Provided this way for easy Flag presets to be applied.
      * @param f2 An Array of {@link MaterialFlag}. If no {@link Collection} is required, use {@link Material.Builder#flags(MaterialFlag...)}.
      */
-    default IMaterialBuilder flags(Collection<MaterialFlag> f1, MaterialFlag... f2) {
-        Collection<MaterialFlag> copy = new ArrayList<>(f1);
-        Collections.addAll(copy, f2);
-        return flags(copy.toArray(new MaterialFlag[0]));
-    }
+    IMaterialBuilder flags(Collection<MaterialFlag> f1, MaterialFlag... f2);
 
     /**
      * Add {@link MaterialFlags} to this Material.<br>
@@ -288,16 +258,17 @@ public interface IMaterialBuilder {
     IMaterialBuilder element(Element element);
 
     /**
-     * Add GregTech and Vanilla-substitute tools to this Material.
+     * Add GregTech and Vanilla-substitute tools to this Material.<br>
+     * Automatically creates Crafting Tools as well.
+     * <br><br>
+     * See {@link #toolStats(float, float, int, int, boolean)} to remove Crafting Tools.
      *
      * @param speed          The mining speed of a tool made from this Material.
      * @param damage         The attack damage of a tool made from this Material.
      * @param durability     The durability of a tool made from this Material.
      * @param enchantability The base enchantability of a tool made from this Material. Iron is 14, Diamond is 10, Stone is 5.
      */
-    default IMaterialBuilder toolStats(float speed, float damage, int durability, int enchantability) {
-        return toolStats(speed, damage, durability, enchantability, false);
-    }
+    IMaterialBuilder toolStats(float speed, float damage, int durability, int enchantability);
 
     /**
      * Add GregTech and Vanilla-substitute tools to this Material.
@@ -315,82 +286,91 @@ public interface IMaterialBuilder {
      * Will generate a Dust -> Ingot EBF recipe at 120 EU/t and a duration based off of the Material's composition.<br>
      * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
      * If the temperature is below ...K, it will automatically add a PBF recipe in addition to the EBF recipe.
+     * <br><br>
+     * See {@link #blastTemp(int, BlastProperty.GasTier, int, int)} for setting your own value(s).
      *
      * @param temp The temperature of the recipe in the EBF.
      */
-    default IMaterialBuilder blastTemp(int temp) {
-        return blastTemp(temp, null, -1, -1);
-    }
+    IMaterialBuilder blastTemp(int temp);
 
     /**
      * Add an EBF Temperature and recipe to this Material.<br>
      * Will generate a Dust -> Ingot EBF recipe at 120 EU/t and a duration based off of the Material's composition.<br>
-     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.
+     * <br><br>
+     * See {@link #blastTemp(int, BlastProperty.GasTier, int, int)} for setting your own value(s).
      *
      * @param temp    The temperature of the recipe in the EBF.
      * @param gasTier The {@link gregtech.api.unification.material.properties.BlastProperty.GasTier} of the Recipe.
      *                Will generate a second EBF recipe using the specified gas of the tier for a speed bonus.
      */
-    default IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier) {
-        return blastTemp(temp, gasTier, -1, -1);
-    }
+    IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier);
 
     /**
      * Add an EBF Temperature and recipe to this Material.<br>
      * Will generate a Dust -> Ingot EBF recipe at a duration based off of the Material's composition.<br>
-     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.
+     * <br><br>
+     * See {@link #blastTemp(int, BlastProperty.GasTier, int, int)} for setting your own value(s).
      *
      * @param temp        The temperature of the recipe in the EBF.
      * @param gasTier     The {@link gregtech.api.unification.material.properties.BlastProperty.GasTier} of the Recipe.
      *                    Will generate a second EBF recipe using the specified gas of the tier for a speed bonus.
      * @param eutOverride Custom recipe EU/t instead of the default 120 EU/t.
      */
-    default IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
-        return blastTemp(temp, gasTier, eutOverride, -1);
-    }
+    IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride);
 
     /**
      * Add an EBF Temperature and recipe to this Material.<br>
      * Will generate a Dust -> Ingot EBF recipe.<br>
-     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.
      *
      * @param temp             The temperature of the recipe in the EBF.
      * @param gasTier          The {@link gregtech.api.unification.material.properties.BlastProperty.GasTier} of the Recipe.
      *                         Will generate a second EBF recipe using the specified gas of the tier for a speed bonus.
      * @param eutOverride      Custom recipe EU/t instead of the default 120 EU/t.
      * @param durationOverride Custom recipe duration instead of the default composition-based duration.
-     * @return
      */
     IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride);
 
     /**
-     * Add an Ore to this Material, with an ore and byproduct multiplier of 1 and without emissive textures.
+     * Add an {@link OreProperty} to this Material.<br>
+     * Automatically adds a {@link DustProperty} to this Material.<br><br>
+     * Sets Ore Multiplier to 1 if not already set.<br>
+     * Sets Byproduct Multiplier to 1 if not already set.<br>
+     * Sets Emissive Textures to false if not already set.
+     * <br><br>
+     * See {@link #ore(int, int, boolean)} for setting your own value(s).
      */
-    default IMaterialBuilder ore() {
-        return ore(1, 1, false);
-    }
+    IMaterialBuilder ore();
 
     /**
-     * Add an Ore to this Material, with an ore and byproduct multiplier of 1.
+     * Add an {@link OreProperty} to this Material.<br>
+     * Automatically adds a {@link DustProperty} to this Material.<br><br>
+     * Sets Ore Multiplier to 1 if not already set.<br>
+     * Sets Byproduct Multiplier to 1 if not already set.
+     * <br><br>
+     * See {@link #ore(int, int, boolean)} for setting your own value(s).
      *
      * @param emissive Whether this Material's Ore Block should use emissive textures on the ore-vein texture overlay.
      */
-    default IMaterialBuilder ore(boolean emissive) {
-        return ore(1, 1, emissive);
-    }
+    IMaterialBuilder ore(boolean emissive);
 
     /**
-     * Add an Ore to this Material without emissive textures.
+     * Add an {@link OreProperty} to this Material.<br>
+     * Automatically adds a {@link DustProperty} to this Material.<br><br>
+     * Sets Emissive Textures to false if not already set.
+     * <br><br>
+     * See {@link #ore(int, int, boolean)} for setting your own value(s).
      *
      * @param oreMultiplier       Crushed output multiplier when the Ore Block is macerated.
      * @param byproductMultiplier Byproduct multiplier on some ore processing steps.
      */
-    default IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier) {
-        return ore(oreMultiplier, byproductMultiplier, false);
-    }
+    IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier);
 
     /**
-     * Add an Ore to this Material.
+     * Add an {@link OreProperty} to this Material.<br>
+     * Automatically adds a {@link DustProperty} to this Material.
      *
      * @param oreMultiplier       Crushed output multiplier when the Ore Block is macerated.
      * @param byproductMultiplier Byproduct multiplier on some ore processing steps.
@@ -399,8 +379,9 @@ public interface IMaterialBuilder {
     IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier, boolean emissive);
 
     /**
-     * Add a custom Fluid Temperatore to the Fluid of this Material.<br>
-     * Automatically adds a {@link FluidProperty} to this Material if it doesn't have one, using the LIQUID type and no Fluid block.
+     * Add a custom Fluid Temperature to the Fluid of this Material.<br>
+     * Automatically adds a {@link FluidProperty} to this Material if it doesn't have one,
+     * using the LIQUID type and no Fluid block (if not already set).
      *
      * @param temp The temperature of this Fluid.
      */
@@ -409,20 +390,18 @@ public interface IMaterialBuilder {
     /**
      * Adds a Chemical Bath ore processing step to this Material's Ore, using 100L of the Fluid.<br>
      * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
-     * with ore and byproduct multipliers of 1 and no emissive textures.
+     * with ore and byproduct multipliers of 1 and no emissive textures (if not already set).
      *
      * @param m The Material that is used as a Chemical Bath fluid for ore processing.
      *          This Material will be given a {@link FluidProperty} if it does not already have one,
      *          of type LIQUID and no Fluid block.
      */
-    default IMaterialBuilder washedIn(Material m) {
-        return washedIn(m, 100);
-    }
+    IMaterialBuilder washedIn(Material m);
 
     /**
      * Adds a Chemical Bath ore processing step to this Material's Ore.<br>
      * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
-     * with ore and byproduct multipliers of 1 and no emissive textures.
+     * with ore and byproduct multipliers of 1 and no emissive textures (if not already set).
      *
      * @param m            The Material that is used as a Chemical Bath fluid for ore processing.
      *                     This Material will be given a {@link FluidProperty} if it does not already have one,
@@ -434,7 +413,7 @@ public interface IMaterialBuilder {
     /**
      * Adds an Electromagnetic Separator recipe to this Material's Purified Dust, which outputs the passed Materials.<br>
      * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
-     * with ore and byproduct multipliers of 1 and no emissive textures.
+     * with ore and byproduct multipliers of 1 and no emissive textures (if not already set).
      *
      * @param m The Materials which should be output by the Electromagnetic Separator in addition to a normal Dust of this Material.
      */
@@ -443,7 +422,7 @@ public interface IMaterialBuilder {
     /**
      * Sets the Material which this Material's Ore Block smelts to directly in a Furnace.<br>
      * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
-     * with ore and byproduct multipliers of 1 and no emissive textures.
+     * with ore and byproduct multipliers of 1 and no emissive textures (if not already set).
      *
      * @param m The Material which should be output when smelting.
      */
@@ -452,7 +431,7 @@ public interface IMaterialBuilder {
     /**
      * Adds a Polarizer recipe to this Material's metal parts, outputting the provided Material.<br>
      * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
-     * with a harvest level of 2 and no Furnace burn time.
+     * with a harvest level of 2 and no Furnace burn time (if not already set).
      *
      * @param m The Material that this Material will be polarized into.
      */
@@ -461,7 +440,7 @@ public interface IMaterialBuilder {
     /**
      * Sets the Material that this Material will automatically transform into in any Arc Furnace recipe.<br>
      * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
-     * with a harvest level of 2 and no Furnace burn time.
+     * with a harvest level of 2 and no Furnace burn time (if not already set).
      *
      * @param m The Material that this Material will turn into in any Arc Furnace recipes.
      */
@@ -471,7 +450,7 @@ public interface IMaterialBuilder {
      * Sets the Material that this Material's Ingot should macerate directly into.<br>
      * A good example is Magnetic Iron, which when macerated, will turn back into normal Iron.<br>
      * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
-     * with a harvest level of 2 and no Furnace burn time.
+     * with a harvest level of 2 and no Furnace burn time (if not already set).
      *
      * @param m The Material that this Material's Ingot should macerate directly into.
      */
@@ -481,7 +460,7 @@ public interface IMaterialBuilder {
      * Sets the Material that this Material's Ingot should smelt directly into in a Furnace.<br>
      * A good example is Magnetic Iron, which when smelted, will turn back into normal Iron.<br>
      * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
-     * with a harvest level of 2 and no Furnace burn time.
+     * with a harvest level of 2 and no Furnace burn time (if not already set).
      *
      * @param m The Material that this Material's Ingot should smelt directly into.
      */
@@ -490,7 +469,7 @@ public interface IMaterialBuilder {
     /**
      * Adds Ore byproducts to this Material.<br>
      * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
-     * with ore and byproduct multipliers of 1 and no emissive textures.
+     * with ore and byproduct multipliers of 1 and no emissive textures (if not already set).
      *
      * @param byproducts The list of Materials which serve as byproducts during ore processing.
      */
@@ -503,9 +482,7 @@ public interface IMaterialBuilder {
      * @param amperage The amperage of this Cable. Should be greater than zero.
      * @param loss     The loss-per-block of this Cable. A value of zero here will still have loss as wires.
      */
-    default IMaterialBuilder cableProperties(long voltage, int amperage, int loss) {
-        return cableProperties(voltage, amperage, loss, false, 0);
-    }
+    IMaterialBuilder cableProperties(long voltage, int amperage, int loss);
 
     /**
      * Add Wires and/or Cables to this Material.
@@ -516,9 +493,7 @@ public interface IMaterialBuilder {
      * @param isSuperCon Whether this Material is a Superconductor. If so, Cables will NOT be generated and
      *                   the Wires will have zero cable loss, ignoring the loss parameter.
      */
-    default IMaterialBuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon) {
-        return cableProperties(voltage, amperage, loss, isSuperCon, 0);
-    }
+    IMaterialBuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon);
 
     /**
      * Add Wires and/or Cables to this Material.
@@ -569,8 +544,6 @@ public interface IMaterialBuilder {
      *
      * @param enchant The default enchantment to apply to all tools made from this Material.
      * @param level   The level that the enchantment starts at when created.
-     *
-     * @throws IllegalStateException if this Material does not have a {@link ToolProperty} before this method is called.
      */
     IMaterialBuilder addDefaultEnchant(Enchantment enchant, int level);
 

--- a/src/main/java/gregtech/api/unification/material/IMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/material/IMaterialBuilder.java
@@ -269,7 +269,7 @@ public interface IMaterialBuilder {
     default IMaterialBuilder flags(Collection<MaterialFlag> f1, MaterialFlag... f2) {
         Collection<MaterialFlag> copy = new ArrayList<>(f1);
         Collections.addAll(copy, f2);
-        return flags((MaterialFlag[]) copy.toArray());
+        return flags(copy.toArray(new MaterialFlag[0]));
     }
 
     /**

--- a/src/main/java/gregtech/api/unification/material/IMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/material/IMaterialBuilder.java
@@ -1,0 +1,583 @@
+package gregtech.api.unification.material;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import gregtech.api.fluids.fluidType.FluidType;
+import gregtech.api.fluids.fluidType.FluidTypes;
+import gregtech.api.unification.Element;
+import gregtech.api.unification.material.info.MaterialFlag;
+import gregtech.api.unification.material.info.MaterialFlags;
+import gregtech.api.unification.material.info.MaterialIconSet;
+import gregtech.api.unification.material.properties.*;
+import gregtech.api.unification.stack.MaterialStack;
+import net.minecraft.enchantment.Enchantment;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Common interface for various implementations of Material Builders */
+public interface IMaterialBuilder {
+
+    /**
+     * Add a {@link FluidProperty} to this Material.<br>
+     * Will be created as a {@link FluidTypes#LIQUID}, without a Fluid Block.
+     *
+     * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder fluid() {
+        return fluid(FluidTypes.LIQUID);
+    }
+
+    /**
+     * Add a {@link FluidProperty} to this Material.<br>
+     * Will be created without a Fluid Block.
+     *
+     * @param type The {@link FluidType} of this Material, either Fluid or Gas.
+     * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder fluid(FluidType type) {
+        return fluid(type, false);
+    }
+
+    /**
+     * Add a {@link FluidProperty} to this Material.
+     *
+     * @param type     The {@link FluidType} of this Material.
+     * @param hasBlock If true, create a Fluid Block for this Material.
+     * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
+     */
+    IMaterialBuilder fluid(FluidType type, boolean hasBlock);
+
+    /**
+     * Add a {@link PlasmaProperty} to this Material.<br>
+     * Is not required to have a {@link FluidProperty}, and will not automatically apply one.
+     *
+     * @throws IllegalArgumentException If a {@link PlasmaProperty} has already been added to this Material.
+     */
+    IMaterialBuilder plasma();
+
+    /**
+     * Add a {@link DustProperty} to this Material.<br>
+     * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).
+     *
+     * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder dust() {
+        return dust(2, 0);
+    }
+
+    /**
+     * Add a {@link DustProperty} to this Material.<br>
+     * Will be created with no Burn Time (Furnace Fuel).
+     *
+     * @param harvestLevel The Harvest Level of this block for Mining.<br>
+     *                     If this Material also has a {@link ToolProperty}, this value will
+     *                     also be used to determine the tool's Mining Level.
+     * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder dust(int harvestLevel) {
+        return dust(harvestLevel, 0);
+    }
+
+    /**
+     * Add a {@link DustProperty} to this Material.
+     *
+     * @param harvestLevel The Harvest Level of this block for Mining.<br>
+     *                     If this Material also has a {@link ToolProperty}, this value will
+     *                     also be used to determine the tool's Mining Level.
+     * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.
+     * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
+     */
+    IMaterialBuilder dust(int harvestLevel, int burnTime);
+
+    /**
+     * Add an {@link IngotProperty} to this Material.<br>
+     * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder ingot() {
+        return ingot(2, 0);
+    }
+
+    /**
+     * Add an {@link IngotProperty} to this Material.<br>
+     * Will be created with no Burn Time (Furnace Fuel).<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @param harvestLevel The Harvest Level of this block for Mining. 2 will make it require a iron tool.<br>
+     *                     If this Material also has a {@link ToolProperty}, this value will
+     *                     also be used to determine the tool's Mining level (-1). So 2 will make the tool harvest diamonds.<br>
+     *                     If this Material already had a Harvest Level defined, it will be overridden.
+     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder ingot(int harvestLevel) {
+        return ingot(harvestLevel, 0);
+    }
+
+    /**
+     * Add an {@link IngotProperty} to this Material.<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @param harvestLevel The Harvest Level of this block for Mining. 2 will make it require a iron tool.<br>
+     *                     If this Material also has a {@link ToolProperty}, this value will
+     *                     also be used to determine the tool's Mining level (-1). So 2 will make the tool harvest diamonds.<br>
+     *                     If this Material already had a Harvest Level defined, it will be overridden.
+     * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
+     *                     If this Material already had a Burn Time defined, it will be overridden.
+     * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
+     */
+    IMaterialBuilder ingot(int harvestLevel, int burnTime);
+
+    /**
+     * Add a {@link GemProperty} to this Material.<br>
+     * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder gem() {
+        return gem(2, 0);
+    }
+
+    /**
+     * Add a {@link GemProperty} to this Material.<br>
+     * Will be created with no Burn Time (Furnace Fuel).<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @param harvestLevel The Harvest Level of this block for Mining.<br>
+     *                     If this Material also has a {@link ToolProperty}, this value will
+     *                     also be used to determine the tool's Mining level.<br>
+     *                     If this Material already had a Harvest Level defined, it will be overridden.
+     * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
+     */
+    default IMaterialBuilder gem(int harvestLevel) {
+        return gem(harvestLevel, 0);
+    }
+
+    /**
+     * Add a {@link GemProperty} to this Material.<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @param harvestLevel The Harvest Level of this block for Mining.<br>
+     *                     If this Material also has a {@link ToolProperty}, this value will
+     *                     also be used to determine the tool's Mining level.<br>
+     *                     If this Material already had a Harvest Level defined, it will be overridden.
+     * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
+     *                     If this Material already had a Burn Time defined, it will be overridden.
+     */
+    IMaterialBuilder gem(int harvestLevel, int burnTime);
+
+    /**
+     * Set the burn time of this Material as a Furnace Fuel.<br>
+     * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
+     *
+     * @param burnTime The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
+     *                 If this Material already had a Burn Time defined, it will be overridden.
+     */
+    IMaterialBuilder burnTime(int burnTime);
+
+    /**
+     * Set the Color of this Material.<br>
+     * Defaults to 0xFFFFFF unless {@link IMaterialBuilder#colorAverage()} was called, where
+     * it will be a weighted average of the components of the Material.
+     *
+     * @param color The RGB-formatted Color.
+     */
+    default IMaterialBuilder color(int color) {
+        return color(color, true);
+    }
+
+    /**
+     * Set the Color of this Material.<br>
+     * Defaults to 0xFFFFFF unless {@link IMaterialBuilder#colorAverage()} was called, where
+     * it will be a weighted average of the components of the Material.
+     *
+     * @param color         The RGB-formatted Color.
+     * @param hasFluidColor Whether the fluid should be colored or not.
+     */
+    IMaterialBuilder color(int color, boolean hasFluidColor);
+
+    /**
+     * Set the Color of this Material to be the average of the components specified in {@link IMaterialBuilder#components}.<br>
+     * Will default to 0xFFFFFF if a components list is not specified.
+     */
+    IMaterialBuilder colorAverage();
+
+    /**
+     * Set the {@link MaterialIconSet} of this Material.<br>
+     * Defaults vary depending on if the Material has a:<br>
+     * <ul>
+     * <li> {@link GemProperty}, it will default to {@link MaterialIconSet#GEM_VERTICAL}
+     * <li> {@link IngotProperty} or {@link DustProperty}, it will default to {@link MaterialIconSet#DULL}
+     * <li> {@link FluidProperty}, it will default to either {@link MaterialIconSet#FLUID}
+     *      or {@link MaterialIconSet#GAS}, depending on the {@link FluidType}
+     * <li> {@link PlasmaProperty}, it will default to {@link MaterialIconSet#FLUID}
+     * </ul>
+     * Default will be determined by first-found Property in this order, unless specified.
+     *
+     * @param iconSet The {@link MaterialIconSet} of this Material.
+     */
+    IMaterialBuilder iconSet(MaterialIconSet iconSet);
+
+    /**
+     * Set the components that make up this Material.<br>
+     * This information is used for automatic decomposition, chemical formula generation, among other things.<br><br>
+     *
+     * @param components An Object array formed as pairs of {@link Material} and Integer, representing the
+     *                   Material and the amount of said Material in this Material's composition.
+     * @throws IllegalArgumentException if the Object array is malformed.
+     */
+    default IMaterialBuilder components(Object... components) {
+        Preconditions.checkArgument(
+                components.length % 2 == 0,
+                "Material Components list malformed!"
+        );
+        ImmutableList.Builder<MaterialStack> builder = ImmutableList.builder();
+
+        for (int i = 0; i < components.length; i += 2) {
+            if (components[i] == null) {
+                throw new IllegalArgumentException();
+            }
+            builder.add(new MaterialStack(
+                    (Material) components[i],
+                    (Integer) components[i + 1]
+            ));
+        }
+        return components(builder.build());
+    }
+
+    /**
+     * Set the components that make up this Material.<br>
+     * This information is used for automatic decomposition, chemical formula generation, among other things.<br><br>
+     *
+     * @param components An {@link ImmutableList} of {@link MaterialStack}, each representing the
+     *                   Material and the amount of said Material in this Material's composition.
+     */
+    IMaterialBuilder components(ImmutableList<MaterialStack> components);
+
+    /**
+     * Add {@link MaterialFlags} to this Material.<br>
+     * Dependent Flags (for example, {@link MaterialFlags#GENERATE_LONG_ROD} requiring
+     * {@link MaterialFlags#GENERATE_ROD}) will be automatically applied.
+     *
+     * @param f1 A {@link Collection} of {@link MaterialFlag}. Provided this way for easy Flag presets to be applied.
+     * @param f2 An Array of {@link MaterialFlag}. If no {@link Collection} is required, use {@link Material.Builder#flags(MaterialFlag...)}.
+     */
+    default IMaterialBuilder flags(Collection<MaterialFlag> f1, MaterialFlag... f2) {
+        Collection<MaterialFlag> copy = new ArrayList<>(f1);
+        Collections.addAll(copy, f2);
+        return flags((MaterialFlag[]) copy.toArray());
+    }
+
+    /**
+     * Add {@link MaterialFlags} to this Material.<br>
+     * Dependent Flags (for example, {@link MaterialFlags#GENERATE_LONG_ROD} requiring
+     * {@link MaterialFlags#GENERATE_ROD}) will be automatically applied.
+     */
+    IMaterialBuilder flags(MaterialFlag... flags);
+
+    /**
+     * Set the Element of this Material.<br>
+     * Should be effectively singleton; each element should only have 1 Material claiming to represent it.
+     *
+     * @param element The {@link Element} that this Material represents.
+     */
+    IMaterialBuilder element(Element element);
+
+    /**
+     * Add GregTech and Vanilla-substitute tools to this Material.
+     *
+     * @param speed          The mining speed of a tool made from this Material.
+     * @param damage         The attack damage of a tool made from this Material.
+     * @param durability     The durability of a tool made from this Material.
+     * @param enchantability The base enchantability of a tool made from this Material. Iron is 14, Diamond is 10, Stone is 5.
+     */
+    default IMaterialBuilder toolStats(float speed, float damage, int durability, int enchantability) {
+        return toolStats(speed, damage, durability, enchantability, false);
+    }
+
+    /**
+     * Add GregTech and Vanilla-substitute tools to this Material.
+     *
+     * @param speed               The mining speed of a tool made from this Material.
+     * @param damage              The attack damage of a tool made from this Material.
+     * @param durability          The durability of a tool made from this Material.
+     * @param enchantability      The base enchantability of a tool made from this Material. Iron is 14, Diamond is 10, Stone is 5.
+     * @param ignoreCraftingTools Whether to ignore GregTech crafting tools for this Material and only make Vanilla-substitute tools.
+     */
+    IMaterialBuilder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools);
+
+    /**
+     * Add an EBF Temperature and recipe to this Material.<br>
+     * Will generate a Dust -> Ingot EBF recipe at 120 EU/t and a duration based off of the Material's composition.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     * If the temperature is below ...K, it will automatically add a PBF recipe in addition to the EBF recipe.
+     *
+     * @param temp The temperature of the recipe in the EBF.
+     */
+    default IMaterialBuilder blastTemp(int temp) {
+        return blastTemp(temp, null, -1, -1);
+    }
+
+    /**
+     * Add an EBF Temperature and recipe to this Material.<br>
+     * Will generate a Dust -> Ingot EBF recipe at 120 EU/t and a duration based off of the Material's composition.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     *
+     * @param temp    The temperature of the recipe in the EBF.
+     * @param gasTier The {@link gregtech.api.unification.material.properties.BlastProperty.GasTier} of the Recipe.
+     *                Will generate a second EBF recipe using the specified gas of the tier for a speed bonus.
+     */
+    default IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier) {
+        return blastTemp(temp, gasTier, -1, -1);
+    }
+
+    /**
+     * Add an EBF Temperature and recipe to this Material.<br>
+     * Will generate a Dust -> Ingot EBF recipe at a duration based off of the Material's composition.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     *
+     * @param temp        The temperature of the recipe in the EBF.
+     * @param gasTier     The {@link gregtech.api.unification.material.properties.BlastProperty.GasTier} of the Recipe.
+     *                    Will generate a second EBF recipe using the specified gas of the tier for a speed bonus.
+     * @param eutOverride Custom recipe EU/t instead of the default 120 EU/t.
+     */
+    default IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
+        return blastTemp(temp, gasTier, eutOverride, -1);
+    }
+
+    /**
+     * Add an EBF Temperature and recipe to this Material.<br>
+     * Will generate a Dust -> Ingot EBF recipe.<br>
+     * If the temperature is above 1750K, it will automatically add a Vacuum Freezer recipe and Hot Ingot.<br>
+     *
+     * @param temp             The temperature of the recipe in the EBF.
+     * @param gasTier          The {@link gregtech.api.unification.material.properties.BlastProperty.GasTier} of the Recipe.
+     *                         Will generate a second EBF recipe using the specified gas of the tier for a speed bonus.
+     * @param eutOverride      Custom recipe EU/t instead of the default 120 EU/t.
+     * @param durationOverride Custom recipe duration instead of the default composition-based duration.
+     * @return
+     */
+    IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride);
+
+    /**
+     * Add an Ore to this Material, with an ore and byproduct multiplier of 1 and without emissive textures.
+     */
+    default IMaterialBuilder ore() {
+        return ore(1, 1, false);
+    }
+
+    /**
+     * Add an Ore to this Material, with an ore and byproduct multiplier of 1.
+     *
+     * @param emissive Whether this Material's Ore Block should use emissive textures on the ore-vein texture overlay.
+     */
+    default IMaterialBuilder ore(boolean emissive) {
+        return ore(1, 1, emissive);
+    }
+
+    /**
+     * Add an Ore to this Material without emissive textures.
+     *
+     * @param oreMultiplier       Crushed output multiplier when the Ore Block is macerated.
+     * @param byproductMultiplier Byproduct multiplier on some ore processing steps.
+     */
+    default IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier) {
+        return ore(oreMultiplier, byproductMultiplier, false);
+    }
+
+    /**
+     * Add an Ore to this Material.
+     *
+     * @param oreMultiplier       Crushed output multiplier when the Ore Block is macerated.
+     * @param byproductMultiplier Byproduct multiplier on some ore processing steps.
+     * @param emissive            Whether this Material's Ore Block should use emissive textures on the ore-vein texture overlay.
+     */
+    IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier, boolean emissive);
+
+    /**
+     * Add a custom Fluid Temperatore to the Fluid of this Material.<br>
+     * Automatically adds a {@link FluidProperty} to this Material if it doesn't have one, using the LIQUID type and no Fluid block.
+     *
+     * @param temp The temperature of this Fluid.
+     */
+    IMaterialBuilder fluidTemp(int temp);
+
+    /**
+     * Adds a Chemical Bath ore processing step to this Material's Ore, using 100L of the Fluid.<br>
+     * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
+     * with ore and byproduct multipliers of 1 and no emissive textures.
+     *
+     * @param m The Material that is used as a Chemical Bath fluid for ore processing.
+     *          This Material will be given a {@link FluidProperty} if it does not already have one,
+     *          of type LIQUID and no Fluid block.
+     */
+    default IMaterialBuilder washedIn(Material m) {
+        return washedIn(m, 100);
+    }
+
+    /**
+     * Adds a Chemical Bath ore processing step to this Material's Ore.<br>
+     * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
+     * with ore and byproduct multipliers of 1 and no emissive textures.
+     *
+     * @param m            The Material that is used as a Chemical Bath fluid for ore processing.
+     *                     This Material will be given a {@link FluidProperty} if it does not already have one,
+     *                     of type LIQUID and no Fluid block.
+     * @param washedAmount The amount of the above Fluid required to wash the Ore.
+     */
+    IMaterialBuilder washedIn(Material m, int washedAmount);
+
+    /**
+     * Adds an Electromagnetic Separator recipe to this Material's Purified Dust, which outputs the passed Materials.<br>
+     * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
+     * with ore and byproduct multipliers of 1 and no emissive textures.
+     *
+     * @param m The Materials which should be output by the Electromagnetic Separator in addition to a normal Dust of this Material.
+     */
+    IMaterialBuilder separatedInto(Material... m);
+
+    /**
+     * Sets the Material which this Material's Ore Block smelts to directly in a Furnace.<br>
+     * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
+     * with ore and byproduct multipliers of 1 and no emissive textures.
+     *
+     * @param m The Material which should be output when smelting.
+     */
+    IMaterialBuilder oreSmeltInto(Material m);
+
+    /**
+     * Adds a Polarizer recipe to this Material's metal parts, outputting the provided Material.<br>
+     * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
+     * with a harvest level of 2 and no Furnace burn time.
+     *
+     * @param m The Material that this Material will be polarized into.
+     */
+    IMaterialBuilder polarizesInto(Material m);
+
+    /**
+     * Sets the Material that this Material will automatically transform into in any Arc Furnace recipe.<br>
+     * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
+     * with a harvest level of 2 and no Furnace burn time.
+     *
+     * @param m The Material that this Material will turn into in any Arc Furnace recipes.
+     */
+    IMaterialBuilder arcSmeltInto(Material m);
+
+    /**
+     * Sets the Material that this Material's Ingot should macerate directly into.<br>
+     * A good example is Magnetic Iron, which when macerated, will turn back into normal Iron.<br>
+     * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
+     * with a harvest level of 2 and no Furnace burn time.
+     *
+     * @param m The Material that this Material's Ingot should macerate directly into.
+     */
+    IMaterialBuilder macerateInto(Material m);
+
+    /**
+     * Sets the Material that this Material's Ingot should smelt directly into in a Furnace.<br>
+     * A good example is Magnetic Iron, which when smelted, will turn back into normal Iron.<br>
+     * Automatically adds an {@link IngotProperty} to this Material if it does not already have one,
+     * with a harvest level of 2 and no Furnace burn time.
+     *
+     * @param m The Material that this Material's Ingot should smelt directly into.
+     */
+    IMaterialBuilder ingotSmeltInto(Material m);
+
+    /**
+     * Adds Ore byproducts to this Material.<br>
+     * Automatically adds an {@link OreProperty} to this Material if it does not already have one,
+     * with ore and byproduct multipliers of 1 and no emissive textures.
+     *
+     * @param byproducts The list of Materials which serve as byproducts during ore processing.
+     */
+    IMaterialBuilder addOreByproducts(Material... byproducts);
+
+    /**
+     * Add Wires and Cables to this Material.
+     *
+     * @param voltage  The voltage tier of this Cable. Should conform to standard GregTech voltage tiers.
+     * @param amperage The amperage of this Cable. Should be greater than zero.
+     * @param loss     The loss-per-block of this Cable. A value of zero here will still have loss as wires.
+     */
+    default IMaterialBuilder cableProperties(long voltage, int amperage, int loss) {
+        return cableProperties(voltage, amperage, loss, false, 0);
+    }
+
+    /**
+     * Add Wires and/or Cables to this Material.
+     *
+     * @param voltage    The voltage tier of this Cable. Should conform to standard GregTech voltage tiers.
+     * @param amperage   The amperage of this Cable. Should be greater than zero.
+     * @param loss       The loss-per-block of this Cable. A value of zero here will still have loss as wires.
+     * @param isSuperCon Whether this Material is a Superconductor. If so, Cables will NOT be generated and
+     *                   the Wires will have zero cable loss, ignoring the loss parameter.
+     */
+    default IMaterialBuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon) {
+        return cableProperties(voltage, amperage, loss, isSuperCon, 0);
+    }
+
+    /**
+     * Add Wires and/or Cables to this Material.
+     *
+     * @param voltage             The voltage tier of this Cable. Should conform to standard GregTech voltage tiers.
+     * @param amperage            The amperage of this Cable. Should be greater than zero.
+     * @param loss                The loss-per-block of this Cable. A value of zero here will still have loss as wires.
+     * @param isSuperCon          Whether this Material is a Superconductor. If so, Cables will NOT be generated and
+     *                            the Wires will have zero cable loss, ignoring the loss parameter.
+     * @param criticalTemperature The critical temperature of this Material's Wires, if it is a Superconductor.
+     *                            Not currently utilized and intended for addons to use.
+     */
+    IMaterialBuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon, int criticalTemperature);
+
+    /**
+     * Add Fluid Pipes to this Material.
+     *
+     * @param maxTemp    The maximum temperature of Fluid that this Pipe can handle before causing damage to the Pipe.
+     * @param throughput The rate at which Fluid can flow through this Pipe.
+     * @param gasProof   Whether this Pipe can hold Gases. If not, some Gas will be lost as it travels through the Pipe.
+     */
+    default IMaterialBuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof) {
+        return fluidPipeProperties(maxTemp, throughput, gasProof, false, false, false);
+    }
+
+    /**
+     * Add Fluid Pipes to this Material.
+     *
+     * @param maxTemp     The maximum temperature of Fluid that this Pipe can handle before causing damage to the Pipe.
+     * @param throughput  The rate at which Fluid can flow through this Pipe.
+     * @param gasProof    Whether this Pipe can hold Gases. If not, some Gas will be lost as it travels through the Pipe.
+     * @param acidProof   Whether this Pipe can hold Acids. If not, the Pipe may lose fluid or cause damage.
+     * @param cryoProof   Whether this Pipe can hold Cryogenic Fluids (below 120K). If not, the Pipe may lose fluid or cause damage.
+     * @param plasmaProof Whether this Pipe can hold Plasmas. If not, the Pipe may lose fluid or cause damage.
+     */
+    IMaterialBuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof);
+
+    /**
+     * Add Item Pipes to this Material.
+     *
+     * @param priority     Priority of this Item Pipe, used for the standard routing mode.
+     * @param stacksPerSec How many stacks of items can be moved per second (20 ticks).
+     */
+    IMaterialBuilder itemPipeProperties(int priority, float stacksPerSec);
+
+    /**
+     * Specify a default enchantment for tools made from this Material to have upon creation.
+     *
+     * @param enchant The default enchantment to apply to all tools made from this Material.
+     * @param level   The level that the enchantment starts at when created.
+     *
+     * @throws IllegalStateException if this Material does not have a {@link ToolProperty} before this method is called.
+     */
+    IMaterialBuilder addDefaultEnchant(Enchantment enchant, int level);
+
+    /**
+     * Verify the passed information and finalize the Material.
+     *
+     * @return The finalized Material.
+     */
+    Material build();
+}

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -489,7 +489,7 @@ public class Material implements Comparable<Material> {
          * <p>
          * Default: none.
          */
-        protected ImmutableList<MaterialStack> componentList;
+        protected ImmutableList<MaterialStack> componentList = ImmutableList.of();
 
         /**
          * The Element of this Material, if it is a direct Element.

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -15,7 +15,6 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.SmallDigits;
-import net.minecraft.enchantment.Enchantment;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import stanhebben.zenscript.annotations.*;
@@ -352,7 +351,7 @@ public class Material implements Comparable<Material> {
      *
      * @since GTCEu 2.0.0
      */
-    public static class Builder implements IMaterialBuilder {
+    public static class Builder extends MaterialBuilder {
 
         private final MaterialInfo materialInfo;
         private final MaterialProperties properties;
@@ -383,59 +382,6 @@ public class Material implements Comparable<Material> {
             materialInfo = new MaterialInfo(id, name);
             properties = new MaterialProperties();
             flags = new MaterialFlags();
-        }
-
-        @Override
-        public Builder fluid(FluidType type, boolean hasBlock) {
-            properties.setProperty(PropertyKey.FLUID, new FluidProperty(type, hasBlock));
-            return this;
-        }
-
-        @Override
-        public Builder plasma() {
-            properties.ensureSet(PropertyKey.PLASMA);
-            return this;
-        }
-
-        @Override
-        public Builder dust(int harvestLevel, int burnTime) {
-            properties.setProperty(PropertyKey.DUST, new DustProperty(harvestLevel, burnTime));
-            return this;
-        }
-
-        @Override
-        public Builder ingot(int harvestLevel, int burnTime) {
-            DustProperty prop = properties.getProperty(PropertyKey.DUST);
-            if (prop == null) dust(harvestLevel, burnTime);
-            else {
-                if (prop.getHarvestLevel() == 2) prop.setHarvestLevel(harvestLevel);
-                if (prop.getBurnTime() == 0) prop.setBurnTime(burnTime);
-            }
-            properties.ensureSet(PropertyKey.INGOT);
-            return this;
-        }
-
-        @Override
-        public Builder gem(int harvestLevel, int burnTime) {
-            DustProperty prop = properties.getProperty(PropertyKey.DUST);
-            if (prop == null) dust(harvestLevel, burnTime);
-            else {
-                if (prop.getHarvestLevel() == 2) prop.setHarvestLevel(harvestLevel);
-                if (prop.getBurnTime() == 0) prop.setBurnTime(burnTime);
-            }
-            properties.ensureSet(PropertyKey.GEM);
-            return this;
-        }
-
-        @Override
-        public Builder burnTime(int burnTime) {
-            DustProperty prop = properties.getProperty(PropertyKey.DUST);
-            if (prop == null) {
-                dust();
-                prop = properties.getProperty(PropertyKey.DUST);
-            }
-            prop.setBurnTime(burnTime);
-            return this;
         }
 
         @Override
@@ -476,113 +422,13 @@ public class Material implements Comparable<Material> {
         }
 
         @Override
-        public Builder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {
-            properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability, ignoreCraftingTools));
-            return this;
+        protected <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, T property) {
+            properties.setProperty(key, property);
         }
 
         @Override
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, durationOverride));
-            return this;
-        }
-
-        @Override
-        public Builder ore(int oreMultiplier, int byproductMultiplier, boolean emissive) {
-            properties.setProperty(PropertyKey.ORE, new OreProperty(oreMultiplier, byproductMultiplier, emissive));
-            return this;
-        }
-
-        @Override
-        public Builder fluidTemp(int temp) {
-            properties.ensureSet(PropertyKey.FLUID);
-            properties.getProperty(PropertyKey.FLUID).setFluidTemperature(temp);
-            return this;
-        }
-
-        @Override
-        public Builder washedIn(Material m, int washedAmount) {
-            properties.ensureSet(PropertyKey.ORE);
-            properties.getProperty(PropertyKey.ORE).setWashedIn(m, washedAmount);
-            return this;
-        }
-
-        @Override
-        public Builder separatedInto(Material... m) {
-            properties.ensureSet(PropertyKey.ORE);
-            properties.getProperty(PropertyKey.ORE).setSeparatedInto(m);
-            return this;
-        }
-
-        @Override
-        public Builder oreSmeltInto(Material m) {
-            properties.ensureSet(PropertyKey.ORE);
-            properties.getProperty(PropertyKey.ORE).setDirectSmeltResult(m);
-            return this;
-        }
-
-        @Override
-        public Builder polarizesInto(Material m) {
-            properties.ensureSet(PropertyKey.INGOT);
-            properties.getProperty(PropertyKey.INGOT).setMagneticMaterial(m);
-            return this;
-        }
-
-        @Override
-        public Builder arcSmeltInto(Material m) {
-            properties.ensureSet(PropertyKey.INGOT);
-            properties.getProperty(PropertyKey.INGOT).setArcSmeltingInto(m);
-            return this;
-        }
-
-        @Override
-        public Builder macerateInto(Material m) {
-            properties.ensureSet(PropertyKey.INGOT);
-            properties.getProperty(PropertyKey.INGOT).setMacerateInto(m);
-            return this;
-        }
-
-        @Override
-        public Builder ingotSmeltInto(Material m) {
-            properties.ensureSet(PropertyKey.INGOT);
-            properties.getProperty(PropertyKey.INGOT).setSmeltingInto(m);
-            return this;
-        }
-
-        @Override
-        public Builder addOreByproducts(Material... byproducts) {
-            properties.ensureSet(PropertyKey.ORE);
-            properties.getProperty(PropertyKey.ORE).setOreByProducts(byproducts);
-            return this;
-        }
-
-        @Override
-        public Builder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon, int criticalTemperature) {
-            properties.ensureSet(PropertyKey.DUST);
-            properties.setProperty(PropertyKey.WIRE, new WireProperties((int) voltage, amperage, loss, isSuperCon, criticalTemperature));
-            return this;
-        }
-
-        @Override
-        public Builder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
-            properties.ensureSet(PropertyKey.INGOT);
-            properties.setProperty(PropertyKey.FLUID_PIPE, new FluidPipeProperties(maxTemp, throughput, gasProof, acidProof, cryoProof, plasmaProof));
-            return this;
-        }
-
-        @Override
-        public Builder itemPipeProperties(int priority, float stacksPerSec) {
-            properties.ensureSet(PropertyKey.INGOT);
-            properties.setProperty(PropertyKey.ITEM_PIPE, new ItemPipeProperties(priority, stacksPerSec));
-            return this;
-        }
-
-        @Override
-        public Builder addDefaultEnchant(Enchantment enchant, int level) {
-            if (!properties.hasProperty(PropertyKey.TOOL)) // cannot assign default here
-                throw new IllegalArgumentException("Material cannot have an Enchant without Tools!");
-            properties.getProperty(PropertyKey.TOOL).addEnchantmentForTools(enchant, level);
-            return this;
+        protected <T extends IMaterialProperty<T>> T getProperty(PropertyKey<T> key) {
+            return properties.getProperty(key);
         }
 
         @Override
@@ -599,7 +445,7 @@ public class Material implements Comparable<Material> {
      * @since GTCEu 2.4
      */
     @SuppressWarnings("unused")
-    public static class Rebuilder implements IMaterialBuilder {
+    public static class Rebuilder extends MaterialBuilder {
 
         private final Material material;
 
@@ -607,78 +453,6 @@ public class Material implements Comparable<Material> {
 
         public Rebuilder(Material material) {
             this.material = material;
-        }
-
-        @Override
-        public Rebuilder fluid(FluidType type, boolean hasBlock) {
-            if (!material.hasProperty(PropertyKey.FLUID)) {
-                material.setProperty(PropertyKey.FLUID, new FluidProperty(type, hasBlock));
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder plasma() {
-            if (!material.hasProperty(PropertyKey.PLASMA)) {
-                material.setProperty(PropertyKey.PLASMA, new PlasmaProperty());
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder dust(int harvestLevel, int burnTime) {
-            if (!material.hasProperty(PropertyKey.DUST)) {
-                material.setProperty(PropertyKey.DUST, new DustProperty(harvestLevel, burnTime));
-            } else {
-                DustProperty property = material.getProperty(PropertyKey.DUST);
-                property.setHarvestLevel(harvestLevel);
-                property.setBurnTime(burnTime);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder ingot(int harvestLevel, int burnTime) {
-            if (!material.hasProperty(PropertyKey.INGOT)) {
-                material.setProperty(PropertyKey.INGOT, new IngotProperty());
-            }
-            if (!material.hasProperty(PropertyKey.DUST)) {
-                DustProperty property = new DustProperty(harvestLevel, burnTime);
-                material.setProperty(PropertyKey.DUST, property);
-            } else {
-                DustProperty property = material.getProperty(PropertyKey.DUST);
-                property.setHarvestLevel(harvestLevel);
-                property.setBurnTime(burnTime);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder gem(int harvestLevel, int burnTime) {
-            if (!material.hasProperty(PropertyKey.GEM)) {
-                material.setProperty(PropertyKey.GEM, new GemProperty());
-            }
-            if (!material.hasProperty(PropertyKey.DUST)) {
-                DustProperty property = new DustProperty(harvestLevel, burnTime);
-                material.setProperty(PropertyKey.DUST, property);
-            } else {
-                DustProperty property = material.getProperty(PropertyKey.DUST);
-                property.setHarvestLevel(harvestLevel);
-                property.setBurnTime(burnTime);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder burnTime(int burnTime) {
-            if (!material.hasProperty(PropertyKey.DUST)) {
-                DustProperty property = new DustProperty(2, burnTime);
-                material.setProperty(PropertyKey.DUST, property);
-            } else {
-                DustProperty property = material.getProperty(PropertyKey.DUST);
-                property.setBurnTime(burnTime);
-            }
-            return this;
         }
 
         @Override
@@ -719,181 +493,13 @@ public class Material implements Comparable<Material> {
         }
 
         @Override
-        public Rebuilder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {
-            if (!material.hasProperty(PropertyKey.TOOL)) {
-                material.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability, ignoreCraftingTools));
-            } else {
-                ToolProperty property = material.getProperty(PropertyKey.TOOL);
-                property.setToolSpeed(speed);
-                property.setToolAttackDamage(damage);
-                property.setToolDurability(durability);
-                property.setToolEnchantability(enchantability);
-                property.setShouldIgnoreCraftingTools(ignoreCraftingTools);
-            }
-            return this;
+        protected <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, T property) {
+            material.setProperty(key, property);
         }
 
         @Override
-        public Rebuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
-            if (!material.hasProperty(PropertyKey.BLAST)) {
-                material.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, durationOverride));
-            } else {
-                BlastProperty property = material.getProperty(PropertyKey.BLAST);
-                property.setBlastTemperature(temp);
-                property.setGasTier(gasTier);
-                property.setEUtOverride(eutOverride);
-                property.setDurationOverride(durationOverride);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder ore(int oreMultiplier, int byproductMultiplier, boolean emissive) {
-            if (!material.hasProperty(PropertyKey.ORE)) {
-                material.setProperty(PropertyKey.ORE, new OreProperty(oreMultiplier, byproductMultiplier, emissive));
-            } else {
-                OreProperty property = material.getProperty(PropertyKey.ORE);
-                property.setOreMultiplier(oreMultiplier);
-                property.setByProductMultiplier(byproductMultiplier);
-                property.setEmissive(emissive);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder fluidTemp(int temp) {
-            if (!material.hasProperty(PropertyKey.FLUID)) {
-                FluidProperty property = new FluidProperty();
-                property.setFluidTemperature(temp);
-                material.setProperty(PropertyKey.FLUID, property);
-            } else {
-                FluidProperty property = material.getProperty(PropertyKey.FLUID);
-                property.setFluidTemperature(temp);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder washedIn(Material m, int washedAmount) {
-            if (!material.hasProperty(PropertyKey.ORE)) {
-                material.setProperty(PropertyKey.ORE, new OreProperty());
-            }
-            material.getProperty(PropertyKey.ORE).setWashedIn(m, washedAmount);
-            return this;
-        }
-
-        @Override
-        public Rebuilder separatedInto(Material... m) {
-            if (!material.hasProperty(PropertyKey.ORE)) {
-                material.setProperty(PropertyKey.ORE, new OreProperty());
-            }
-            material.getProperty(PropertyKey.ORE).setSeparatedInto(m);
-            return this;
-        }
-
-        @Override
-        public Rebuilder oreSmeltInto(Material m) {
-            if (!material.hasProperty(PropertyKey.ORE)) {
-                material.setProperty(PropertyKey.ORE, new OreProperty());
-            }
-            material.getProperty(PropertyKey.ORE).setDirectSmeltResult(m);
-            return this;
-        }
-
-        @Override
-        public Rebuilder polarizesInto(Material m) {
-            if (!material.hasProperty(PropertyKey.INGOT)) {
-                material.setProperty(PropertyKey.INGOT, new IngotProperty());
-            }
-            material.getProperty(PropertyKey.INGOT).setMagneticMaterial(m);
-            return this;
-        }
-
-        @Override
-        public Rebuilder arcSmeltInto(Material m) {
-            if (!material.hasProperty(PropertyKey.INGOT)) {
-                material.setProperty(PropertyKey.INGOT, new IngotProperty());
-            }
-            material.getProperty(PropertyKey.INGOT).setArcSmeltingInto(m);
-            return this;
-        }
-
-        @Override
-        public Rebuilder macerateInto(Material m) {
-            if (!material.hasProperty(PropertyKey.INGOT)) {
-                material.setProperty(PropertyKey.INGOT, new IngotProperty());
-            }
-            material.getProperty(PropertyKey.INGOT).setMacerateInto(m);
-            return this;
-        }
-
-        @Override
-        public Rebuilder ingotSmeltInto(Material m) {
-            if (!material.hasProperty(PropertyKey.INGOT)) {
-                material.setProperty(PropertyKey.INGOT, new IngotProperty());
-            }
-            material.getProperty(PropertyKey.INGOT).setSmeltingInto(m);
-            return this;
-        }
-
-        @Override
-        public Rebuilder addOreByproducts(Material... byproducts) {
-            if (!material.hasProperty(PropertyKey.ORE)) {
-                material.setProperty(PropertyKey.ORE, new OreProperty());
-            }
-            material.getProperty(PropertyKey.ORE).setOreByProducts(byproducts);
-            return this;
-        }
-
-        @Override
-        public Rebuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon, int criticalTemperature) {
-            if (!material.hasProperty(PropertyKey.WIRE)) {
-                material.setProperty(PropertyKey.WIRE, new WireProperties((int) voltage, amperage, loss, isSuperCon, criticalTemperature));
-            } else {
-                WireProperties property = material.getProperty(PropertyKey.WIRE);
-                property.setVoltage((int) voltage);
-                property.setAmperage(amperage);
-                property.setLossPerBlock(loss);
-                property.setSuperconductor(isSuperCon);
-                property.setSuperconductorCriticalTemperature(criticalTemperature);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
-            if (!material.hasProperty(PropertyKey.FLUID_PIPE)) {
-                material.setProperty(PropertyKey.FLUID_PIPE, new FluidPipeProperties(maxTemp, throughput, gasProof, acidProof, cryoProof, plasmaProof));
-            } else {
-                FluidPipeProperties property = material.getProperty(PropertyKey.FLUID_PIPE);
-                property.setMaxFluidTemperature(maxTemp);
-                property.setThroughput(throughput);
-                property.setGasProof(gasProof);
-                property.setAcidProof(acidProof);
-                property.setCryoProof(cryoProof);
-                property.setPlasmaProof(plasmaProof);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder itemPipeProperties(int priority, float stacksPerSec) {
-            if (!material.hasProperty(PropertyKey.ITEM_PIPE)) {
-                material.setProperty(PropertyKey.ITEM_PIPE, new ItemPipeProperties(priority, stacksPerSec));
-            } else {
-                ItemPipeProperties property = material.getProperty(PropertyKey.ITEM_PIPE);
-                property.setPriority(priority);
-                property.setTransferRate(stacksPerSec);
-            }
-            return this;
-        }
-
-        @Override
-        public Rebuilder addDefaultEnchant(Enchantment enchant, int level) {
-            if (!material.hasProperty(PropertyKey.TOOL)) // cannot assign default here
-                throw new IllegalArgumentException("Material cannot have an Enchant without Tools!");
-            material.getProperty(PropertyKey.TOOL).addEnchantmentForTools(enchant, level);
-            return this;
+        protected <T extends IMaterialProperty<T>> T getProperty(PropertyKey<T> key) {
+            return material.getProperty(key);
         }
 
         @Override

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -1,11 +1,9 @@
 package gregtech.api.unification.material;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import crafttweaker.annotations.ZenRegister;
 import gregtech.api.GregTechAPI;
 import gregtech.api.fluids.fluidType.FluidType;
-import gregtech.api.fluids.fluidType.FluidTypes;
 import gregtech.api.unification.Element;
 import gregtech.api.unification.Elements;
 import gregtech.api.unification.material.info.MaterialFlag;
@@ -350,9 +348,11 @@ public class Material implements Comparable<Material> {
     }
 
     /**
+     * Builder used to construct a new Material.
+     *
      * @since GTCEu 2.0.0
      */
-    public static class Builder {
+    public static class Builder implements IMaterialBuilder {
 
         private final MaterialInfo materialInfo;
         private final MaterialProperties properties;
@@ -385,132 +385,25 @@ public class Material implements Comparable<Material> {
             flags = new MaterialFlags();
         }
 
-        /*
-         * Material Types
-         */
-
-        /**
-         * Add a {@link FluidProperty} to this Material.<br>
-         * Will be created as a {@link FluidTypes#LIQUID}, without a Fluid Block.
-         *
-         * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
-         */
-        public Builder fluid() {
-            properties.ensureSet(PropertyKey.FLUID);
-            return this;
-        }
-
-        /**
-         * Add a {@link FluidProperty} to this Material.<br>
-         * Will be created without a Fluid Block.
-         *
-         * @param type The {@link FluidType} of this Material, either Fluid or Gas.
-         * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
-         */
-        public Builder fluid(FluidType type) {
-            return fluid(type, false);
-        }
-
-        /**
-         * Add a {@link FluidProperty} to this Material.
-         *
-         * @param type     The {@link FluidType} of this Material.
-         * @param hasBlock If true, create a Fluid Block for this Material.
-         * @throws IllegalArgumentException If a {@link FluidProperty} has already been added to this Material.
-         */
+        @Override
         public Builder fluid(FluidType type, boolean hasBlock) {
             properties.setProperty(PropertyKey.FLUID, new FluidProperty(type, hasBlock));
             return this;
         }
 
-        /**
-         * Add a {@link PlasmaProperty} to this Material.<br>
-         * Is not required to have a {@link FluidProperty}, and will not automatically apply one.
-         *
-         * @throws IllegalArgumentException If a {@link PlasmaProperty} has already been added to this Material.
-         */
+        @Override
         public Builder plasma() {
             properties.ensureSet(PropertyKey.PLASMA);
             return this;
         }
 
-        /**
-         * Add a {@link DustProperty} to this Material.<br>
-         * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).
-         *
-         * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
-         */
-        public Builder dust() {
-            properties.ensureSet(PropertyKey.DUST);
-            return this;
-        }
-
-        /**
-         * Add a {@link DustProperty} to this Material.<br>
-         * Will be created with no Burn Time (Furnace Fuel).
-         *
-         * @param harvestLevel The Harvest Level of this block for Mining.<br>
-         *                     If this Material also has a {@link ToolProperty}, this value will
-         *                     also be used to determine the tool's Mining Level.
-         * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
-         */
-        public Builder dust(int harvestLevel) {
-            return dust(harvestLevel, 0);
-        }
-
-        /**
-         * Add a {@link DustProperty} to this Material.
-         *
-         * @param harvestLevel The Harvest Level of this block for Mining.<br>
-         *                     If this Material also has a {@link ToolProperty}, this value will
-         *                     also be used to determine the tool's Mining Level.
-         * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.
-         * @throws IllegalArgumentException If a {@link DustProperty} has already been added to this Material.
-         */
+        @Override
         public Builder dust(int harvestLevel, int burnTime) {
             properties.setProperty(PropertyKey.DUST, new DustProperty(harvestLevel, burnTime));
             return this;
         }
 
-        /**
-         * Add an {@link IngotProperty} to this Material.<br>
-         * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).<br>
-         * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-         *
-         * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
-         */
-        public Builder ingot() {
-            properties.ensureSet(PropertyKey.INGOT);
-            return this;
-        }
-
-        /**
-         * Add an {@link IngotProperty} to this Material.<br>
-         * Will be created with no Burn Time (Furnace Fuel).<br>
-         * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-         *
-         * @param harvestLevel The Harvest Level of this block for Mining. 2 will make it require a iron tool.<br>
-         *                     If this Material also has a {@link ToolProperty}, this value will
-         *                     also be used to determine the tool's Mining level (-1). So 2 will make the tool harvest diamonds.<br>
-         *                     If this Material already had a Harvest Level defined, it will be overridden.
-         * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
-         */
-        public Builder ingot(int harvestLevel) {
-            return ingot(harvestLevel, 0);
-        }
-
-        /**
-         * Add an {@link IngotProperty} to this Material.<br>
-         * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-         *
-         * @param harvestLevel The Harvest Level of this block for Mining. 2 will make it require a iron tool.<br>
-         *                     If this Material also has a {@link ToolProperty}, this value will
-         *                     also be used to determine the tool's Mining level (-1). So 2 will make the tool harvest diamonds.<br>
-         *                     If this Material already had a Harvest Level defined, it will be overridden.
-         * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
-         *                     If this Material already had a Burn Time defined, it will be overridden.
-         * @throws IllegalArgumentException If an {@link IngotProperty} has already been added to this Material.
-         */
+        @Override
         public Builder ingot(int harvestLevel, int burnTime) {
             DustProperty prop = properties.getProperty(PropertyKey.DUST);
             if (prop == null) dust(harvestLevel, burnTime);
@@ -522,44 +415,7 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        /**
-         * Add a {@link GemProperty} to this Material.<br>
-         * Will be created with a Harvest Level of 2 and no Burn Time (Furnace Fuel).<br>
-         * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-         *
-         * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
-         */
-        public Builder gem() {
-            properties.ensureSet(PropertyKey.GEM);
-            return this;
-        }
-
-        /**
-         * Add a {@link GemProperty} to this Material.<br>
-         * Will be created with no Burn Time (Furnace Fuel).<br>
-         * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-         *
-         * @param harvestLevel The Harvest Level of this block for Mining.<br>
-         *                     If this Material also has a {@link ToolProperty}, this value will
-         *                     also be used to determine the tool's Mining level.<br>
-         *                     If this Material already had a Harvest Level defined, it will be overridden.
-         * @throws IllegalArgumentException If a {@link GemProperty} has already been added to this Material.
-         */
-        public Builder gem(int harvestLevel) {
-            return gem(harvestLevel, 0);
-        }
-
-        /**
-         * Add a {@link GemProperty} to this Material.<br>
-         * Will automatically add a {@link DustProperty} to this Material if it does not already have one.
-         *
-         * @param harvestLevel The Harvest Level of this block for Mining.<br>
-         *                     If this Material also has a {@link ToolProperty}, this value will
-         *                     also be used to determine the tool's Mining level.<br>
-         *                     If this Material already had a Harvest Level defined, it will be overridden.
-         * @param burnTime     The Burn Time (in ticks) of this Material as a Furnace Fuel.<br>
-         *                     If this Material already had a Burn Time defined, it will be overridden.
-         */
+        @Override
         public Builder gem(int harvestLevel, int burnTime) {
             DustProperty prop = properties.getProperty(PropertyKey.DUST);
             if (prop == null) dust(harvestLevel, burnTime);
@@ -571,6 +427,7 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        @Override
         public Builder burnTime(int burnTime) {
             DustProperty prop = properties.getProperty(PropertyKey.DUST);
             if (prop == null) {
@@ -581,251 +438,146 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        /**
-         * Set the Color of this Material.<br>
-         * Defaults to 0xFFFFFF unless {@link Builder#colorAverage()} was called, where
-         * it will be a weighted average of the components of the Material.
-         *
-         * @param color The RGB-formatted Color.
-         */
-        public Builder color(int color) {
-            color(color, true);
-            return this;
-        }
-
-        /**
-         * Set the Color of this Material.<br>
-         * Defaults to 0xFFFFFF unless {@link Builder#colorAverage()} was called, where
-         * it will be a weighted average of the components of the Material.
-         *
-         * @param color         The RGB-formatted Color.
-         * @param hasFluidColor Whether the fluid should be colored or not.
-         */
+        @Override
         public Builder color(int color, boolean hasFluidColor) {
             this.materialInfo.color = color;
             this.materialInfo.hasFluidColor = hasFluidColor;
             return this;
         }
 
+        @Override
         public Builder colorAverage() {
             this.averageRGB = true;
             return this;
         }
 
-        /**
-         * Set the {@link MaterialIconSet} of this Material.<br>
-         * Defaults vary depending on if the Material has a:<br>
-         * <ul>
-         * <li> {@link GemProperty}, it will default to {@link MaterialIconSet#GEM_VERTICAL}
-         * <li> {@link IngotProperty} or {@link DustProperty}, it will default to {@link MaterialIconSet#DULL}
-         * <li> {@link FluidProperty}, it will default to either {@link MaterialIconSet#FLUID}
-         *      or {@link MaterialIconSet#GAS}, depending on the {@link FluidType}
-         * <li> {@link PlasmaProperty}, it will default to {@link MaterialIconSet#FLUID}
-         * </ul>
-         * Default will be determined by first-found Property in this order, unless specified.
-         *
-         * @param iconSet The {@link MaterialIconSet} of this Material.
-         */
+        @Override
         public Builder iconSet(MaterialIconSet iconSet) {
             materialInfo.iconSet = iconSet;
             return this;
         }
 
-        public Builder components(Object... components) {
-            Preconditions.checkArgument(
-                    components.length % 2 == 0,
-                    "Material Components list malformed!"
-            );
-
-            for (int i = 0; i < components.length; i += 2) {
-                if (components[i] == null) {
-                    throw new IllegalArgumentException("Material in Components List is null for Material "
-                            + this.materialInfo.name);
-                }
-                composition.add(new MaterialStack(
-                        (Material) components[i],
-                        (Integer) components[i + 1]
-                ));
-            }
-            return this;
-        }
-
+        @Override
         public Builder components(ImmutableList<MaterialStack> components) {
             composition = components;
             return this;
         }
 
-        /**
-         * Add {@link MaterialFlags} to this Material.<br>
-         * Dependent Flags (for example, {@link MaterialFlags#GENERATE_LONG_ROD} requiring
-         * {@link MaterialFlags#GENERATE_ROD}) will be automatically applied.
-         */
+        @Override
         public Builder flags(MaterialFlag... flags) {
             this.flags.addFlags(flags);
             return this;
         }
 
-        /**
-         * Add {@link MaterialFlags} to this Material.<br>
-         * Dependent Flags (for example, {@link MaterialFlags#GENERATE_LONG_ROD} requiring
-         * {@link MaterialFlags#GENERATE_ROD}) will be automatically applied.
-         *
-         * @param f1 A {@link Collection} of {@link MaterialFlag}. Provided this way for easy Flag presets to be applied.
-         * @param f2 An Array of {@link MaterialFlag}. If no {@link Collection} is required, use {@link Builder#flags(MaterialFlag...)}.
-         */
-        public Builder flags(Collection<MaterialFlag> f1, MaterialFlag... f2) {
-            this.flags.addFlags(f1.toArray(new MaterialFlag[0]));
-            this.flags.addFlags(f2);
-            return this;
-        }
-
+        @Override
         public Builder element(Element element) {
             this.materialInfo.element = element;
             return this;
         }
 
-        public Builder toolStats(float speed, float damage, int durability, int enchantability) {
-            return toolStats(speed, damage, durability, enchantability, false);
-        }
-
+        @Override
         public Builder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {
             properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability, ignoreCraftingTools));
             return this;
         }
 
-        public Builder blastTemp(int temp) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp));
-            return this;
-        }
-
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, -1, -1));
-            return this;
-        }
-
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, -1));
-            return this;
-        }
-
+        @Override
         public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
             properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, durationOverride));
             return this;
         }
 
-        public Builder ore() {
-            properties.ensureSet(PropertyKey.ORE);
-            return this;
-        }
-
-        public Builder ore(boolean emissive) {
-            properties.setProperty(PropertyKey.ORE, new OreProperty(1, 1, emissive));
-            return this;
-        }
-
-        public Builder ore(int oreMultiplier, int byproductMultiplier) {
-            properties.setProperty(PropertyKey.ORE, new OreProperty(oreMultiplier, byproductMultiplier));
-            return this;
-        }
-
+        @Override
         public Builder ore(int oreMultiplier, int byproductMultiplier, boolean emissive) {
             properties.setProperty(PropertyKey.ORE, new OreProperty(oreMultiplier, byproductMultiplier, emissive));
             return this;
         }
 
+        @Override
         public Builder fluidTemp(int temp) {
             properties.ensureSet(PropertyKey.FLUID);
             properties.getProperty(PropertyKey.FLUID).setFluidTemperature(temp);
             return this;
         }
 
-        public Builder washedIn(Material m) {
-            properties.ensureSet(PropertyKey.ORE);
-            properties.getProperty(PropertyKey.ORE).setWashedIn(m);
-            return this;
-        }
-
+        @Override
         public Builder washedIn(Material m, int washedAmount) {
             properties.ensureSet(PropertyKey.ORE);
             properties.getProperty(PropertyKey.ORE).setWashedIn(m, washedAmount);
             return this;
         }
 
+        @Override
         public Builder separatedInto(Material... m) {
             properties.ensureSet(PropertyKey.ORE);
             properties.getProperty(PropertyKey.ORE).setSeparatedInto(m);
             return this;
         }
 
+        @Override
         public Builder oreSmeltInto(Material m) {
             properties.ensureSet(PropertyKey.ORE);
             properties.getProperty(PropertyKey.ORE).setDirectSmeltResult(m);
             return this;
         }
 
+        @Override
         public Builder polarizesInto(Material m) {
             properties.ensureSet(PropertyKey.INGOT);
             properties.getProperty(PropertyKey.INGOT).setMagneticMaterial(m);
             return this;
         }
 
+        @Override
         public Builder arcSmeltInto(Material m) {
             properties.ensureSet(PropertyKey.INGOT);
             properties.getProperty(PropertyKey.INGOT).setArcSmeltingInto(m);
             return this;
         }
 
+        @Override
         public Builder macerateInto(Material m) {
             properties.ensureSet(PropertyKey.INGOT);
             properties.getProperty(PropertyKey.INGOT).setMacerateInto(m);
             return this;
         }
 
+        @Override
         public Builder ingotSmeltInto(Material m) {
             properties.ensureSet(PropertyKey.INGOT);
             properties.getProperty(PropertyKey.INGOT).setSmeltingInto(m);
             return this;
         }
 
+        @Override
         public Builder addOreByproducts(Material... byproducts) {
             properties.ensureSet(PropertyKey.ORE);
             properties.getProperty(PropertyKey.ORE).setOreByProducts(byproducts);
             return this;
         }
 
-        public Builder cableProperties(long voltage, int amperage, int loss) {
-            cableProperties((int) voltage, amperage, loss, false);
-            return this;
-        }
-
-        public Builder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon) {
-            properties.ensureSet(PropertyKey.DUST);
-            properties.setProperty(PropertyKey.WIRE, new WireProperties((int) voltage, amperage, loss, isSuperCon));
-            return this;
-        }
-
+        @Override
         public Builder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon, int criticalTemperature) {
             properties.ensureSet(PropertyKey.DUST);
             properties.setProperty(PropertyKey.WIRE, new WireProperties((int) voltage, amperage, loss, isSuperCon, criticalTemperature));
             return this;
         }
 
-        public Builder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof) {
-            return fluidPipeProperties(maxTemp, throughput, gasProof, false, false, false);
-        }
-
+        @Override
         public Builder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
             properties.ensureSet(PropertyKey.INGOT);
             properties.setProperty(PropertyKey.FLUID_PIPE, new FluidPipeProperties(maxTemp, throughput, gasProof, acidProof, cryoProof, plasmaProof));
             return this;
         }
 
+        @Override
         public Builder itemPipeProperties(int priority, float stacksPerSec) {
             properties.ensureSet(PropertyKey.INGOT);
             properties.setProperty(PropertyKey.ITEM_PIPE, new ItemPipeProperties(priority, stacksPerSec));
             return this;
         }
 
+        @Override
         public Builder addDefaultEnchant(Enchantment enchant, int level) {
             if (!properties.hasProperty(PropertyKey.TOOL)) // cannot assign default here
                 throw new IllegalArgumentException("Material cannot have an Enchant without Tools!");
@@ -833,10 +585,321 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        @Override
         public Material build() {
             materialInfo.componentList = ImmutableList.copyOf(composition);
             materialInfo.verifyInfo(properties, averageRGB);
             return new Material(materialInfo, properties, flags);
+        }
+    }
+
+    /**
+     * Builder used to easily append onto an existing Material.
+     *
+     * @since GTCEu 2.4
+     */
+    @SuppressWarnings("unused")
+    public static class Rebuilder implements IMaterialBuilder {
+
+        private final Material material;
+
+        private boolean reaverageColor = false;
+
+        public Rebuilder(Material material) {
+            this.material = material;
+        }
+
+        @Override
+        public Rebuilder fluid(FluidType type, boolean hasBlock) {
+            if (!material.hasProperty(PropertyKey.FLUID)) {
+                material.setProperty(PropertyKey.FLUID, new FluidProperty(type, hasBlock));
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder plasma() {
+            if (!material.hasProperty(PropertyKey.PLASMA)) {
+                material.setProperty(PropertyKey.PLASMA, new PlasmaProperty());
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder dust(int harvestLevel, int burnTime) {
+            if (!material.hasProperty(PropertyKey.DUST)) {
+                material.setProperty(PropertyKey.DUST, new DustProperty(harvestLevel, burnTime));
+            } else {
+                DustProperty property = material.getProperty(PropertyKey.DUST);
+                property.setHarvestLevel(harvestLevel);
+                property.setBurnTime(burnTime);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder ingot(int harvestLevel, int burnTime) {
+            if (!material.hasProperty(PropertyKey.INGOT)) {
+                material.setProperty(PropertyKey.INGOT, new IngotProperty());
+            }
+            if (!material.hasProperty(PropertyKey.DUST)) {
+                DustProperty property = new DustProperty(harvestLevel, burnTime);
+                material.setProperty(PropertyKey.DUST, property);
+            } else {
+                DustProperty property = material.getProperty(PropertyKey.DUST);
+                property.setHarvestLevel(harvestLevel);
+                property.setBurnTime(burnTime);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder gem(int harvestLevel, int burnTime) {
+            if (!material.hasProperty(PropertyKey.GEM)) {
+                material.setProperty(PropertyKey.GEM, new GemProperty());
+            }
+            if (!material.hasProperty(PropertyKey.DUST)) {
+                DustProperty property = new DustProperty(harvestLevel, burnTime);
+                material.setProperty(PropertyKey.DUST, property);
+            } else {
+                DustProperty property = material.getProperty(PropertyKey.DUST);
+                property.setHarvestLevel(harvestLevel);
+                property.setBurnTime(burnTime);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder burnTime(int burnTime) {
+            if (!material.hasProperty(PropertyKey.DUST)) {
+                DustProperty property = new DustProperty(2, burnTime);
+                material.setProperty(PropertyKey.DUST, property);
+            } else {
+                DustProperty property = material.getProperty(PropertyKey.DUST);
+                property.setBurnTime(burnTime);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder color(int color, boolean hasFluidColor) {
+            material.setMaterialRGB(color);
+            material.materialInfo.hasFluidColor = hasFluidColor;
+            return this;
+        }
+
+        @Override
+        public Rebuilder colorAverage() {
+            reaverageColor = true;
+            return this;
+        }
+
+        @Override
+        public Rebuilder iconSet(MaterialIconSet iconSet) {
+            material.materialInfo.iconSet = iconSet;
+            return this;
+        }
+
+        @Override
+        public IMaterialBuilder components(ImmutableList<MaterialStack> components) {
+            material.materialInfo.componentList = components;
+            return this;
+        }
+
+        @Override
+        public Rebuilder flags(MaterialFlag... flags) {
+            material.addFlags(flags);
+            return this;
+        }
+
+        @Override
+        public Rebuilder element(Element element) {
+            material.materialInfo.element = element;
+            return this;
+        }
+
+        @Override
+        public Rebuilder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {
+            if (!material.hasProperty(PropertyKey.TOOL)) {
+                material.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability, ignoreCraftingTools));
+            } else {
+                ToolProperty property = material.getProperty(PropertyKey.TOOL);
+                property.setToolSpeed(speed);
+                property.setToolAttackDamage(damage);
+                property.setToolDurability(durability);
+                property.setToolEnchantability(enchantability);
+                property.setShouldIgnoreCraftingTools(ignoreCraftingTools);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
+            if (!material.hasProperty(PropertyKey.BLAST)) {
+                material.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, durationOverride));
+            } else {
+                BlastProperty property = material.getProperty(PropertyKey.BLAST);
+                property.setBlastTemperature(temp);
+                property.setGasTier(gasTier);
+                property.setEUtOverride(eutOverride);
+                property.setDurationOverride(durationOverride);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder ore(int oreMultiplier, int byproductMultiplier, boolean emissive) {
+            if (!material.hasProperty(PropertyKey.ORE)) {
+                material.setProperty(PropertyKey.ORE, new OreProperty(oreMultiplier, byproductMultiplier, emissive));
+            } else {
+                OreProperty property = material.getProperty(PropertyKey.ORE);
+                property.setOreMultiplier(oreMultiplier);
+                property.setByProductMultiplier(byproductMultiplier);
+                property.setEmissive(emissive);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder fluidTemp(int temp) {
+            if (!material.hasProperty(PropertyKey.FLUID)) {
+                FluidProperty property = new FluidProperty();
+                property.setFluidTemperature(temp);
+                material.setProperty(PropertyKey.FLUID, property);
+            } else {
+                FluidProperty property = material.getProperty(PropertyKey.FLUID);
+                property.setFluidTemperature(temp);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder washedIn(Material m, int washedAmount) {
+            if (!material.hasProperty(PropertyKey.ORE)) {
+                material.setProperty(PropertyKey.ORE, new OreProperty());
+            }
+            material.getProperty(PropertyKey.ORE).setWashedIn(m, washedAmount);
+            return this;
+        }
+
+        @Override
+        public Rebuilder separatedInto(Material... m) {
+            if (!material.hasProperty(PropertyKey.ORE)) {
+                material.setProperty(PropertyKey.ORE, new OreProperty());
+            }
+            material.getProperty(PropertyKey.ORE).setSeparatedInto(m);
+            return this;
+        }
+
+        @Override
+        public Rebuilder oreSmeltInto(Material m) {
+            if (!material.hasProperty(PropertyKey.ORE)) {
+                material.setProperty(PropertyKey.ORE, new OreProperty());
+            }
+            material.getProperty(PropertyKey.ORE).setDirectSmeltResult(m);
+            return this;
+        }
+
+        @Override
+        public Rebuilder polarizesInto(Material m) {
+            if (!material.hasProperty(PropertyKey.INGOT)) {
+                material.setProperty(PropertyKey.INGOT, new IngotProperty());
+            }
+            material.getProperty(PropertyKey.INGOT).setMagneticMaterial(m);
+            return this;
+        }
+
+        @Override
+        public Rebuilder arcSmeltInto(Material m) {
+            if (!material.hasProperty(PropertyKey.INGOT)) {
+                material.setProperty(PropertyKey.INGOT, new IngotProperty());
+            }
+            material.getProperty(PropertyKey.INGOT).setArcSmeltingInto(m);
+            return this;
+        }
+
+        @Override
+        public Rebuilder macerateInto(Material m) {
+            if (!material.hasProperty(PropertyKey.INGOT)) {
+                material.setProperty(PropertyKey.INGOT, new IngotProperty());
+            }
+            material.getProperty(PropertyKey.INGOT).setMacerateInto(m);
+            return this;
+        }
+
+        @Override
+        public Rebuilder ingotSmeltInto(Material m) {
+            if (!material.hasProperty(PropertyKey.INGOT)) {
+                material.setProperty(PropertyKey.INGOT, new IngotProperty());
+            }
+            material.getProperty(PropertyKey.INGOT).setSmeltingInto(m);
+            return this;
+        }
+
+        @Override
+        public Rebuilder addOreByproducts(Material... byproducts) {
+            if (!material.hasProperty(PropertyKey.ORE)) {
+                material.setProperty(PropertyKey.ORE, new OreProperty());
+            }
+            material.getProperty(PropertyKey.ORE).setOreByProducts(byproducts);
+            return this;
+        }
+
+        @Override
+        public Rebuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon, int criticalTemperature) {
+            if (!material.hasProperty(PropertyKey.WIRE)) {
+                material.setProperty(PropertyKey.WIRE, new WireProperties((int) voltage, amperage, loss, isSuperCon, criticalTemperature));
+            } else {
+                WireProperties property = material.getProperty(PropertyKey.WIRE);
+                property.setVoltage((int) voltage);
+                property.setAmperage(amperage);
+                property.setLossPerBlock(loss);
+                property.setSuperconductor(isSuperCon);
+                property.setSuperconductorCriticalTemperature(criticalTemperature);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
+            if (!material.hasProperty(PropertyKey.FLUID_PIPE)) {
+                material.setProperty(PropertyKey.FLUID_PIPE, new FluidPipeProperties(maxTemp, throughput, gasProof, acidProof, cryoProof, plasmaProof));
+            } else {
+                FluidPipeProperties property = material.getProperty(PropertyKey.FLUID_PIPE);
+                property.setMaxFluidTemperature(maxTemp);
+                property.setThroughput(throughput);
+                property.setGasProof(gasProof);
+                property.setAcidProof(acidProof);
+                property.setCryoProof(cryoProof);
+                property.setPlasmaProof(plasmaProof);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder itemPipeProperties(int priority, float stacksPerSec) {
+            if (!material.hasProperty(PropertyKey.ITEM_PIPE)) {
+                material.setProperty(PropertyKey.ITEM_PIPE, new ItemPipeProperties(priority, stacksPerSec));
+            } else {
+                ItemPipeProperties property = material.getProperty(PropertyKey.ITEM_PIPE);
+                property.setPriority(priority);
+                property.setTransferRate(stacksPerSec);
+            }
+            return this;
+        }
+
+        @Override
+        public Rebuilder addDefaultEnchant(Enchantment enchant, int level) {
+            if (!material.hasProperty(PropertyKey.TOOL)) // cannot assign default here
+                throw new IllegalArgumentException("Material cannot have an Enchant without Tools!");
+            material.getProperty(PropertyKey.TOOL).addEnchantmentForTools(enchant, level);
+            return this;
+        }
+
+        @Override
+        public Material build() {
+            material.materialInfo.verifyInfo(material.properties, reaverageColor);
+            return material;
         }
     }
 

--- a/src/main/java/gregtech/api/unification/material/MaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/material/MaterialBuilder.java
@@ -3,7 +3,11 @@ package gregtech.api.unification.material;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import gregtech.api.fluids.fluidType.FluidType;
+import gregtech.api.unification.Element;
+import gregtech.api.unification.material.Material.MaterialInfo;
 import gregtech.api.unification.material.info.MaterialFlag;
+import gregtech.api.unification.material.info.MaterialFlags;
+import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.material.properties.*;
 import gregtech.api.unification.stack.MaterialStack;
 import net.minecraft.enchantment.Enchantment;
@@ -17,6 +21,10 @@ public abstract class MaterialBuilder implements IMaterialBuilder {
     protected abstract <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, T property);
 
     protected abstract <T extends IMaterialProperty<T>> T getProperty(PropertyKey<T> key);
+
+    protected abstract MaterialInfo getMaterialInfo();
+
+    protected abstract MaterialFlags getMaterialFlags();
 
     protected <T extends IMaterialProperty<T>> T getOrDefaultProperty(PropertyKey<T> key) {
         T property = getProperty(key);
@@ -152,7 +160,27 @@ public abstract class MaterialBuilder implements IMaterialBuilder {
 
     @Override
     public IMaterialBuilder color(int color) {
-        return color(color, true);
+        getMaterialInfo().color = color;
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder color(int color, boolean hasFluidColor) {
+        getMaterialInfo().color = color;
+        getMaterialInfo().hasFluidColor = hasFluidColor;
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder colorAverage() {
+        getMaterialInfo().averageRGB = true;
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder iconSet(MaterialIconSet iconSet) {
+        getMaterialInfo().iconSet = iconSet;
+        return this;
     }
 
     @Override
@@ -176,10 +204,28 @@ public abstract class MaterialBuilder implements IMaterialBuilder {
     }
 
     @Override
+    public IMaterialBuilder components(ImmutableList<MaterialStack> components) {
+        getMaterialInfo().componentList = components;
+        return this;
+    }
+
+    @Override
     public IMaterialBuilder flags(Collection<MaterialFlag> f1, MaterialFlag... f2) {
         Collection<MaterialFlag> copy = new ArrayList<>(f1);
         Collections.addAll(copy, f2);
         return flags(copy.toArray(new MaterialFlag[0]));
+    }
+
+    @Override
+    public IMaterialBuilder flags(MaterialFlag... flags) {
+        getMaterialFlags().addFlags(flags);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder element(Element element) {
+        getMaterialInfo().element = element;
+        return this;
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/material/MaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/material/MaterialBuilder.java
@@ -1,0 +1,432 @@
+package gregtech.api.unification.material;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import gregtech.api.fluids.fluidType.FluidType;
+import gregtech.api.unification.material.info.MaterialFlag;
+import gregtech.api.unification.material.properties.*;
+import gregtech.api.unification.stack.MaterialStack;
+import net.minecraft.enchantment.Enchantment;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public abstract class MaterialBuilder implements IMaterialBuilder {
+
+    protected abstract <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, T property);
+
+    protected abstract <T extends IMaterialProperty<T>> T getProperty(PropertyKey<T> key);
+
+    protected <T extends IMaterialProperty<T>> T getOrDefaultProperty(PropertyKey<T> key) {
+        T property = getProperty(key);
+        return property != null ? property : key.constructDefault();
+    }
+
+    @Override
+    public IMaterialBuilder fluid() {
+        FluidProperty property = getOrDefaultProperty(PropertyKey.FLUID);
+        setProperty(PropertyKey.FLUID, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder fluid(FluidType type) {
+        FluidProperty property = getOrDefaultProperty(PropertyKey.FLUID);
+        property.setFluidType(type);
+        setProperty(PropertyKey.FLUID, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder fluid(FluidType type, boolean hasBlock) {
+        FluidProperty property = getOrDefaultProperty(PropertyKey.FLUID);
+        property.setFluidType(type);
+        property.setHasBlock(hasBlock);
+        setProperty(PropertyKey.FLUID, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder plasma() {
+        PlasmaProperty property = getOrDefaultProperty(PropertyKey.PLASMA);
+        setProperty(PropertyKey.PLASMA, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder dust() {
+        DustProperty property = getOrDefaultProperty(PropertyKey.DUST);
+        setProperty(PropertyKey.DUST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder dust(int harvestLevel) {
+        DustProperty property = getOrDefaultProperty(PropertyKey.DUST);
+        property.setHarvestLevel(harvestLevel);
+        setProperty(PropertyKey.DUST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder dust(int harvestLevel, int burnTime) {
+        DustProperty property = getOrDefaultProperty(PropertyKey.DUST);
+        property.setHarvestLevel(harvestLevel);
+        property.setBurnTime(burnTime);
+        setProperty(PropertyKey.DUST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ingot() {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        setProperty(PropertyKey.INGOT, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ingot(int harvestLevel) {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        setProperty(PropertyKey.INGOT, property);
+
+        // Dust holds harvestLevel
+        DustProperty dustProperty = getOrDefaultProperty(PropertyKey.DUST);
+        dustProperty.setHarvestLevel(harvestLevel);
+        setProperty(PropertyKey.DUST, dustProperty);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ingot(int harvestLevel, int burnTime) {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        setProperty(PropertyKey.INGOT, property);
+
+        // Dust holds harvestLevel and burnTime
+        DustProperty dustProperty = getOrDefaultProperty(PropertyKey.DUST);
+        dustProperty.setHarvestLevel(harvestLevel);
+        dustProperty.setBurnTime(burnTime);
+        setProperty(PropertyKey.DUST, dustProperty);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder gem() {
+        GemProperty property = getOrDefaultProperty(PropertyKey.GEM);
+        setProperty(PropertyKey.GEM, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder gem(int harvestLevel) {
+        GemProperty property = getOrDefaultProperty(PropertyKey.GEM);
+        setProperty(PropertyKey.GEM, property);
+
+        // Dust holds harvestLevel
+        DustProperty dustProperty = getOrDefaultProperty(PropertyKey.DUST);
+        dustProperty.setHarvestLevel(harvestLevel);
+        setProperty(PropertyKey.DUST, dustProperty);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder gem(int harvestLevel, int burnTime) {
+        GemProperty property = getOrDefaultProperty(PropertyKey.GEM);
+        setProperty(PropertyKey.GEM, property);
+
+        // Dust holds harvestLevel and burnTime
+        DustProperty dustProperty = getOrDefaultProperty(PropertyKey.DUST);
+        dustProperty.setHarvestLevel(harvestLevel);
+        dustProperty.setBurnTime(burnTime);
+        setProperty(PropertyKey.DUST, dustProperty);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder burnTime(int burnTime) {
+        DustProperty property = getOrDefaultProperty(PropertyKey.DUST);
+        property.setBurnTime(burnTime);
+        setProperty(PropertyKey.DUST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder color(int color) {
+        return color(color, true);
+    }
+
+    @Override
+    public IMaterialBuilder components(Object... components) {
+        Preconditions.checkArgument(
+                components.length % 2 == 0,
+                "Material Components list malformed!"
+        );
+        ImmutableList.Builder<MaterialStack> builder = ImmutableList.builder();
+
+        for (int i = 0; i < components.length; i += 2) {
+            if (components[i] == null) {
+                throw new IllegalArgumentException();
+            }
+            builder.add(new MaterialStack(
+                    (Material) components[i],
+                    (Integer) components[i + 1]
+            ));
+        }
+        return components(builder.build());
+    }
+
+    @Override
+    public IMaterialBuilder flags(Collection<MaterialFlag> f1, MaterialFlag... f2) {
+        Collection<MaterialFlag> copy = new ArrayList<>(f1);
+        Collections.addAll(copy, f2);
+        return flags(copy.toArray(new MaterialFlag[0]));
+    }
+
+    @Override
+    public IMaterialBuilder toolStats(float speed, float damage, int durability, int enchantability) {
+        ToolProperty property = getOrDefaultProperty(PropertyKey.TOOL);
+        property.setToolSpeed(speed);
+        property.setToolAttackDamage(damage);
+        property.setToolDurability(durability);
+        property.setToolEnchantability(enchantability);
+        setProperty(PropertyKey.TOOL, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder toolStats(float speed, float damage, int durability, int enchantability, boolean ignoreCraftingTools) {
+        ToolProperty property = getOrDefaultProperty(PropertyKey.TOOL);
+        property.setToolSpeed(speed);
+        property.setToolAttackDamage(damage);
+        property.setToolDurability(durability);
+        property.setToolEnchantability(enchantability);
+        property.setShouldIgnoreCraftingTools(ignoreCraftingTools);
+        setProperty(PropertyKey.TOOL, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder blastTemp(int temp) {
+        BlastProperty property = getOrDefaultProperty(PropertyKey.BLAST);
+        property.setBlastTemperature(temp);
+        setProperty(PropertyKey.BLAST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier) {
+        BlastProperty property = getOrDefaultProperty(PropertyKey.BLAST);
+        property.setBlastTemperature(temp);
+        property.setGasTier(gasTier);
+        setProperty(PropertyKey.BLAST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
+        BlastProperty property = getOrDefaultProperty(PropertyKey.BLAST);
+        property.setBlastTemperature(temp);
+        property.setGasTier(gasTier);
+        property.setEUtOverride(eutOverride);
+        setProperty(PropertyKey.BLAST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
+        BlastProperty property = getOrDefaultProperty(PropertyKey.BLAST);
+        property.setBlastTemperature(temp);
+        property.setGasTier(gasTier);
+        property.setEUtOverride(eutOverride);
+        property.setDurationOverride(durationOverride);
+        setProperty(PropertyKey.BLAST, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ore() {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ore(boolean emissive) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setEmissive(emissive);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setOreMultiplier(oreMultiplier);
+        property.setByProductMultiplier(byproductMultiplier);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ore(int oreMultiplier, int byproductMultiplier, boolean emissive) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setOreMultiplier(oreMultiplier);
+        property.setByProductMultiplier(byproductMultiplier);
+        property.setEmissive(emissive);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder fluidTemp(int temp) {
+        FluidProperty property = getOrDefaultProperty(PropertyKey.FLUID);
+        property.setFluidTemperature(temp);
+        setProperty(PropertyKey.FLUID, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder washedIn(Material m) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setWashedIn(m);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder washedIn(Material m, int washedAmount) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setWashedIn(m, washedAmount);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder separatedInto(Material... m) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setSeparatedInto(m);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder oreSmeltInto(Material m) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setDirectSmeltResult(m);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder polarizesInto(Material m) {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        property.setMagneticMaterial(m);
+        setProperty(PropertyKey.INGOT, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder arcSmeltInto(Material m) {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        property.setArcSmeltingInto(m);
+        setProperty(PropertyKey.INGOT, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder macerateInto(Material m) {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        property.setMacerateInto(m);
+        setProperty(PropertyKey.INGOT, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder ingotSmeltInto(Material m) {
+        IngotProperty property = getOrDefaultProperty(PropertyKey.INGOT);
+        property.setSmeltingInto(m);
+        setProperty(PropertyKey.INGOT, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder addOreByproducts(Material... byproducts) {
+        OreProperty property = getOrDefaultProperty(PropertyKey.ORE);
+        property.setOreByProducts(byproducts);
+        setProperty(PropertyKey.ORE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder cableProperties(long voltage, int amperage, int loss) {
+        WireProperties property = getOrDefaultProperty(PropertyKey.WIRE);
+        property.setVoltage((int) voltage);
+        property.setAmperage(amperage);
+        property.setLossPerBlock(loss);
+        setProperty(PropertyKey.WIRE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon) {
+        WireProperties property = getOrDefaultProperty(PropertyKey.WIRE);
+        property.setVoltage((int) voltage);
+        property.setAmperage(amperage);
+        property.setLossPerBlock(loss);
+        property.setSuperconductor(isSuperCon);
+        setProperty(PropertyKey.WIRE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder cableProperties(long voltage, int amperage, int loss, boolean isSuperCon, int criticalTemperature) {
+        WireProperties property = getOrDefaultProperty(PropertyKey.WIRE);
+        property.setVoltage((int) voltage);
+        property.setAmperage(amperage);
+        property.setLossPerBlock(loss);
+        property.setSuperconductor(isSuperCon);
+        property.setSuperconductorCriticalTemperature(criticalTemperature);
+        setProperty(PropertyKey.WIRE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof) {
+        FluidPipeProperties property = getOrDefaultProperty(PropertyKey.FLUID_PIPE);
+        property.setMaxFluidTemperature(maxTemp);
+        property.setThroughput(throughput);
+        property.setGasProof(gasProof);
+        setProperty(PropertyKey.FLUID_PIPE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
+        FluidPipeProperties property = getOrDefaultProperty(PropertyKey.FLUID_PIPE);
+        property.setMaxFluidTemperature(maxTemp);
+        property.setThroughput(throughput);
+        property.setGasProof(gasProof);
+        property.setAcidProof(acidProof);
+        property.setCryoProof(cryoProof);
+        property.setPlasmaProof(plasmaProof);
+        setProperty(PropertyKey.FLUID_PIPE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder itemPipeProperties(int priority, float stacksPerSec) {
+        ItemPipeProperties property = getOrDefaultProperty(PropertyKey.ITEM_PIPE);
+        property.setPriority(priority);
+        property.setTransferRate(stacksPerSec);
+        setProperty(PropertyKey.ITEM_PIPE, property);
+        return this;
+    }
+
+    @Override
+    public IMaterialBuilder addDefaultEnchant(Enchantment enchant, int level) {
+        ToolProperty property = getOrDefaultProperty(PropertyKey.TOOL);
+        property.addEnchantmentForTools(enchant, level);
+        setProperty(PropertyKey.TOOL, property);
+        return this;
+    }
+}

--- a/src/main/java/gregtech/api/unification/material/properties/BlastProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/BlastProperty.java
@@ -66,12 +66,24 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
         return gasTier;
     }
 
+    public void setGasTier(GasTier gasTier) {
+        this.gasTier = gasTier;
+    }
+
     public int getDurationOverride() {
         return durationOverride;
     }
 
+    public void setDurationOverride(int durationOverride) {
+        this.durationOverride = durationOverride;
+    }
+
     public int getEUtOverride() {
         return eutOverride;
+    }
+
+    public void setEUtOverride(int eutOverride) {
+        this.eutOverride = eutOverride;
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/material/properties/DustProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/DustProperty.java
@@ -30,7 +30,7 @@ public class DustProperty implements IMaterialProperty<DustProperty> {
     }
 
     public void setHarvestLevel(int harvestLevel) {
-        if (harvestLevel <= 0) throw new IllegalArgumentException("Harvest Level must be greater than zero!");
+        if (harvestLevel < 0) throw new IllegalArgumentException("Harvest Level must be greater than or equal to zero!");
         this.harvestLevel = harvestLevel;
     }
 

--- a/src/main/java/gregtech/api/unification/material/properties/FluidPipeProperties.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidPipeProperties.java
@@ -40,12 +40,6 @@ public class FluidPipeProperties implements IMaterialProperty<FluidPipePropertie
     @Override
     public void verifyProperty(MaterialProperties properties) {
         properties.ensureSet(PropertyKey.INGOT, true);
-
-        if (properties.hasProperty(PropertyKey.ITEM_PIPE)) {
-            throw new IllegalStateException(
-                    "Material " + properties.getMaterial() +
-                            " has both Fluid and Item Pipe Property, which is not allowed!");
-        }
     }
 
     public int getTanks() {

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -17,7 +17,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
      */
     private Fluid fluid;
 
-    private final FluidType fluidType;
+    private FluidType fluidType;
 
     private boolean hasBlock;
     private boolean isGas;
@@ -88,6 +88,10 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
     @Nonnull
     public FluidType getFluidType() {
         return this.fluidType;
+    }
+
+    public void setFluidType(FluidType type) {
+        this.fluidType = type;
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/material/properties/GemProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/GemProperty.java
@@ -5,10 +5,5 @@ public class GemProperty implements IMaterialProperty<GemProperty> {
     @Override
     public void verifyProperty(MaterialProperties properties) {
         properties.ensureSet(PropertyKey.DUST, true);
-        if (properties.hasProperty(PropertyKey.INGOT)) {
-            throw new IllegalStateException(
-                    "Material " + properties.getMaterial() +
-                            " has both Ingot and Gem Property, which is not allowed!");
-        }
     }
 }

--- a/src/main/java/gregtech/api/unification/material/properties/IngotProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/IngotProperty.java
@@ -61,11 +61,6 @@ public class IngotProperty implements IMaterialProperty<IngotProperty> {
     @Override
     public void verifyProperty(MaterialProperties properties) {
         properties.ensureSet(PropertyKey.DUST, true);
-        if (properties.hasProperty(PropertyKey.GEM)) {
-            throw new IllegalStateException(
-                    "Material " + properties.getMaterial() +
-                            " has both Ingot and Gem Property, which is not allowed!");
-        }
 
         if (smeltInto == null) smeltInto = properties.getMaterial();
         else smeltInto.getProperties().ensureSet(PropertyKey.INGOT, true);

--- a/src/main/java/gregtech/api/unification/material/properties/ItemPipeProperties.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ItemPipeProperties.java
@@ -63,12 +63,6 @@ public class ItemPipeProperties implements IMaterialProperty<ItemPipeProperties>
     @Override
     public void verifyProperty(MaterialProperties properties) {
         properties.ensureSet(PropertyKey.INGOT, true);
-
-        if (properties.hasProperty(PropertyKey.FLUID_PIPE)) {
-            throw new IllegalStateException(
-                    "Material " + properties.getMaterial() +
-                            " has both Fluid and Item Pipe Property, which is not allowed!");
-        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/material/properties/MaterialProperties.java
+++ b/src/main/java/gregtech/api/unification/material/properties/MaterialProperties.java
@@ -33,8 +33,11 @@ public class MaterialProperties {
 
     public <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, IMaterialProperty<T> value) {
         if (value == null) throw new IllegalArgumentException("Material Property must not be null!");
-        if (hasProperty(key))
-            throw new IllegalArgumentException("Material Property " + key.toString() + " already registered!");
+        propertyMap.keySet().forEach(k -> {
+            if (k.isIncompatible(key)) {
+                throw new IllegalArgumentException("Material cannot have both " + k + " and " + key + " properties!");
+            }
+        });
         propertyMap.put(key, value);
     }
 

--- a/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
@@ -15,7 +15,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * <p>
      * Default: none, meaning only this property's Material.
      */
-    //@ZenProperty
     private final List<Material> oreByProducts = new ArrayList<>();
 
     /**
@@ -23,7 +22,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * <p>
      * Default: 1 (no multiplier).
      */
-    //@ZenProperty
     private int oreMultiplier;
 
     /**
@@ -31,7 +29,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * <p>
      * Default: 1 (no multiplier).
      */
-    //@ZenProperty
     private int byProductMultiplier;
 
     /**
@@ -39,7 +36,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * <p>
      * Default: false.
      */
-    //@ZenProperty
     private boolean emissive;
 
     /**
@@ -48,7 +44,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * Material will have a Dust Property.
      * Default: none.
      */
-    //@ZenProperty
     @Nullable
     private Material directSmeltResult;
 
@@ -58,7 +53,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * Material will have a Fluid Property.
      * Default: none.
      */
-    //@ZenProperty
     @Nullable
     private Material washedIn;
 
@@ -78,7 +72,6 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
      * Material will have a Dust Property.
      * Default: none.
      */
-    //@ZenProperty
     private final List<Material> separatedInto = new ArrayList<>();
 
     public OreProperty(int oreMultiplier, int byProductMultiplier) {

--- a/src/main/java/gregtech/api/unification/material/properties/PropertyKey.java
+++ b/src/main/java/gregtech/api/unification/material/properties/PropertyKey.java
@@ -1,37 +1,49 @@
 package gregtech.api.unification.material.properties;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class PropertyKey<T extends IMaterialProperty<T>> {
 
     public static final PropertyKey<BlastProperty> BLAST = new PropertyKey<>("blast", BlastProperty.class);
     public static final PropertyKey<DustProperty> DUST = new PropertyKey<>("dust", DustProperty.class);
-    public static final PropertyKey<FluidPipeProperties> FLUID_PIPE = new PropertyKey<>("fluid_pipe", FluidPipeProperties.class);
+    public static final PropertyKey<FluidPipeProperties> FLUID_PIPE = new PropertyKey<>("fluid_pipe", FluidPipeProperties.class, ItemPipeProperties.class);
     public static final PropertyKey<FluidProperty> FLUID = new PropertyKey<>("fluid", FluidProperty.class);
-    public static final PropertyKey<GemProperty> GEM = new PropertyKey<>("gem", GemProperty.class);
-    public static final PropertyKey<IngotProperty> INGOT = new PropertyKey<>("ingot", IngotProperty.class);
-    public static final PropertyKey<ItemPipeProperties> ITEM_PIPE = new PropertyKey<>("item_pipe", ItemPipeProperties.class);
+    public static final PropertyKey<GemProperty> GEM = new PropertyKey<>("gem", GemProperty.class, IngotProperty.class);
+    public static final PropertyKey<IngotProperty> INGOT = new PropertyKey<>("ingot", IngotProperty.class, GemProperty.class);
+    public static final PropertyKey<ItemPipeProperties> ITEM_PIPE = new PropertyKey<>("item_pipe", ItemPipeProperties.class, FluidPipeProperties.class);
     public static final PropertyKey<OreProperty> ORE = new PropertyKey<>("ore", OreProperty.class);
     public static final PropertyKey<PlasmaProperty> PLASMA = new PropertyKey<>("plasma", PlasmaProperty.class);
     public static final PropertyKey<ToolProperty> TOOL = new PropertyKey<>("tool", ToolProperty.class);
     public static final PropertyKey<WireProperties> WIRE = new PropertyKey<>("wire", WireProperties.class);
 
+    private final List<Class<? extends IMaterialProperty<?>>> incompatibleTypes = new ArrayList<>();
     private final String key;
     private final Class<T> type;
 
-    public PropertyKey(String key, Class<T> type) {
+    @SafeVarargs
+    public PropertyKey(String key, Class<T> type, Class<? extends IMaterialProperty<?>>... incompatibleTypes) {
         this.key = key;
         this.type = type;
+        this.incompatibleTypes.addAll(Arrays.asList(incompatibleTypes));
     }
 
     protected String getKey() {
         return key;
     }
 
-    protected T constructDefault() {
+    public T constructDefault() {
         try {
             return type.newInstance();
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public boolean isIncompatible(@Nonnull PropertyKey<?> otherKey) {
+        return this.incompatibleTypes.contains(otherKey.type) || otherKey.incompatibleTypes.contains(this.type);
     }
 
     public T cast(IMaterialProperty<?> property) {


### PR DESCRIPTION
Extracts all methods from `Material.Builder` into an interface, `IMaterialBuilder`, so that new implementations of Material Builders can be created.

Creates a new implementation of `IMaterialBuilder`, aptly named `Material.Rebuilder`, which functions similarly to the standard builder, but instead of creating a new Material, it will modify an existing Material. This is useful for if there are a lot of changes or additions required for a Material that already exists, such as the elements, which exist but do not possess any properties, flags, etc.. This is now an easy way to expand on those in a familiar format.

Additionally, I finished the javadocs for Material Builder methods, as many of them were missing before.