### PR TITLE
Fix shortcut with magnetic dusts

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -82,6 +82,12 @@ public class RecyclingRecipes {
             if (OreDictUnifier.getPrefix(input) == OrePrefix.ingot && m.getProperty(PropertyKey.INGOT).getArcSmeltInto() == m) {
                 return;
             }
+
+            // Prevent Magnetic dust -> Regular Ingot Arc Furnacing, avoiding the EBF recipe
+            // "I will rework magnetic materials soon" - DStrand1
+            if(prefix == OrePrefix.dust && m.hasFlag(IS_MAGNETIC)) {
+                return;
+            }
         }
         registerArcRecycling(input, components, prefix);
     }


### PR DESCRIPTION
**What:**
Fixes a shortcut with magnetic dusts, pointed out in #1059.

Closes #1059 

**Implementation Details:**
I want to add a check to make this only apply to EBF recipes, like samarium, but it is not guaranteed that the magnetic material will have the Blast property even if the non-magnetic material has this property (see samarium). Therefore, I am unsure of a way to make the arc furnace black list of magnetic dusts -> regular ingots only apply to materials that are made in the EBF

**Outcome:**
Removes the ability to go from Magnetic Dust -> Regular Ingot in the Arc furnace, skipping some EBF recipes.
