### PR TITLE
Attempt to fix the Wireless Digital Interface Cover

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverDigitalInterfaceWireless.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterfaceWireless.java
@@ -7,8 +7,8 @@ import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.BlockPosFace;
+import gregtech.client.renderer.texture.Textures;
 import gregtech.common.items.behaviors.CoverDigitalInterfaceWirelessPlaceBehaviour;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
 import net.minecraft.entity.player.EntityPlayer;
@@ -66,7 +66,7 @@ public class CoverDigitalInterfaceWireless extends CoverDigitalInterface{
     }
 
     @Override
-    public void onAttached(ItemStack itemStack) {
+    public void onAttached(ItemStack itemStack, EntityPlayer player) {
         remote = CoverDigitalInterfaceWirelessPlaceBehaviour.getRemotePos(itemStack);
     }
 


### PR DESCRIPTION
## What
This should hopefully fix the wireless digital interface cover, which was reported broken in #1061. Closes #1061 

## Implementation Details
Dues to the signature change of `onAttached`, the WDIC was no longer setting remotes.

## Outcome
Fix Wireless Digital Interface Cover
