### PR TITLE
Fix being able to silk touch VariantActiveBlocks

### DIFF
--- a/src/main/java/gregtech/api/block/VariantActiveBlock.java
+++ b/src/main/java/gregtech/api/block/VariantActiveBlock.java
@@ -35,6 +35,12 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
         return getActive(getStateFromMeta(stack.getItemDamage()));
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    protected boolean canSilkHarvest() {
+        return false;
+    }
+
     @Nonnull
     @Override
     protected BlockStateContainer createBlockState() {

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -1,6 +1,7 @@
 package gregtech.common;
 
 import gregtech.api.GTValues;
+import gregtech.api.block.VariantActiveBlock;
 import gregtech.api.enchants.EnchantmentHardHammer;
 import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -14,6 +15,7 @@ import gregtech.common.items.armor.IStepAssist;
 import gregtech.common.items.behaviors.ToggleEnergyConsumerBehavior;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
 import gregtech.common.tools.ToolUtility;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
@@ -50,6 +52,8 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
+
+import java.util.List;
 
 @Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class EventHandlers {
@@ -252,6 +256,20 @@ public class EventHandlers {
     public static void onFurnaceFuelBurnTime(FurnaceFuelBurnTimeEvent event) {
         if (ItemStack.areItemStacksEqual(event.getItemStack(), FluidUtil.getFilledBucket(Materials.Creosote.getFluid(1000)))) {
             event.setBurnTime(6400);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onBlockHarvestEvent(BlockEvent.HarvestDropsEvent event) {
+
+        IBlockState state = event.getState();
+
+        if(state.getProperties().containsKey(VariantActiveBlock.ACTIVE) && state.getValue(VariantActiveBlock.ACTIVE)) {
+            List<ItemStack> drops = event.getDrops();
+            drops.clear();
+
+            IBlockState newState = state.withProperty(VariantActiveBlock.ACTIVE, false);
+            drops.add(GTUtility.toItem(newState, 1));
         }
     }
 }

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -1,7 +1,6 @@
 package gregtech.common;
 
 import gregtech.api.GTValues;
-import gregtech.api.block.VariantActiveBlock;
 import gregtech.api.enchants.EnchantmentHardHammer;
 import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -15,7 +14,6 @@ import gregtech.common.items.armor.IStepAssist;
 import gregtech.common.items.behaviors.ToggleEnergyConsumerBehavior;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
 import gregtech.common.tools.ToolUtility;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
@@ -52,8 +50,6 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
-
-import java.util.List;
 
 @Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class EventHandlers {
@@ -256,20 +252,6 @@ public class EventHandlers {
     public static void onFurnaceFuelBurnTime(FurnaceFuelBurnTimeEvent event) {
         if (ItemStack.areItemStacksEqual(event.getItemStack(), FluidUtil.getFilledBucket(Materials.Creosote.getFluid(1000)))) {
             event.setBurnTime(6400);
-        }
-    }
-
-    @SubscribeEvent
-    public static void onBlockHarvestEvent(BlockEvent.HarvestDropsEvent event) {
-
-        IBlockState state = event.getState();
-
-        if(state.getProperties().containsKey(VariantActiveBlock.ACTIVE) && state.getValue(VariantActiveBlock.ACTIVE)) {
-            List<ItemStack> drops = event.getDrops();
-            drops.clear();
-
-            IBlockState newState = state.withProperty(VariantActiveBlock.ACTIVE, false);
-            drops.add(GTUtility.toItem(newState, 1));
         }
     }
 }


### PR DESCRIPTION
**What:**
Fixes being able to silk touch VariantActiveBlocks and get the active block version.

This prevents, for example, being able to silk touch to get a lit Firebox, or an EBF coil with bloom effects still applied.

**Implementation Details:**
If anyone sees a better way of doing this, let me know.

I did try and keep it as generic as possible, so that one solution would work for all VariantActiveBlocks, but we could also do it case by case.

**Outcome:**
Prevents being able to get the active variant of a VariantActiveBlock when using silk touch
