### PR TITLE
Add Processing Array compatibility for Rock Breaker

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -955,9 +955,7 @@ public class GTUtility {
         }
 
         MetaTileEntity machine = getMetaTileEntity(machineStack);
-        // Blacklist the Rock Breaker here instead of through the config option so we don't get people removing the config entry and then
-        // complaining it does not work. Remove from here if we ever decide to implement PA Rock Breaker
-        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity || machine instanceof MetaTileEntityRockBreaker))
+        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity))
             return !findMachineInBlacklist(machine.getRecipeMap().getUnlocalizedName(), recipeMapBlacklist);
 
         return false;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityRockBreaker.java
@@ -42,7 +42,11 @@ public class MetaTileEntityRockBreaker extends SimpleMachineMetaTileEntity {
     }
 
     private void checkAdjacentFluids() {
-        if (getWorld() == null || getWorld().isRemote) {
+        if (getWorld() == null) {
+            hasValidFluids = true;
+            return;
+        }
+        if (getWorld().isRemote) {
             hasValidFluids = false;
             return;
         }


### PR DESCRIPTION
**What:**
Allows the Rock Breaker to be run in Processing Arrays.

**Implementation Details:**
If `getWorld()` returns null, the check for fluids simply returns true instead of false. In theory, this should also allow Rock Breaker recipes to run in other "virtual" environments.
Allows Rock Breaker to be put into Machine Access Interface.

Water and Lava are not required to run Rock Breaker recipes in PA for now. This should be fine considering the tier of the PA, but it could be implemented.

**Outcome:**
Allows Rock Breaker to be run in PA

**Possible compatibility issue:**
No
