### PR TITLE
Fix being able to dupe items via Machine Access Interface

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -17,8 +17,8 @@ import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
+import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
@@ -236,7 +236,8 @@ public class GTUtility {
                 continue; //if itemstacks don't match, continue
             int slotMaxStackSize = Math.min(stackInSlot.getMaxStackSize(), slot.getItemStackLimit(stackInSlot));
             int amountToInsert = Math.min(itemStack.getCount(), slotMaxStackSize - stackInSlot.getCount());
-            if (amountToInsert == 0)
+            // Need to check <= 0 for the PA, which could have this value negative due to slot limits in the Machine Access Interface
+            if (amountToInsert <= 0)
                 continue; //if we can't insert anything, continue
             //shrink our stack, grow slot's stack and mark slot as changed
             if (!simulate) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -15,6 +15,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.ItemStackHashStrategy;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -90,7 +91,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
         if (getController() instanceof IMachineHatchMultiblock) {
             return ((IMachineHatchMultiblock) getController()).getMachineLimit();
         }
-        return 16;
+        return 64;
     }
 
     @Override
@@ -108,23 +109,72 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
 
         @Nonnull
         @Override
+        // Insert item returns the remainder stack that was not inserted
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
 
+            // If the item was not valid, nothing from the stack can be inserted
             if (!isItemValid(slot, stack)) {
                 return stack;
             }
 
-            return super.insertItem(slot, stack, simulate);
+            // Return Empty if passed Empty
+            if(stack.isEmpty()) {
+                return ItemStack.EMPTY;
+            }
+
+            // If the stacks do not match, nothing can be inserted
+            if(!ItemStackHashStrategy.comparingAllButCount().equals(stack, this.getStackInSlot(slot)) && !this.getStackInSlot(slot).isEmpty()) {
+                return stack;
+            }
+
+            int amountInSlot = this.getStackInSlot(slot).getCount();
+            int slotLimit = getSlotLimit(slot);
+
+            // If the current stack size in the slot is greater than the limit of the Multiblock, nothing can be inserted
+            if(amountInSlot >= slotLimit) {
+                return stack;
+            }
+
+            // This will always be positive and greater than zero if reached
+            int spaceAvailable = slotLimit - amountInSlot;
+
+            // Insert the minimum amount between the amount of space available and the amount being inserted
+            int amountToInsert = Math.min(spaceAvailable, stack.getCount());
+
+            // The remainder that was not inserted
+            int remainderAmount = stack.getCount() - amountToInsert;
+
+            // Handle any remainder
+            ItemStack remainder = ItemStack.EMPTY;
+
+            if(remainderAmount > 0) {
+                remainder = stack.copy();
+                remainder.setCount(remainderAmount);
+            }
+
+
+            if(!simulate) {
+                // Perform the actual insertion
+                ItemStack temp = stack.copy();
+                temp.setCount(amountInSlot + amountToInsert);
+                this.setStackInSlot(slot, temp);
+                //this.getStackInSlot(slot).grow(amountToInsert);
+            }
+
+            return remainder;
         }
 
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+
+            boolean slotMatches = this.getStackInSlot(slot).isEmpty() || ItemStackHashStrategy.comparingAllButCount().equals(this.getStackInSlot(slot), stack);
+
             MultiblockControllerBase controller = getController();
             if (controller instanceof IMachineHatchMultiblock)
-                return GTUtility.isMachineValidForMachineHatch(stack, ((IMachineHatchMultiblock) controller).getBlacklist());
+                return GTUtility.isMachineValidForMachineHatch(stack, ((IMachineHatchMultiblock) controller).getBlacklist()) && slotMatches;
 
             //If the controller is null, this part is not attached to any Multiblock
-            return true;
+            return slotMatches;
         }
 
         @Nonnull
@@ -151,7 +201,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
         }
 
         @Override
-        protected int getStackLimit(int slot, @Nonnull ItemStack stack) {
+        public int getSlotLimit(int slot) {
             return MetaTileEntityMachineHatch.this.getMachineLimit();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -14,8 +14,8 @@ import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
+import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -90,7 +90,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
         if (getController() instanceof IMachineHatchMultiblock) {
             return ((IMachineHatchMultiblock) getController()).getMachineLimit();
         }
-        return 64;
+        return 16;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -59,11 +59,6 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
     }
 
     @Override
-    public IItemHandlerModifiable getImportItems() {
-        return machineHandler;
-    }
-
-    @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176,
                         18 + 18 + 94)

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -153,7 +153,6 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
                 ItemStack temp = stack.copy();
                 temp.setCount(amountInSlot + amountToInsert);
                 this.setStackInSlot(slot, temp);
-                //this.getStackInSlot(slot).grow(amountToInsert);
             }
 
             return remainder;
@@ -166,7 +165,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
 
             MultiblockControllerBase controller = getController();
             if (controller instanceof IMachineHatchMultiblock)
-                return GTUtility.isMachineValidForMachineHatch(stack, ((IMachineHatchMultiblock) controller).getBlacklist()) && slotMatches;
+                return slotMatches && GTUtility.isMachineValidForMachineHatch(stack, ((IMachineHatchMultiblock) controller).getBlacklist());
 
             //If the controller is null, this part is not attached to any Multiblock
             return slotMatches;


### PR DESCRIPTION
**What:**
Fixes being able to dupe machines with the Machine Access Interface as shown in #1008 

**Implementation Details:**
The dupe was occurring because of the `super.insertItems` call in the `MetatileEntityMachineHatch` item handler returning the stack when attempting to insert into a slot that had reached/exceeded its slot limit.

This fix simply sets the base slot limit of the Machine Access Interface to 16 (The amount for a regular Processing Array). The fix was done this way to also prevent people from attempting to cheese things, by placing a stack of machines into a Machine Access Interface attached to an unformed PA, and then forming the PA, thus having 1 stack of machines when the PA is only supposed to handle 16.

This works around the problematic behavior when the amount in the slot was greater than the slot limit.

**Outcome:**
Fixes being able to dupe machines in the Machine Access Interface. Closes #1008 
