### PR TITLE
Add Machine Particles

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -63,10 +63,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static gregtech.api.util.GTUtility.getMetaTileEntity;
 
@@ -498,5 +495,13 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
             return super.canEntityDestroy(state, world, pos, entity);
         }
         return !((entity instanceof EntityWither || entity instanceof EntityWitherSkull) && metaTileEntity.getWitherProof());
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick(@Nonnull IBlockState stateIn, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Random rand) {
+        super.randomDisplayTick(stateIn, worldIn, pos, rand);
+        MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
+        if (metaTileEntity != null) metaTileEntity.randomDisplayTick();
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -7,8 +7,8 @@ import gregtech.api.damagesources.DamageSources;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.common.advancement.GTTriggers;
 import gregtech.common.ConfigHolder;
+import gregtech.common.advancement.GTTriggers;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockSnow;
 import net.minecraft.block.state.IBlockState;
@@ -28,8 +28,6 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.fluids.IFluidTank;
 
 import javax.annotation.Nonnull;
-
-import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
 
 public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
 
@@ -157,7 +155,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
         double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
         double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
 
-        world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
+        world.spawnParticle(EnumParticleTypes.CLOUD, posX, posY, posZ,
                 7 + world.rand.nextInt(3),
                 ventingSide.getXOffset() / 2.0,
                 ventingSide.getYOffset() / 2.0,

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
@@ -154,14 +154,13 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
         double posY = machinePos.getY() + 0.5 + ventingSide.getYOffset() * 0.6;
         double posZ = machinePos.getZ() + 0.5 + ventingSide.getZOffset() * 0.6;
 
-        world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, posX, posY, posZ,
-                7 + world.rand.nextInt(3),
+        world.spawnParticle(EnumParticleTypes.CLOUD, posX, posY, posZ,
+                7 + GTValues.RNG.nextInt(3),
                 ventingSide.getXOffset() / 2.0,
                 ventingSide.getYOffset() / 2.0,
                 ventingSide.getZOffset() / 2.0, 0.1);
         if (ConfigHolder.machines.machineSounds && !metaTileEntity.isMuffled()){
             world.playSound(null, posX, posY, posZ, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1.0f, 1.0f);
         }
-
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -231,7 +231,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
 
     /**
      * Used to display things like particles on random display ticks
-     * This method is typically used by torches or vanilla forces, as an example use-case
+     * This method is typically used by torches or nether portals, as an example use-case
      */
     @SideOnly(Side.CLIENT)
     public void randomDisplayTick() {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -230,6 +230,15 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     /**
+     * Used to display things like particles on random display ticks
+     * This method is typically used by torches or vanilla forces, as an example use-case
+     */
+    @SideOnly(Side.CLIENT)
+    public void randomDisplayTick() {
+
+    }
+
+    /**
      * Called from ItemBlock to initialize this MTE with data contained in ItemStack
      *
      * @param itemStack itemstack of itemblock
@@ -1291,7 +1300,6 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public RecipeMap<?> getRecipeMap() {
-
         for (int i = 0; i < mteTraits.size(); i++) {
             if (mteTraits.get(i).getName().equals("RecipeMapWorkable")) {
                 return ((AbstractRecipeLogic) mteTraits.get(i)).getRecipeMap();

--- a/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
@@ -18,6 +18,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
@@ -144,15 +145,15 @@ public abstract class SteamMetaTileEntity extends MetaTileEntity {
                 else z -= 0.52F;
                 x += horizontalOffset;
             }
+            if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
+                getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+            }
             randomDisplayTick(x, y, z, EnumParticleTypes.FLAME, isHighPressure ? EnumParticleTypes.SMOKE_LARGE : EnumParticleTypes.SMOKE_NORMAL);
         }
     }
 
     @SideOnly(Side.CLIENT)
     protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
-        if (GTValues.RNG.nextDouble() < 0.1) {
-            getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
-        }
         getWorld().spawnParticle(smoke, x, y, z, 0, 0, 0);
         getWorld().spawnParticle(flame, x, y, z, 0, 0, 0);
     }

--- a/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
@@ -5,6 +5,7 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.GTValues;
 import gregtech.api.capability.impl.FilteredFluidHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.RecipeLogicSteam;
@@ -13,13 +14,15 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.client.renderer.ICubeRenderer;
-import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
+import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
+import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.*;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -118,5 +121,39 @@ public abstract class SteamMetaTileEntity extends MetaTileEntity {
     @Override
     public SoundEvent getSound() {
         return workableHandler.getRecipeMap().getSound();
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        if (this.isActive()) {
+            final BlockPos pos = getPos();
+            float x = pos.getX() + 0.5F;
+            float z = pos.getZ() + 0.5F;
+
+            final EnumFacing facing = getFrontFacing();
+            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
+            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F;
+
+            if (facing.getAxis() == EnumFacing.Axis.X) {
+                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
+                else x -= 0.52F;
+                z += horizontalOffset;
+            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
+                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
+                else z -= 0.52F;
+                x += horizontalOffset;
+            }
+            randomDisplayTick(x, y, z, EnumParticleTypes.FLAME, isHighPressure ? EnumParticleTypes.SMOKE_LARGE : EnumParticleTypes.SMOKE_NORMAL);
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
+        if (GTValues.RNG.nextDouble() < 0.1) {
+            getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+        }
+        getWorld().spawnParticle(smoke, x, y, z, 0, 0, 0);
+        getWorld().spawnParticle(flame, x, y, z, 0, 0, 0);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -11,9 +11,9 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
-import gregtech.api.util.GTUtility;
 import net.minecraft.block.BlockDragonEgg;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -26,6 +26,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntitySelectors;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
@@ -109,6 +110,11 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
                 writeCustomData(IS_WORKING, w -> w.writeBoolean(isActive));
             }
         }
+    }
+
+    @Override
+    public boolean isActive() {
+        return this.isActive;
     }
 
     @Override
@@ -204,4 +210,20 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
         return null;
     }
 
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        if (isActive() && !this.hasDragonEggAmplifier) {
+            final BlockPos pos = getPos();
+            for (int i = 0; i < 4; i++) {
+                getWorld().spawnParticle(EnumParticleTypes.PORTAL,
+                        pos.getX() + 0.5F,
+                        pos.getY() + GTValues.RNG.nextFloat(),
+                        pos.getZ() + 0.5F,
+                        (GTValues.RNG.nextFloat() - 0.5F) * 0.5F,
+                        (GTValues.RNG.nextFloat() - 0.5F) * 0.5F,
+                        (GTValues.RNG.nextFloat() - 0.5F) * 0.5F);
+            }
+        }
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.multi;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.GTValues;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
@@ -15,12 +16,18 @@ import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.MetaTileEntities;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
 
 import javax.annotation.Nonnull;
 
@@ -93,5 +100,33 @@ public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockControll
                         .setOverlayTexture(GuiTextures.PRIMITIVE_LARGE_FLUID_TANK_OVERLAY)
                         .setContainerClicking(true, false))
                 .bindPlayerInventory(entityPlayer.inventory, GuiTextures.PRIMITIVE_SLOT, 0);
+    }
+
+    @Override
+    public void randomDisplayTick() {
+        if (this.isActive()) {
+            final BlockPos pos = getPos();
+            float x = pos.getX() + 0.5F;
+            float z = pos.getZ() + 0.5F;
+
+            final EnumFacing facing = getFrontFacing();
+            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
+            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F + 0.3F;
+
+            if (facing.getAxis() == EnumFacing.Axis.X) {
+                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
+                else x -= 0.52F;
+                z += horizontalOffset;
+            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
+                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
+                else z -= 0.52F;
+                x += horizontalOffset;
+            }
+            if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
+                getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+            }
+            getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, x, y, z, 0, 0, 0);
+            getWorld().spawnParticle(EnumParticleTypes.FLAME, x, y, z, 0, 0, 0);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -25,13 +25,13 @@ import gregtech.client.renderer.cclop.ColourOperation;
 import gregtech.client.renderer.cclop.LightMapOperation;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.BloomEffectUtil;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import org.apache.commons.lang3.ArrayUtils;
@@ -147,5 +147,33 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
         BlockPos middlePos = this.getPos();
         middlePos = middlePos.offset(getFrontFacing().getOpposite());
         this.getWorld().getEntitiesWithinAABB(EntityLivingBase.class, new AxisAlignedBB(middlePos)).forEach(entity -> entity.attackEntityFrom(DamageSource.LAVA, 3.0f));
+    }
+
+    @Override
+    public void randomDisplayTick() {
+        if (this.isActive()) {
+            final BlockPos pos = getPos();
+            float x = pos.getX() + 0.5F;
+            float z = pos.getZ() + 0.5F;
+
+            final EnumFacing facing = getFrontFacing();
+            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
+            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F + 0.3F;
+
+            if (facing.getAxis() == EnumFacing.Axis.X) {
+                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
+                else x -= 0.52F;
+                z += horizontalOffset;
+            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
+                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
+                else z -= 0.52F;
+                x += horizontalOffset;
+            }
+            if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
+                getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+            }
+            getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, x, y, z, 0, 0, 0);
+            getWorld().spawnParticle(EnumParticleTypes.FLAME, x, y, z, 0, 0, 0);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.steam;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -10,7 +11,10 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamAlloySmelter extends SteamMetaTileEntity {
@@ -48,5 +52,14 @@ public class SteamAlloySmelter extends SteamMetaTileEntity {
                         GuiTextures.PROGRESS_BAR_ARROW_STEAM.get(isHighPressure), MoveType.HORIZONTAL, workableHandler.getRecipeMap())
                 .slot(this.exportItems, 0, 107, 25, true, false, GuiTextures.SLOT_STEAM.get(isHighPressure))
                 .build(getHolder(), player);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
+        super.randomDisplayTick(x, y, z, flame, smoke);
+        if (GTValues.RNG.nextBoolean()) {
+            getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y + 0.5F, z, 0, 0, 0);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamCompressor.java
@@ -11,6 +11,8 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamCompressor extends SteamMetaTileEntity {
@@ -42,5 +44,11 @@ public class SteamCompressor extends SteamMetaTileEntity {
                         GuiTextures.PROGRESS_BAR_COMPRESS_STEAM.get(isHighPressure), MoveType.HORIZONTAL, workableHandler.getRecipeMap())
                 .slot(this.exportItems, 0, 107, 25, true, false, GuiTextures.SLOT_STEAM.get(isHighPressure))
                 .build(getHolder(), player);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        // steam compressors do not make particles
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
@@ -10,7 +10,10 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamExtractor extends SteamMetaTileEntity {
@@ -42,5 +45,11 @@ public class SteamExtractor extends SteamMetaTileEntity {
                         GuiTextures.PROGRESS_BAR_EXTRACT_STEAM.get(isHighPressure), MoveType.HORIZONTAL, workableHandler.getRecipeMap())
                 .slot(this.exportItems, 0, 107, 25, true, false, GuiTextures.SLOT_STEAM.get(isHighPressure))
                 .build(getHolder(), player);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
+        getWorld().spawnParticle(EnumParticleTypes.CLOUD, x, y, z, 0, 0, 0);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.steam;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -10,7 +11,12 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamFurnace extends SteamMetaTileEntity {
@@ -47,5 +53,16 @@ public class SteamFurnace extends SteamMetaTileEntity {
                         GuiTextures.PROGRESS_BAR_ARROW_STEAM.get(isHighPressure), MoveType.HORIZONTAL, workableHandler.getRecipeMap())
                 .slot(this.exportItems, 0, 107, 25, true, false, GuiTextures.SLOT_STEAM.get(isHighPressure))
                 .build(getHolder(), player);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
+        y += 0.5F;
+        if (GTValues.RNG.nextDouble() < 0.1) {
+            getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+        }
+        getWorld().spawnParticle(smoke, x, y, z, 0, 0, 0);
+        getWorld().spawnParticle(flame, x, y, z, 0, 0, 0);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
@@ -1,6 +1,5 @@
 package gregtech.common.metatileentities.steam;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -11,10 +10,8 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.SoundEvents;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.SoundCategory;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -58,11 +55,6 @@ public class SteamFurnace extends SteamMetaTileEntity {
     @SideOnly(Side.CLIENT)
     @Override
     protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
-        y += 0.5F;
-        if (GTValues.RNG.nextDouble() < 0.1) {
-            getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
-        }
-        getWorld().spawnParticle(smoke, x, y, z, 0, 0, 0);
-        getWorld().spawnParticle(flame, x, y, z, 0, 0, 0);
+        super.randomDisplayTick(x, y + 0.5F, z, flame, smoke);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
@@ -11,6 +11,8 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamHammer extends SteamMetaTileEntity {
@@ -43,5 +45,11 @@ public class SteamHammer extends SteamMetaTileEntity {
                 .image(79, 41, 20, 18, GuiTextures.PROGRESS_BAR_HAMMER_BASE_STEAM.get(isHighPressure))
                 .slot(this.exportItems, 0, 107, 25, true, false, GuiTextures.SLOT_STEAM.get(isHighPressure))
                 .build(getHolder(), player);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        // steam hammers do not make particles
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.steam;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -10,7 +11,11 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamMacerator extends SteamMetaTileEntity {
@@ -47,5 +52,16 @@ public class SteamMacerator extends SteamMetaTileEntity {
     @Override
     public int getItemOutputLimit() {
         return 1;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        if (isActive()) {
+            final BlockPos pos = getPos();
+            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
+            getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX() + horizontalOffset, pos.getY() + 0.52F, pos.getZ() + horizontalOffset,
+                    GTValues.RNG.nextFloat() * 0.125F,  GTValues.RNG.nextFloat() * 0.375F, GTValues.RNG.nextFloat() * 0.125F);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
@@ -16,8 +16,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class SteamRockBreaker extends SteamMetaTileEntity {
@@ -102,6 +105,12 @@ public class SteamRockBreaker extends SteamMetaTileEntity {
         if (data.hasKey("hasValidFluids")) {
             this.hasValidFluids = data.getBoolean("hasValidFluids");
         }
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
+        getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y + 0.4F, z, 0, 0, 0);
     }
 
     protected class SteamRockBreakerRecipeLogic extends RecipeLogicSteam {

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.steam.boiler;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IFuelInfo;
 import gregtech.api.capability.IFuelable;
@@ -15,13 +16,19 @@ import gregtech.api.unification.material.Materials;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
 
@@ -108,5 +115,14 @@ public class SteamLavaBoiler extends SteamBoiler implements IFuelable {
                 .widget(new TankWidget(fuelFluidTank, 119, 26, 10, 54)
                         .setBackgroundTexture(GuiTextures.PROGRESS_BAR_BOILER_EMPTY.get(isHighPressure)))
                 .build(getHolder(), entityPlayer);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick(float x, float y, float z) {
+        super.randomDisplayTick(x, y, z);
+        if (GTValues.RNG.nextFloat() < 0.3F) {
+            getWorld().spawnParticle(EnumParticleTypes.LAVA, x + GTValues.RNG.nextFloat(), y, z + GTValues.RNG.nextFloat(), 0.0F, 0.0F, 0.0F);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamSolarBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamSolarBoiler.java
@@ -9,7 +9,8 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class SteamSolarBoiler extends SteamBoiler {
 
@@ -50,5 +51,11 @@ public class SteamSolarBoiler extends SteamBoiler {
                 .progressBar(() -> GTUtility.canSeeSunClearly(getWorld(), getPos()) ? 1.0 : 0.0, 114, 44, 20, 20,
                         GuiTextures.PROGRESS_BAR_SOLAR_STEAM.get(isHighPressure), MoveType.HORIZONTAL)
                 .build(getHolder(), entityPlayer);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        // Solar boilers do not display particles
     }
 }


### PR DESCRIPTION
**What:**
This PR adds particles to MetaTileEntities. It currently implements them for Steam machines, the Magic Energy Absorber, the PBF, and the Coke Oven.

**Implementation Details:**
The implementation uses minecraft's `randomDisplayTick` method in order to show the particles, which should not impact performance.

**Outcome:**
Added particles to various machines.