### PR TITLE
Disable Clipboard rotation

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -221,6 +221,11 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
         return true;
     }
 
+    @Override
+    public boolean onWrenchClick(EntityPlayer playerIn, EnumHand hand, EnumFacing wrenchSide, CuboidRayTraceResult hitResult) {
+        return false;
+    }
+
     private void breakClipboard(@Nullable EntityPlayer player) {
         if (!getWorld().isRemote) {
             BlockPos pos = this.getPos(); // Saving this for later so it doesn't get mangled
@@ -250,8 +255,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
 
     @Override
     public void setFrontFacing(EnumFacing frontFacing) {
-        super.setFrontFacing(frontFacing);
-        this.didSetFacing = true;
+        return;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -255,6 +255,8 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
 
     @Override
     public void setFrontFacing(EnumFacing frontFacing) {
+        super.setFrontFacing(frontFacing);
+        this.didSetFacing = true;
     }
 
     @Override
@@ -326,6 +328,11 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
         y /= 14.0 / 16;
 
         return new double[]{x, y};
+    }
+
+    @Override
+    public boolean isValidFrontFacing(EnumFacing facing) {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -255,7 +255,6 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
 
     @Override
     public void setFrontFacing(EnumFacing frontFacing) {
-        return;
     }
 
     @Override


### PR DESCRIPTION
**What:**
Previously Clipboard can be rotated by both wrench and GT Console App
This PR disables it

**Additional info:**
Clipboard still has incorrect TOP tooltips but I didn't fix it because it will conflict with #997 