### PR TITLE
Fix Prospector showing Copper Ore everywhere on GC planets

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -316,8 +316,8 @@ public class MinerLogic {
                     // check every block along the x-axis
                     if (x.get() <= startX.get() + currentRadius * 2) {
                         BlockPos blockPos = new BlockPos(x.get(), y.get(), z.get());
-                        Block block = metaTileEntity.getWorld().getBlockState(blockPos).getBlock();
-                        if (block.blockHardness >= 0 && metaTileEntity.getWorld().getTileEntity(blockPos) == null && GTUtility.isOre(block)) {
+                        IBlockState state = metaTileEntity.getWorld().getBlockState(blockPos);
+                        if (state.getBlock().blockHardness >= 0 && metaTileEntity.getWorld().getTileEntity(blockPos) == null && GTUtility.isOre(GTUtility.toItem(state))) {
                             blocks.addLast(blockPos);
                         }
                         // move to the next x position

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -360,7 +360,7 @@ public class MinerLogic {
      * @param tier the tier at which the operation is performed, used for calculating the chanced output boost
      */
     protected static void applyTieredHammerNoRandomDrops(@Nonnull IBlockState blockState, List<ItemStack> drops, int fortuneLevel, @Nonnull RecipeMap<?> map, int tier) {
-        ItemStack itemStack = new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState));
+        ItemStack itemStack = GTUtility.toItem(blockState);
         Recipe recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(itemStack), Collections.emptyList(), 0);
         if (recipe != null && !recipe.getOutputs().isEmpty()) {
             drops.clear();

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -17,8 +17,8 @@ import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
+import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
@@ -906,8 +906,16 @@ public class GTUtility {
         return romanNumeralConversions.get(conversion) + romanNumeralString(num - conversion);
     }
 
-    public static boolean isOre(Block block) {
-        OrePrefix orePrefix = OreDictUnifier.getPrefix(new ItemStack(block));
+    public static ItemStack toItem(IBlockState state) {
+        return toItem(state, 1);
+    }
+
+    public static ItemStack toItem(IBlockState state, int amount) {
+        return new ItemStack(state.getBlock(), amount, state.getBlock().getMetaFromState(state));
+    }
+
+    public static boolean isOre(ItemStack item) {
+        OrePrefix orePrefix = OreDictUnifier.getPrefix(item);
         return orePrefix != null && orePrefix.name().startsWith("ore");
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockCompressed.java
+++ b/src/main/java/gregtech/common/blocks/BlockCompressed.java
@@ -7,6 +7,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.info.MaterialIconType;
 import gregtech.api.unification.material.properties.PropertyKey;
+import gregtech.api.util.GTUtility;
 import gregtech.client.model.IModelSupplier;
 import gregtech.client.model.SimpleStateMapper;
 import gregtech.common.blocks.properties.PropertyMaterial;
@@ -94,7 +95,7 @@ public final class BlockCompressed extends DelayedStateBlock implements IModelSu
     }
 
     public ItemStack getItem(IBlockState blockState) {
-        return new ItemStack(this, 1, getMetaFromState(blockState));
+        return GTUtility.toItem(blockState);
     }
 
     public ItemStack getItem(Material material) {

--- a/src/main/java/gregtech/common/blocks/BlockFrame.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrame.java
@@ -3,6 +3,7 @@ package gregtech.common.blocks;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.block.DelayedStateBlock;
+import gregtech.api.util.GTUtility;
 import gregtech.client.model.IModelSupplier;
 import gregtech.client.model.SimpleStateMapper;
 import gregtech.api.pipenet.block.BlockPipe;
@@ -130,7 +131,7 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     public ItemStack getItem(IBlockState blockState) {
-        return new ItemStack(this, 1, getMetaFromState(blockState));
+        return GTUtility.toItem(blockState);
     }
 
     public ItemStack getItem(Material material) {

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -5,6 +5,7 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.StoneType;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.IBlockOre;
 import gregtech.client.model.IModelSupplier;
 import gregtech.client.model.SimpleStateMapper;
@@ -116,7 +117,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     public ItemStack getItem(IBlockState blockState) {
-        return new ItemStack(this, 1, getMetaFromState(blockState));
+        return GTUtility.toItem(blockState);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockSurfaceRock.java
+++ b/src/main/java/gregtech/common/blocks/BlockSurfaceRock.java
@@ -6,6 +6,7 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.properties.PropertyMaterial;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
@@ -71,7 +72,7 @@ public class BlockSurfaceRock extends DelayedStateBlock {
     }
 
     public ItemStack getItem(IBlockState blockState) {
-        return new ItemStack(this, 1, getMetaFromState(blockState));
+        return GTUtility.toItem(blockState);
     }
 
     public ItemStack getItem(Material material) {

--- a/src/main/java/gregtech/common/terminal/app/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/terminal/app/prospector/widget/WidgetProspectingMap.java
@@ -10,12 +10,14 @@ import gregtech.api.util.Size;
 import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
 import gregtech.common.terminal.app.prospector.ProspectingTexture;
 import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -103,13 +105,16 @@ public class WidgetProspectingMap extends Widget {
 
             switch (mode) {
                 case ORE_PROSPECTING_MODE:
+                    BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
                     for (int x = 0; x < 16; x++) {
                         for (int z = 0; z < 16; z++) {
                             int ySize = chunk.getHeightValue(x, z);
                             for (int y = 1; y < ySize; y++) {
-                                Block block = chunk.getBlockState(x, y, z).getBlock();
-                                if (GTUtility.isOre(block)) {
-                                    packet.addBlock(x, y, z, OreDictUnifier.getOreDictionaryNames(new ItemStack(block)).stream().findFirst().get());
+                                pos.setPos(x, y, z);
+                                IBlockState state = chunk.getBlockState(pos);
+                                ItemStack itemBlock = GTUtility.toItem(state);
+                                if (GTUtility.isOre(itemBlock)) {
+                                    packet.addBlock(x, y, z, OreDictUnifier.getOreDictionaryNames(itemBlock).stream().findFirst().get());
                                 }
                             }
                         }

--- a/src/main/java/gregtech/common/tools/ToolHardHammer.java
+++ b/src/main/java/gregtech/common/tools/ToolHardHammer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import gregtech.api.enchants.EnchantmentHardHammer;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.util.GTUtility;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.Enchantment;
@@ -74,7 +75,7 @@ public class ToolHardHammer extends ToolBase {
     @Override
     public boolean canMineBlock(IBlockState block, ItemStack stack) {
         String tool = block.getBlock().getHarvestTool(block);
-        ItemStack itemStack = new ItemStack(block.getBlock(), 1, block.getBlock().getMetaFromState(block));
+        ItemStack itemStack = GTUtility.toItem(block);
         return (tool != null && HAMMER_TOOL_CLASSES.contains(tool)) ||
                 block.getMaterial() == Material.ROCK ||
                 block.getMaterial() == Material.GLASS ||

--- a/src/main/java/gregtech/common/tools/ToolUtility.java
+++ b/src/main/java/gregtech/common/tools/ToolUtility.java
@@ -98,25 +98,25 @@ public class ToolUtility {
     }
 
     public static void applyHammerDrops(Random random, IBlockState blockState, List<ItemStack> drops, int fortuneLevel, EntityPlayer player) {
+        ItemStack blockItem = GTUtility.toItem(blockState);
         ItemStack inputStack;
         if (blockState.getBlock() instanceof BlockOre) {
             inputStack = drops.get(0);
         } else {
-            inputStack = new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState));
+            inputStack = blockItem.copy();
         }
         MaterialStack input = OreDictUnifier.getMaterial(inputStack);
-        if (input != null && input.material.hasProperty(PropertyKey.ORE) && GTUtility.isOre(GTUtility.toItem(blockState)) && !(player instanceof FakePlayer)) {
+        if (input != null && input.material.hasProperty(PropertyKey.ORE) && GTUtility.isOre(blockItem) && !(player instanceof FakePlayer)) {
             drops.clear();
-            OrePrefix prefix = OreDictUnifier.getPrefix(new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState)));
+            OrePrefix prefix = OreDictUnifier.getPrefix(blockItem);
             int multiplier = (prefix == OrePrefix.oreEndstone || prefix == OrePrefix.oreNetherrack) ? 2 : 1;
             ItemStack output = OreDictUnifier.get(OrePrefix.crushed, input.material);
 
-            if(fortuneLevel > 0){
-                if(fortuneLevel > 3) fortuneLevel = 3;
+            if (fortuneLevel > 0) {
+                if (fortuneLevel > 3) fortuneLevel = 3;
                 output.setCount((input.material.getProperty((PropertyKey.ORE)).getOreMultiplier() * multiplier) * (random.nextFloat() <= (fortuneLevel / 3.0) ? 2 : 1));
                 if (output.getCount() == 0) output.setCount(1);
-            }
-            else{
+            } else {
                 output.setCount(input.material.getProperty((PropertyKey.ORE)).getOreMultiplier() * multiplier);
             }
             drops.add(output);

--- a/src/main/java/gregtech/common/tools/ToolUtility.java
+++ b/src/main/java/gregtech/common/tools/ToolUtility.java
@@ -105,7 +105,7 @@ public class ToolUtility {
             inputStack = new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState));
         }
         MaterialStack input = OreDictUnifier.getMaterial(inputStack);
-        if (input != null && input.material.hasProperty(PropertyKey.ORE) && GTUtility.isOre(blockState.getBlock()) && !(player instanceof FakePlayer)) {
+        if (input != null && input.material.hasProperty(PropertyKey.ORE) && GTUtility.isOre(GTUtility.toItem(blockState)) && !(player instanceof FakePlayer)) {
             drops.clear();
             OrePrefix prefix = OreDictUnifier.getPrefix(new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState)));
             int multiplier = (prefix == OrePrefix.oreEndstone || prefix == OrePrefix.oreNetherrack) ? 2 : 1;

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -3,6 +3,7 @@ package gregtech.integration.jei;
 import com.google.common.collect.ImmutableList;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
+import gregtech.api.util.GTUtility;
 import gregtech.api.worldgen.config.FillerConfigUtils;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.filler.BlockFiller;
@@ -166,7 +167,7 @@ public class GTOreInfo implements IRecipeWrapper {
 
     private List<ItemStack> getStacksFromStates(Collection<IBlockState> states, List<ItemStack> list) {
         for (IBlockState state : states) {
-            list.add(new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state)));
+            list.add(GTUtility.toItem(state));
         }
         return list;
     }
@@ -233,7 +234,7 @@ public class GTOreInfo implements IRecipeWrapper {
         // Surface Block support
         else if (veinPopulator instanceof SurfaceBlockPopulator) {
             state = ((SurfaceBlockPopulator) veinPopulator).getBlockState();
-            stack = new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state));
+            stack = GTUtility.toItem(state);
             return stack;
         }
         //Fluid generation support


### PR DESCRIPTION
Blockstate where not properly converted to `ItemStack`.
Also fixes for other `isOre` usages