### PR TITLE
Fix Energy Hatch causes inifinite loop on explosion

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -402,7 +402,10 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
 
     public void explodeMultiblock() {
         List<IMultiblockPart> parts = new ArrayList<>(getMultiblockParts());
-        parts.forEach(p -> ((MetaTileEntity) p).doExplosion(8));
+        for (IMultiblockPart part : parts) {
+            part.removeFromMultiBlock(this);
+            ((MetaTileEntity) part).doExplosion(8);
+        }
         doExplosion(8);
     }
 }


### PR DESCRIPTION
**What:**
When the Energy Hatch explodes in rain or water, it will make every multiblock part explodes
However "every multiblock part" includes the Energy Hatch itself so there is an infinite loop
https://pastes.dev/3pjKTD9T73

**Implementation Details:**
When the multiblock controller explodes, it will detach every part from it so Energy Hatch is no longer able to call other parts

**Outcome:**
no StackOverFlow Error
 
**Additional info:**
it is needed to test in variety of situations
