### PR TITLE
Add extra ZenMethod to get meta item.

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTUtilities.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes.crafttweaker;
 
 import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -13,5 +14,15 @@ public class CTUtilities {
     @ZenMethod("RemoveMultiblockPreviewFromJei")
     public static void removeMulti(String name) {
         REGISTER.removeIf(multi -> multi.metaTileEntityId.toString().equals(name));
+    }
+
+    @ZenMethod("GetMetaItem")
+    public static IItemStack getMetaItem(String metaId) {
+        return MetaItemBracketHandler.getMetaItem(metaId);
+    }
+
+    @ZenMethod("GetMetaTileEntity")
+    public static IItemStack getMetaTileEntityItem(String metaId) {
+        return MetaTileEntityBracketHandler.getMetaTileEntityItem(metaId);
     }
 }


### PR DESCRIPTION
**What:**
Add extra ZenMethod to get meta item(tile entity items also), make getting a large number of meta items in scripts easier.

Practical:
```zenscript
import mods.gregtech.general.utils as CTUtilities;
import crafttweaker.item.IItemStack;

var fromBH as IItemStack = <metaitem:circuit.integrated>;
var fromMethod as IItemStack = CTUtilities.GetMetaItem("circuit.integrated");
```

**Outcome:**
Add extra ZenMethod to get meta item.