### PR TITLE
Fix zh_cn.lang pipe transfer rate unit

### DIFF
--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -4779,7 +4779,7 @@ gregtech.cable.amperage=最大安培: §e%d
 gregtech.cable.loss_per_block=线损: §c%d§7 EU-V
 gregtech.cable.superconductor=§d%s 超导体
 
-gregtech.fluid_pipe.throughput=§9传输效率: %,d L/s
+gregtech.fluid_pipe.throughput=§9传输效率: %,d L/t
 gregtech.fluid_pipe.capacity=§9内容物: %,d L
 gregtech.fluid_pipe.max_temperature=§c温度范围: %,d K
 gregtech.fluid_pipe.channels=§ee频道: %d


### PR DESCRIPTION
**What:**
The fluid pipe transfer rate unit in zh_cn (L/s) was outdated (in en_us, this should be L/t). This PR fixes the unit.

**Implementation Details:**
A character of change,

**Outcome:**
buff the pipes 20 times XD.