### PR TITLE
Various small fixes to the cleanroom structure and to its recipes

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -124,8 +124,10 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
             NBTTagCompound metaTileEntityData = compound.getCompoundTag("MetaTileEntity");
             if (sampleMetaTileEntity != null) {
                 setRawMetaTileEntity(sampleMetaTileEntity.createMetaTileEntity(this));
-                this.metaTileEntity.onAttached();
+                /* Note: NBTs need to be read before onAttached is run, since NBTs may contain important information
+                * about the composition of the BlockPattern that onAttached may generate. */
                 this.metaTileEntity.readFromNBT(metaTileEntityData);
+                this.metaTileEntity.onAttached();
             } else {
                 GTLog.logger.error("Failed to load MetaTileEntity with invalid ID " + metaTileEntityIdRaw);
             }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -543,8 +543,8 @@ public class MachineRecipeLoader {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.STEEL_TURBINE_CASING)).input(OrePrefix.plate, Materials.Titanium, 6).notConsumable(new IntCircuitIngredient(6)).outputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.TITANIUM_TURBINE_CASING, 2)).duration(50).buildAndRegister();
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(16).inputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.STEEL_TURBINE_CASING)).input(OrePrefix.plate, Materials.TungstenSteel, 6).notConsumable(new IntCircuitIngredient(6)).outputs(MetaBlocks.TURBINE_CASING.getItemVariant(TurbineCasingType.TUNGSTENSTEEL_TURBINE_CASING, 2)).duration(50).buildAndRegister();
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(48).input(OrePrefix.frameGt, Materials.Steel).input(OrePrefix.plate, Materials.Polyethylene, 6).fluidInputs(Concrete.getFluid(L)).outputs(MetaBlocks.CLEANROOM_CASING.getItemVariant(BlockCleanroomCasing.CasingType.PLASCRETE, 2)).duration(200).buildAndRegister();
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(48).input(OrePrefix.frameGt, Materials.Steel).input(OrePrefix.plate, Materials.Polyethylene, 6).fluidInputs(Glass.getFluid(L)).outputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(BlockGlassCasing.CasingType.CLEANROOM_GLASS, 2)).duration(200).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(48).input(OrePrefix.frameGt, Materials.Steel).input(OrePrefix.plate, Materials.Polyethylene, 6).fluidInputs(Concrete.getFluid(L)).outputs(MetaBlocks.CLEANROOM_CASING.getItemVariant(BlockCleanroomCasing.CasingType.PLASCRETE, 2)).duration(100).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(48).input(OrePrefix.frameGt, Materials.Steel).input(OrePrefix.plate, Materials.Polyethylene, 6).fluidInputs(Glass.getFluid(L)).outputs(MetaBlocks.TRANSPARENT_CASING.getItemVariant(BlockGlassCasing.CasingType.CLEANROOM_GLASS, 2)).duration(100).buildAndRegister();
 
         // If these recipes are changed, change the values in MaterialInfoLoader.java
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe.chemistry;
 
-import gregtech.api.metatileentity.multiblock.CleanroomType;
 import gregtech.api.unification.material.Materials;
 import gregtech.common.items.MetaItems;
 
@@ -95,7 +94,6 @@ public class DistillationRecipes {
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeedOil.getFluid(24))
                 .fluidOutputs(Lubricant.getFluid(12))
-                .cleanroom(CleanroomType.CLEANROOM)
                 .duration(16).EUt(96).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
@@ -36,6 +36,7 @@ public class GrowthMediumRecipes {
                 .input(BIO_CHAFF, 4)
                 .fluidInputs(DistilledWater.getFluid(1000))
                 .fluidOutputs(Bacteria.getFluid(1000))
+                .cleanroom(CleanroomType.STERILE_CLEANROOM)
                 .buildAndRegister();
 
         // Bacterial Sludge


### PR DESCRIPTION
This pull request fixes an issue where cleanroom structures other than 5x5x5s became invalidated upon world reload.

As per the requests of Quarri6343:
- Made the recipe that turned bio chaff into bacteria now requires a cleanroom
- Made the recipe that turned seed oil into lubricant no longer require a cleanroom
- Shortened the time needed to create the plascrete casing and glass down to five seconds

I did not change the PassthroughHatchItem inventory size since neither its tier nor the tier of its fluid counterpart appear to be modifiable. As I am not very well-versed in creating recipes for this modpack, I did not attempt to create a recipe for either item.