### PR TITLE
Fix Multiblock coil bonuses not applying if the recipe was not overcl…

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -392,7 +392,12 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return - true if the recipe is successful, false if the recipe is not successful
      */
     protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
-        if (!hasEnoughPower(calculateOverclock(recipe))) {
+
+        int[] overclockResults = calculateOverclock(recipe);
+
+        performNonOverclockBonuses(overclockResults);
+
+        if (!hasEnoughPower(overclockResults)) {
             return false;
         }
 
@@ -449,6 +454,16 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             // Return true if we can fit at least 1A of energy into the energy output
             return getEnergyStored() - (long) power <= getEnergyCapacity();
         }
+    }
+
+    /**
+     * A stub method for modifying the overclock results.
+     * Useful for Multiblock coil bonuses
+     *
+     * @param overclockResults The overclocked recipe duration and EUt
+     */
+    protected void performNonOverclockBonuses(int[] overclockResults) {
+
     }
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -8,7 +8,6 @@ import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -110,17 +109,14 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected int[] performOverclocking(Recipe recipe) {
-            int[] overclock = super.performOverclocking(recipe);
+        protected void performNonOverclockBonuses(int[] resultOverclock) {
 
             int coilTier = ((MetaTileEntityCrackingUnit) metaTileEntity).getCoilTier();
             if (coilTier <= 0)
-                return overclock;
+                return;
 
-            overclock[0] *= 1.0f - coilTier * 0.1; // each coil above cupronickel (coilTier = 0) uses 10% less energy
-            overclock[0] = Math.max(1, overclock[0]);
-
-            return overclock;
+            resultOverclock[0] *= 1.0f - coilTier * 0.1; // each coil above cupronickel (coilTier = 0) uses 10% less energy
+            resultOverclock[0] = Math.max(1, resultOverclock[0]);
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -8,7 +8,6 @@ import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -121,19 +120,16 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected int[] performOverclocking(Recipe recipe) {
-            int[] overclock = super.performOverclocking(recipe);
+        protected void performNonOverclockBonuses(int[] resultOverclock) {
 
             int coilTier = ((MetaTileEntityPyrolyseOven) metaTileEntity).getCoilTier();
             if (coilTier == -1)
-                return overclock;
+                return;
 
-            if (coilTier == 0) overclock[1] *= 5.0 / 4; // 25% slower with cupronickel (coilTier = 0)
-            else overclock[1] *= 2.0f / (coilTier + 1); // each coil above kanthal (coilTier = 1) is 50% faster
+            if (coilTier == 0) resultOverclock[1] *= 5.0 / 4; // 25% slower with cupronickel (coilTier = 0)
+            else resultOverclock[1] *= 2.0f / (coilTier + 1); // each coil above kanthal (coilTier = 1) is 50% faster
 
-            overclock[1] = Math.max(1, overclock[1]);
-
-            return overclock;
+            resultOverclock[1] = Math.max(1, resultOverclock[1]);
         }
     }
 }


### PR DESCRIPTION
…ocked

**What:**
This PR fixes Multiblock coil bonuses not being applied if the recipe was not overclocked. Fixes #1025 

**Implementation Details:**
Introduces a new method, which acts on the result of the overclock calculations, to perform modifications to the overclock result.

Since this method is not gated behind a check for if the recipe can overclock, but rather acts on the results of the overclock, coil bonuses will still be applied even if the recipe is not overclocked.

**Outcome:**
Fixes Multiblock coil bonuses not applying to recipes that were not overclocked.
