### PR TITLE
Remove crafting station accessing from the Console App in the Terminal.

### DIFF
--- a/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
+++ b/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
@@ -28,10 +28,10 @@ public class ConsoleApp extends AbstractApplication {
 
     @Override
     public AbstractApplication initApp() {
-        IGregTechTileEntity MTEResult = getMTE(); // Moved to make single call
+        IGregTechTileEntity mteResult = getMTE(); // Moved to make single call
 
-        if (MTEResult == null ||
-            MTEResult.getMetaTileEntity() instanceof MetaTileEntityWorkbench) // Remove Crafting Station compat
+        if (mteResult == null ||
+            mteResult.getMetaTileEntity() instanceof MetaTileEntityWorkbench) // Remove Crafting Station compat
         { // 333 232
             TerminalDialogWidget.showInfoDialog(os,
                     "terminal.dialog.notice",

--- a/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
+++ b/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
@@ -7,6 +7,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.terminal.app.AbstractApplication;
 import gregtech.api.terminal.gui.widgets.MachineSceneWidget;
 import gregtech.api.terminal.os.TerminalDialogWidget;
+import gregtech.common.metatileentities.storage.MetaTileEntityWorkbench;
 import net.minecraft.tileentity.TileEntity;
 
 public class ConsoleApp extends AbstractApplication {
@@ -27,7 +28,11 @@ public class ConsoleApp extends AbstractApplication {
 
     @Override
     public AbstractApplication initApp() {
-        if (getMTE() == null) { // 333 232
+        IGregTechTileEntity MTEResult = getMTE(); // Moved to make single call
+
+        if (MTEResult == null ||
+            MTEResult.getMetaTileEntity() instanceof MetaTileEntityWorkbench) // Remove Crafting Station compat
+        { // 333 232
             TerminalDialogWidget.showInfoDialog(os,
                     "terminal.dialog.notice",
                     "terminal.console.notice",

--- a/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
+++ b/src/main/java/gregtech/common/terminal/app/console/ConsoleApp.java
@@ -28,7 +28,7 @@ public class ConsoleApp extends AbstractApplication {
 
     @Override
     public AbstractApplication initApp() {
-        IGregTechTileEntity mteResult = getMTE(); // Moved to make single call
+        IGregTechTileEntity mteResult = getMTE();
 
         if (mteResult == null ||
             mteResult.getMetaTileEntity() instanceof MetaTileEntityWorkbench) // Remove Crafting Station compat


### PR DESCRIPTION
**What:**
https://github.com/GregTechCEu/GregTech/issues/966

**Implementation Details:**
Adds explicit instance-based gate in ConsoleApp to stop it from even opening with Crafting Stations

**Outcome:**
Technically negates https://github.com/GregTechCEu/GregTech/issues/966 by virtue of literally not supporting it, because fuck that noise.

**Additional info:**
This was easier, since the Crafting Station is a mess. Also, uses short circuit evaluation since it is far more terse. Piggybacks off of it already not opening up other tile entities.

**Possible compatibility issue:**
The error message *may* be a bit confusing, but in all honesty it'd be a bit much to specifically build wordage around this.
