### PR TITLE
Various Overclocking Bonus fixes

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -46,6 +46,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     private boolean allowOverclocking = true;
     protected int parallelRecipesPerformed;
     private long overclockVoltage = 0;
+    private int[] overclockResults;
 
     protected boolean canRecipeProgress = true;
 
@@ -419,7 +420,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      */
     protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
 
-        int[] overclockResults = calculateOverclock(recipe);
+        overclockResults = calculateOverclock(recipe);
 
         performNonOverclockBonuses(overclockResults);
 
@@ -635,10 +636,9 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @param recipe the recipe to run
      */
     protected void setupRecipe(Recipe recipe) {
-        int[] resultOverclock = calculateOverclock(recipe);
         this.progressTime = 1;
-        setMaxProgress(resultOverclock[1]);
-        this.recipeEUt = resultOverclock[0];
+        setMaxProgress(overclockResults[1]);
+        this.recipeEUt = overclockResults[0];
         this.fluidOutputs = GTUtility.copyFluidList(recipe.getAllFluidOutputs(metaTileEntity.getFluidOutputLimit()));
         this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(GTUtility.getTierByVoltage(recipeEUt), getRecipeMap()));
 
@@ -663,6 +663,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.hasNotEnoughEnergy = false;
         this.wasActiveAndNeedsUpdate = true;
         this.parallelRecipesPerformed = 0;
+        this.overclockResults = new int[]{0, 0};
     }
 
     public double getProgressPercent() {

--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -55,7 +55,7 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
             lines.add(I18n.format("tile.wire_coil.tooltip_pyro"));
             lines.add(I18n.format("tile.wire_coil.tooltip_speed_pyro", coilTier == 0 ? 75 : 50 * (coilTier + 1)));
             lines.add(I18n.format("tile.wire_coil.tooltip_cracking"));
-            lines.add(I18n.format("tile.wire_coil.tooltip_energy_cracking", 100 - 5 * coilTier));
+            lines.add(I18n.format("tile.wire_coil.tooltip_energy_cracking", 100 - 10 * coilTier));
         } else {
             lines.add(I18n.format("gregtech.tooltip.hold_shift"));
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -66,7 +66,7 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
     protected void addDisplayText(List<ITextComponent> textList) {
         super.addDisplayText(textList);
         if (isStructureFormed())
-            textList.add(new TextComponentTranslation("gregtech.multiblock.cracking_unit.energy", 100 - 5 * coilTier));
+            textList.add(new TextComponentTranslation("gregtech.multiblock.cracking_unit.energy", 100 - 10 * coilTier));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -74,7 +74,7 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
         super.formStructure(context);
         Object type = context.get("CoilType");
         if (type instanceof IHeatingCoilBlockStats)
-            this.coilTier = ((IHeatingCoilBlockStats) type).getLevel();
+            this.coilTier = ((IHeatingCoilBlockStats) type).getTier();
         else
             this.coilTier = 0;
     }
@@ -126,7 +126,9 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
             if (coilTier == -1)
                 return;
 
-            if (coilTier == 0) resultOverclock[1] *= 5.0 / 4; // 25% slower with cupronickel (coilTier = 0)
+            if (coilTier == 0) {
+                resultOverclock[1] *= 5.0 / 4; // 25% slower with cupronickel (coilTier = 0)
+            }
             else resultOverclock[1] *= 2.0f / (coilTier + 1); // each coil above kanthal (coilTier = 1) is 50% faster
 
             resultOverclock[1] = Math.max(1, resultOverclock[1]);


### PR DESCRIPTION
**What:**
Fixes various bugs relating to overclocking bonuses.

1. Fixes the Pyrolyse Oven using the wrong method for getting the coil tier, resulting in the Cupronickel coil no longer applying its malus, and other coils providing too much of a bonus.
2. Fixes tooltips in the Wire Coils and in the oil cracking unit to display their correct energy discounts
3. Fixes an issue that prevented bonuses from being applied because the overclock results were recalculated, and the bonus were not recalculated after the second time.

**Implementation Details:**
Does the new `overclockResults` variable need to be invalidated for multiblocks?

**Outcome:**
Fixes various issues relating to Coil Overclock Bonuses.
