### PR TITLE
Rounds energy displayed by TOP

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -358,4 +358,6 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements ILas
     public void setWorkingEnabled(boolean isWorkingAllowed) {
         setActive(isWorkingAllowed);
     }
+
+
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -358,6 +358,4 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements ILas
     public void setWorkingEnabled(boolean isWorkingAllowed) {
         setActive(isWorkingAllowed);
     }
-
-
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -3,8 +3,10 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.util.TextFormattingUtil;
-
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.NumberFormat;
+import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
@@ -37,7 +39,8 @@ public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnerg
         long maxStorage = capability.getEnergyCapacity();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
         probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
-                .suffix(" / " + TextFormattingUtil.formatNumbers(maxStorage) + " EU")
+                .numberFormat(player.isSneaking() ? NumberFormat.FULL : NumberFormat.COMPACT)
+                .suffix(" / " + (player.isSneaking() ? maxStorage + " EU" : ElementProgress.format(maxStorage, NumberFormat.COMPACT, " EU")))
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
                 .borderColor(0xFF555555).numberFormat(mcjty.theoneprobe.api.NumberFormat.COMMAS));

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -5,16 +5,14 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.ILaserContainer;
 
-import mcjty.theoneprobe.api.IProbeHitData;
-import mcjty.theoneprobe.api.IProbeInfo;
-import mcjty.theoneprobe.api.NumberFormat;
-import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
 
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.NumberFormat;
+import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import org.jetbrains.annotations.NotNull;
 
 public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnergyContainer> {
@@ -41,9 +39,10 @@ public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnerg
         long maxStorage = capability.getEnergyCapacity();
         long stored = capability.getEnergyStored();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
-        probeInfo.progress(capability.getEnergyStored() , maxStorage, probeInfo.defaultProgressStyle()
+        probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
                 .numberFormat(player.isSneaking() || stored < 10000 ? NumberFormat.FULL : NumberFormat.COMPACT)
-                .suffix(" / " + (player.isSneaking() || maxStorage < 10000 ? maxStorage + " EU" : ElementProgress.format(maxStorage, NumberFormat.COMPACT, "EU")))
+                .suffix(" / " + (player.isSneaking() || maxStorage < 10000 ? maxStorage + " EU" :
+                        ElementProgress.format(maxStorage, NumberFormat.COMPACT, "EU")))
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
                 .borderColor(0xFF555555));

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -3,6 +3,8 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.ILaserContainer;
+
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.NumberFormat;
@@ -30,19 +32,20 @@ public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnerg
 
     @Override
     protected boolean allowDisplaying(@NotNull IEnergyContainer capability) {
-        return !capability.isOneProbeHidden();
+        return !capability.isOneProbeHidden() && !(capability instanceof ILaserContainer);
     }
 
     @Override
     protected void addProbeInfo(@NotNull IEnergyContainer capability, @NotNull IProbeInfo probeInfo,
                                 EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         long maxStorage = capability.getEnergyCapacity();
+        long stored = capability.getEnergyStored();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
-        probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
-                .numberFormat(player.isSneaking() ? NumberFormat.FULL : NumberFormat.COMPACT)
-                .suffix(" / " + (player.isSneaking() ? maxStorage + " EU" : ElementProgress.format(maxStorage, NumberFormat.COMPACT, " EU")))
+        probeInfo.progress(capability.getEnergyStored() , maxStorage, probeInfo.defaultProgressStyle()
+                .numberFormat(player.isSneaking() || stored < 10000 ? NumberFormat.FULL : NumberFormat.COMPACT)
+                .suffix(" / " + (player.isSneaking() || maxStorage < 10000 ? maxStorage + " EU" : ElementProgress.format(maxStorage, NumberFormat.COMPACT, "EU")))
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
-                .borderColor(0xFF555555).numberFormat(mcjty.theoneprobe.api.NumberFormat.COMMAS));
+                .borderColor(0xFF555555));
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
@@ -5,6 +5,8 @@ import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.ILaserContainer;
 import gregtech.api.util.TextFormattingUtil;
 
+import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
@@ -31,12 +33,14 @@ public class LaserContainerInfoProvider extends CapabilityInfoProvider<ILaserCon
     protected void addProbeInfo(ILaserContainer capability, IProbeInfo probeInfo, EntityPlayer player,
                                 TileEntity tileEntity, IProbeHitData data) {
         long maxStorage = capability.getEnergyCapacity();
+        long stored = capability.getEnergyStored();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
-        probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
-                .suffix(" / " + TextFormattingUtil.formatNumbers(maxStorage) + " EU")
+        probeInfo.progress(stored, maxStorage, probeInfo.defaultProgressStyle()
+                .numberFormat(player.isSneaking() || stored < 10000 ? NumberFormat.FULL : NumberFormat.COMPACT)
+                .suffix(" / " + (player.isSneaking() || maxStorage < 10000 ? maxStorage + " EU" : ElementProgress.format(maxStorage, NumberFormat.COMPACT, "EU")))
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
-                .borderColor(0xFF555555).numberFormat(NumberFormat.COMMAS));
+                .borderColor(0xFF555555));
     }
 
     @Override

--- a/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
@@ -3,9 +3,6 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.ILaserContainer;
-import gregtech.api.util.TextFormattingUtil;
-
-import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -14,6 +11,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.NumberFormat;
+import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import org.jetbrains.annotations.NotNull;
 
 public class LaserContainerInfoProvider extends CapabilityInfoProvider<ILaserContainer> {
@@ -37,7 +35,8 @@ public class LaserContainerInfoProvider extends CapabilityInfoProvider<ILaserCon
         if (maxStorage == 0) return; // do not add empty max storage progress bar
         probeInfo.progress(stored, maxStorage, probeInfo.defaultProgressStyle()
                 .numberFormat(player.isSneaking() || stored < 10000 ? NumberFormat.FULL : NumberFormat.COMPACT)
-                .suffix(" / " + (player.isSneaking() || maxStorage < 10000 ? maxStorage + " EU" : ElementProgress.format(maxStorage, NumberFormat.COMPACT, "EU")))
+                .suffix(" / " + (player.isSneaking() || maxStorage < 10000 ? maxStorage + " EU" :
+                        ElementProgress.format(maxStorage, NumberFormat.COMPACT, "EU")))
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
                 .borderColor(0xFF555555));


### PR DESCRIPTION
**What:**
Some people wants rounded energy display and I agree with that

**Implementation Details:**
If you are sneaking the TOP works like the same as before
If not, TOP truncates energy like this:
![キャプチャ1404](https://user-images.githubusercontent.com/39122497/177036357-c1a6a344-929c-4285-bf20-7be8c0798435.PNG)


**Outcome:**
closes #1062 

**Additional info:**
If we want to display 4 digits instead of 3,
we have to write [25 lines](https://github.com/vfyjxf/GregicProbe/blob/755ab102b7ae3038f5a58a2a7be52d9a70d4da6f/src/main/java/vfyjxf/gregicprobe/integration/gregtech/EnergyInfoProvider.java#L38) like GregicProbes did