### PR TITLE
(WIP) Fix cable facades all black with Optifine shaders enabled

### DIFF
--- a/src/main/java/gregtech/client/model/pipeline/VertexLighterFlatSpecial.java
+++ b/src/main/java/gregtech/client/model/pipeline/VertexLighterFlatSpecial.java
@@ -1,0 +1,194 @@
+package gregtech.client.model.pipeline;
+
+import gregtech.client.shader.Shaders;
+import net.minecraft.client.renderer.color.BlockColors;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.renderer.vertex.VertexFormatElement;
+import net.minecraftforge.client.model.pipeline.LightUtil;
+import net.minecraftforge.client.model.pipeline.VertexLighterFlat;
+
+import javax.vecmath.Vector3f;
+import java.util.Objects;
+
+public class VertexLighterFlatSpecial extends VertexLighterFlat {
+
+    public int tint = -1;
+    public boolean diffuse = true;
+
+    public VertexLighterFlatSpecial(BlockColors colors) {
+        super(colors);
+    }
+
+    @Override
+    public void setVertexFormat(VertexFormat format) {
+
+        if (!Objects.equals(format, baseFormat)) {
+            baseFormat = format;
+
+            if (!format.hasNormal()) {
+                format = new VertexFormat(format).addElement(NORMAL_4F);
+            }
+
+            this.format = format;
+            dataLength = new byte[format.getElementCount()];
+            quadData = new float[format.getElementCount()][4][4];
+
+            updateIndices();
+        }
+
+    }
+
+    //This was copied over from VertexLighterFlat because it was private and thus inaccessible from this extended implementation
+    private void updateIndices() {
+        for (int i = 0; i < getVertexFormat().getElementCount(); i++) {
+            switch (getVertexFormat().getElement(i).getUsage()) {
+                case POSITION:
+                    posIndex = i;
+                    break;
+                case NORMAL:
+                    normalIndex = i;
+                    break;
+                case COLOR:
+                    colorIndex = i;
+                    break;
+                case UV:
+                    if (getVertexFormat().getElement(i).getIndex() == 1) {
+                        lightmapIndex = i;
+                    }
+                    break;
+                default:
+            }
+        }
+        if (posIndex == -1) {
+            throw new IllegalArgumentException("vertex lighter needs format with position");
+        }
+        if (lightmapIndex == -1) {
+            throw new IllegalArgumentException("vertex lighter needs format with lightmap");
+        }
+        if (colorIndex == -1) {
+            throw new IllegalArgumentException("vertex lighter needs format with color");
+        }
+    }
+
+    //This was copied over from VertexLighterFlat because it needed tweaks to the color handling
+    @Override
+    protected void processQuad() {
+
+        float[][] position = quadData[posIndex];
+        float[][] normal = null;
+        float[][] lightmap = quadData[lightmapIndex];
+        float[][] color = quadData[colorIndex];
+
+        if (dataLength[normalIndex] >= 3
+                && (quadData[normalIndex][0][0] != -1
+                || quadData[normalIndex][0][1] != -1
+                || quadData[normalIndex][0][2] != -1)) {
+            normal = quadData[normalIndex];
+        } else { // normals must be generated
+            normal = new float[4][4];
+            Vector3f v1 = new Vector3f(position[3]);
+            Vector3f t = new Vector3f(position[1]);
+            Vector3f v2 = new Vector3f(position[2]);
+            v1.sub(t);
+            t.set(position[0]);
+            v2.sub(t);
+            v1.cross(v2, v1);
+            v1.normalize();
+            for (int v = 0; v < 4; v++) {
+                normal[v][0] = v1.x;
+                normal[v][1] = v1.y;
+                normal[v][2] = v1.z;
+                normal[v][3] = 0;
+            }
+        }
+
+        int multiplier = 0xFFFFFFFF;//white
+        if (tint != -1) {
+            multiplier = blockInfo.getColorMultiplier(tint);
+        }
+
+        VertexFormat format = parent.getVertexFormat();
+        int count = format.getElementCount();
+
+        for (int v = 0; v < 4; v++) {
+            position[v][0] += blockInfo.getShx();
+            position[v][1] += blockInfo.getShy();
+            position[v][2] += blockInfo.getShz();
+
+            float x = position[v][0] - .5f;
+            float y = position[v][1] - .5f;
+            float z = position[v][2] - .5f;
+
+            x += normal[v][0] * .5f;
+            y += normal[v][1] * .5f;
+            z += normal[v][2] * .5f;
+
+            color[v][0] = color[v][1] = color[v][2] = color[v][3] = 1.0f;//Default to white
+
+            float blockLight = lightmap[v][0];
+            float skyLight = lightmap[v][1];
+            updateLightmap(normal[v], lightmap[v], x, y, z);
+            if (dataLength[lightmapIndex] > 1) {
+                if (blockLight > lightmap[v][0]) lightmap[v][0] = blockLight;
+                if (skyLight > lightmap[v][1]) lightmap[v][1] = skyLight;
+            }
+
+            updateColor(normal[v], color[v], x, y, z, tint, multiplier);
+
+            //When enabled this causes the rendering to be black with Optifine
+            if (!Shaders.isOptiFineShaderPackLoaded() && diffuse) {
+                float d = LightUtil.diffuseLight(normal[v][0], normal[v][1], normal[v][2]);
+                for (int i = 0; i < 3; i++) {
+                    color[v][i] *= d;
+                }
+            }
+
+            // no need for remapping cause all we could've done is add 1 element to the end
+            for (int e = 0; e < count; e++) {
+                VertexFormatElement element = format.getElement(e);
+                switch (element.getUsage()) {
+                    case POSITION:
+                        parent.put(e, position[v]);
+                        break;
+                    case NORMAL:
+                        if (normalIndex != -1) {
+                            parent.put(e, normal[v]);
+                            break;
+                        }
+                    case COLOR:
+                        //color[v][0] = color[v][1] = color[v][2] = color[v][3] = 1.0f;//Default to white
+                        parent.put(e, color[v]);
+                        break;
+                    case UV:
+                        if (element.getIndex() == 1) {
+                            parent.put(e, lightmap[v]);
+                            break;
+                        }
+                    default:
+                        parent.put(e, quadData[e][v]);
+                }
+            }
+        }
+        tint = -1;
+    }
+
+    //This was copied over from VertexLighterFlat because the tint parameter shouldn't be a float
+    protected void updateColor(float[] normal, float[] color, float x, float y, float z, int tint, int multiplier) {
+        if (tint != -1) {
+            color[0] *= (float) (multiplier >> 0x10 & 0xFF) / 0xFF;
+            color[1] *= (float) (multiplier >> 0x8 & 0xFF) / 0xFF;
+            color[2] *= (float) (multiplier & 0xFF) / 0xFF;
+        }
+    }
+
+    @Override
+    public void setQuadTint(int tint) {
+        this.tint = tint;
+    }
+
+    @Override
+    public void setApplyDiffuseLighting(boolean diffuse) {
+        this.diffuse = diffuse;
+    }
+
+}

--- a/src/main/java/gregtech/client/model/pipeline/VertexLighterSmoothAoSpecial.java
+++ b/src/main/java/gregtech/client/model/pipeline/VertexLighterSmoothAoSpecial.java
@@ -1,0 +1,157 @@
+package gregtech.client.model.pipeline;
+
+import gregtech.client.shader.Shaders;
+import net.minecraft.client.renderer.color.BlockColors;
+import net.minecraft.util.math.MathHelper;
+
+//This is a verbatim copy of VertexLighterSmoothAo except with a custom base class.
+//Ao Features are disabled when the shader is active.
+public class VertexLighterSmoothAoSpecial extends VertexLighterFlatSpecial {
+
+    public VertexLighterSmoothAoSpecial(BlockColors colors) {
+        super(colors);
+    }
+
+    @Override
+    protected void updateLightmap(float[] normal, float[] lightmap, float x, float y, float z) {
+        if (Shaders.isOptiFineShaderPackLoaded()) {
+            super.updateLightmap(normal, lightmap, x, y, z);
+            return;
+        }
+
+        lightmap[0] = calcLightmap(blockInfo.getBlockLight(), x, y, z);
+        lightmap[1] = calcLightmap(blockInfo.getSkyLight(), x, y, z);
+    }
+
+    @Override
+    protected void updateColor(float[] normal, float[] color, float x, float y, float z, float tint, int multiplier) {
+        super.updateColor(normal, color, x, y, z, tint, multiplier);
+
+        if (Shaders.isOptiFineShaderPackLoaded()) {
+            return;
+        }
+
+        float a = getAo(x, y, z);
+        color[0] *= a;
+        color[1] *= a;
+        color[2] *= a;
+    }
+
+    protected float calcLightmap(float[][][][] light, float x, float y, float z) {
+        x *= 2;
+        y *= 2;
+        z *= 2;
+        float l2 = x * x + y * y + z * z;
+        if (l2 > 6 - 2e-2f) {
+            float s = (float) Math.sqrt((6 - 2e-2f) / l2);
+            x *= s;
+            y *= s;
+            z *= s;
+        }
+        float ax = x > 0 ? x : -x;
+        float ay = y > 0 ? y : -y;
+        float az = z > 0 ? z : -z;
+        float e1 = 1 + 1e-4f;
+        if (ax > 2 - 1e-4f && ay <= e1 && az <= e1) {
+            x = x < 0 ? -2 + 1e-4f : 2 - 1e-4f;
+        } else if (ay > 2 - 1e-4f && az <= e1 && ax <= e1) {
+            y = y < 0 ? -2 + 1e-4f : 2 - 1e-4f;
+        } else if (az > 2 - 1e-4f && ax <= e1 && ay <= e1) {
+            z = z < 0 ? -2 + 1e-4f : 2 - 1e-4f;
+        }
+        ax = x > 0 ? x : -x;
+        ay = y > 0 ? y : -y;
+        az = z > 0 ? z : -z;
+        if (ax <= e1 && ay + az > 3f - 1e-4f) {
+            float s = (3f - 1e-4f) / (ay + az);
+            y *= s;
+            z *= s;
+        } else if (ay <= e1 && az + ax > 3f - 1e-4f) {
+            float s = (3f - 1e-4f) / (az + ax);
+            z *= s;
+            x *= s;
+        } else if (az <= e1 && ax + ay > 3f - 1e-4f) {
+            float s = (3f - 1e-4f) / (ax + ay);
+            x *= s;
+            y *= s;
+        } else if (ax + ay + az > 4 - 1e-4f) {
+            float s = (4 - 1e-4f) / (ax + ay + az);
+            x *= s;
+            y *= s;
+            z *= s;
+        }
+
+        float l = 0;
+        float s = 0;
+
+        for (int ix = 0; ix <= 1; ix++) {
+            for (int iy = 0; iy <= 1; iy++) {
+                for (int iz = 0; iz <= 1; iz++) {
+                    float vx = x * (1 - ix * 2);
+                    float vy = y * (1 - iy * 2);
+                    float vz = z * (1 - iz * 2);
+
+                    float s3 = vx + vy + vz + 4;
+                    float sx = vy + vz + 3;
+                    float sy = vz + vx + 3;
+                    float sz = vx + vy + 3;
+
+                    float bx = (2 * vx + vy + vz + 6) / (s3 * sy * sz * (vx + 2));
+                    s += bx;
+                    l += bx * light[0][ix][iy][iz];
+
+                    float by = (2 * vy + vz + vx + 6) / (s3 * sz * sx * (vy + 2));
+                    s += by;
+                    l += by * light[1][ix][iy][iz];
+
+                    float bz = (2 * vz + vx + vy + 6) / (s3 * sx * sy * (vz + 2));
+                    s += bz;
+                    l += bz * light[2][ix][iy][iz];
+                }
+            }
+        }
+
+        l /= s;
+
+        if (l > 15f * 0x20 / 0xFFFF) l = 15f * 0x20 / 0xFFFF;
+        if (l < 0) l = 0;
+
+        return l;
+    }
+
+    protected float getAo(float x, float y, float z) {
+        int sx = x < 0 ? 1 : 2;
+        int sy = y < 0 ? 1 : 2;
+        int sz = z < 0 ? 1 : 2;
+
+        if (x < 0) x++;
+        if (y < 0) y++;
+        if (z < 0) z++;
+
+        float a = 0;
+        float[][][] ao = blockInfo.getAo();
+        a += ao[sx - 1][sy - 1][sz - 1] * (1 - x) * (1 - y) * (1 - z);
+        a += ao[sx - 1][sy - 1][sz - 0] * (1 - x) * (1 - y) * (0 + z);
+        a += ao[sx - 1][sy - 0][sz - 1] * (1 - x) * (0 + y) * (1 - z);
+        a += ao[sx - 1][sy - 0][sz - 0] * (1 - x) * (0 + y) * (0 + z);
+        a += ao[sx - 0][sy - 1][sz - 1] * (0 + x) * (1 - y) * (1 - z);
+        a += ao[sx - 0][sy - 1][sz - 0] * (0 + x) * (1 - y) * (0 + z);
+        a += ao[sx - 0][sy - 0][sz - 1] * (0 + x) * (0 + y) * (1 - z);
+        a += ao[sx - 0][sy - 0][sz - 0] * (0 + x) * (0 + y) * (0 + z);
+
+        a = MathHelper.clamp(a, 0, 1);
+        return a;
+    }
+
+    @Override
+    public void updateBlockInfo() {
+        if (Shaders.isOptiFineShaderPackLoaded()) {
+            super.updateBlockInfo();
+            return;
+        }
+
+        blockInfo.updateShift();
+        blockInfo.updateLightMatrix();
+    }
+
+}

--- a/src/main/java/gregtech/client/renderer/handler/FacadeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/FacadeRenderer.java
@@ -14,6 +14,8 @@ import com.google.common.cache.CacheBuilder;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.util.ModCompatibility;
+import gregtech.client.model.pipeline.VertexLighterFlatSpecial;
+import gregtech.client.model.pipeline.VertexLighterSmoothAoSpecial;
 import gregtech.client.utils.AdvCCRSConsumer;
 import gregtech.client.utils.FacadeBlockAccess;
 import gregtech.common.covers.facade.FacadeHelper;
@@ -37,7 +39,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.model.pipeline.VertexLighterFlat;
-import net.minecraftforge.client.model.pipeline.VertexLighterSmoothAo;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -61,8 +62,8 @@ public class FacadeRenderer implements IItemRenderer {
     private final static float FACADE_RENDER_OFFSET = 2.0f / 512.0f;
     private final static float FACADE_RENDER_OFFSET2 = 1 - FACADE_RENDER_OFFSET;
 
-    public static final ThreadLocal<VertexLighterFlat> lighterFlat = ThreadLocal.withInitial(() -> new VertexLighterFlat(Minecraft.getMinecraft().getBlockColors()));
-    public static final ThreadLocal<VertexLighterFlat> lighterSmooth = ThreadLocal.withInitial(() -> new VertexLighterSmoothAo(Minecraft.getMinecraft().getBlockColors()));
+    public static final ThreadLocal<VertexLighterFlat> lighterFlat = ThreadLocal.withInitial(() -> new VertexLighterFlatSpecial(Minecraft.getMinecraft().getBlockColors()));
+    public static final ThreadLocal<VertexLighterFlat> lighterSmooth = ThreadLocal.withInitial(() -> new VertexLighterSmoothAoSpecial(Minecraft.getMinecraft().getBlockColors()));
 
     public static final Cache<String, List<CCQuad>> itemQuadCache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build();
 


### PR DESCRIPTION
**What:**
This PR tries to fix cable facades all black when Optifine shaders are enabled (even the "internal" ones). 

**Implementation Details:**
I've found a problem with quad normals when rendering facade quads being zeroed. I've applied normals from facing direction and this fixes the issue. Note that this may be not proper fix in terms of minecraft rendering practices, as I don't have deep understanding of it. Therefore, someone more knowledgeable may spend time to review the fix. If possible, please do it.

**Outcome:**
Facades have proper textures now. See images.

**Additional info:**
Before/after:
![изображение](https://user-images.githubusercontent.com/6342849/182667592-758cf1d9-2a88-4d40-a83a-ff8ddbd2d22e.png)
![изображение](https://user-images.githubusercontent.com/6342849/182667609-251dd0c1-4b08-4ab2-9682-ea19a7be6e48.png)
