### PR TITLE
Add decomposition for some vanilla items

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -689,6 +689,7 @@ public class Materials {
     public static Material Amethyst;
     public static Material Lapis;
     public static Material Blaze;
+    public static Material Prismarine;
     public static Material Apatite;
     public static Material BlackSteel;
     public static Material DamascusSteel;

--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -638,6 +638,7 @@ public class Materials {
     public static Material Collagen;
     public static Material Gelatin;
     public static Material Agar;
+    public static Material Purpur;
     public static Material Andesite;
     public static Material Milk;
     public static Material Cocoa;

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -82,7 +82,13 @@ public class SecondDegreeMaterials {
                 .fluidTemp(4000)
                 .build();
 
-        // Free ID 2009
+        Prismarine = new Material.Builder(2009, "prismarine")
+                .gem(1)
+                .color(0x73B5AA).iconSet(FINE)
+                .flags(CRYSTALLIZABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, DISABLE_DECOMPOSITION, NO_WORKING)
+                .components(Pyrolusite, 1, BrownLimonite, 1, Water, 1)
+                .build()
+                .setFormula("(Fe,Mn)HO2(H2O)2", true);
 
         Apatite = new Material.Builder(2010, "apatite")
                 .gem(1).ore(4, 2)

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -317,7 +317,10 @@ public class UnknownCompositionMaterials {
                 .color(0x4F7942).iconSet(ROUGH)
                 .build();
 
-        // FREE ID 1609
+        Purpur = new Material.Builder(1609, "purpur")
+                .dust(1)
+                .color(0xA545A5)
+                .build();
 
         // FREE ID 1610
 

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -319,7 +319,7 @@ public class UnknownCompositionMaterials {
 
         Purpur = new Material.Builder(1609, "purpur")
                 .dust(1)
-                .color(0xA545A5)
+                .color(0xCC94CC).iconSet(FINE)
                 .build();
 
         // FREE ID 1610

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -282,6 +282,7 @@ public class OrePrefix {
         gem.setIgnored(Materials.Lapis);
         gem.setIgnored(Materials.NetherQuartz);
         gem.setIgnored(Materials.Coal);
+        gem.setIgnored(Materials.Prismarine);
 
         excludeAllGems(Materials.Charcoal);
         excludeAllGems(Materials.NetherStar);
@@ -296,6 +297,7 @@ public class OrePrefix {
         dust.setIgnored(Materials.Sugar);
         dust.setIgnored(Materials.Bone);
         dust.setIgnored(Materials.Blaze);
+        dust.setIgnored(Materials.Prismarine);
 
         stick.setIgnored(Materials.Wood);
         stick.setIgnored(Materials.Bone);
@@ -342,6 +344,7 @@ public class OrePrefix {
         block.setIgnored(Materials.Concrete);
         block.setIgnored(Materials.Blaze);
         block.setIgnored(Materials.Lapotron);
+        block.setIgnored(Materials.Prismarine);
 
         ore.addSecondaryMaterial(new MaterialStack(Materials.Stone, dust.materialAmount));
         oreNetherrack.addSecondaryMaterial(new MaterialStack(Materials.Netherrack, dust.materialAmount));
@@ -483,7 +486,8 @@ public class OrePrefix {
             if (material == Materials.Glowstone ||
                     material == Materials.NetherQuartz ||
                     material == Materials.Brick ||
-                    material == Materials.Clay)
+                    material == Materials.Clay ||
+                    material == Materials.Prismarine)
                 return M * 4;
                 //glass, ice and obsidian gain only one dust
             else if (material == Materials.Glass ||

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -314,6 +314,11 @@ public class MaterialInfoLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.COBBLESTONE_WALL, 1), new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
         OreDictUnifier.registerOre(new ItemStack(Items.END_CRYSTAL, 1), new ItemMaterialInfo(new MaterialStack(Materials.Glass, M * 7), new MaterialStack(Materials.EnderEye, M)));
 
+        OreDictUnifier.registerOre(new ItemStack(Blocks.PRISMARINE, 1, 1), new ItemMaterialInfo(new MaterialStack(Materials.Prismarine, M * 9)));
+        OreDictUnifier.registerOre(new ItemStack(Blocks.PRISMARINE, 1, 2), new ItemMaterialInfo(new MaterialStack(Materials.Prismarine, M * 8)));
+        OreDictUnifier.registerOre(new ItemStack(Blocks.SEA_LANTERN, 1), new ItemMaterialInfo(new MaterialStack(Materials.Prismarine, M * 9)));
+
+
         if (ConfigHolder.recipes.hardToolArmorRecipes) {
             OreDictUnifier.registerOre(new ItemStack(Items.CLOCK, 1, W), new ItemMaterialInfo
                     (new MaterialStack(Materials.Gold, (13 * M) / 8), // M + ring + 3 * bolt

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -314,6 +314,11 @@ public class MaterialInfoLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.COBBLESTONE_WALL, 1), new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
         OreDictUnifier.registerOre(new ItemStack(Items.END_CRYSTAL, 1), new ItemMaterialInfo(new MaterialStack(Materials.Glass, M * 7), new MaterialStack(Materials.EnderEye, M)));
 
+        OreDictUnifier.registerOre(new ItemStack(Items.CHORUS_FRUIT_POPPED, 1), new ItemMaterialInfo(new MaterialStack(Materials.Purpur, M)));
+        OreDictUnifier.registerOre(new ItemStack(Blocks.PURPUR_BLOCK, 1), new ItemMaterialInfo(new MaterialStack(Materials.Purpur, M)));
+        OreDictUnifier.registerOre(new ItemStack(Blocks.PURPUR_PILLAR, 1), new ItemMaterialInfo(new MaterialStack(Materials.Purpur, M)));
+        OreDictUnifier.registerOre(new ItemStack(Blocks.END_ROD, 1), new ItemMaterialInfo(new MaterialStack(Materials.Purpur, M / 4), new MaterialStack(Materials.Blaze, M)));
+
         OreDictUnifier.registerOre(new ItemStack(Blocks.PRISMARINE, 1, 1), new ItemMaterialInfo(new MaterialStack(Materials.Prismarine, M * 9)));
         OreDictUnifier.registerOre(new ItemStack(Blocks.PRISMARINE, 1, 2), new ItemMaterialInfo(new MaterialStack(Materials.Prismarine, M * 8)));
         OreDictUnifier.registerOre(new ItemStack(Blocks.SEA_LANTERN, 1), new ItemMaterialInfo(new MaterialStack(Materials.Prismarine, M * 9)));

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -1167,12 +1167,6 @@ public class VanillaStandardRecipes {
                 .duration(200).EUt(2).buildAndRegister();
 
         PACKER_RECIPES.recipeBuilder()
-                .inputs(new ItemStack(Items.PRISMARINE_SHARD, 4))
-                .notConsumable(new IntCircuitIngredient(4))
-                .outputs(new ItemStack(Blocks.PRISMARINE))
-                .duration(100).EUt(2).buildAndRegister();
-
-        PACKER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.PRISMARINE_SHARD, 9))
                 .notConsumable(new IntCircuitIngredient(9))
                 .outputs(new ItemStack(Blocks.PRISMARINE, 1, 1))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -215,6 +215,15 @@ public class SeparationRecipes {
                 .chancedOutput(dustSmall, Tantalite, 500, 130)
                 .buildAndRegister();
 
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
+                .input(dust, Prismarine)
+                .chancedOutput(dustSmall, Pyrolusite, 7500, 500)
+                .chancedOutput(dustSmall, BrownLimonite, 7500, 500)
+                .chancedOutput(dustSmall, CobaltOxide, 500, 100)
+                .chancedOutput(dustSmall, Garnierite, 500, 100)
+                .fluidOutputs(Water.getFluid(250))
+                .buildAndRegister();
+
         CENTRIFUGE_RECIPES.recipeBuilder().duration(64).EUt(20)
                 .input(dust, RareEarth)
                 .chancedOutput(dustSmall, Cadmium, 2500, 400)
@@ -319,15 +328,6 @@ public class SeparationRecipes {
                 .fluidInputs(SaltWater.getFluid(1000))
                 .output(dust, Salt, 2)
                 .fluidOutputs(Water.getFluid(1000))
-                .buildAndRegister();
-
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
-                .input(dust, Prismarine, 6)
-                .output(dust, Pyrolusite)
-                .output(dust, BrownLimonite)
-                .chancedOutput(dust, CobaltOxide, 500, 100)
-                .chancedOutput(dust, Garnierite, 500, 100)
-                .fluidOutputs(Water.getFluid(2000))
                 .buildAndRegister();
 
         // Electrolyzer

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -215,6 +215,17 @@ public class SeparationRecipes {
                 .chancedOutput(dustSmall, Tantalite, 500, 130)
                 .buildAndRegister();
 
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(100).EUt(80)
+                .inputs(new ItemStack(Blocks.MAGMA))
+                .chancedOutput(dust, SiliconDioxide, 9500, 150)
+                .chancedOutput(dustSmall, Obsidian, 6000, 150)
+                .chancedOutput(dustSmall, GarnetYellow, 5000, 130)
+                .chancedOutput(dustSmall, Pyrochlore, 500, 130)
+                .chancedOutput(dustTiny, Barite, 750, 50)
+                .chancedOutput(nugget, Gold, 250, 80)
+                .fluidOutputs(Lava.getFluid(250))
+                .buildAndRegister();
+
         CENTRIFUGE_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
                 .input(dust, Prismarine)
                 .chancedOutput(dustSmall, Pyrolusite, 7500, 500)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -239,8 +239,8 @@ public class SeparationRecipes {
                 .input(dust, Purpur)
                 .chancedOutput(dustSmall, Asbestos, 9500, 150)
                 .chancedOutput(dustSmall, Endstone, 3000, 125)
+                .chancedOutput(dustSmall, EnderPearl, 2000, 110)
                 .chancedOutput(dustTiny, Vanadium, 2000, 110)
-                .fluidOutputs(Naphtha.getFluid(40))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(64).EUt(20)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -235,6 +235,14 @@ public class SeparationRecipes {
                 .fluidOutputs(Water.getFluid(250))
                 .buildAndRegister();
 
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(60).EUt(VA[HV])
+                .input(dust, Purpur)
+                .chancedOutput(dustSmall, Asbestos, 9500, 150)
+                .chancedOutput(dustSmall, Endstone, 3000, 125)
+                .chancedOutput(dustTiny, Vanadium, 2000, 110)
+                .fluidOutputs(Naphtha.getFluid(75))
+                .buildAndRegister();
+
         CENTRIFUGE_RECIPES.recipeBuilder().duration(64).EUt(20)
                 .input(dust, RareEarth)
                 .chancedOutput(dustSmall, Cadmium, 2500, 400)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -321,6 +321,15 @@ public class SeparationRecipes {
                 .fluidOutputs(Water.getFluid(1000))
                 .buildAndRegister();
 
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(100).EUt(VA[MV])
+                .input(dust, Prismarine, 6)
+                .output(dust, Pyrolusite)
+                .output(dust, BrownLimonite)
+                .chancedOutput(dust, CobaltOxide, 500, 100)
+                .chancedOutput(dust, Garnierite, 500, 100)
+                .fluidOutputs(Water.getFluid(2000))
+                .buildAndRegister();
+
         // Electrolyzer
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .input(dust, SodiumBisulfate, 7)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -240,7 +240,7 @@ public class SeparationRecipes {
                 .chancedOutput(dustSmall, Asbestos, 9500, 150)
                 .chancedOutput(dustSmall, Endstone, 3000, 125)
                 .chancedOutput(dustTiny, Vanadium, 2000, 110)
-                .fluidOutputs(Naphtha.getFluid(75))
+                .fluidOutputs(Naphtha.getFluid(40))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(64).EUt(20)

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1789,6 +1789,7 @@ material.nitro_fuel=Cetane-Boosted Diesel
 material.collagen=Collagen
 material.gelatin=Gelatin
 material.agar=Agar
+material.purpur=Purpur
 material.andesite=Andesite
 material.milk=Milk
 material.cocoa=Cocoa

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1839,6 +1839,7 @@ material.opal=Opal
 material.amethyst=Amethyst
 material.lapis=Lapis
 material.blaze=Blaze
+material.prismarine=Prismarine
 material.apatite=Apatite
 material.black_steel=Black Steel
 material.damascus_steel=Damascus Steel

--- a/src/main/resources/assets/gregtech/lang/ja_jp.lang
+++ b/src/main/resources/assets/gregtech/lang/ja_jp.lang
@@ -1829,6 +1829,7 @@ material.opal=オパール
 material.amethyst=アメジスト
 material.lapis=ラピス
 material.blaze=ブレイズ
+material.prismarine=プリズマリン
 material.apatite=アパタイト
 material.black_steel=ブラックスチール
 material.damascus_steel=ダマスカススチール

--- a/src/main/resources/assets/gregtech/lang/ja_jp.lang
+++ b/src/main/resources/assets/gregtech/lang/ja_jp.lang
@@ -1778,6 +1778,7 @@ material.nitro_fuel=セタン価改質ディーゼル
 material.collagen=コラーゲン
 material.gelatin=ゼラチン
 material.agar=寒天
+material.purpur=プルプァ
 material.andesite=安山岩
 material.milk=牛乳
 material.cocoa=カカオ

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -2840,6 +2840,7 @@ material.gelatin_mixture=Желатиновая смесь
 material.collagen=Коллаген
 material.gelatin=Желатин
 material.agar=Агар
+material.purpur=Пурпурный
 material.uranium_hexafluoride=Гексафторид урана
 material.enriched_uranium_hexafluoride=Обогащенный гексафторид урана
 material.depleted_uranium_hexafluoride=Обедненный гексафторид урана

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -1229,6 +1229,7 @@ material.opal=Опал
 material.amethyst=Аметист
 material.lapis=Лазурит
 material.blaze=Огненный порошок
+material.prismarine=Призмарин
 material.ender_pearl=Жемчуг края
 material.ender_eye=Око Эндера
 material.flint=Кремень

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -1856,6 +1856,7 @@ material.gelatin_mixture=胶状诱变剂
 material.collagen=胶原蛋白
 material.gelatin=凝胶
 material.agar=琼脂
+material.purpur=紫珀
 
 material.uranium_hexafluoride=六氟化铀
 material.enriched_uranium_hexafluoride=浓缩六氟化铀

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -1734,6 +1734,7 @@ material.amethyst=紫水晶
 material.redstone=红石
 material.lapis=青金石
 material.blaze=烈焰
+material.prismarine=海晶石
 material.ender_pearl=末影珍珠
 material.ender_eye=末影之眼
 material.flint=燧石


### PR DESCRIPTION
**What:**
As requested in Discord, adds decomposition recipes for some vanilla items and materials.

**Implementation Details:**
Adds 2 new materials: Prismarine and Purpur (Popped Chorus), with decomposition recipes. Adds material compositions to the relevant items (Prismarine Shard, Prismarine Crystals, Prismarine (block), Dark Prismarine, Sea Lantern, Popped Chorus Fruit, Purpur Block, Purpur Pillar, End Rod) 
Adds a new Centrifuge recipe for Magma Blocks.

Translation keys for `ja_jp`, `ru_ru`, and `zh_cn` were taken from Minecraft Wiki.

By Forge default, Prismarine Crystals are oredicted to `dustPrismarine`. For maximum compatibility, that is simply used as the dust item.

**Outcome:**
Adds decomposition recipes for Magma Block, Purpur, and Prismarine.

**Additional info:**
In order: CoO 5% +1%; NiO 5% +1%; MnO₂ 75% +5%; FeHO₂ 75% +5%; Water
![image](https://user-images.githubusercontent.com/61507029/181921077-b9dc8c5f-4dd7-4141-9355-bbc0d7e8e141.png)

In order: Au 2.5% +0.8%; Ca₂Nb₂O₇ 5% +1.3%; BaSO₄ 7.5% +0.5%; Yellow Garnet 50% +1.3%; Obsidian 60% +1.5%; SiO₂ 95% +1.5%; Lava
![image](https://user-images.githubusercontent.com/61507029/181921142-47b6b8cc-7210-46f1-bdb1-da5c4aa4a224.png)

In order: V 20% +1.1%; Endstone 30% +1.25%; Asbestos 95% +1.5%; Naphtha
![image](https://user-images.githubusercontent.com/61507029/181922104-86e55f95-5a6d-4d0d-aa23-4f8dabf10db1.png)

**Possible compatibility issue:**
Material IDs 1609 and 2009 were used.
Magma blocks can be crafted using Blaze Powder + Slimeball resulting in "transmutation" of materials. However this is already present in Andesite/Diorite so it is not of concern IMO.