### PR TITLE
Fix NPE with Ender Fluid Link Cover

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverEnderFluidLink.java
+++ b/src/main/java/gregtech/common/covers/CoverEnderFluidLink.java
@@ -119,6 +119,7 @@ public class CoverEnderFluidLink extends CoverBehavior implements CoverWithUI, I
 
     protected void transferFluids() {
         IFluidHandler fluidHandler = coverHolder.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, attachedSide);
+        if (fluidHandler == null) return;
         if (pumpMode == CoverPump.PumpMode.IMPORT) {
             GTTransferUtils.transferFluids(fluidHandler, linkedTank, TRANSFER_RATE, fluidFilter::testFluidStack);
         } else if (pumpMode == CoverPump.PumpMode.EXPORT) {


### PR DESCRIPTION
**What:**
Setting the output side of a machine where an Ender Fluid Link Cover will result in not returning fluid handler capability, however the code was still set to transfer fluid regardless, resulting in a Null Pointer Exception.

**Implementation Details:**
Null check

**Outcome:**
No crash