### PR TITLE
Add time in seconds display to the debug scanner

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -64,6 +64,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     private final int[] timeStatistics = new int[20];
     private int timeStatisticsIndex = 0;
     private int lagWarningCount = 0;
+    protected static final DecimalFormat tricorderFormat = new DecimalFormat("#.#########");
 
     public MetaTileEntity getMetaTileEntity() {
         return metaTileEntity;
@@ -248,7 +249,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
                         new TextComponentTranslation(GTUtility.formatNumbers(timeStatistics.length)).setStyle(new Style().setColor(TextFormatting.GREEN)),
                         new TextComponentTranslation(GTUtility.formatNumbers(worstTickTime)).setStyle(new Style().setColor(TextFormatting.RED))
                 ));
-                list.add(new TextComponentTranslation("behavior.tricorder.debug_cpu_load_seconds", new DecimalFormat("#.#########").format(worstTickTime / 1000000000)));
+                list.add(new TextComponentTranslation("behavior.tricorder.debug_cpu_load_seconds", tricorderFormat.format(worstTickTime / 1000000000)));
             }
             if (lagWarningCount > 0) {
                 list.add(new TextComponentTranslation("behavior.tricorder.debug_lag_count",

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -30,22 +30,21 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.Style;
-import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.*;
 import net.minecraft.world.IWorldNameable;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.Optional.*;
+import net.minecraftforge.fml.common.Optional.Interface;
+import net.minecraftforge.fml.common.Optional.InterfaceList;
+import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 
 import static gregtech.api.capability.GregtechDataCodes.INITIALIZE_MTE;
@@ -249,6 +248,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
                         new TextComponentTranslation(GTUtility.formatNumbers(timeStatistics.length)).setStyle(new Style().setColor(TextFormatting.GREEN)),
                         new TextComponentTranslation(GTUtility.formatNumbers(worstTickTime)).setStyle(new Style().setColor(TextFormatting.RED))
                 ));
+                list.add(new TextComponentTranslation("behavior.tricorder.debug_cpu_load_seconds", new DecimalFormat("#.#########").format(worstTickTime / 1000000000)));
             }
             if (lagWarningCount > 0) {
                 list.add(new TextComponentTranslation("behavior.tricorder.debug_lag_count",

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2282,6 +2282,7 @@ behavior.tricorder.debug_machine_valid= valid
 behavior.tricorder.debug_machine_invalid= invalid!
 behavior.tricorder.debug_machine_invalid_null=invalid! MetaTileEntity == null!
 behavior.tricorder.debug_cpu_load=Average CPU load of ~%sns over %s ticks with worst time of %sns.
+behavior.tricorder.debug_cpu_load_seconds=This is %s seconds.
 behavior.tricorder.debug_lag_count=Caused %s Lag Spike Warnings (anything taking longer than %sms) on the Server.
 
 metaitem.item_magnet.lv.name=Low Voltage Item Magnet


### PR DESCRIPTION
**What:**
Add the time in seconds to the debug scanner to attempt to prevent large number scares.

**Outcome:**
Add additional information to the debug scanner.