### PR TITLE
Fix crash with distinct buses and no buses

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -310,7 +310,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     public boolean isDistinct() {
-        return isDistinct && (inputInventory.getSlots() + inputFluidInventory.getTanks() > 0);
+        return isDistinct && inputInventory.getSlots() > 0;
     }
 
     protected void toggleDistinct() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -310,7 +310,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     public boolean isDistinct() {
-        return isDistinct;
+        return isDistinct && inputInventory.getSlots() > 0;
     }
 
     protected void toggleDistinct() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -5,6 +5,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import com.google.common.collect.Lists;
 import gregtech.api.GTValues;
+import gregtech.api.block.VariantActiveBlock;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.EnergyContainerList;
@@ -21,7 +22,6 @@ import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockFireboxCasing;
-import gregtech.api.block.VariantActiveBlock;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
@@ -310,7 +310,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     public boolean isDistinct() {
-        return isDistinct;
+        return isDistinct && (inputInventory.getSlots() + inputFluidInventory.getTanks() > 0);
     }
 
     protected void toggleDistinct() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -182,7 +182,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 
-            if (canBeDistinct()) {
+            if (canBeDistinct() && inputInventory.getSlots() > 0) {
                 ITextComponent buttonText = new TextComponentTranslation("gregtech.multiblock.universal.distinct");
                 buttonText.appendText(" ");
                 ITextComponent button = AdvancedTextWidget.withButton(isDistinct() ?
@@ -310,7 +310,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     public boolean isDistinct() {
-        return isDistinct && inputInventory.getSlots() > 0;
+        return isDistinct;
     }
 
     protected void toggleDistinct() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -17,10 +17,10 @@ import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.sound.GTSounds;
-import gregtech.client.renderer.ICubeRenderer;
-import gregtech.client.renderer.texture.cube.OrientedOverlayRenderer;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
+import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
+import gregtech.client.renderer.texture.cube.OrientedOverlayRenderer;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
@@ -114,7 +114,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
     @Override
     public boolean canBeDistinct() {
-        return true;
+        return (inputInventory.getSlots() + inputFluidInventory.getTanks() > 0);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -114,7 +114,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
     @Override
     public boolean canBeDistinct() {
-        return (inputInventory.getSlots() + inputFluidInventory.getTanks() > 0);
+        return inputInventory.getSlots() > 0;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -114,7 +114,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
     @Override
     public boolean canBeDistinct() {
-        return inputInventory.getSlots() > 0;
+        return true;
     }
 
     @Override

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -328,6 +328,11 @@ public class MultiblockRecipeLogicTest {
 
                             }
 
+                            @Override
+                            public boolean isDistinct() {
+                                return true;
+                            }
+
                             // function checks for the temperature of the recipe against the coils
                             @Override
                             public boolean checkRecipe(@Nonnull Recipe recipe, boolean consumeIfSuccess) {
@@ -353,14 +358,6 @@ public class MultiblockRecipeLogicTest {
         }
 
         ((MetaTileEntityHolder) mbt.getHolder()).setWorld(world);
-
-        try {
-            Field field = RecipeMapMultiblockController.class.getDeclaredField("isDistinct");
-            field.setAccessible(true);
-            field.setBoolean(mbt, true);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
-        }
 
 
         //Controller and isAttachedToMultiBlock need the world so we fake it here.


### PR DESCRIPTION
**What:**
Fixes a crash that occurs when toggling distinct bus mode when there are no item or fluid inputs. Closes #1095 

This can currently only happen with the PA, as all other multiblocks that can be distinct have minimums of at least 1 for the item/fluid bus.

In addition, when the PA does not have any item or fluid input buses, the text in the GUI for toggling distinct mode is hidden.

**Outcome:**
Fixes a crash when toggling distinct buses in the PA with no item or fluid inputs.
