### PR TITLE
Added IControllable functionality to ItemBuses and Fluid Hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -3,6 +3,10 @@ package gregtech.common.metatileentities.multi.multiblockpart;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.capability.GregtechDataCodes;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IControllable;
+import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.FilteredItemHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.NotifiableFluidTank;
@@ -24,8 +28,11 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -35,16 +42,18 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank> {
+public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank>, IControllable {
 
     private static final int INITIAL_INVENTORY_SIZE = 8000;
 
     // only holding this for convenience
     private final FluidTank fluidTank;
+    private boolean workingEnabled;
 
     public MetaTileEntityFluidHatch(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {
         super(metaTileEntityId, tier, isExportHatch);
         this.fluidTank = new NotifiableFluidTank(getInventorySize(), this, isExportHatch);
+        this.workingEnabled = true;
         initializeInventory();
     }
 
@@ -56,12 +65,14 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
+        data.setBoolean("workingEnabled", workingEnabled);
         return data;
     }
 
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
+        this.workingEnabled = data.getBoolean("workingEnabled");
         if (data.hasKey("ContainerInventory")) {
             MetaTileEntityQuantumTank.legacyTankItemHandlerNBTReading(this, data.getCompoundTag("ContainerInventory"), 0, 1);
         }
@@ -71,14 +82,50 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     public void update() {
         super.update();
         if (!getWorld().isRemote) {
-            fillContainerFromInternalTank(fluidTank);
-            if (isExportHatch) {
-                pushFluidsIntoNearbyHandlers(getFrontFacing());
-            } else {
-                fillInternalTankFromFluidContainer(fluidTank);
-                pullFluidsFromNearbyHandlers(getFrontFacing());
+            if(workingEnabled) {
+                fillContainerFromInternalTank(fluidTank);
+                if (isExportHatch) {
+                    pushFluidsIntoNearbyHandlers(getFrontFacing());
+                } else {
+                    fillInternalTankFromFluidContainer(fluidTank);
+                    pullFluidsFromNearbyHandlers(getFrontFacing());
+                }
             }
         }
+    }
+
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        this.workingEnabled = workingEnabled;
+        World world = getWorld();
+        if (world != null && !world.isRemote) {
+            writeCustomData(GregtechDataCodes.WORKING_ENABLED, buf -> buf.writeBoolean(workingEnabled));
+        }
+    }
+
+    @Override
+    public boolean isWorkingEnabled() {
+        return workingEnabled;
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing side) {
+        if (capability == GregtechTileCapabilities.CAPABILITY_CONTROLLABLE) {
+            return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE.cast(this);
+        }
+        return super.getCapability(capability, side);
+    }
+
+    @Override
+    public void writeInitialSyncData(PacketBuffer buf) {
+        super.writeInitialSyncData(buf);
+        buf.writeBoolean(workingEnabled);
+    }
+
+    @Override
+    public void receiveInitialSyncData(PacketBuffer buf) {
+        super.receiveInitialSyncData(buf);
+        this.workingEnabled = buf.readBoolean();
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.INotifiableHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.NotifiableFluidTank;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
+import gregtech.api.cover.ICoverable;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.IFluidTank;
@@ -11,7 +12,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEntityMultiblockPart {
+public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEntityMultiblockPart implements ICoverable {
     protected final boolean isExportHatch;
 
     public MetaTileEntityMultiblockNotifiablePart(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.INotifiableHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.NotifiableFluidTank;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
-import gregtech.api.cover.ICoverable;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.IFluidTank;
@@ -12,7 +11,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEntityMultiblockPart implements ICoverable {
+public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEntityMultiblockPart {
     protected final boolean isExportHatch;
 
     public MetaTileEntityMultiblockNotifiablePart(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {


### PR DESCRIPTION
**What:**
Adds the functionality of disabling and enabling auto import and export of items and fluid from multiblock item buses and fluid hatches


**Outcome:**
I added a way to disable/enable any hatches on a hatch by hatch basis

**Additional info:**
_This section is for screenshots to demonstrate any GUI, rendering, recipe changes, or any additional info that reviewers should be aware of._

**Possible compatibility issue:**
i've added backward compact, all buses/hatches default to enabled when loaded from an older ceu world

