### PR TITLE
Fix doubled tanks in TOP for Multi-Fluid Hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -173,7 +173,7 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
 
     @Override
     protected FluidTankList createExportFluidHandler() {
-        return new FluidTankList(false, fluidTanks);
+        return isExportHatch ? new FluidTankList(false, fluidTanks) : new FluidTankList(false);
     }
 
     @Override
@@ -183,7 +183,7 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
 
     @Override
     public void registerAbilities(List<IFluidTank> abilityList) {
-        abilityList.addAll(isExportHatch ? this.exportFluids.getFluidTanks() : this.importFluids.getFluidTanks());
+        abilityList.addAll(fluidTanks.getFluidTanks());
     }
 
     @Override
@@ -196,7 +196,7 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
         for (int y = 0; y < rowSize; y++) {
             for (int x = 0; x < rowSize; x++) {
                 int index = y * rowSize + x;
-                builder.widget(new TankWidget(isExportHatch ? exportFluids.getTankAt(index) : importFluids.getTankAt(index), 89 - rowSize * 9 + x * 18, 18 + y * 18, 18, 18)
+                builder.widget(new TankWidget(fluidTanks.getTankAt(index), 89 - rowSize * 9 + x * 18, 18 + y * 18, 18, 18)
                         .setBackgroundTexture(GuiTextures.FLUID_SLOT)
                         .setContainerClicking(true, !isExportHatch)
                         .setAlwaysShowFull(true));


### PR DESCRIPTION
**What:**
Fixes doubled tanks showing in TOP for Multi-Fluid hatches. Closes #1085.

Basically just takes dan's implementation for single tank hatches from #1017 since I think he forgot the multi fluid tanks.

**Outcome:**
Fixes showing doubled tanks in TOP for Multi Fluid Hatches
