### PR TITLE
extend ShapedOreRecipe along with implementing a fluid ingredient for crafting recipes

### DIFF
--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -19,6 +19,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -77,6 +79,19 @@ public class MachineItemBlock extends ItemBlock {
     public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(stack);
         return metaTileEntity == null ? null : metaTileEntity.initItemStackCapabilities(stack);
+    }
+
+    @Override
+    public boolean hasContainerItem(ItemStack stack) {
+        return stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null) != null;
+    }
+
+    @Override
+    public @Nonnull ItemStack getContainerItem(@Nonnull ItemStack itemStack) {
+        if (!hasContainerItem(itemStack)) {
+            return ItemStack.EMPTY;
+        }
+        return itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null).getContainer().copy();
     }
 
     @Override

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.relauncher.Side;
@@ -95,7 +96,10 @@ public class MachineItemBlock extends ItemBlock {
             IFluidHandlerItem handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null) != null) {
                 if (handler != null) {
-                    handler.drain(1000, true);
+                    FluidStack drained = handler.drain(1000, true);
+                    if (drained == null || drained.amount != 1000) {
+                        return ItemStack.EMPTY;
+                    }
                     return handler.getContainer().copy();
                 }
             }

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -94,17 +94,15 @@ public class MachineItemBlock extends ItemBlock {
         }
         if (itemStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
             IFluidHandlerItem handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
-            if (itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null) != null) {
-                if (handler != null) {
-                    FluidStack drained = handler.drain(1000, true);
-                    if (drained == null || drained.amount != 1000) {
-                        return ItemStack.EMPTY;
-                    }
-                    return handler.getContainer().copy();
+            if (handler != null) {
+                FluidStack drained = handler.drain(1000, true);
+                if (drained == null || drained.amount != 1000) {
+                    return ItemStack.EMPTY;
                 }
+                return handler.getContainer().copy();
             }
         }
-        return itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null).getContainer().copy();
+        return ItemStack.EMPTY;
     }
 
     @Override

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -91,6 +91,15 @@ public class MachineItemBlock extends ItemBlock {
         if (!hasContainerItem(itemStack)) {
             return ItemStack.EMPTY;
         }
+        if (itemStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+            IFluidHandlerItem handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+            if (itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null) != null) {
+                if (handler != null) {
+                    handler.drain(1000, true);
+                    return handler.getContainer().copy();
+                }
+            }
+        }
         return itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null).getContainer().copy();
     }
 

--- a/src/main/java/gregtech/api/items/metaitem/stats/ItemFluidContainer.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/ItemFluidContainer.java
@@ -1,0 +1,21 @@
+package gregtech.api.items.metaitem.stats;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+public class ItemFluidContainer implements IItemContainerItemProvider {
+    @Override
+    public ItemStack getContainerItem(ItemStack itemStack) {
+        IFluidHandlerItem handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (handler != null) {
+            FluidStack drained = handler.drain(1000, false);
+            if (drained == null) return ItemStack.EMPTY;
+            if (drained.amount == 1000) {
+                return handler.getContainer();
+            }
+        }
+        return itemStack;
+    }
+}

--- a/src/main/java/gregtech/api/items/metaitem/stats/ItemFluidContainer.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/ItemFluidContainer.java
@@ -11,10 +11,8 @@ public class ItemFluidContainer implements IItemContainerItemProvider {
         IFluidHandlerItem handler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
         if (handler != null) {
             FluidStack drained = handler.drain(1000, false);
-            if (drained == null) return ItemStack.EMPTY;
-            if (drained.amount == 1000) {
-                return handler.getContainer();
-            }
+            if (drained == null || drained.amount != 1000) return ItemStack.EMPTY;
+            return handler.getContainer();
         }
         return itemStack;
     }

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -21,7 +21,10 @@ import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.ShapedOreEnergyTransferRecipe;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.ConfigHolder;
+import gregtech.common.crafting.GTShapedNBTClearingOreRecipe;
 import gregtech.common.crafting.GTShapedOreRecipe;
+import gregtech.common.crafting.GTShapelessNBTClearingOreRecipe;
+import gregtech.common.crafting.GTShapelessOreRecipe;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.inventory.InventoryCrafting;
@@ -250,7 +253,7 @@ public class ModHandler {
             return;
         }
 
-        IRecipe shapedOreRecipe = new ShapedOreRecipe(new ResourceLocation(GTValues.MODID, "general"), result.copy(), finalizeShapedRecipeInput(recipe))
+        IRecipe shapedOreRecipe = new GTShapedOreRecipe(new ResourceLocation(GTValues.MODID, "general"), result.copy(), finalizeShapedRecipeInput(recipe))
                 .setMirrored(true)
                 .setRegistryName(regName);
         ForgeRegistries.RECIPES.register(shapedOreRecipe);
@@ -288,10 +291,18 @@ public class ModHandler {
      * </ul>
      */
     public static void addShapedRecipe(String regName, ItemStack result, Object... recipe) {
-        addShapedRecipe(false, regName, result, recipe);
+        addShapedRecipe(false, regName, result, false, recipe);
+    }
+
+    public static void addShapedNBTClearingRecipe(String regName, ItemStack result, Object... recipe) {
+        addShapedRecipe(false, regName, result, true, recipe);
     }
 
     public static void addShapedRecipe(boolean withUnificationData, String regName, ItemStack result, Object... recipe) {
+        addShapedRecipe(withUnificationData, regName, result, false, recipe);
+    }
+
+    public static void addShapedRecipe(boolean withUnificationData, String regName, ItemStack result, boolean isNBTClearing, Object... recipe) {
         boolean skip = false;
         if (result.isEmpty()) {
             GTLog.logger.error("Result cannot be an empty ItemStack. Recipe: {}", regName);
@@ -304,12 +315,20 @@ public class ModHandler {
             return;
         }
 
-        IRecipe shapedOreRecipe = new GTShapedOreRecipe(null, result.copy(), finalizeShapedRecipeInput(recipe))
-                .setMirrored(false) //make all recipes not mirrored by default
-                .setRegistryName(regName);
+        IRecipe shapedOreRecipe;
+        if (isNBTClearing) {
+            shapedOreRecipe = new GTShapedNBTClearingOreRecipe(null, result.copy(), finalizeShapedRecipeInput(recipe))
+                    .setMirrored(false) //make all recipes not mirrored by default
+                    .setRegistryName(regName);
+        } else {
+            shapedOreRecipe = new GTShapedOreRecipe(null, result.copy(), finalizeShapedRecipeInput(recipe))
+                    .setMirrored(false) //make all recipes not mirrored by default
+                    .setRegistryName(regName);
+        }
         ForgeRegistries.RECIPES.register(shapedOreRecipe);
 
-        if (withUnificationData) OreDictUnifier.registerOre(result, getRecyclingIngredients(result.getCount(), recipe));
+        if (withUnificationData)
+            OreDictUnifier.registerOre(result, getRecyclingIngredients(result.getCount(), recipe));
     }
 
     public static void addShapedEnergyTransferRecipe(String regName, ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, Object... recipe) {
@@ -492,7 +511,16 @@ public class ModHandler {
     /**
      * Add Shapeless Crafting Recipes
      */
+
     public static void addShapelessRecipe(String regName, ItemStack result, Object... recipe) {
+        addShapelessRecipe(regName, result, false, recipe);
+    }
+
+    public static void addShapelessNBTClearingRecipe(String regName, ItemStack result, Object... recipe) {
+        addShapelessRecipe(regName, result, true, recipe);
+    }
+
+    public static void addShapelessRecipe(String regName, ItemStack result, boolean isNBTClearing, Object... recipe) {
         boolean skip = false;
         if (result.isEmpty()) {
             GTLog.logger.error("Result cannot be an empty ItemStack. Recipe: {}", regName);
@@ -527,9 +555,14 @@ public class ModHandler {
                 throw new IllegalArgumentException(recipe.getClass().getSimpleName() + " type is not suitable for crafting input.");
             }
         }
-
-        IRecipe shapelessRecipe = new ShapelessOreRecipe(null, result.copy(), recipe)
-                .setRegistryName(regName);
+        IRecipe shapelessRecipe;
+        if (isNBTClearing) {
+            shapelessRecipe = new GTShapelessNBTClearingOreRecipe(null, result.copy(), recipe)
+                    .setRegistryName(regName);
+        } else {
+            shapelessRecipe = new GTShapelessOreRecipe(null, result.copy(), recipe)
+                    .setRegistryName(regName);
+        }
 
         try {
             //workaround for MC bug that makes all shaped recipe inputs that have enchanted items

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -21,6 +21,7 @@ import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.ShapedOreEnergyTransferRecipe;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.ConfigHolder;
+import gregtech.common.crafting.GTShapedOreRecipe;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.inventory.InventoryCrafting;
@@ -303,7 +304,7 @@ public class ModHandler {
             return;
         }
 
-        IRecipe shapedOreRecipe = new ShapedOreRecipe(null, result.copy(), finalizeShapedRecipeInput(recipe))
+        IRecipe shapedOreRecipe = new GTShapedOreRecipe(null, result.copy(), finalizeShapedRecipeInput(recipe))
                 .setMirrored(false) //make all recipes not mirrored by default
                 .setRegistryName(regName);
         ForgeRegistries.RECIPES.register(shapedOreRecipe);

--- a/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
+++ b/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
@@ -1,0 +1,37 @@
+package gregtech.common.crafting;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+import javax.annotation.Nullable;
+
+public class GTFluidCraftingIngredient extends Ingredient {
+    private final FluidStack fluidStack;
+
+    GTFluidCraftingIngredient(ItemStack... stacks) {
+        super(stacks);
+        this.fluidStack = stacks[0].getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null).drain(Integer.MAX_VALUE, false);
+    }
+
+    @Override
+    public boolean apply(@Nullable ItemStack testedStack) {
+            IFluidHandlerItem handler = null;
+            if (testedStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+                handler = testedStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+            }
+            if (handler != null) {
+                FluidStack drained = handler.drain(fluidStack, false);
+                if (drained != null && drained.amount >= fluidStack.amount) {
+                    return drained.isFluidEqual(fluidStack);
+                }
+            }
+        return false;
+    }
+
+    public FluidStack getFluidStack() {
+        return fluidStack;
+    }
+}

--- a/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
+++ b/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
@@ -18,16 +18,17 @@ public class GTFluidCraftingIngredient extends Ingredient {
 
     @Override
     public boolean apply(@Nullable ItemStack testedStack) {
-            IFluidHandlerItem handler = null;
-            if (testedStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
-                handler = testedStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        IFluidHandlerItem handler = null;
+        if (testedStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+            handler = testedStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        }
+        if (handler != null) {
+            if (fluidStack == null || fluidStack.amount == 0) return true;
+            FluidStack drained = handler.drain(fluidStack, false);
+            if (drained != null && drained.amount >= fluidStack.amount) {
+                return drained.isFluidEqual(fluidStack);
             }
-            if (handler != null) {
-                FluidStack drained = handler.drain(fluidStack, false);
-                if (drained != null && drained.amount >= fluidStack.amount) {
-                    return drained.isFluidEqual(fluidStack);
-                }
-            }
+        }
         return false;
     }
 

--- a/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
+++ b/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
@@ -13,11 +13,17 @@ public class GTFluidCraftingIngredient extends Ingredient {
 
     GTFluidCraftingIngredient(ItemStack... stacks) {
         super(stacks);
-        this.fluidStack = stacks[0].getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null).drain(Integer.MAX_VALUE, false);
+        IFluidHandlerItem handler = stacks[0].getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (handler != null) {
+            this.fluidStack = stacks[0].getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null).drain(Integer.MAX_VALUE, false);
+        } else {
+            throw new IllegalArgumentException("The ItemStack " + stacks[0] + " has no FLUID_HANDLER_ITEM_CAPABILITY!");
+        }
     }
 
     @Override
     public boolean apply(@Nullable ItemStack testedStack) {
+        if (testedStack == null || testedStack.isEmpty()) return false;
         IFluidHandlerItem handler = null;
         if (testedStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
             handler = testedStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);

--- a/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
+++ b/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
@@ -23,7 +23,6 @@ public class GTFluidCraftingIngredient extends Ingredient {
             handler = testedStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
         }
         if (handler != null) {
-            if (fluidStack == null || fluidStack.amount == 0) return true;
             FluidStack drained = handler.drain(fluidStack, false);
             if (drained != null && drained.amount >= fluidStack.amount) {
                 return drained.isFluidEqual(fluidStack);

--- a/src/main/java/gregtech/common/crafting/GTShapedNBTClearingOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapedNBTClearingOreRecipe.java
@@ -1,0 +1,19 @@
+package gregtech.common.crafting;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nonnull;
+
+public class GTShapedNBTClearingOreRecipe extends GTShapedOreRecipe {
+    public GTShapedNBTClearingOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+        super(group, result, recipe);
+    }
+
+    @Override
+    public @Nonnull NonNullList<ItemStack> getRemainingItems(@Nonnull InventoryCrafting inv) {
+        return NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+    }
+}

--- a/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
@@ -1,0 +1,193 @@
+package gregtech.common.crafting;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.UniversalBucket;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.OreIngredient;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Set;
+
+public class GTShapedOreRecipe extends ShapedOreRecipe {
+
+
+    public GTShapedOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+        super(group, result, parseShaped(recipe));
+    }
+
+    //a copy of the CraftingHelper.ShapedPrimer.parseShaped method.
+    //the on difference is calling getIngredient of this class.
+
+    public static CraftingHelper.ShapedPrimer parseShaped(Object... recipe)
+    {
+        CraftingHelper.ShapedPrimer ret = new CraftingHelper.ShapedPrimer();
+        String shape = "";
+        int idx = 0;
+
+        if (recipe[idx] instanceof Boolean)
+        {
+            ret.mirrored = (Boolean)recipe[idx];
+            if (recipe[idx+1] instanceof Object[])
+                recipe = (Object[])recipe[idx+1];
+            else
+                idx = 1;
+        }
+
+        if (recipe[idx] instanceof String[])
+        {
+            String[] parts = ((String[])recipe[idx++]);
+
+            for (String s : parts)
+            {
+                ret.width = s.length();
+                shape += s;
+            }
+
+            ret.height = parts.length;
+        }
+        else
+        {
+            while (recipe[idx] instanceof String)
+            {
+                String s = (String)recipe[idx++];
+                shape += s;
+                ret.width = s.length();
+                ret.height++;
+            }
+        }
+
+        if (ret.width * ret.height != shape.length() || shape.length() == 0)
+        {
+            String err = "Invalid shaped recipe: ";
+            for (Object tmp :  recipe)
+            {
+                err += tmp + ", ";
+            }
+            throw new RuntimeException(err);
+        }
+
+        HashMap<Character, Ingredient> itemMap = Maps.newHashMap();
+        itemMap.put(' ', Ingredient.EMPTY);
+
+        for (; idx < recipe.length; idx += 2)
+        {
+            Character chr = (Character)recipe[idx];
+            Object in = recipe[idx + 1];
+            Ingredient ing = getIngredient(in);
+
+            if (' ' == chr.charValue())
+                throw new JsonSyntaxException("Invalid key entry: ' ' is a reserved symbol.");
+
+            if (ing != null)
+            {
+                itemMap.put(chr, ing);
+            }
+            else
+            {
+                String err = "Invalid shaped ore recipe: ";
+                for (Object tmp :  recipe)
+                {
+                    err += tmp + ", ";
+                }
+                throw new RuntimeException(err);
+            }
+        }
+
+        ret.input = NonNullList.withSize(ret.width * ret.height, Ingredient.EMPTY);
+
+        Set<Character> keys = Sets.newHashSet(itemMap.keySet());
+        keys.remove(' ');
+
+        int x = 0;
+        for (char chr : shape.toCharArray())
+        {
+            Ingredient ing = itemMap.get(chr);
+            if (ing == null)
+                throw new IllegalArgumentException("Pattern references symbol '" + chr + "' but it's not defined in the key");
+            ret.input.set(x++, ing);
+            keys.remove(chr);
+        }
+
+        if (!keys.isEmpty())
+            throw new IllegalArgumentException("Key defines symbols that aren't used in pattern: " + keys);
+
+        return ret;
+    }
+
+    //a copy of the CraftingHelper getIngredient method.
+    //the only difference is checking for a filled bucket and making
+    //it an GTFluidCraftingIngredient
+    private static Ingredient getIngredient(Object obj)
+    {
+        if (obj instanceof Ingredient)
+            return (Ingredient)obj;
+        else if (obj instanceof ItemStack) {
+            ItemStack ing = (ItemStack)obj;
+            if (ing.getItem() instanceof UniversalBucket) {
+                IFluidHandlerItem  handler = ing.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+                if (handler != null) {
+                    FluidStack extracted = handler.drain(Integer.MAX_VALUE, false);
+                    if (extracted != null && extracted.amount > 0) {
+                        return new GTFluidCraftingIngredient(((ItemStack) obj).copy());
+                    }
+                }
+            }
+            return Ingredient.fromStacks(((ItemStack) obj).copy());
+        }
+        else if (obj instanceof Item)
+            return Ingredient.fromItem((Item)obj);
+        else if (obj instanceof Block)
+            return Ingredient.fromStacks(new ItemStack((Block)obj, 1, OreDictionary.WILDCARD_VALUE));
+        else if (obj instanceof String)
+            return new OreIngredient((String)obj);
+        else if (obj instanceof JsonElement)
+            throw new IllegalArgumentException("JsonObjects must use getIngredient(JsonObject, JsonContext)");
+
+        return null;
+    }
+
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
+        NonNullList<ItemStack> nonnulllist = NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+
+        for (int i = 0; i < nonnulllist.size(); ++i) {
+            ItemStack itemstack = inv.getStackInSlot(i);
+            if (input.get(i) instanceof GTFluidCraftingIngredient) {
+                if (input.get(i).apply(itemstack)) {
+                    FluidStack fluidStack = ((GTFluidCraftingIngredient) input.get(i)).getFluidStack();
+                    IFluidHandlerItem handler = null;
+                    if (itemstack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+                        handler = itemstack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+                    }
+                    if (handler != null) {
+                        FluidStack drained = handler.drain(fluidStack, false);
+                        if (drained != null && drained.amount >= fluidStack.amount) {
+                            handler.drain(fluidStack, true);
+                            ItemStack returnStack = itemstack.getItem().getContainerItem(handler.getContainer());
+                            nonnulllist.set(i, returnStack);
+                        }
+                    }
+                }
+            } else {
+                nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
+            }
+        }
+        return nonnulllist;
+    }
+}

--- a/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
@@ -13,7 +13,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.UniversalBucket;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.oredict.OreDictionary;
@@ -139,13 +138,10 @@ public class GTShapedOreRecipe extends ShapedOreRecipe {
             return (Ingredient)obj;
         else if (obj instanceof ItemStack) {
             ItemStack ing = (ItemStack)obj;
-            if (ing.getItem() instanceof UniversalBucket) {
-                IFluidHandlerItem  handler = ing.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+            if (ing.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+                IFluidHandlerItem handler = ing.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
                 if (handler != null) {
-                    FluidStack extracted = handler.drain(Integer.MAX_VALUE, false);
-                    if (extracted != null && extracted.amount > 0) {
-                        return new GTFluidCraftingIngredient(((ItemStack) obj).copy());
-                    }
+                    return new GTFluidCraftingIngredient(((ItemStack) obj).copy());
                 }
             }
             return Ingredient.fromStacks(((ItemStack) obj).copy());
@@ -160,34 +156,5 @@ public class GTShapedOreRecipe extends ShapedOreRecipe {
             throw new IllegalArgumentException("JsonObjects must use getIngredient(JsonObject, JsonContext)");
 
         return null;
-    }
-
-    @Override
-    public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
-        NonNullList<ItemStack> nonnulllist = NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
-
-        for (int i = 0; i < nonnulllist.size(); ++i) {
-            ItemStack itemstack = inv.getStackInSlot(i);
-            if (input.get(i) instanceof GTFluidCraftingIngredient) {
-                if (input.get(i).apply(itemstack)) {
-                    FluidStack fluidStack = ((GTFluidCraftingIngredient) input.get(i)).getFluidStack();
-                    IFluidHandlerItem handler = null;
-                    if (itemstack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
-                        handler = itemstack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
-                    }
-                    if (handler != null) {
-                        FluidStack drained = handler.drain(fluidStack, false);
-                        if (drained != null && drained.amount >= fluidStack.amount) {
-                            handler.drain(fluidStack, true);
-                            ItemStack returnStack = itemstack.getItem().getContainerItem(handler.getContainer());
-                            nonnulllist.set(i, returnStack);
-                        }
-                    }
-                }
-            } else {
-                nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
-            }
-        }
-        return nonnulllist;
     }
 }

--- a/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
@@ -33,49 +33,38 @@ public class GTShapedOreRecipe extends ShapedOreRecipe {
     //a copy of the CraftingHelper.ShapedPrimer.parseShaped method.
     //the on difference is calling getIngredient of this class.
 
-    public static CraftingHelper.ShapedPrimer parseShaped(Object... recipe)
-    {
+    public static CraftingHelper.ShapedPrimer parseShaped(Object... recipe) {
         CraftingHelper.ShapedPrimer ret = new CraftingHelper.ShapedPrimer();
         String shape = "";
         int idx = 0;
 
-        if (recipe[idx] instanceof Boolean)
-        {
-            ret.mirrored = (Boolean)recipe[idx];
-            if (recipe[idx+1] instanceof Object[])
-                recipe = (Object[])recipe[idx+1];
-            else
-                idx = 1;
+        if (recipe[idx] instanceof Boolean) {
+            ret.mirrored = (Boolean) recipe[idx];
+            if (recipe[idx + 1] instanceof Object[]) recipe = (Object[]) recipe[idx + 1];
+            else idx = 1;
         }
 
-        if (recipe[idx] instanceof String[])
-        {
-            String[] parts = ((String[])recipe[idx++]);
+        if (recipe[idx] instanceof String[]) {
+            String[] parts = ((String[]) recipe[idx++]);
 
-            for (String s : parts)
-            {
+            for (String s : parts) {
                 ret.width = s.length();
                 shape += s;
             }
 
             ret.height = parts.length;
-        }
-        else
-        {
-            while (recipe[idx] instanceof String)
-            {
-                String s = (String)recipe[idx++];
+        } else {
+            while (recipe[idx] instanceof String) {
+                String s = (String) recipe[idx++];
                 shape += s;
                 ret.width = s.length();
                 ret.height++;
             }
         }
 
-        if (ret.width * ret.height != shape.length() || shape.length() == 0)
-        {
+        if (ret.width * ret.height != shape.length() || shape.length() == 0) {
             String err = "Invalid shaped recipe: ";
-            for (Object tmp :  recipe)
-            {
+            for (Object tmp : recipe) {
                 err += tmp + ", ";
             }
             throw new RuntimeException(err);
@@ -84,24 +73,18 @@ public class GTShapedOreRecipe extends ShapedOreRecipe {
         HashMap<Character, Ingredient> itemMap = Maps.newHashMap();
         itemMap.put(' ', Ingredient.EMPTY);
 
-        for (; idx < recipe.length; idx += 2)
-        {
-            Character chr = (Character)recipe[idx];
+        for (; idx < recipe.length; idx += 2) {
+            Character chr = (Character) recipe[idx];
             Object in = recipe[idx + 1];
             Ingredient ing = getIngredient(in);
 
-            if (' ' == chr.charValue())
-                throw new JsonSyntaxException("Invalid key entry: ' ' is a reserved symbol.");
+            if (' ' == chr.charValue()) throw new JsonSyntaxException("Invalid key entry: ' ' is a reserved symbol.");
 
-            if (ing != null)
-            {
+            if (ing != null) {
                 itemMap.put(chr, ing);
-            }
-            else
-            {
+            } else {
                 String err = "Invalid shaped ore recipe: ";
-                for (Object tmp :  recipe)
-                {
+                for (Object tmp : recipe) {
                     err += tmp + ", ";
                 }
                 throw new RuntimeException(err);
@@ -114,8 +97,7 @@ public class GTShapedOreRecipe extends ShapedOreRecipe {
         keys.remove(' ');
 
         int x = 0;
-        for (char chr : shape.toCharArray())
-        {
+        for (char chr : shape.toCharArray()) {
             Ingredient ing = itemMap.get(chr);
             if (ing == null)
                 throw new IllegalArgumentException("Pattern references symbol '" + chr + "' but it's not defined in the key");
@@ -132,29 +114,32 @@ public class GTShapedOreRecipe extends ShapedOreRecipe {
     //a copy of the CraftingHelper getIngredient method.
     //the only difference is checking for a filled bucket and making
     //it an GTFluidCraftingIngredient
-    private static Ingredient getIngredient(Object obj)
-    {
-        if (obj instanceof Ingredient)
-            return (Ingredient)obj;
+    private static Ingredient getIngredient(Object obj) {
+        if (obj instanceof Ingredient) return (Ingredient) obj;
         else if (obj instanceof ItemStack) {
-            ItemStack ing = (ItemStack)obj;
+            ItemStack ing = (ItemStack) obj;
             if (ing.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
                 IFluidHandlerItem handler = ing.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
                 if (handler != null) {
-                    return new GTFluidCraftingIngredient(((ItemStack) obj).copy());
+                    FluidStack drained = handler.drain(Integer.MAX_VALUE, false);
+                    if (drained != null && drained.amount > 0) {
+                        return new GTFluidCraftingIngredient(((ItemStack) obj).copy());
+                    }
                 }
             }
             return Ingredient.fromStacks(((ItemStack) obj).copy());
-        }
-        else if (obj instanceof Item)
-            return Ingredient.fromItem((Item)obj);
+        } else if (obj instanceof Item) return Ingredient.fromItem((Item) obj);
         else if (obj instanceof Block)
-            return Ingredient.fromStacks(new ItemStack((Block)obj, 1, OreDictionary.WILDCARD_VALUE));
-        else if (obj instanceof String)
-            return new OreIngredient((String)obj);
+            return Ingredient.fromStacks(new ItemStack((Block) obj, 1, OreDictionary.WILDCARD_VALUE));
+        else if (obj instanceof String) return new OreIngredient((String) obj);
         else if (obj instanceof JsonElement)
             throw new IllegalArgumentException("JsonObjects must use getIngredient(JsonObject, JsonContext)");
 
         return null;
+    }
+
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
+        return super.getRemainingItems(inv);
     }
 }

--- a/src/main/java/gregtech/common/crafting/GTShapelessNBTClearingOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapelessNBTClearingOreRecipe.java
@@ -1,0 +1,19 @@
+package gregtech.common.crafting;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nonnull;
+
+public class GTShapelessNBTClearingOreRecipe extends GTShapelessOreRecipe {
+    public GTShapelessNBTClearingOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+        super(group, result, recipe);
+    }
+
+    @Override
+    public @Nonnull NonNullList<ItemStack> getRemainingItems(@Nonnull InventoryCrafting inv) {
+        return NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+    }
+}

--- a/src/main/java/gregtech/common/crafting/GTShapelessOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapelessOreRecipe.java
@@ -18,19 +18,14 @@ import javax.annotation.Nonnull;
 public class GTShapelessOreRecipe extends ShapelessOreRecipe {
     public GTShapelessOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
         super(group, result);
-        for (Object in : recipe)
-        {
+        for (Object in : recipe) {
             Ingredient ing = getIngredient(in);
-            if (ing != null)
-            {
+            if (ing != null) {
                 input.add(ing);
                 this.isSimple &= ing.isSimple();
-            }
-            else
-            {
+            } else {
                 String ret = "Invalid shapeless ore recipe: ";
-                for (Object tmp :  recipe)
-                {
+                for (Object tmp : recipe) {
                     ret += tmp + ", ";
                 }
                 ret += output;
@@ -42,12 +37,10 @@ public class GTShapelessOreRecipe extends ShapelessOreRecipe {
     //a copy of the CraftingHelper getIngredient method.
     //the only difference is checking for a filled bucket and making
     //it an GTFluidCraftingIngredient
-    private static Ingredient getIngredient(Object obj)
-    {
-        if (obj instanceof Ingredient)
-            return (Ingredient)obj;
+    private static Ingredient getIngredient(Object obj) {
+        if (obj instanceof Ingredient) return (Ingredient) obj;
         else if (obj instanceof ItemStack) {
-            ItemStack ing = (ItemStack)obj;
+            ItemStack ing = (ItemStack) obj;
             if (ing.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
                 IFluidHandlerItem handler = ing.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
                 if (handler != null) {
@@ -58,13 +51,10 @@ public class GTShapelessOreRecipe extends ShapelessOreRecipe {
                 }
             }
             return Ingredient.fromStacks(((ItemStack) obj).copy());
-        }
-        else if (obj instanceof Item)
-            return Ingredient.fromItem((Item)obj);
+        } else if (obj instanceof Item) return Ingredient.fromItem((Item) obj);
         else if (obj instanceof Block)
-            return Ingredient.fromStacks(new ItemStack((Block)obj, 1, OreDictionary.WILDCARD_VALUE));
-        else if (obj instanceof String)
-            return new OreIngredient((String)obj);
+            return Ingredient.fromStacks(new ItemStack((Block) obj, 1, OreDictionary.WILDCARD_VALUE));
+        else if (obj instanceof String) return new OreIngredient((String) obj);
         else if (obj instanceof JsonElement)
             throw new IllegalArgumentException("JsonObjects must use getIngredient(JsonObject, JsonContext)");
 

--- a/src/main/java/gregtech/common/crafting/GTShapelessOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapelessOreRecipe.java
@@ -1,0 +1,73 @@
+package gregtech.common.crafting;
+
+import com.google.gson.JsonElement;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.OreIngredient;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+import javax.annotation.Nonnull;
+
+public class GTShapelessOreRecipe extends ShapelessOreRecipe {
+    public GTShapelessOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+        super(group, result);
+        for (Object in : recipe)
+        {
+            Ingredient ing = getIngredient(in);
+            if (ing != null)
+            {
+                input.add(ing);
+                this.isSimple &= ing.isSimple();
+            }
+            else
+            {
+                String ret = "Invalid shapeless ore recipe: ";
+                for (Object tmp :  recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+    }
+
+    //a copy of the CraftingHelper getIngredient method.
+    //the only difference is checking for a filled bucket and making
+    //it an GTFluidCraftingIngredient
+    private static Ingredient getIngredient(Object obj)
+    {
+        if (obj instanceof Ingredient)
+            return (Ingredient)obj;
+        else if (obj instanceof ItemStack) {
+            ItemStack ing = (ItemStack)obj;
+            if (ing.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+                IFluidHandlerItem handler = ing.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+                if (handler != null) {
+                    FluidStack drained = handler.drain(Integer.MAX_VALUE, false);
+                    if (drained != null && drained.amount > 0) {
+                        return new GTFluidCraftingIngredient(((ItemStack) obj).copy());
+                    }
+                }
+            }
+            return Ingredient.fromStacks(((ItemStack) obj).copy());
+        }
+        else if (obj instanceof Item)
+            return Ingredient.fromItem((Item)obj);
+        else if (obj instanceof Block)
+            return Ingredient.fromStacks(new ItemStack((Block)obj, 1, OreDictionary.WILDCARD_VALUE));
+        else if (obj instanceof String)
+            return new OreIngredient((String)obj);
+        else if (obj instanceof JsonElement)
+            throw new IllegalArgumentException("JsonObjects must use getIngredient(JsonObject, JsonContext)");
+
+        return null;
+    }
+}

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.*;
 import gregtech.api.items.metaitem.stats.IItemComponent;
 import gregtech.api.items.metaitem.stats.IItemContainerItemProvider;
+import gregtech.api.items.metaitem.stats.ItemFluidContainer;
 import gregtech.api.sound.GTSounds;
 import gregtech.api.terminal.hardware.HardwareProvider;
 import gregtech.api.unification.OreDictUnifier;
@@ -120,33 +121,33 @@ public class MetaItem1 extends StandardMetaItem {
         }
 
         // Fluid Cells: ID 78-88
-        FLUID_CELL = addItem(78, "fluid_cell").addComponents(new ThermalFluidStats(1000, 1800, true, false, false, false, false));
+        FLUID_CELL = addItem(78, "fluid_cell").addComponents(new ThermalFluidStats(1000, 1800, true, false, false, false, false), new ItemFluidContainer());
 
-        FLUID_CELL_UNIVERSAL = addItem(79, "fluid_cell.universal").addComponents(new ThermalFluidStats(1000, 1800, true, false, false, false, true));
+        FLUID_CELL_UNIVERSAL = addItem(79, "fluid_cell.universal").addComponents(new ThermalFluidStats(1000, 1800, true, false, false, false, true), new ItemFluidContainer());
 
         FLUID_CELL_LARGE_STEEL = addItem(80, "large_fluid_cell.steel")
-                .addComponents(new ThermalFluidStats(8000, Materials.Steel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(8000, Materials.Steel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true), new ItemFluidContainer())
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4))); // ingot * 4
 
         FLUID_CELL_LARGE_ALUMINIUM = addItem(81, "large_fluid_cell.aluminium")
-                .addComponents(new ThermalFluidStats(32000, Materials.Aluminium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(32000, Materials.Aluminium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true), new ItemFluidContainer())
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Aluminium, M * 4))); // ingot * 4
 
         FLUID_CELL_LARGE_STAINLESS_STEEL = addItem(82, "large_fluid_cell.stainless_steel")
-                .addComponents(new ThermalFluidStats(64000, Materials.StainlessSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, true, true, false, true))
+                .addComponents(new ThermalFluidStats(64000, Materials.StainlessSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, true, true, false, true), new ItemFluidContainer())
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, M * 6))); // ingot * 6
 
         FLUID_CELL_LARGE_TITANIUM = addItem(83, "large_fluid_cell.titanium")
-                .addComponents(new ThermalFluidStats(128000, Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(128000, Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true), new ItemFluidContainer())
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Titanium, M * 6))); // ingot * 6
 
         FLUID_CELL_LARGE_TUNGSTEN_STEEL = addItem(84, "large_fluid_cell.tungstensteel")
-                .addComponents(new ThermalFluidStats(512000, Materials.TungstenSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true))
+                .addComponents(new ThermalFluidStats(512000, Materials.TungstenSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false, false, false, true), new ItemFluidContainer())
                 .setMaxStackSize(32)
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.TungstenSteel, M * 8))); // ingot * 8
 
         FLUID_CELL_GLASS_VIAL = addItem(85, "fluid_cell.glass_vial")
-                .addComponents(new ThermalFluidStats(1000, 1200, false, true, false, false, true))
+                .addComponents(new ThermalFluidStats(1000, 1200, false, true, false, false, true), new ItemFluidContainer())
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 4))); // small dust
 
         // Limited-Use Items: ID 89-95

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -927,29 +927,29 @@ public class MachineRecipeLoader {
     private static void registerNBTRemoval() {
         for (MetaTileEntityQuantumChest chest : MetaTileEntities.QUANTUM_CHEST)
             if (chest != null) {
-                ModHandler.addShapelessRecipe("quantum_chest_nbt_" + chest.getTier() + chest.getMetaName(), chest.getStackForm(), chest.getStackForm());
+                ModHandler.addShapelessNBTClearingRecipe("quantum_chest_nbt_" + chest.getTier() + chest.getMetaName(), chest.getStackForm(), chest.getStackForm());
             }
 
         for (MetaTileEntityQuantumTank tank : MetaTileEntities.QUANTUM_TANK)
             if (tank != null) {
-                ModHandler.addShapelessRecipe("quantum_tank_nbt_" + tank.getTier() + tank.getMetaName(), tank.getStackForm(), tank.getStackForm());
+                ModHandler.addShapelessNBTClearingRecipe("quantum_tank_nbt_" + tank.getTier() + tank.getMetaName(), tank.getStackForm(), tank.getStackForm());
             }
 
         //Drums
-        ModHandler.addShapelessRecipe("drum_nbt_wood", MetaTileEntities.WOODEN_DRUM.getStackForm(), MetaTileEntities.WOODEN_DRUM.getStackForm());
-        ModHandler.addShapelessRecipe("drum_nbt_bronze", MetaTileEntities.BRONZE_DRUM.getStackForm(), MetaTileEntities.BRONZE_DRUM.getStackForm());
-        ModHandler.addShapelessRecipe("drum_nbt_steel", MetaTileEntities.STEEL_DRUM.getStackForm(), MetaTileEntities.STEEL_DRUM.getStackForm());
-        ModHandler.addShapelessRecipe("drum_nbt_aluminium", MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), MetaTileEntities.ALUMINIUM_DRUM.getStackForm());
-        ModHandler.addShapelessRecipe("drum_nbt_stainless_steel", MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_wood", MetaTileEntities.WOODEN_DRUM.getStackForm(), MetaTileEntities.WOODEN_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_bronze", MetaTileEntities.BRONZE_DRUM.getStackForm(), MetaTileEntities.BRONZE_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_steel", MetaTileEntities.STEEL_DRUM.getStackForm(), MetaTileEntities.STEEL_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_aluminium", MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), MetaTileEntities.ALUMINIUM_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_stainless_steel", MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm());
 
         // Cells
-        ModHandler.addShapedRecipe("cell_nbt_regular", MetaItems.FLUID_CELL.getStackForm(), " C", "  ", 'C', MetaItems.FLUID_CELL.getStackForm());
-        ModHandler.addShapedRecipe("cell_nbt_universal", MetaItems.FLUID_CELL_UNIVERSAL.getStackForm(), " C", "  ", 'C', MetaItems.FLUID_CELL_UNIVERSAL.getStackForm());
-        ModHandler.addShapelessRecipe("cell_nbt_steel", MetaItems.FLUID_CELL_LARGE_STEEL.getStackForm(), MetaItems.FLUID_CELL_LARGE_STEEL.getStackForm());
-        ModHandler.addShapelessRecipe("cell_nbt_aluminium", MetaItems.FLUID_CELL_LARGE_ALUMINIUM.getStackForm(), MetaItems.FLUID_CELL_LARGE_ALUMINIUM.getStackForm());
-        ModHandler.addShapelessRecipe("cell_nbt_stainless_steel", MetaItems.FLUID_CELL_LARGE_STAINLESS_STEEL.getStackForm(), MetaItems.FLUID_CELL_LARGE_STAINLESS_STEEL.getStackForm());
-        ModHandler.addShapelessRecipe("cell_nbt_titanium", MetaItems.FLUID_CELL_LARGE_TITANIUM.getStackForm(), MetaItems.FLUID_CELL_LARGE_TITANIUM.getStackForm());
-        ModHandler.addShapelessRecipe("cell_nbt_tungstensteel", MetaItems.FLUID_CELL_LARGE_TUNGSTEN_STEEL.getStackForm(), MetaItems.FLUID_CELL_LARGE_TUNGSTEN_STEEL.getStackForm());
+        ModHandler.addShapedNBTClearingRecipe("cell_nbt_regular", MetaItems.FLUID_CELL.getStackForm(), " C", "  ", 'C', MetaItems.FLUID_CELL.getStackForm());
+        ModHandler.addShapedNBTClearingRecipe("cell_nbt_universal", MetaItems.FLUID_CELL_UNIVERSAL.getStackForm(), " C", "  ", 'C', MetaItems.FLUID_CELL_UNIVERSAL.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("cell_nbt_steel", MetaItems.FLUID_CELL_LARGE_STEEL.getStackForm(), MetaItems.FLUID_CELL_LARGE_STEEL.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("cell_nbt_aluminium", MetaItems.FLUID_CELL_LARGE_ALUMINIUM.getStackForm(), MetaItems.FLUID_CELL_LARGE_ALUMINIUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("cell_nbt_stainless_steel", MetaItems.FLUID_CELL_LARGE_STAINLESS_STEEL.getStackForm(), MetaItems.FLUID_CELL_LARGE_STAINLESS_STEEL.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("cell_nbt_titanium", MetaItems.FLUID_CELL_LARGE_TITANIUM.getStackForm(), MetaItems.FLUID_CELL_LARGE_TITANIUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("cell_nbt_tungstensteel", MetaItems.FLUID_CELL_LARGE_TUNGSTEN_STEEL.getStackForm(), MetaItems.FLUID_CELL_LARGE_TUNGSTEN_STEEL.getStackForm());
 
 
         //Jetpacks


### PR DESCRIPTION
## What
Allows crafting recipes to actually CHECK for the actual fluid in a bucket. since Forge doesnt account for any of it by itself.

## Implementation Details
Properly implementing container item methods allows for use of drums and quantum tanks to be used along with those recipes, without being consumed

## Outcome
Fixes: #1125

## Potential Compatibility Issues
None *wishful thinking*
