### PR TITLE
Fix a NPE when clicking on unpowered Central Monitor

### DIFF
--- a/src/main/java/gregtech/api/gui/UIFactory.java
+++ b/src/main/java/gregtech/api/gui/UIFactory.java
@@ -34,6 +34,11 @@ public abstract class UIFactory<E extends IUIHolder> {
             return;
         }
         ModularUI uiTemplate = createUITemplate(holder, player);
+
+        if(uiTemplate == null) {
+            // Central monitor Screen can return null if clicked when not powered, maybe other multis too
+            return;
+        }
         uiTemplate.initWidgets();
 
         player.getNextWindowId();


### PR DESCRIPTION
**What:**
Fixes an NPE that occurs when attempting to open the GUI of an unpowered, formed Central Monitor.

**Implementation Details:**
I think this is safe?

**Outcome:**
Fixes NPE when attempting to open GUI of unpowered Central Monitor
