### PR TITLE
Minimum 1 fluid input for Multiblock Miner

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -174,7 +174,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
                 .where('S', selfPredicate())
                 .where('X', states(getCasingState())
                         .or(abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(1).setPreviewCount(1))
-                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMaxGlobalLimited(1).setPreviewCount(1))
+                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setExactLimit(1).setPreviewCount(1))
                         .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3).setPreviewCount(1)))
                 .where('C', states(getCasingState()))
                 .where('F', states(getFrameState()))


### PR DESCRIPTION
**What:**
Sets the minimum number of fluid inputs for the multiblock miner to 1, as the structure always requires a fluid input for drilling fluid.
This change negates a crash that occurred when there were no fluid inputs on the multiblock miner.

**Outcome:**
The Multiblock Miners now require 1 fluid input.
