### PR TITLE
Fix RecipeMap Text Overlaps in JEI

### DIFF
--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -36,7 +36,6 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
     private final RecipeMap<?> recipeMap;
     private final Recipe recipe;
-    private String lastCopiedRemoval;
 
     public GTRecipeWrapper(RecipeMap<?> recipeMap, Recipe recipe) {
         this.recipeMap = recipeMap;
@@ -159,7 +158,6 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                     String copyString = output + recipeLine + "\n";
                     ClipboardUtil.copyToClipboard(copyString);
                     Minecraft.getMinecraft().player.sendMessage(new TextComponentString("Copied [\u00A76" + recipeLine + "\u00A7r] to the clipboard"));
-                    this.lastCopiedRemoval = copyString;
                     return true;
                 })
                 .setActiveSupplier(creativePlayerCtPredicate));

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -196,8 +196,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     }
 
     private static boolean shouldShiftWidgets(@Nonnull RecipeMap<?> recipeMap) {
-        return recipeMap.getMaxOutputs() >= 6 || recipeMap.getMaxInputs() >= 6 ||
-                recipeMap.getMaxFluidOutputs() >= 6 || recipeMap.getMaxFluidInputs() >= 6;
+        return recipeMap.getMaxInputs() + recipeMap.getMaxOutputs() >= 6 ||
+                recipeMap.getMaxFluidInputs() + recipeMap.getMaxFluidInputs() >= 6;
     }
 
     private static int getPropertyShiftAmount(@Nonnull RecipeMap<?> recipeMap) {

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -197,7 +197,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
 
     private static boolean shouldShiftWidgets(@Nonnull RecipeMap<?> recipeMap) {
         return recipeMap.getMaxInputs() + recipeMap.getMaxOutputs() >= 6 ||
-                recipeMap.getMaxFluidInputs() + recipeMap.getMaxFluidInputs() >= 6;
+                recipeMap.getMaxFluidInputs() + recipeMap.getMaxFluidOutputs() >= 6;
     }
 
     private static int getPropertyShiftAmount(@Nonnull RecipeMap<?> recipeMap) {


### PR DESCRIPTION
**What:**
Fixes information text overlapping RecipeMap slots in JEI. It was caused by not checking the combined fluid and item slot totals on each side of the progress bar, and instead checked them separately.

**Outcome:**
Fixes RecipeMap text overlaps in JEI.

**Additional info:**
This was caused by a RecipeMap with 2 item inputs, 4 fluid inputs, 2 item outputs, and 4 fluid outputs. Because the combined i/o amounts were not checked, overlaps occurred. This PR fixes this as the combined i/o totals are >= 6.
![image](https://user-images.githubusercontent.com/37029404/180916987-32a350e2-c245-47a9-9b2a-49dbd15da786.png)