### PR TITLE
Log Errors in Material Related Logs Better

### DIFF
--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -55,9 +55,9 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     public void addCableMaterial(Material material, WireProperties wireProperties) {
-        Preconditions.checkNotNull(material, "material");
-        Preconditions.checkNotNull(wireProperties, "wireProperties");
-        Preconditions.checkArgument(GregTechAPI.MATERIAL_REGISTRY.getNameForObject(material) != null, "material is not registered");
+        Preconditions.checkNotNull(material, "material was null");
+        Preconditions.checkNotNull(wireProperties, "material %s wireProperties was null", material);
+        Preconditions.checkArgument(GregTechAPI.MATERIAL_REGISTRY.getNameForObject(material) != null, "material %s is not registered", material);
         if (!pipeType.orePrefix.isIgnored(material)) {
             this.enabledMaterials.put(material, wireProperties);
         }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -48,8 +48,8 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
 
     public void addPipeMaterial(Material material, FluidPipeProperties fluidPipeProperties) {
         Preconditions.checkNotNull(material, "material");
-        Preconditions.checkNotNull(fluidPipeProperties, "fluidPipeProperties");
-        Preconditions.checkArgument(GregTechAPI.MATERIAL_REGISTRY.getNameForObject(material) != null, "material is not registered");
+        Preconditions.checkNotNull(fluidPipeProperties, "material %s fluidPipeProperties was null", material);
+        Preconditions.checkArgument(GregTechAPI.MATERIAL_REGISTRY.getNameForObject(material) != null, "material %s is not registered", material);
         this.enabledMaterials.put(material, fluidPipeProperties);
     }
 

--- a/src/main/java/gregtech/common/pipelike/itempipe/BlockItemPipe.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/BlockItemPipe.java
@@ -44,8 +44,8 @@ public class BlockItemPipe extends BlockMaterialPipe<ItemPipeType, ItemPipePrope
 
     public void addPipeMaterial(Material material, ItemPipeProperties properties) {
         Preconditions.checkNotNull(material, "material");
-        Preconditions.checkNotNull(properties, "itemPipeProperties");
-        Preconditions.checkArgument(GregTechAPI.MATERIAL_REGISTRY.getNameForObject(material) != null, "material is not registered");
+        Preconditions.checkNotNull(properties, "material %s itemPipeProperties was null", material);
+        Preconditions.checkArgument(GregTechAPI.MATERIAL_REGISTRY.getNameForObject(material) != null, "material %s is not registered", material);
         this.enabledMaterials.put(material, properties);
     }
 


### PR DESCRIPTION
**What:**
This PR displays the problematic material in the log when errors occur during material related block creation.

**Outcome:**
Improves material related block error logging.