### PR TITLE
Allow Batteries to charge FE items

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
@@ -1,6 +1,7 @@
 package gregtech.api.items.metaitem;
 
 import gregtech.api.GTValues;
+import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.capability.impl.ElectricItem;
@@ -8,6 +9,7 @@ import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.metaitem.stats.IItemCapabilityProvider;
 import gregtech.api.items.metaitem.stats.IItemComponent;
 import gregtech.api.items.metaitem.stats.IItemMaxStackSizeProvider;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,6 +22,8 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -72,12 +76,23 @@ public class ElectricStats implements IItemComponent, IItemCapabilityProvider, I
             for (int i = 0; i < inventoryPlayer.getSizeInventory(); i++) {
                 ItemStack itemInSlot = inventoryPlayer.getStackInSlot(i);
                 IElectricItem slotElectricItem = itemInSlot.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
+                IEnergyStorage feEnergyItem = itemInSlot.getCapability(CapabilityEnergy.ENERGY, null);
                 if (slotElectricItem != null && !slotElectricItem.canProvideChargeExternally()) {
 
                     long chargedAmount = chargeElectricItem(transferLimit, electricItem, slotElectricItem);
                     if (chargedAmount > 0L) {
                         transferLimit -= chargedAmount;
                         if (transferLimit == 0L) break;
+                    }
+                }
+                else if(ConfigHolder.compat.energy.nativeEUToFE && feEnergyItem != null) {
+                    if(feEnergyItem.getEnergyStored() < feEnergyItem.getMaxEnergyStored()) {
+                       int energyMissing = feEnergyItem.getMaxEnergyStored() - feEnergyItem.getEnergyStored();
+                       long euToCharge = FeCompat.toEu(energyMissing, ConfigHolder.compat.energy.feToEuRatio);
+                       long energyToTransfer = Math.min(euToCharge, transferLimit);
+                       long maxDischargeAmount = Math.min(energyToTransfer, electricItem.discharge(energyToTransfer, electricItem.getTier(), false, true, true));
+                       FeCompat.insertEu(feEnergyItem, maxDischargeAmount);
+                       electricItem.discharge(maxDischargeAmount, electricItem.getTier(), false, true, false);
                     }
                 }
             }


### PR DESCRIPTION
**What:**
Allows batteries to charge FE items when the config is enabled and the batteries are in discharge mode. Closes #893 

**Outcome:**
Allows batteries to charge Forge Energy items when they are in discharge mode and the energy conversion config is enabled.
