### PR TITLE
Fix MTE fluid handler issues

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -62,6 +62,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static gregtech.api.capability.GregtechDataCodes.*;
@@ -900,49 +901,21 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return capabilityResult;
     }
 
-    public boolean fillInternalTankFromFluidContainer(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, int inputSlot, int outputSlot) {
-        ItemStack inputContainerStack = importItems.extractItem(inputSlot, 1, true);
-        FluidActionResult result = FluidUtil.tryEmptyContainer(inputContainerStack, importFluids, Integer.MAX_VALUE, null, false);
-        if (result.isSuccess()) {
-            ItemStack remainingItem = result.getResult();
-            if (ItemStack.areItemStacksEqual(inputContainerStack, remainingItem))
-                return false; //do not fill if item stacks match
-            if (!remainingItem.isEmpty() && !exportItems.insertItem(outputSlot, remainingItem, true).isEmpty())
-                return false; //do not fill if can't put remaining item
-            FluidUtil.tryEmptyContainer(inputContainerStack, importFluids, Integer.MAX_VALUE, null, true);
-            importItems.extractItem(inputSlot, 1, false);
-            exportItems.insertItem(outputSlot, remainingItem, false);
-            return true;
-        }
-        return false;
-    }
-
-    public boolean fillContainerFromInternalTank(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, int inputSlot, int outputSlot) {
-        ItemStack emptyContainer = importItems.extractItem(inputSlot, 1, true);
-        FluidActionResult result = FluidUtil.tryFillContainer(emptyContainer, exportFluids, Integer.MAX_VALUE, null, false);
-        if (result.isSuccess()) {
-            ItemStack remainingItem = result.getResult();
-            if (!remainingItem.isEmpty() && !exportItems.insertItem(outputSlot, remainingItem, true).isEmpty())
-                return false;
-            FluidUtil.tryFillContainer(emptyContainer, exportFluids, Integer.MAX_VALUE, null, true);
-            importItems.extractItem(inputSlot, 1, false);
-            exportItems.insertItem(outputSlot, remainingItem, false);
-            return true;
-        }
-        return false;
-    }
-
     public void fillInternalTankFromFluidContainer() {
+        fillInternalTankFromFluidContainer(importFluids);
+    }
+
+    public void fillInternalTankFromFluidContainer(IFluidHandler fluidHandler) {
         for (int i = 0; i < importItems.getSlots(); i++) {
             ItemStack inputContainerStack = importItems.extractItem(i, 1, true);
-            FluidActionResult result = FluidUtil.tryEmptyContainer(inputContainerStack, importFluids, Integer.MAX_VALUE, null, false);
+            FluidActionResult result = FluidUtil.tryEmptyContainer(inputContainerStack, fluidHandler, Integer.MAX_VALUE, null, false);
             if (result.isSuccess()) {
                 ItemStack remainingItem = result.getResult();
                 if (ItemStack.areItemStacksEqual(inputContainerStack, remainingItem))
                     continue; //do not fill if item stacks match
                 if (!remainingItem.isEmpty() && !GTTransferUtils.insertItem(exportItems, remainingItem, true).isEmpty())
                     continue; //do not fill if can't put remaining item
-                FluidUtil.tryEmptyContainer(inputContainerStack, importFluids, Integer.MAX_VALUE, null, true);
+                FluidUtil.tryEmptyContainer(inputContainerStack, fluidHandler, Integer.MAX_VALUE, null, true);
                 importItems.extractItem(i, 1, false);
                 GTTransferUtils.insertItem(exportItems, remainingItem, false);
             }
@@ -950,14 +923,18 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public void fillContainerFromInternalTank() {
+        fillContainerFromInternalTank(exportFluids);
+    }
+
+    public void fillContainerFromInternalTank(IFluidHandler fluidHandler) {
         for (int i = 0; i < importItems.getSlots(); i++) {
             ItemStack emptyContainer = importItems.extractItem(i, 1, true);
-            FluidActionResult result = FluidUtil.tryFillContainer(emptyContainer, exportFluids, Integer.MAX_VALUE, null, false);
+            FluidActionResult result = FluidUtil.tryFillContainer(emptyContainer, fluidHandler, Integer.MAX_VALUE, null, false);
             if (result.isSuccess()) {
                 ItemStack remainingItem = result.getResult();
                 if (!remainingItem.isEmpty() && !GTTransferUtils.insertItem(exportItems, remainingItem, true).isEmpty())
                     continue;
-                FluidUtil.tryFillContainer(emptyContainer, exportFluids, Integer.MAX_VALUE, null, true);
+                FluidUtil.tryFillContainer(emptyContainer, fluidHandler, Integer.MAX_VALUE, null, true);
                 importItems.extractItem(i, 1, false);
                 GTTransferUtils.insertItem(exportItems, remainingItem, false);
             }
@@ -965,63 +942,22 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public void pushFluidsIntoNearbyHandlers(EnumFacing... allowedFaces) {
-        PooledMutableBlockPos blockPos = PooledMutableBlockPos.retain();
-        for (EnumFacing nearbyFacing : allowedFaces) {
-            blockPos.setPos(getPos()).move(nearbyFacing);
-            TileEntity tileEntity = getWorld().getTileEntity(blockPos);
-            if (tileEntity == null) {
-                continue;
-            }
-            IFluidHandler fluidHandler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, nearbyFacing.getOpposite());
-            //use getCoverCapability so fluid tank index filtering and fluid filtering covers will work properly
-            IFluidHandler myFluidHandler = getCoverCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, nearbyFacing);
-            if (fluidHandler == null || myFluidHandler == null) {
-                continue;
-            }
-            GTTransferUtils.transferFluids(myFluidHandler, fluidHandler, Integer.MAX_VALUE);
-        }
-        blockPos.release();
+        transferToNearby(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, GTTransferUtils::transferFluids, allowedFaces);
     }
 
     public void pullFluidsFromNearbyHandlers(EnumFacing... allowedFaces) {
-        PooledMutableBlockPos blockPos = PooledMutableBlockPos.retain();
-        for (EnumFacing nearbyFacing : allowedFaces) {
-            blockPos.setPos(getPos()).move(nearbyFacing);
-            TileEntity tileEntity = getWorld().getTileEntity(blockPos);
-            if (tileEntity == null) {
-                continue;
-            }
-            IFluidHandler fluidHandler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, nearbyFacing.getOpposite());
-            //use getCoverCapability so fluid tank index filtering and fluid filtering covers will work properly
-            IFluidHandler myFluidHandler = getCoverCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, nearbyFacing);
-            if (fluidHandler == null || myFluidHandler == null) {
-                continue;
-            }
-            GTTransferUtils.transferFluids(fluidHandler, myFluidHandler, Integer.MAX_VALUE);
-        }
-        blockPos.release();
+        transferToNearby(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, (thisCap, otherCap) -> GTTransferUtils.transferFluids(otherCap, thisCap), allowedFaces);
     }
 
     public void pushItemsIntoNearbyHandlers(EnumFacing... allowedFaces) {
-        PooledMutableBlockPos blockPos = PooledMutableBlockPos.retain();
-        for (EnumFacing nearbyFacing : allowedFaces) {
-            blockPos.setPos(getPos()).move(nearbyFacing);
-            TileEntity tileEntity = getWorld().getTileEntity(blockPos);
-            if (tileEntity == null) {
-                continue;
-            }
-            IItemHandler itemHandler = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing.getOpposite());
-            //use getCoverCapability so item/ore dictionary filter covers will work properly
-            IItemHandler myItemHandler = getCoverCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing);
-            if (itemHandler == null || myItemHandler == null) {
-                continue;
-            }
-            GTTransferUtils.moveInventoryItems(myItemHandler, itemHandler);
-        }
-        blockPos.release();
+        transferToNearby(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, GTTransferUtils::moveInventoryItems, allowedFaces);
     }
 
     public void pullItemsFromNearbyHandlers(EnumFacing... allowedFaces) {
+        transferToNearby(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, (thisCap, otherCap) -> GTTransferUtils.moveInventoryItems(otherCap, thisCap), allowedFaces);
+    }
+
+    private <T> void transferToNearby(Capability<T> capability, BiConsumer<T, T> transfer, EnumFacing... allowedFaces) {
         PooledMutableBlockPos blockPos = PooledMutableBlockPos.retain();
         for (EnumFacing nearbyFacing : allowedFaces) {
             blockPos.setPos(getPos()).move(nearbyFacing);
@@ -1029,13 +965,10 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
             if (tileEntity == null) {
                 continue;
             }
-            IItemHandler itemHandler = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing.getOpposite());
+            T otherCap = tileEntity.getCapability(capability, nearbyFacing.getOpposite());
             //use getCoverCapability so item/ore dictionary filter covers will work properly
-            IItemHandler myItemHandler = getCoverCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, nearbyFacing);
-            if (itemHandler == null || myItemHandler == null) {
-                continue;
-            }
-            GTTransferUtils.moveInventoryItems(itemHandler, myItemHandler);
+            T thisCap = getCoverCapability(capability, nearbyFacing);
+            transfer.accept(thisCap, otherCap);
         }
         blockPos.release();
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOvenHatch.java
@@ -47,7 +47,7 @@ public class MetaTileEntityCokeOvenHatch extends MetaTileEntityMultiblockPart {
             TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(getFrontFacing()));
             IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (fluidHandler != null) {
-                GTTransferUtils.transferFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE);
+                GTTransferUtils.transferFluids(fluidInventory, fluidHandler);
             }
             IItemHandler itemHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (itemHandler != null) {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
@@ -37,11 +37,9 @@ import java.util.List;
 public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidTank> {
 
     private static final int FLUID_TANK_SIZE = 1000;
-    private final FluidTank waterTank;
 
     public MetaTileEntityPumpHatch(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, 0);
-        this.waterTank = new FluidTank(FLUID_TANK_SIZE);
         initializeInventory();
     }
 
@@ -75,13 +73,8 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    protected FluidTankList createImportFluidHandler() {
-        return new FluidTankList(false);
-    }
-
-    @Override
     protected FluidTankList createExportFluidHandler() {
-        return new FluidTankList(false, waterTank);
+        return new FluidTankList(false, new FluidTank(FLUID_TANK_SIZE));
     }
 
     @Override
@@ -106,12 +99,12 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
 
     @Override
     public void registerAbilities(List<IFluidTank> abilityList) {
-        abilityList.add(waterTank);
+        abilityList.add(exportFluids.getTankAt(0));
     }
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
-        return createTankUI(waterTank, getMetaFullName(), entityPlayer)
+        return createTankUI(exportFluids.getTankAt(0), getMetaFullName(), entityPlayer)
                 .build(getHolder(), entityPlayer);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
@@ -73,7 +73,7 @@ public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implem
             TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(getFrontFacing()));
             IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getFrontFacing().getOpposite());
             if (fluidHandler != null) {
-                GTTransferUtils.transferFluids(fluidInventory, fluidHandler, Integer.MAX_VALUE);
+                GTTransferUtils.transferFluids(fluidInventory, fluidHandler);
             }
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -38,6 +38,8 @@ import java.util.List;
 public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank> {
 
     private static final int INITIAL_INVENTORY_SIZE = 8000;
+
+    // only holding this for convenience
     private final FluidTank fluidTank;
 
     public MetaTileEntityFluidHatch(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {
@@ -69,11 +71,11 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
-            fillContainerFromInternalTank();
+            fillContainerFromInternalTank(fluidTank);
             if (isExportHatch) {
                 pushFluidsIntoNearbyHandlers(getFrontFacing());
             } else {
-                fillInternalTankFromFluidContainer();
+                fillInternalTankFromFluidContainer(fluidTank);
                 pullFluidsFromNearbyHandlers(getFrontFacing());
             }
         }
@@ -101,7 +103,7 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
 
     @Override
     protected FluidTankList createExportFluidHandler() {
-        return new FluidTankList(false, fluidTank);
+        return isExportHatch ? new FluidTankList(false, fluidTank) : new FluidTankList(false);
     }
 
     @Override
@@ -121,13 +123,12 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
 
     @Override
     public void registerAbilities(List<IFluidTank> abilityList) {
-        abilityList.addAll(isExportHatch ? this.exportFluids.getFluidTanks() : this.importFluids.getFluidTanks());
+        abilityList.add(fluidTank);
     }
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
-        return createTankUI((isExportHatch ? exportFluids : importFluids).getTankAt(0), getMetaFullName(), entityPlayer)
-                .build(getHolder(), entityPlayer);
+        return createTankUI(fluidTank, getMetaFullName(), entityPlayer).build(getHolder(), entityPlayer);
     }
 
     public ModularUI.Builder createTankUI(IFluidTank fluidTank, String title, EntityPlayer entityPlayer) {

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -17,6 +17,7 @@ import gregtech.api.metatileentity.IDataInfoProvider;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.sound.GTSounds;
+import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -172,7 +173,7 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
                 generateSteam();
             }
 
-            fillInternalTankFromFluidContainer(containerInventory, containerInventory, 0, 1);
+            GTTransferUtils.fillInternalTankFromFluidContainer(importFluids, containerInventory, 0, 1);
 
             if (getOffsetTimer() % 5 == 0) {
                 pushFluidsIntoNearbyHandlers(STEAM_PUSH_DIRECTIONS);

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
@@ -30,7 +30,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -44,12 +43,8 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
     private static final int INVENTORY_SIZE = 64000;
     private static final boolean IS_STEEL = ConfigHolder.machines.steelSteamMultiblocks;
 
-    private final FluidTank steamFluidTank;
-
     public MetaTileEntitySteamHatch(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, 0);
-        this.steamFluidTank = new FilteredFluidHandler(INVENTORY_SIZE).setFillPredicate(ModHandler::isSteam);
-        initializeInventory();
     }
 
     @Override
@@ -69,7 +64,7 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
-            fillContainerFromInternalTank();
+            fillContainerFromInternalTank(importFluids);
             fillInternalTankFromFluidContainer();
             pullFluidsFromNearbyHandlers(getFrontFacing());
         }
@@ -99,12 +94,7 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
 
     @Override
     protected FluidTankList createImportFluidHandler() {
-        return new FluidTankList(false, steamFluidTank);
-    }
-
-    @Override
-    protected FluidTankList createExportFluidHandler() {
-        return new FluidTankList(false, steamFluidTank);
+        return new FluidTankList(false, new FilteredFluidHandler(INVENTORY_SIZE).setFillPredicate(ModHandler::isSteam));
     }
 
     @Override


### PR DESCRIPTION
### Fixes
- Fix 2 tanks shown in TOP on some MTEs
- Fix Fluids being extractable from Fluid Input Hatch and Steam Hatch via pipes

### API Changes
- MetaTileEntity additions:
    - `void fillInternalTankFromFluidContainer(IFluidHandler fluidHandler)`
    - `void fillContainerFromInternalTank(IFluidHandler fluidHandler)`
    - Both of these allow the original no-args methods to have a Fluid Handler specified instead of forcing to the default (`importFluids` and `exportFluids` respectively)
- MetaTileEntity removals:
    - `void fillInternalTankFromFluidContainer(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, int inputSlot, int outputSlot)`
        - This was moved to `GTTransferUtils`, but should be removed eventually. It is only used by the Steam Boiler class, but this should be refactored away eventually.
    - `void fillContainerFromInternalTank(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, int inputSlot, int outputSlot)`
 
### Other Changes
This also cleaned up the various "push to nearby handlers" methods in MetaTileEntity, reducing duplicate code.

Supersedes #829 