### PR TITLE
Decrease many vanilla and cover machine recipe times

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -404,14 +404,14 @@ public class MachineRecipeLoader {
                 .inputs(new ItemStack(Items.IRON_DOOR))
                 .input(OrePrefix.plate, material, 2)
                 .outputs(MetaItems.COVER_SHUTTER.getStackForm(2))
-                .EUt(16).duration(400)
+                .EUt(16).duration(100)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(WORKBENCH.getStackForm())
                 .input(plate, material)
                 .outputs(COVER_CRAFTING.getStackForm())
-                .EUt(16).duration(400)
+                .EUt(16).duration(100)
                 .buildAndRegister();
 
         for (FluidStack solder : new FluidStack[]{Tin.getFluid(L), SolderingAlloy.getFluid(L / 2)}) {
@@ -420,7 +420,7 @@ public class MachineRecipeLoader {
                     .input(OrePrefix.plate, material)
                     .fluidInputs(solder)
                     .outputs(MetaItems.COVER_MACHINE_CONTROLLER.getStackForm(1))
-                    .EUt(16).duration(200)
+                    .EUt(16).duration(100)
                     .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
@@ -429,7 +429,7 @@ public class MachineRecipeLoader {
                     .input(plate, material)
                     .fluidInputs(solder)
                     .outputs(COVER_ENERGY_DETECTOR.getStackForm())
-                    .EUt(16).duration(400)
+                    .EUt(16).duration(100)
                     .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
@@ -437,7 +437,7 @@ public class MachineRecipeLoader {
                     .input(plate, material)
                     .fluidInputs(solder)
                     .outputs(COVER_ACTIVITY_DETECTOR.getStackForm())
-                    .EUt(16).duration(400)
+                    .EUt(16).duration(100)
                     .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
@@ -446,7 +446,7 @@ public class MachineRecipeLoader {
                     .input(plate, Aluminium)
                     .fluidInputs(solder)
                     .outputs(COVER_ACTIVITY_DETECTOR_ADVANCED.getStackForm())
-                    .EUt(16).duration(400)
+                    .EUt(16).duration(100)
                     .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
@@ -454,7 +454,7 @@ public class MachineRecipeLoader {
                     .input(plate, material)
                     .fluidInputs(solder)
                     .outputs(COVER_FLUID_DETECTOR.getStackForm())
-                    .EUt(16).duration(400)
+                    .EUt(16).duration(100)
                     .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
@@ -462,7 +462,7 @@ public class MachineRecipeLoader {
                     .input(plate, material)
                     .fluidInputs(solder)
                     .outputs(COVER_ITEM_DETECTOR.getStackForm())
-                    .EUt(16).duration(400)
+                    .EUt(16).duration(100)
                     .buildAndRegister();
         }
 
@@ -480,7 +480,7 @@ public class MachineRecipeLoader {
                 .inputs(new ItemStack(Items.CAULDRON))
                 .input(circuit, MarkerMaterials.Tier.HV)
                 .output(COVER_INFINITE_WATER)
-                .EUt(VA[HV]).duration(200)
+                .EUt(VA[HV]).duration(100)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -1033,7 +1033,7 @@ public class VanillaStandardRecipes {
         ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(4).duration(40).inputs(new ItemStack(Items.NETHERBRICK, 2)).inputs(new ItemStack(Items.NETHER_WART, 2)).outputs(new ItemStack(Blocks.RED_NETHER_BRICK)).buildAndRegister();
 
         if (!ConfigHolder.recipes.hardMiscRecipes) {
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(8).input(stoneCobble, 8).outputs(new ItemStack(Blocks.FURNACE)).duration(100).EUt(VA[ULV]).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().inputs(new ItemStack(Blocks.OBSIDIAN, 4)).input(gem, Diamond, 2).inputs(new ItemStack(Items.BOOK)).outputs(new ItemStack(Blocks.ENCHANTING_TABLE)).duration(100).EUt(VA[ULV]).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -381,129 +381,129 @@ public class VanillaStandardRecipes {
                 .input(plank, Wood, 6)
                 .inputs(new ItemStack(Items.BOOK, 3))
                 .outputs(new ItemStack(Blocks.BOOKSHELF))
-                .duration(400).EUt(4)
+                .duration(60).EUt(4)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plank, Wood, 3).circuitMeta(3)
                 .outputs(new ItemStack(Blocks.TRAPDOOR, 2))
-                .duration(300).EUt(4)
+                .duration(60).EUt(4)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plank, Wood, 8)
                 .outputs(new ItemStack(Blocks.CHEST))
-                .duration(800).EUt(4).circuitMeta(8)
+                .duration(60).EUt(4).circuitMeta(8)
                 .buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.COAL, 1, GTValues.W))
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 4))
-                .duration(100).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Coal)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 4))
-                .duration(100).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Charcoal)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 4))
-                .duration(100).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(gem, Coke)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 8))
-                .duration(100).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Coke)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 8))
-                .duration(100).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 0))
                 .outputs(new ItemStack(Blocks.OAK_FENCE))
                 .circuitMeta(1)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 1))
                 .outputs(new ItemStack(Blocks.SPRUCE_FENCE))
                 .circuitMeta(1)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 2))
                 .outputs(new ItemStack(Blocks.BIRCH_FENCE))
                 .circuitMeta(1)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 3))
                 .outputs(new ItemStack(Blocks.JUNGLE_FENCE))
                 .circuitMeta(1)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 4))
                 .outputs(new ItemStack(Blocks.ACACIA_FENCE))
                 .circuitMeta(1)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 5))
                 .outputs(new ItemStack(Blocks.DARK_OAK_FENCE))
                 .circuitMeta(1)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 0))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.OAK_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 1))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.SPRUCE_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 2))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.BIRCH_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 3))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.JUNGLE_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 4))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.ACACIA_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 5))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.DARK_OAK_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(300).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ModHandler.addShapedRecipe("sticky_resin_torch", new ItemStack(Blocks.TORCH, 3), "X", "Y", 'X', MetaItems.STICKY_RESIN, 'Y', new UnificationEntry(OrePrefix.stick, Materials.Wood));
         ModHandler.addShapedRecipe("torch_sulfur", new ItemStack(Blocks.TORCH, 2), "C", "S", 'C', new UnificationEntry(OrePrefix.dust, Materials.Sulfur), 'S', new UnificationEntry(OrePrefix.stick, Materials.Wood));
@@ -514,23 +514,23 @@ public class VanillaStandardRecipes {
         ModHandler.addShapedRecipe("torch_coke_dust", new ItemStack(Blocks.TORCH, 8), "C", "S", 'C', new UnificationEntry(OrePrefix.dust, Materials.Coke), 'S', new UnificationEntry(OrePrefix.stick, Materials.Wood));
         ModHandler.addShapedRecipe("torch_creosote", new ItemStack(Blocks.TORCH, 16), "WB", "S ", 'W', OreDictUnifier.get("wool"), 'S', new UnificationEntry(stick, Wood), 'B', FluidUtil.getFilledBucket(Creosote.getFluid(1000)));
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(dust, Redstone).input(stick, Wood).outputs(new ItemStack(Blocks.REDSTONE_TORCH, 1)).duration(400).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Sulfur).outputs(new ItemStack(Blocks.TORCH, 2)).duration(100).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Phosphorus).outputs(new ItemStack(Blocks.TORCH, 6)).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(dust, Redstone).input(stick, Wood).outputs(new ItemStack(Blocks.REDSTONE_TORCH, 1)).duration(60).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Sulfur).outputs(new ItemStack(Blocks.TORCH, 2)).duration(60).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Phosphorus).outputs(new ItemStack(Blocks.TORCH, 6)).duration(60).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 0)).outputs(new ItemStack(Blocks.OAK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 1)).outputs(new ItemStack(Blocks.SPRUCE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 2)).outputs(new ItemStack(Blocks.BIRCH_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 3)).outputs(new ItemStack(Blocks.JUNGLE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 4)).outputs(new ItemStack(Blocks.ACACIA_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 5)).outputs(new ItemStack(Blocks.DARK_OAK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 0)).outputs(new ItemStack(Blocks.OAK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 1)).outputs(new ItemStack(Blocks.SPRUCE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 2)).outputs(new ItemStack(Blocks.BIRCH_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 3)).outputs(new ItemStack(Blocks.JUNGLE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 4)).outputs(new ItemStack(Blocks.ACACIA_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 5)).outputs(new ItemStack(Blocks.DARK_OAK_STAIRS, 4)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(40).circuitMeta(7).inputs(new ItemStack(Items.STICK, 7)).outputs(new ItemStack(Blocks.LADDER, 2)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(400).inputs(new ItemStack(Items.MINECART)).inputs(OreDictUnifier.get("chestWood")).outputs(new ItemStack(Items.CHEST_MINECART)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(400).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.FURNACE)).outputs(new ItemStack(Items.FURNACE_MINECART)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(400).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.TNT)).outputs(new ItemStack(Items.TNT_MINECART)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(400).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.HOPPER)).outputs(new ItemStack(Items.HOPPER_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(OreDictUnifier.get("chestWood")).outputs(new ItemStack(Items.CHEST_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.FURNACE)).outputs(new ItemStack(Items.FURNACE_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.TNT)).outputs(new ItemStack(Items.TNT_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.HOPPER)).outputs(new ItemStack(Items.HOPPER_MINECART)).buildAndRegister();
     }
 
     /**
@@ -704,65 +704,65 @@ public class VanillaStandardRecipes {
                 .inputs(MetaItems.STICKY_RESIN.getStackForm())
                 .inputs(new ItemStack(Blocks.PISTON))
                 .outputs(new ItemStack(Blocks.STICKY_PISTON))
-                .duration(100).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input("slimeball", 1)
                 .inputs(new ItemStack(Blocks.PISTON))
                 .outputs(new ItemStack(Blocks.STICKY_PISTON))
-                .duration(100).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PISTON))
                 .fluidInputs(Glue.getFluid(100))
                 .outputs(new ItemStack(Blocks.STICKY_PISTON))
-                .duration(100).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Wood, 2)
                 .input(OrePrefix.ring, Materials.Iron, 2)
                 .outputs(new ItemStack(Blocks.TRIPWIRE_HOOK, 1))
-                .duration(400).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Wood, 2)
                 .input(OrePrefix.ring, Materials.WroughtIron, 2)
                 .outputs(new ItemStack(Blocks.TRIPWIRE_HOOK, 1))
-                .duration(400).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Redstone, 4)
                 .input(dust, Glowstone, 4)
                 .outputs(new ItemStack(Blocks.REDSTONE_LAMP))
-                .duration(400).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 2))
                 .input(OrePrefix.dust, Materials.Redstone)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.REPEATER))
-                .duration(80).EUt(10).buildAndRegister();
+                .duration(60).EUt(10).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 3))
                 .input(OrePrefix.gem, Materials.NetherQuartz)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.COMPARATOR))
-                .duration(800).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 3))
                 .input(OrePrefix.gem, Materials.CertusQuartz)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.COMPARATOR))
-                .duration(800).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 3))
                 .input(OrePrefix.gem, Materials.Quartzite)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.COMPARATOR))
-                .duration(800).EUt(1).buildAndRegister();
+                .duration(60).EUt(1).buildAndRegister();
 
         if (ConfigHolder.recipes.hardRedstoneRecipes)
             return;
@@ -795,21 +795,21 @@ public class VanillaStandardRecipes {
                 'R', STICKY_RESIN.getStackForm(),
                 'P', new ItemStack(Blocks.PISTON));
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Iron).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Bronze).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Steel).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 2)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Aluminium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Titanium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 8)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Iron).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Bronze).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Steel).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 2)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Aluminium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Titanium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 8)).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Gold, 2)
                 .outputs(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1))
-                .circuitMeta(2).duration(200).EUt(4).buildAndRegister();
+                .circuitMeta(2).duration(60).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Iron, 2)
                 .outputs(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1))
-                .circuitMeta(2).duration(200).EUt(4).buildAndRegister();
+                .circuitMeta(2).duration(60).EUt(4).buildAndRegister();
 
         ModHandler.addShapedRecipe("comparator_certus", new ItemStack(Items.COMPARATOR), " T ", "TQT", "SSS",
                 'T', new ItemStack(Blocks.REDSTONE_TORCH),
@@ -835,8 +835,8 @@ public class VanillaStandardRecipes {
                 'P', new ItemStack(Blocks.WOODEN_SLAB, 1, GTValues.W)
         );
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(dust, Redstone).outputs(new ItemStack(Blocks.NOTEBLOCK)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(gem, Diamond).outputs(new ItemStack(Blocks.JUKEBOX)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(dust, Redstone).outputs(new ItemStack(Blocks.NOTEBLOCK)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(gem, Diamond).outputs(new ItemStack(Blocks.JUKEBOX)).buildAndRegister();
     }
 
     /**
@@ -848,7 +848,7 @@ public class VanillaStandardRecipes {
                 .circuitMeta(12)
                 .input(OrePrefix.plate, Materials.Iron, 3)
                 .outputs(new ItemStack(Items.BUCKET))
-                .duration(800).EUt(4)
+                .duration(60).EUt(4)
                 .buildAndRegister();
 
         if (!ConfigHolder.recipes.hardToolArmorRecipes) {
@@ -856,13 +856,13 @@ public class VanillaStandardRecipes {
                     .input(dust, Redstone)
                     .input(plate, Iron, 4)
                     .outputs(new ItemStack(Items.COMPASS))
-                    .duration(400).EUt(4).buildAndRegister();
+                    .duration(60).EUt(4).buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
                     .input(dust, Redstone)
                     .input(plate, Gold, 4)
                     .outputs(new ItemStack(Items.CLOCK))
-                    .duration(400).EUt(4).buildAndRegister();
+                    .duration(60).EUt(4).buildAndRegister();
         }
 
         ModHandler.addShapedRecipe("iron_horse_armor", new ItemStack(Items.IRON_HORSE_ARMOR), "hdH", "PCP", "LSL",
@@ -940,7 +940,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.PAPER, 8))
                 .inputs(new ItemStack(Items.COMPASS))
                 .outputs(new ItemStack(Items.MAP))
-                .duration(100).EUt(VA[ULV]).buildAndRegister();
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(dust, Materials.Netherrack)
@@ -958,20 +958,20 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.STRING, 4, GTValues.W))
                 .inputs(new ItemStack(Items.SLIME_BALL, 1, GTValues.W))
                 .outputs(new ItemStack(Items.LEAD, 2))
-                .duration(200).EUt(2).buildAndRegister();
+                .duration(60).EUt(2).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.LEATHER))
                 .inputs(new ItemStack(Items.LEAD))
                 .fluidInputs(Materials.Glue.getFluid(100))
                 .outputs(new ItemStack(Items.NAME_TAG))
-                .duration(100).EUt(VA[ULV]).buildAndRegister();
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.STRING, 3, GTValues.W))
                 .input(OrePrefix.stick, Materials.Wood, 3)
                 .outputs(new ItemStack(Items.BOW, 1))
-                .duration(400).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder().duration(128).EUt(4).notConsumable(SHAPE_MOLD_BALL).fluidInputs(Water.getFluid(250)).outputs(new ItemStack(Items.SNOWBALL)).buildAndRegister();
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder().duration(128).EUt(4).notConsumable(SHAPE_MOLD_BALL).fluidInputs(DistilledWater.getFluid(250)).outputs(new ItemStack(Items.SNOWBALL)).buildAndRegister();
@@ -991,7 +991,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.STRING, 4))
                 .notConsumable(new IntCircuitIngredient(4))
                 .outputs(new ItemStack(Blocks.WOOL, 1, 0))
-                .duration(100).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(cobblestone, 1)
@@ -1005,16 +1005,16 @@ public class VanillaStandardRecipes {
                 .outputs(new ItemStack(Blocks.STONEBRICK, 1, 1))
                 .duration(40).EUt(1).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).input(stoneCobble, 6).outputs(new ItemStack(Blocks.STONE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.BRICK_BLOCK, 6)).outputs(new ItemStack(Blocks.BRICK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.STONEBRICK, 6, GTValues.W)).outputs(new ItemStack(Blocks.STONE_BRICK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.NETHER_BRICK, 6)).outputs(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.SANDSTONE, 6)).outputs(new ItemStack(Blocks.SANDSTONE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 6)).outputs(new ItemStack(Blocks.QUARTZ_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PURPUR_BLOCK, 6)).outputs(new ItemStack(Blocks.PURPUR_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).input(stoneCobble, 6).outputs(new ItemStack(Blocks.STONE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.BRICK_BLOCK, 6)).outputs(new ItemStack(Blocks.BRICK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.STONEBRICK, 6, GTValues.W)).outputs(new ItemStack(Blocks.STONE_BRICK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.NETHER_BRICK, 6)).outputs(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.SANDSTONE, 6)).outputs(new ItemStack(Blocks.SANDSTONE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 6)).outputs(new ItemStack(Blocks.QUARTZ_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PURPUR_BLOCK, 6)).outputs(new ItemStack(Blocks.PURPUR_STAIRS, 4)).buildAndRegister();
 
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(2).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 0)).outputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 2)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(2).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 0)).outputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 2)).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(4).inputs(new ItemStack(Blocks.STONE)).outputs(new ItemStack(Blocks.STONEBRICK, 1, 0)).circuitMeta(4).duration(50).buildAndRegister();
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(4).inputs(new ItemStack(Blocks.END_STONE)).outputs(new ItemStack(Blocks.END_BRICKS, 1, 0)).circuitMeta(4).duration(50).buildAndRegister();
@@ -1026,37 +1026,37 @@ public class VanillaStandardRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(4).inputs(new ItemStack(Blocks.RED_SANDSTONE, 1, 2)).outputs(new ItemStack(Blocks.RED_SANDSTONE, 1, 0)).circuitMeta(1).duration(50).buildAndRegister();
 
 
-        CANNER_RECIPES.recipeBuilder().EUt(4).duration(200).inputs(new ItemStack(Blocks.PUMPKIN)).inputs(new ItemStack(Blocks.TORCH)).outputs(new ItemStack(Blocks.LIT_PUMPKIN)).buildAndRegister();
+        CANNER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Blocks.PUMPKIN)).inputs(new ItemStack(Blocks.TORCH)).outputs(new ItemStack(Blocks.LIT_PUMPKIN)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(40).inputs(new ItemStack(Items.PRISMARINE_CRYSTALS, 5)).inputs(new ItemStack(Items.PRISMARINE_SHARD, 4)).outputs(new ItemStack(Blocks.SEA_LANTERN)).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(4).duration(40).inputs(new ItemStack(Items.NETHERBRICK, 2)).inputs(new ItemStack(Items.NETHER_WART, 2)).outputs(new ItemStack(Blocks.RED_NETHER_BRICK)).buildAndRegister();
 
         if (!ConfigHolder.recipes.hardMiscRecipes) {
-            ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(8).input(stoneCobble, 8).outputs(new ItemStack(Blocks.FURNACE)).duration(100).EUt(VA[ULV]).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().inputs(new ItemStack(Blocks.OBSIDIAN, 4)).input(gem, Diamond, 2).inputs(new ItemStack(Items.BOOK)).outputs(new ItemStack(Blocks.ENCHANTING_TABLE)).duration(100).EUt(VA[ULV]).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(2).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).input(dust, Redstone).outputs(new ItemStack(Blocks.DROPPER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).circuitMeta(2).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).input(dust, Redstone).outputs(new ItemStack(Blocks.DROPPER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
         }
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(4).circuitMeta(3).inputs(new ItemStack(Blocks.NETHER_BRICK)).outputs(new ItemStack(Blocks.NETHER_BRICK_FENCE)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).circuitMeta(3).inputs(new ItemStack(Blocks.NETHER_BRICK)).outputs(new ItemStack(Blocks.NETHER_BRICK_FENCE)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(300).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Items.CHORUS_FRUIT_POPPED)).inputs(new ItemStack(Items.BLAZE_ROD)).outputs(new ItemStack(Blocks.END_ROD, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).inputs(new ItemStack(Items.CHORUS_FRUIT_POPPED)).inputs(new ItemStack(Items.BLAZE_ROD)).outputs(new ItemStack(Blocks.END_ROD, 4)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).input("chestWood", 1).inputs(new ItemStack(Items.SHULKER_SHELL, 2)).outputs(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[ULV]).input("chestWood", 1).inputs(new ItemStack(Items.SHULKER_SHELL, 2)).outputs(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).circuitMeta(1).input("wool", 1).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.PAINTING)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Items.LEATHER)).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.ITEM_FRAME)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).input("plankWood", 6).inputs(new ItemStack(Items.STICK)).outputs(new ItemStack(Items.SIGN, 3)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).circuitMeta(1).input("wool", 1).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.PAINTING)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).inputs(new ItemStack(Items.LEATHER)).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.ITEM_FRAME)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).input("plankWood", 6).inputs(new ItemStack(Items.STICK)).outputs(new ItemStack(Items.SIGN, 3)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(10).EUt(2).inputs(new ItemStack(Items.BRICK, 3)).outputs(new ItemStack(Items.FLOWER_POT)).buildAndRegister();
 
@@ -1069,7 +1069,7 @@ public class VanillaStandardRecipes {
                 .input(OrePrefix.stick, Materials.Wood)
                 .circuitMeta(1)
                 .outputs(new ItemStack(Blocks.RAIL, 32))
-                .duration(200).EUt(VA[LV]).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Gold, 12)
@@ -1077,7 +1077,7 @@ public class VanillaStandardRecipes {
                 .input(dust, Redstone)
                 .circuitMeta(1)
                 .outputs(new ItemStack(Blocks.GOLDEN_RAIL, 12))
-                .duration(200).EUt(VA[LV]).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Iron, 12)
@@ -1085,7 +1085,7 @@ public class VanillaStandardRecipes {
                 .input(dust, Redstone)
                 .circuitMeta(3)
                 .outputs(new ItemStack(Blocks.DETECTOR_RAIL, 12))
-                .duration(200).EUt(VA[LV]).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(stick, Iron, 12)
@@ -1093,13 +1093,13 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH))
                 .circuitMeta(3)
                 .outputs(new ItemStack(Blocks.ACTIVATOR_RAIL, 12))
-                .duration(200).EUt(VA[LV]).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Iron, 3)
                 .input(OrePrefix.ring, Materials.Iron, 4)
                 .outputs(new ItemStack(Items.MINECART))
-                .duration(200).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
 
         ModHandler.addShapedRecipe("saddle", new ItemStack(Items.SADDLE), "LLL", "LCL", "RSR",
                 'L', new ItemStack(Items.LEATHER),
@@ -1198,13 +1198,13 @@ public class VanillaStandardRecipes {
                 .input(dust, Materials.Gunpowder)
                 .input(dust, Materials.Blaze)
                 .outputs(new ItemStack(Items.FIRE_CHARGE, 3))
-                .duration(400).EUt(VA[LV]).buildAndRegister();
+                .duration(60).EUt(VA[LV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.GRAVEL))
                 .inputs(new ItemStack(Blocks.DIRT))
                 .outputs(new ItemStack(Blocks.DIRT, 2, 1))
-                .duration(100).EUt(4).buildAndRegister();
+                .duration(60).EUt(4).buildAndRegister();
     }
 
     private static void dyeRecipes() {

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -381,129 +381,129 @@ public class VanillaStandardRecipes {
                 .input(plank, Wood, 6)
                 .inputs(new ItemStack(Items.BOOK, 3))
                 .outputs(new ItemStack(Blocks.BOOKSHELF))
-                .duration(60).EUt(4)
+                .duration(100).EUt(4)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plank, Wood, 3).circuitMeta(3)
                 .outputs(new ItemStack(Blocks.TRAPDOOR, 2))
-                .duration(60).EUt(4)
+                .duration(100).EUt(4)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plank, Wood, 8)
                 .outputs(new ItemStack(Blocks.CHEST))
-                .duration(60).EUt(4).circuitMeta(8)
+                .duration(100).EUt(4).circuitMeta(8)
                 .buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.COAL, 1, GTValues.W))
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 4))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Coal)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 4))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Charcoal)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 4))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(gem, Coke)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 8))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Coke)
                 .input(OrePrefix.stick, Materials.Wood, 1)
                 .outputs(new ItemStack(Blocks.TORCH, 8))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 0))
                 .outputs(new ItemStack(Blocks.OAK_FENCE))
                 .circuitMeta(1)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 1))
                 .outputs(new ItemStack(Blocks.SPRUCE_FENCE))
                 .circuitMeta(1)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 2))
                 .outputs(new ItemStack(Blocks.BIRCH_FENCE))
                 .circuitMeta(1)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 3))
                 .outputs(new ItemStack(Blocks.JUNGLE_FENCE))
                 .circuitMeta(1)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 4))
                 .outputs(new ItemStack(Blocks.ACACIA_FENCE))
                 .circuitMeta(1)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 1, 5))
                 .outputs(new ItemStack(Blocks.DARK_OAK_FENCE))
                 .circuitMeta(1)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 0))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.OAK_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 1))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.SPRUCE_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 2))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.BIRCH_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 3))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.JUNGLE_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 4))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.ACACIA_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PLANKS, 2, 5))
                 .input(stick, Wood, 2)
                 .outputs(new ItemStack(Blocks.DARK_OAK_FENCE_GATE))
                 .circuitMeta(2)
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ModHandler.addShapedRecipe("sticky_resin_torch", new ItemStack(Blocks.TORCH, 3), "X", "Y", 'X', MetaItems.STICKY_RESIN, 'Y', new UnificationEntry(OrePrefix.stick, Materials.Wood));
         ModHandler.addShapedRecipe("torch_sulfur", new ItemStack(Blocks.TORCH, 2), "C", "S", 'C', new UnificationEntry(OrePrefix.dust, Materials.Sulfur), 'S', new UnificationEntry(OrePrefix.stick, Materials.Wood));
@@ -514,23 +514,23 @@ public class VanillaStandardRecipes {
         ModHandler.addShapedRecipe("torch_coke_dust", new ItemStack(Blocks.TORCH, 8), "C", "S", 'C', new UnificationEntry(OrePrefix.dust, Materials.Coke), 'S', new UnificationEntry(OrePrefix.stick, Materials.Wood));
         ModHandler.addShapedRecipe("torch_creosote", new ItemStack(Blocks.TORCH, 16), "WB", "S ", 'W', OreDictUnifier.get("wool"), 'S', new UnificationEntry(stick, Wood), 'B', FluidUtil.getFilledBucket(Creosote.getFluid(1000)));
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(dust, Redstone).input(stick, Wood).outputs(new ItemStack(Blocks.REDSTONE_TORCH, 1)).duration(60).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Sulfur).outputs(new ItemStack(Blocks.TORCH, 2)).duration(60).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Phosphorus).outputs(new ItemStack(Blocks.TORCH, 6)).duration(60).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(dust, Redstone).input(stick, Wood).outputs(new ItemStack(Blocks.REDSTONE_TORCH, 1)).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Sulfur).outputs(new ItemStack(Blocks.TORCH, 2)).duration(100).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).input(stick, Wood).input(dust, Phosphorus).outputs(new ItemStack(Blocks.TORCH, 6)).duration(100).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 0)).outputs(new ItemStack(Blocks.OAK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 1)).outputs(new ItemStack(Blocks.SPRUCE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 2)).outputs(new ItemStack(Blocks.BIRCH_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 3)).outputs(new ItemStack(Blocks.JUNGLE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 4)).outputs(new ItemStack(Blocks.ACACIA_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 5)).outputs(new ItemStack(Blocks.DARK_OAK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 0)).outputs(new ItemStack(Blocks.OAK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 1)).outputs(new ItemStack(Blocks.SPRUCE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 2)).outputs(new ItemStack(Blocks.BIRCH_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 3)).outputs(new ItemStack(Blocks.JUNGLE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 4)).outputs(new ItemStack(Blocks.ACACIA_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PLANKS, 6, 5)).outputs(new ItemStack(Blocks.DARK_OAK_STAIRS, 4)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(40).circuitMeta(7).inputs(new ItemStack(Items.STICK, 7)).outputs(new ItemStack(Blocks.LADDER, 2)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(OreDictUnifier.get("chestWood")).outputs(new ItemStack(Items.CHEST_MINECART)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.FURNACE)).outputs(new ItemStack(Items.FURNACE_MINECART)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.TNT)).outputs(new ItemStack(Items.TNT_MINECART)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.HOPPER)).outputs(new ItemStack(Items.HOPPER_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(100).inputs(new ItemStack(Items.MINECART)).inputs(OreDictUnifier.get("chestWood")).outputs(new ItemStack(Items.CHEST_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(100).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.FURNACE)).outputs(new ItemStack(Items.FURNACE_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(100).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.TNT)).outputs(new ItemStack(Items.TNT_MINECART)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(100).inputs(new ItemStack(Items.MINECART)).inputs(new ItemStack(Blocks.HOPPER)).outputs(new ItemStack(Items.HOPPER_MINECART)).buildAndRegister();
     }
 
     /**
@@ -704,65 +704,65 @@ public class VanillaStandardRecipes {
                 .inputs(MetaItems.STICKY_RESIN.getStackForm())
                 .inputs(new ItemStack(Blocks.PISTON))
                 .outputs(new ItemStack(Blocks.STICKY_PISTON))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input("slimeball", 1)
                 .inputs(new ItemStack(Blocks.PISTON))
                 .outputs(new ItemStack(Blocks.STICKY_PISTON))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PISTON))
                 .fluidInputs(Glue.getFluid(100))
                 .outputs(new ItemStack(Blocks.STICKY_PISTON))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Wood, 2)
                 .input(OrePrefix.ring, Materials.Iron, 2)
                 .outputs(new ItemStack(Blocks.TRIPWIRE_HOOK, 1))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Wood, 2)
                 .input(OrePrefix.ring, Materials.WroughtIron, 2)
                 .outputs(new ItemStack(Blocks.TRIPWIRE_HOOK, 1))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Redstone, 4)
                 .input(dust, Glowstone, 4)
                 .outputs(new ItemStack(Blocks.REDSTONE_LAMP))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 2))
                 .input(OrePrefix.dust, Materials.Redstone)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.REPEATER))
-                .duration(60).EUt(10).buildAndRegister();
+                .duration(100).EUt(10).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 3))
                 .input(OrePrefix.gem, Materials.NetherQuartz)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.COMPARATOR))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 3))
                 .input(OrePrefix.gem, Materials.CertusQuartz)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.COMPARATOR))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH, 3))
                 .input(OrePrefix.gem, Materials.Quartzite)
                 .fluidInputs(Materials.Concrete.getFluid(GTValues.L))
                 .outputs(new ItemStack(Items.COMPARATOR))
-                .duration(60).EUt(1).buildAndRegister();
+                .duration(100).EUt(1).buildAndRegister();
 
         if (ConfigHolder.recipes.hardRedstoneRecipes)
             return;
@@ -795,21 +795,21 @@ public class VanillaStandardRecipes {
                 'R', STICKY_RESIN.getStackForm(),
                 'P', new ItemStack(Blocks.PISTON));
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Iron).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Bronze).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Steel).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 2)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Aluminium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).input(plate, Titanium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 8)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Iron).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Bronze).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Steel).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 2)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Aluminium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).input(plate, Titanium).inputs(new ItemStack(Blocks.PLANKS, 3, GTValues.W)).inputs(new ItemStack(Blocks.COBBLESTONE, 4)).input(dust, Redstone).outputs(new ItemStack(Blocks.PISTON, 8)).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Gold, 2)
                 .outputs(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1))
-                .circuitMeta(2).duration(60).EUt(4).buildAndRegister();
+                .circuitMeta(2).duration(100).EUt(4).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Iron, 2)
                 .outputs(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1))
-                .circuitMeta(2).duration(60).EUt(4).buildAndRegister();
+                .circuitMeta(2).duration(100).EUt(4).buildAndRegister();
 
         ModHandler.addShapedRecipe("comparator_certus", new ItemStack(Items.COMPARATOR), " T ", "TQT", "SSS",
                 'T', new ItemStack(Blocks.REDSTONE_TORCH),
@@ -835,8 +835,8 @@ public class VanillaStandardRecipes {
                 'P', new ItemStack(Blocks.WOODEN_SLAB, 1, GTValues.W)
         );
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(dust, Redstone).outputs(new ItemStack(Blocks.NOTEBLOCK)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(gem, Diamond).outputs(new ItemStack(Blocks.JUKEBOX)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(dust, Redstone).outputs(new ItemStack(Blocks.NOTEBLOCK)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(16).inputs(new ItemStack(Blocks.PLANKS, 8, GTValues.W)).input(gem, Diamond).outputs(new ItemStack(Blocks.JUKEBOX)).buildAndRegister();
     }
 
     /**
@@ -848,7 +848,7 @@ public class VanillaStandardRecipes {
                 .circuitMeta(12)
                 .input(OrePrefix.plate, Materials.Iron, 3)
                 .outputs(new ItemStack(Items.BUCKET))
-                .duration(60).EUt(4)
+                .duration(100).EUt(4)
                 .buildAndRegister();
 
         if (!ConfigHolder.recipes.hardToolArmorRecipes) {
@@ -856,13 +856,13 @@ public class VanillaStandardRecipes {
                     .input(dust, Redstone)
                     .input(plate, Iron, 4)
                     .outputs(new ItemStack(Items.COMPASS))
-                    .duration(60).EUt(4).buildAndRegister();
+                    .duration(100).EUt(4).buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
                     .input(dust, Redstone)
                     .input(plate, Gold, 4)
                     .outputs(new ItemStack(Items.CLOCK))
-                    .duration(60).EUt(4).buildAndRegister();
+                    .duration(100).EUt(4).buildAndRegister();
         }
 
         ModHandler.addShapedRecipe("iron_horse_armor", new ItemStack(Items.IRON_HORSE_ARMOR), "hdH", "PCP", "LSL",
@@ -940,7 +940,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.PAPER, 8))
                 .inputs(new ItemStack(Items.COMPASS))
                 .outputs(new ItemStack(Items.MAP))
-                .duration(60).EUt(VA[ULV]).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(dust, Materials.Netherrack)
@@ -958,20 +958,20 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.STRING, 4, GTValues.W))
                 .inputs(new ItemStack(Items.SLIME_BALL, 1, GTValues.W))
                 .outputs(new ItemStack(Items.LEAD, 2))
-                .duration(60).EUt(2).buildAndRegister();
+                .duration(100).EUt(2).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.LEATHER))
                 .inputs(new ItemStack(Items.LEAD))
                 .fluidInputs(Materials.Glue.getFluid(100))
                 .outputs(new ItemStack(Items.NAME_TAG))
-                .duration(60).EUt(VA[ULV]).buildAndRegister();
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.STRING, 3, GTValues.W))
                 .input(OrePrefix.stick, Materials.Wood, 3)
                 .outputs(new ItemStack(Items.BOW, 1))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder().duration(128).EUt(4).notConsumable(SHAPE_MOLD_BALL).fluidInputs(Water.getFluid(250)).outputs(new ItemStack(Items.SNOWBALL)).buildAndRegister();
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder().duration(128).EUt(4).notConsumable(SHAPE_MOLD_BALL).fluidInputs(DistilledWater.getFluid(250)).outputs(new ItemStack(Items.SNOWBALL)).buildAndRegister();
@@ -991,7 +991,7 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.STRING, 4))
                 .notConsumable(new IntCircuitIngredient(4))
                 .outputs(new ItemStack(Blocks.WOOL, 1, 0))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(cobblestone, 1)
@@ -1005,16 +1005,16 @@ public class VanillaStandardRecipes {
                 .outputs(new ItemStack(Blocks.STONEBRICK, 1, 1))
                 .duration(40).EUt(1).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).input(stoneCobble, 6).outputs(new ItemStack(Blocks.STONE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.BRICK_BLOCK, 6)).outputs(new ItemStack(Blocks.BRICK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.STONEBRICK, 6, GTValues.W)).outputs(new ItemStack(Blocks.STONE_BRICK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.NETHER_BRICK, 6)).outputs(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.SANDSTONE, 6)).outputs(new ItemStack(Blocks.SANDSTONE_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 6)).outputs(new ItemStack(Blocks.QUARTZ_STAIRS, 4)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(7).inputs(new ItemStack(Blocks.PURPUR_BLOCK, 6)).outputs(new ItemStack(Blocks.PURPUR_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).input(stoneCobble, 6).outputs(new ItemStack(Blocks.STONE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.BRICK_BLOCK, 6)).outputs(new ItemStack(Blocks.BRICK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.STONEBRICK, 6, GTValues.W)).outputs(new ItemStack(Blocks.STONE_BRICK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.NETHER_BRICK, 6)).outputs(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.SANDSTONE, 6)).outputs(new ItemStack(Blocks.SANDSTONE_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 6)).outputs(new ItemStack(Blocks.QUARTZ_STAIRS, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(7).inputs(new ItemStack(Blocks.PURPUR_BLOCK, 6)).outputs(new ItemStack(Blocks.PURPUR_STAIRS, 4)).buildAndRegister();
 
 
-        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(60).circuitMeta(2).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 0)).outputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 2)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(1).duration(100).circuitMeta(2).inputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 0)).outputs(new ItemStack(Blocks.QUARTZ_BLOCK, 1, 2)).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(4).inputs(new ItemStack(Blocks.STONE)).outputs(new ItemStack(Blocks.STONEBRICK, 1, 0)).circuitMeta(4).duration(50).buildAndRegister();
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(4).inputs(new ItemStack(Blocks.END_STONE)).outputs(new ItemStack(Blocks.END_BRICKS, 1, 0)).circuitMeta(4).duration(50).buildAndRegister();
@@ -1026,37 +1026,37 @@ public class VanillaStandardRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(4).inputs(new ItemStack(Blocks.RED_SANDSTONE, 1, 2)).outputs(new ItemStack(Blocks.RED_SANDSTONE, 1, 0)).circuitMeta(1).duration(50).buildAndRegister();
 
 
-        CANNER_RECIPES.recipeBuilder().EUt(4).duration(60).inputs(new ItemStack(Blocks.PUMPKIN)).inputs(new ItemStack(Blocks.TORCH)).outputs(new ItemStack(Blocks.LIT_PUMPKIN)).buildAndRegister();
+        CANNER_RECIPES.recipeBuilder().EUt(4).duration(100).inputs(new ItemStack(Blocks.PUMPKIN)).inputs(new ItemStack(Blocks.TORCH)).outputs(new ItemStack(Blocks.LIT_PUMPKIN)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().EUt(4).duration(40).inputs(new ItemStack(Items.PRISMARINE_CRYSTALS, 5)).inputs(new ItemStack(Items.PRISMARINE_SHARD, 4)).outputs(new ItemStack(Blocks.SEA_LANTERN)).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(4).duration(40).inputs(new ItemStack(Items.NETHERBRICK, 2)).inputs(new ItemStack(Items.NETHER_WART, 2)).outputs(new ItemStack(Blocks.RED_NETHER_BRICK)).buildAndRegister();
 
         if (!ConfigHolder.recipes.hardMiscRecipes) {
-            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(6).circuitMeta(4).input("plankWood", 4).outputs(new ItemStack(Blocks.CRAFTING_TABLE)).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().circuitMeta(8).input(stoneCobble, 8).outputs(new ItemStack(Blocks.FURNACE)).duration(100).EUt(VA[ULV]).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().inputs(new ItemStack(Blocks.OBSIDIAN, 4)).input(gem, Diamond, 2).inputs(new ItemStack(Items.BOOK)).outputs(new ItemStack(Blocks.ENCHANTING_TABLE)).duration(100).EUt(VA[ULV]).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).circuitMeta(2).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).input(dust, Redstone).outputs(new ItemStack(Blocks.DROPPER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
-            ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(1).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).inputs(new ItemStack(Items.BOW)).input(dust, Redstone).outputs(new ItemStack(Blocks.DISPENSER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).circuitMeta(2).inputs(new ItemStack(Blocks.COBBLESTONE, 7)).input(dust, Redstone).outputs(new ItemStack(Blocks.DROPPER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
         }
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).circuitMeta(3).inputs(new ItemStack(Blocks.NETHER_BRICK)).outputs(new ItemStack(Blocks.NETHER_BRICK_FENCE)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).circuitMeta(3).inputs(new ItemStack(Blocks.NETHER_BRICK)).outputs(new ItemStack(Blocks.NETHER_BRICK_FENCE)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).inputs(new ItemStack(Items.CHORUS_FRUIT_POPPED)).inputs(new ItemStack(Items.BLAZE_ROD)).outputs(new ItemStack(Blocks.END_ROD, 4)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Items.CHORUS_FRUIT_POPPED)).inputs(new ItemStack(Items.BLAZE_ROD)).outputs(new ItemStack(Blocks.END_ROD, 4)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(VA[ULV]).input("chestWood", 1).inputs(new ItemStack(Items.SHULKER_SHELL, 2)).outputs(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).input("chestWood", 1).inputs(new ItemStack(Items.SHULKER_SHELL, 2)).outputs(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).buildAndRegister();
 
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).circuitMeta(1).input("wool", 1).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.PAINTING)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).inputs(new ItemStack(Items.LEATHER)).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.ITEM_FRAME)).buildAndRegister();
-        ASSEMBLER_RECIPES.recipeBuilder().duration(60).EUt(4).input("plankWood", 6).inputs(new ItemStack(Items.STICK)).outputs(new ItemStack(Items.SIGN, 3)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).circuitMeta(1).input("wool", 1).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.PAINTING)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Items.LEATHER)).inputs(new ItemStack(Items.STICK, 8)).outputs(new ItemStack(Items.ITEM_FRAME)).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).input("plankWood", 6).inputs(new ItemStack(Items.STICK)).outputs(new ItemStack(Items.SIGN, 3)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(10).EUt(2).inputs(new ItemStack(Items.BRICK, 3)).outputs(new ItemStack(Items.FLOWER_POT)).buildAndRegister();
 
@@ -1069,7 +1069,7 @@ public class VanillaStandardRecipes {
                 .input(OrePrefix.stick, Materials.Wood)
                 .circuitMeta(1)
                 .outputs(new ItemStack(Blocks.RAIL, 32))
-                .duration(60).EUt(VA[LV]).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Materials.Gold, 12)
@@ -1077,7 +1077,7 @@ public class VanillaStandardRecipes {
                 .input(dust, Redstone)
                 .circuitMeta(1)
                 .outputs(new ItemStack(Blocks.GOLDEN_RAIL, 12))
-                .duration(60).EUt(VA[LV]).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, Iron, 12)
@@ -1085,7 +1085,7 @@ public class VanillaStandardRecipes {
                 .input(dust, Redstone)
                 .circuitMeta(3)
                 .outputs(new ItemStack(Blocks.DETECTOR_RAIL, 12))
-                .duration(60).EUt(VA[LV]).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(stick, Iron, 12)
@@ -1093,13 +1093,13 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH))
                 .circuitMeta(3)
                 .outputs(new ItemStack(Blocks.ACTIVATOR_RAIL, 12))
-                .duration(60).EUt(VA[LV]).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Iron, 3)
                 .input(OrePrefix.ring, Materials.Iron, 4)
                 .outputs(new ItemStack(Items.MINECART))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
 
         ModHandler.addShapedRecipe("saddle", new ItemStack(Items.SADDLE), "LLL", "LCL", "RSR",
                 'L', new ItemStack(Items.LEATHER),
@@ -1198,13 +1198,13 @@ public class VanillaStandardRecipes {
                 .input(dust, Materials.Gunpowder)
                 .input(dust, Materials.Blaze)
                 .outputs(new ItemStack(Items.FIRE_CHARGE, 3))
-                .duration(60).EUt(VA[LV]).buildAndRegister();
+                .duration(100).EUt(VA[LV]).buildAndRegister();
 
         MIXER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.GRAVEL))
                 .inputs(new ItemStack(Blocks.DIRT))
                 .outputs(new ItemStack(Blocks.DIRT, 2, 1))
-                .duration(60).EUt(4).buildAndRegister();
+                .duration(100).EUt(4).buildAndRegister();
     }
 
     private static void dyeRecipes() {


### PR DESCRIPTION
**What:**
As discussed in #1039, decreases machine recipe times for crafting vanilla items which otherwise could be hand-crafted.

**Implementation Details:**
The big majority of recipes which craft vanilla items in machines have had their recipe times decreased to `60` (3 seconds). Some recipes were left as-is, such as Chlorine bleaching of wool. The hard vanilla recipe config recipes were not touched.

**Outcome:**
Closes #1039 

**Possible compatibility issue:**
None
