### PR TITLE
Fix some issues when crafting with Electric items

### DIFF
--- a/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
+++ b/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
@@ -33,7 +33,7 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
     private void fixOutputItemMaxCharge() {
         long totalMaxCharge = getIngredients().stream()
                 .mapToLong(it -> Arrays.stream(it.getMatchingStacks())
-                        .map(stack -> stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null))
+                        .map(stack -> stack.copy().getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null))
                         .filter(Objects::nonNull)
                         .mapToLong(IElectricItem::getMaxCharge)
                         .max().orElse(0L)).sum();
@@ -65,11 +65,8 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
                     continue;
                 }
                 totalMaxCharge += batteryItem.getMaxCharge();
-                long discharged = batteryItem.discharge(Long.MAX_VALUE, Integer.MAX_VALUE, true, true, false);
+                long discharged = batteryItem.discharge(Long.MAX_VALUE, Integer.MAX_VALUE, true, true, true);
                 electricItem.charge(discharged, Integer.MAX_VALUE, true, false);
-                if (discharged > 0L) {
-                    ingredients.setInventorySlotContents(slotIndex, stackInSlot);
-                }
             }
         }
         if (electricItem instanceof ElectricItem && transferMaxCharge) {


### PR DESCRIPTION
## What
This PR fixes some issues with crafting recipes with Electric Items.

1. Crafting Recipes would not transfer all charge to the output item from the input items.
- EG, crafting an MV drill with afully charge power unit made from a Lithium Battery should receive a charge of 420,000, as that is the charge in the power unit. However, it was only receiving a charge of 400,000 (The maximum was still 420,000 though)

2. Electric Items would have their charge wiped when removed from the crafting table when the recipe was not complete. This is either by closing the crafting GUI or taking the item out of the crafting slots and placing it back in the player's inventory. 

## Implementation Details
The first issue was fixed by copying the electric item when fixing the maximum charge. (Don't ask me how, it just did)

The second issue was fixed by setting the discharge of the electric item component in the recipe to simulate = true. This also allowed for removing the `setInventorySlotContents` call, which actually caused an infinite loop through `setInventorySlotContents` -> `ContainerWorkbench#onCraftMatrixChanged`-> `Container#slotChangedCraftingGrid` -> `IRecipe#getCraftingResult`, which is overridden in `ShapedOreEnergyTransferRecipe`

## Outcome
Fix incorrect charge amount transferring when crafting Electric Items.
Fix Electric Items losing all charge when removed from the Crafting Grid without completing the recipe.
