### PR TITLE
Add Passthrough Hatch MultiblockAbility for addons

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/IPassthroughHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IPassthroughHatch.java
@@ -1,0 +1,17 @@
+package gregtech.api.metatileentity.multiblock;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Used with {@link IMultiblockAbilityPart} for hatches allowed in cleanroom-like structures for pass-through
+ */
+public interface IPassthroughHatch {
+
+    /**
+     *
+     * @return the type of data passed into/out of the hatch
+     */
+    @SuppressWarnings("unused")
+    @Nonnull
+    Class<?> getPassthroughType();
+}

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockAbility.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockAbility.java
@@ -44,6 +44,8 @@ public class MultiblockAbility<T> {
 
     public static final MultiblockAbility<IFluidHandler> TANK_VALVE = new MultiblockAbility<>("tank_valve");
 
+    public static final MultiblockAbility<IPassthroughHatch> PASSTHROUGH_HATCH = new MultiblockAbility<>("passthrough_hatch");
+
     public static void registerMultiblockAbility(MultiblockAbility<?> ability, MetaTileEntity part) {
         if (!REGISTRY.containsKey(ability)) {
             REGISTRY.put(ability, new ArrayList<>());

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -12,6 +12,9 @@ import gregtech.api.capability.tool.ISoftHammerItem;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
@@ -35,7 +38,7 @@ import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.AMP_INDEX;
 
-public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart {
+public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
 
     protected IEnergyContainer energyContainer;
 
@@ -162,5 +165,21 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart {
         tooltip.add(I18n.format("gregtech.machine.diode.tooltip_tool_usage"));
         tooltip.add(I18n.format("gregtech.universal.tooltip.voltage_in",
                 energyContainer.getInputVoltage(), GTValues.VNF[getTier()]));
+    }
+
+    @Override
+    public MultiblockAbility<IPassthroughHatch> getAbility() {
+        return MultiblockAbility.PASSTHROUGH_HATCH;
+    }
+
+    @Override
+    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+        abilityList.add(this);
+    }
+
+    @Nonnull
+    @Override
+    public Class<?> getPassthroughType() {
+        return IEnergyContainer.class;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
@@ -13,6 +13,9 @@ import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.PipelineUtil;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
@@ -31,7 +34,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class MetaTileEntityHull extends MetaTileEntityMultiblockPart {
+public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
 
     protected IEnergyContainer energyContainer;
     private AENetworkProxy gridProxy;
@@ -113,5 +116,21 @@ public class MetaTileEntityHull extends MetaTileEntityMultiblockPart {
             gridProxy = new AENetworkProxy((MetaTileEntityHolder) getHolder(), "proxy", getStackForm(), true);
         }
         return gridProxy;
+    }
+
+    @Override
+    public MultiblockAbility<IPassthroughHatch> getAbility() {
+        return MultiblockAbility.PASSTHROUGH_HATCH;
+    }
+
+    @Override
+    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+        abilityList.add(this);
+    }
+
+    @Nonnull
+    @Override
+    public Class<?> getPassthroughType() {
+        return IEnergyContainer.class;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -315,10 +315,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
                 .where('B', states(getCasingState()).or(basePredicate))
                 .where('X', wallPredicate.or(basePredicate)
                         .or(doorPredicate().setMaxGlobalLimited(8))
-                        .or(metaTileEntities(MetaTileEntities.PASSTHROUGH_HATCH_ITEM).setMaxGlobalLimited(10))
-                        .or(metaTileEntities(MetaTileEntities.PASSTHROUGH_HATCH_FLUID).setMaxGlobalLimited(10))
-                        .or(metaTileEntities(MetaTileEntities.HULL).setMaxGlobalLimited(5))
-                        .or(metaTileEntities(MetaTileEntities.DIODES).setMaxGlobalLimited(5)))
+                        .or(abilities(MultiblockAbility.PASSTHROUGH_HATCH).setMaxGlobalLimited(30)))
                 .where('K', wallPredicate) // the block beneath the controller must only be a casing for structure dimension checks
                 .where('F', filterPredicate())
                 .where(' ', innerPredicate())

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -11,6 +11,9 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -18,12 +21,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultiblockPart {
+public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
 
     private static final int TANK_SIZE = 16_000;
 
@@ -129,5 +134,21 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         tooltip.add(I18n.format("gregtech.machine.multi_fluid_hatch_universal.tooltip.1"));
         tooltip.add(I18n.format("gregtech.machine.multi_fluid_hatch_universal.tooltip.2", getTier() + 1));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
+    }
+
+    @Override
+    public MultiblockAbility<IPassthroughHatch> getAbility() {
+        return MultiblockAbility.PASSTHROUGH_HATCH;
+    }
+
+    @Override
+    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+        abilityList.add(this);
+    }
+
+    @Nonnull
+    @Override
+    public Class<IFluidHandler> getPassthroughType() {
+        return IFluidHandler.class;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -9,6 +9,9 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,10 +23,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblockPart {
+public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
 
     private ItemStackHandler itemStackHandler;
 
@@ -131,5 +135,21 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("gregtech.universal.tooltip.item_storage_capacity", getInventorySize()));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
+    }
+
+    @Override
+    public MultiblockAbility<IPassthroughHatch> getAbility() {
+        return MultiblockAbility.PASSTHROUGH_HATCH;
+    }
+
+    @Override
+    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+        abilityList.add(this);
+    }
+
+    @Nonnull
+    @Override
+    public Class<IItemHandlerModifiable> getPassthroughType() {
+        return IItemHandlerModifiable.class;
     }
 }


### PR DESCRIPTION
## What
This PR adds a Passthrough Hatch MultiblockAbility for addons to add their own hatches to send things into the cleanroom. An example of this is for GCYS to add a Pressure Passthrough Hatch for machinery inside the cleanroom.

## Outcome
Adds Passthrough Hatch MultiblockAbility for addon cleanroom compat.