### PR TITLE
Fix Addon Recipe Removal and Addition Bug

### DIFF
--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -39,6 +39,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
@@ -350,14 +351,17 @@ public class ModHandler {
                             .collect(Collectors.joining(", ")));
             GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
             skip = true;
-        } else if (ForgeRegistries.RECIPES.containsKey(new ResourceLocation(GTValues.MODID, regName))) {
-            GTLog.logger.error("Tried to register recipe, {}, with duplicate key. Recipe: {}", regName,
-                    Arrays.stream(recipe)
-                            .map(Object::toString)
-                            .map(s -> "\"" + s + "\"")
-                            .collect(Collectors.joining(", ")));
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
-            skip = true;
+        } else {
+            ModContainer container = Loader.instance().activeModContainer();
+            if (ForgeRegistries.RECIPES.containsKey(new ResourceLocation(container == null ? GTValues.MODID : container.getModId().toLowerCase(), regName))) {
+                GTLog.logger.error("Tried to register recipe, {}, with duplicate key. Recipe: {}", regName,
+                        Arrays.stream(recipe)
+                                .map(Object::toString)
+                                .map(s -> "\"" + s + "\"")
+                                .collect(Collectors.joining(", ")));
+                GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                skip = true;
+            }
         }
         return skip;
     }


### PR DESCRIPTION
**What:**
As an addon, attempting to remove a recipe registered with the `gregtech` modid, and then adding a recipe with the addon modid and same recipe name will fail.

Code Example:
```java
// remove the GTCEu recipe, which replaces it with a dummy recipe under the same modid and registry name
ModHandler.removeRecipeByName("gregtech:casing_uhv");

// add a new recipe, as an addon, with the same recipe name but different modid.
ModHandler.addShapedRecipe(true, "casing_uhv", MetaBlocks.MACHINE_CASING.getItemVariant(BlockMachineCasing.MachineCasingType.UHV),
                "PPP", "PwP", "PPP",
                'P', new UnificationEntry(plate, Neutronium));
```

**Implementation Details:**
When checking for adding duplicate recipes, ModHandler assumes the recipe added will be under the `gregtech` modid, instead of the modid the recipe is being registered under. This means the dummy recipe used to remove the old recipe is considered a duplicate of the new recipe, as the name is the same and it is being checked as if both were using the gregtech modid. With this change, the modids will be different, so it will not be considered a duplicate.

**Outcome:**
Fixes problems with addons removing and adding recipes with the same name.