### PR TITLE
FIx machines not accepting valid fluid for recipes or stalling after being flagged as full

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -13,7 +13,6 @@ import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.logic.IParallelableRecipeLogic;
 import gregtech.api.recipes.recipeproperties.CleanroomProperty;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
-import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
@@ -197,6 +196,9 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         // if the inputs were bad last time, check if they've changed before trying to find a new recipe.
         if (this.invalidInputsForRecipes && !hasNotifiedInputs()) return false;
         else {
+            //the change in inputs (especially by removal of ingredient by the player) might change the current valid recipe.
+            //and if the previous recipe produced fluids and the new recipe doesn't, then outputs are not full.
+            this.isOutputsFull = false;
             this.invalidInputsForRecipes = false;
             this.metaTileEntity.getNotifiedItemInputList().clear();
             this.metaTileEntity.getNotifiedFluidInputList().clear();

--- a/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
@@ -142,15 +142,8 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity 
                 fluidInputs.add(fluidStack);
             }
         }
-        List<ItemStack> itemInputs = new ArrayList<>();
-        for (int i= 0; i< this.importItems.getSlots(); i++) {
-            ItemStack itemStack = this.importItems.getStackInSlot(i);
-            if (!(itemStack.isEmpty())) {
-                itemInputs.add(itemStack);
-            }
-        }
 
-        return recipeMap != null && recipeMap.acceptsFluid(itemInputs, fluidInputs, inputFluid);
+        return recipeMap != null && recipeMap.acceptsFluid(fluidInputs, inputFluid);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
@@ -8,11 +8,9 @@ import gregtech.api.capability.impl.*;
 import gregtech.api.metatileentity.multiblock.ICleanroomProvider;
 import gregtech.api.metatileentity.multiblock.ICleanroomReceiver;
 import gregtech.api.recipes.FluidKey;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
-import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -31,7 +29,6 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -145,7 +142,15 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity 
                 fluidInputs.add(fluidStack);
             }
         }
-        return recipeMap != null && recipeMap.acceptsFluid(fluidInputs, inputFluid);
+        List<ItemStack> itemInputs = new ArrayList<>();
+        for (int i= 0; i< this.importItems.getSlots(); i++) {
+            ItemStack itemStack = this.importItems.getStackInSlot(i);
+            if (!(itemStack.isEmpty())) {
+                itemInputs.add(itemStack);
+            }
+        }
+
+        return recipeMap != null && recipeMap.acceptsFluid(itemInputs, fluidInputs, inputFluid);
     }
 
     @Override


### PR DESCRIPTION
## What
This PR fixes machines which recipemaps contains fluids AND items, to accept more than 1 of the fluid, if the recipe is made of items AND fluids.
This PR also clears the isOutputFull flag on input changes, due to changes to the input inventory. For example if a machine is stalled due the recipe outputting fluids, then the player removes that recipes ingredients, the machine will keep stalled until it fluid or changes to item output occurs.

This does not, however, makes the machine switch from the current cached recipe if the current ingredients in the machine could form, say a recipe that outputs only items.

## Implementation Details
Included items in the valid fluid recipe lookup

## Outcome
Mod is playable again!
Might fix #1147 ?
