### PR TITLE
Restore Supply Exact above 1 stack

### DIFF
--- a/src/main/java/gregtech/common/covers/TransferMode.java
+++ b/src/main/java/gregtech/common/covers/TransferMode.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 
 public enum TransferMode implements IStringSerializable {
     TRANSFER_ANY("cover.robotic_arm.transfer_mode.transfer_any", 1),
-    TRANSFER_EXACT("cover.robotic_arm.transfer_mode.transfer_exact", 64),
+    TRANSFER_EXACT("cover.robotic_arm.transfer_mode.transfer_exact", 1024),
     KEEP_EXACT("cover.robotic_arm.transfer_mode.keep_exact", 1024);
 
     public final String localeName;


### PR DESCRIPTION
**What:**
Restores the ability to specify Supply Exact mode > 1 stack in Robot Arms, which was originally introduced in #635 but reverted in #466. I asked Trouser's about the change and he said he did not know why the Supply Exact change was made, so we think it could have been a bad rebase, since 635 went in before 466.

**Outcome:**
Restores the ability for Robot Arms to Supply Exact > 1 stack.
