### PR TITLE
Prevent placing some blocks where they can't be placed

### DIFF
--- a/src/main/java/gregtech/api/pattern/BlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/BlockPattern.java
@@ -85,7 +85,7 @@ public class BlockPattern {
             }
         }
         if (centerOffset == null) {
-            throw new IllegalArgumentException("Didn't found center predicate");
+            throw new IllegalArgumentException("Didn't find center predicate");
         }
     }
 

--- a/src/main/java/gregtech/common/terminal/app/multiblockhelper/MachineBuilderWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/multiblockhelper/MachineBuilderWidget.java
@@ -18,6 +18,8 @@ import gregtech.api.terminal.os.TerminalTheme;
 import gregtech.api.util.BlockInfo;
 import gregtech.client.utils.RenderBufferHelper;
 import gregtech.common.inventory.handlers.CycleItemStackHandler;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockBush;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
@@ -37,7 +39,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created with IntelliJ IDEA.
@@ -186,7 +191,18 @@ public class MachineBuilderWidget extends WidgetGroup {
                     float hitX = pos.getX() + 0.5f;
                     float hitY = pos.getY() + 0.5f;
                     float hitZ = pos.getZ() + 0.5f;
-                    IBlockState state = itemBlock.getBlock().getStateFromMeta(itemBlock.getMetadata(itemStack.getMetadata()));
+                    Block block = itemBlock.getBlock();
+                    IBlockState state = block.getStateFromMeta(itemBlock.getMetadata(itemStack.getMetadata()));
+                    if(block instanceof BlockBush) {
+                        // Prevent placing lilypads, grass, etc where they should not be
+                        if(!((BlockBush) block).canBlockStay(world, offset, state)) {
+                            if(clickData.isClient) {
+                                TerminalDialogWidget.showInfoDialog(os, "terminal.component.error", "This Block cannot be placed here").setClientSide().open();
+                            }
+                            return;
+                        }
+                    }
+
                     itemBlock.placeBlockAt(itemStack, gui.entityPlayer, world, offset, facing, hitX, hitY, hitZ, state);
                     itemStack.shrink(1);
                 }

--- a/src/main/java/gregtech/common/terminal/app/multiblockhelper/MultiBlockPreviewARApp.java
+++ b/src/main/java/gregtech/common/terminal/app/multiblockhelper/MultiBlockPreviewARApp.java
@@ -76,7 +76,7 @@ public class MultiBlockPreviewARApp extends ARApplication {
 
     private void drawBuilderButton(double x, double y, int width, int height) {
         if (Shaders.allowedShader()) {
-            float time =(gui.entityPlayer.ticksExisted + partialTicks) / 20f;
+            float time = (gui.entityPlayer.ticksExisted + partialTicks) / 20f;
 
             MultiblockControllerBase controllerBase = getController();
             int color = controllerBase == null ? -1 : controllerBase.getPaintingColorForRendering();
@@ -131,7 +131,7 @@ public class MultiBlockPreviewARApp extends ARApplication {
     private void buildMode() {
         if (getAppTier() == 0) {
             TerminalDialogWidget.showInfoDialog(getOs(), "terminal.dialog.notice", "terminal.multiblock_ar.unlock").open();
-        } else if (getController() != null){
+        } else if (getController() != null) {
             widgets.forEach(this::waitToRemoved);
             MultiblockControllerBase controllerBase = getController();
             MachineBuilderWidget builderWidget = new MachineBuilderWidget(200, 16, 133, 200, controllerBase, getOs());


### PR DESCRIPTION
**What:**
Some changes to the Terminal Multiblock Helper App, specifically the builder part of the App.

First change, prevent placing blocks like lilypads, grass/tallgrass, etc where they cannot normally be placed, as brought up in #817 


**Outcome:**
Changes to the Multiblock builder App (description in progress)
