### PR TITLE
Prevent Chisel Concrete from Conflicting with GT Concrete

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -256,7 +256,7 @@ public class SecondDegreeMaterials {
         Concrete = new Material.Builder(2034, "concrete")
                 .dust().fluid()
                 .color(0x646464).iconSet(ROUGH)
-                .flags(NO_SMASHING)
+                .flags(NO_SMASHING, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .components(Stone, 1)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -488,7 +488,8 @@ public class OrePrefix {
                 //glass, ice and obsidian gain only one dust
             else if (material == Materials.Glass ||
                     material == Materials.Ice ||
-                    material == Materials.Obsidian)
+                    material == Materials.Obsidian ||
+                    material == Materials.Concrete)
                 return M;
         } else if (this == stick) {
             if (material == Materials.Blaze)

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -104,8 +104,8 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.RED_GRANITE, 1), OrePrefix.stone, Materials.GraniteRed);
         OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.MARBLE, 1), OrePrefix.stone, Materials.Marble);
         OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.BASALT, 1), OrePrefix.stone, Materials.Basalt);
-        OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.CONCRETE_LIGHT, 1), OrePrefix.stone, Materials.Concrete);
-        OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.CONCRETE_DARK, 1), OrePrefix.stone, Materials.Concrete);
+        OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.CONCRETE_LIGHT, 1), OrePrefix.block, Materials.Concrete);
+        OreDictUnifier.registerOre(MetaBlocks.STONE_SMOOTH.getItemVariant(BlockStoneSmooth.BlockType.CONCRETE_DARK, 1), OrePrefix.block, Materials.Concrete);
 
         OreDictUnifier.registerOre(new ItemStack(Blocks.ANVIL), "craftingAnvil");
         OreDictUnifier.registerOre(new ItemStack(Blocks.OBSIDIAN, 1, W), OrePrefix.stone, Materials.Obsidian);

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -873,12 +873,6 @@ public class MachineRecipeLoader {
                     .duration(100).EUt(16).buildAndRegister();
         }
 
-        FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
-                .fluidInputs(Concrete.getFluid(GTValues.L))
-                .notConsumable(MetaItems.SHAPE_MOLD_BLOCK.getStackForm())
-                .output(stone, Concrete)
-                .duration(98).EUt(VA[ULV]).buildAndRegister();
-
         FLUID_HEATER_RECIPES.recipeBuilder().duration(30).EUt(VA[LV]).fluidInputs(Water.getFluid(6)).circuitMeta(1).fluidOutputs(Steam.getFluid(960)).buildAndRegister();
         FLUID_HEATER_RECIPES.recipeBuilder().duration(30).EUt(VA[LV]).fluidInputs(DistilledWater.getFluid(6)).circuitMeta(1).fluidOutputs(Steam.getFluid(960)).buildAndRegister();
     }


### PR DESCRIPTION
## What
Chisel's concrete blocks use the blockConcrete oredict, and yet, GT's concrete blocks are currently oredicted as stoneConcrete. This makes material unification set Chisel's concrete as the block form for the concrete material, and thus creates a recipe that messes with fluid solidification of concrete, as well as several unwanted recipes converting from chisel concrete into concrete dust and vice versa.

## Outcome
This PR simply resolved this by changing the (regular light and dark) concretes' oredicts to blockConcrete. Furthermore, by hardcoding concrete's block material value to 1, and removing the previous recipe that solidified concrete, the correct recipes were registered. 

## Potential Compatibility Issues
Any addons or modpacks using the stoneConcrete oredict will no longer be able to use it properly. As major changes will be done to StoneSmooth.java in the ore rework, I believe that this will simply move those problems to occur in an earlier version.
