### PR TITLE
Apply Recycling voltage multiplier to magnetic materials if applicable

### DIFF
--- a/src/main/java/gregtech/api/unification/material/properties/IngotProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/IngotProperty.java
@@ -33,6 +33,10 @@ public class IngotProperty implements IMaterialProperty<IngotProperty> {
         this.smeltInto = smeltInto;
     }
 
+    public Material getSmeltingInto() {
+        return this.smeltInto;
+    }
+
     public void setArcSmeltingInto(Material arcSmeltingInto) {
         this.arcSmeltInto = arcSmeltingInto;
     }

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -290,6 +290,12 @@ public class RecyclingRecipes {
                     highestTemp = prop.getBlastTemperature();
                 }
             }
+            else if(m.hasFlag(IS_MAGNETIC) && m.hasProperty(PropertyKey.INGOT) && m.getProperty(PropertyKey.INGOT).getSmeltingInto().hasProperty(PropertyKey.BLAST)) {
+                BlastProperty prop = m.getProperty(PropertyKey.INGOT).getSmeltingInto().getProperty(PropertyKey.BLAST);
+                if (prop.getBlastTemperature() > highestTemp) {
+                    highestTemp = prop.getBlastTemperature();
+                }
+            }
         }
 
         // No blast temperature in the list means no multiplier


### PR DESCRIPTION
**What:**
This PR makes the voltage multiplier for recycling recipes also be applied to magnetic materials, if it would be applied to the non-magnetic versions of the material.

This is done because of possible progression skips, where previously you could have made steel, made it into magnetic steel, fluid extracted it at LV to get steel fluid, and then use cheaper recipes for steel components in the fluid solidifier.

I really want some nice way to go from magnetic material -> non magnetic material without having to jump through all these hoops.

**Outcome:**
Apply voltage multiplier for recycling recipes to magnetic materials if the multiplier would also be applied to the non-magnetic version.
