### PR TITLE
Fix portal crashing clients when teleporting on a server

### DIFF
--- a/src/main/java/gregtech/common/entities/PortalEntity.java
+++ b/src/main/java/gregtech/common/entities/PortalEntity.java
@@ -69,11 +69,14 @@ public class PortalEntity extends Entity {
         }
 
         this.onEntityUpdate();
-        List<Entity> list = this.world.getEntitiesInAABBexcluding(this, this.getEntityBoundingBox(), null);
-        for(Entity entity : list){
-            if (!(entity instanceof PortalEntity)) {
-                GTTeleporter teleporter = new GTTeleporter(TeleportHandler.getWorldByDimensionID(targetDim), targetX, targetY, targetZ);
-                TeleportHandler.teleport(entity, targetDim, teleporter, targetX + entity.getLookVec().x, targetY, targetZ + entity.getLookVec().z);
+
+        if(!this.world.isRemote) {
+            List<Entity> list = this.world.getEntitiesInAABBexcluding(this, this.getEntityBoundingBox(), null);
+            for (Entity entity : list) {
+                if (!(entity instanceof PortalEntity)) {
+                    GTTeleporter teleporter = new GTTeleporter(TeleportHandler.getWorldByDimensionID(targetDim), targetX, targetY, targetZ);
+                    TeleportHandler.teleport(entity, targetDim, teleporter, targetX + entity.getLookVec().x, targetY, targetZ + entity.getLookVec().z);
+                }
             }
         }
         --timeToDespawn;


### PR DESCRIPTION
**What:**
Fixing client crash when trying to use the teleporter on a server

**Implementation Details:**
Just added a check for !world.isRemote

**Outcome:**
Crash doesn't happen anymore
