### PR TITLE
Fix clipboard buttons not updating upon page change

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -35,11 +35,11 @@ public class GregtechDataCodes {
     public static final int SYNC_TILE_MODE = 500;
 
     // Clipboard
-    public static final int UPDATE_UI = 0;
     public static final int CREATE_FAKE_UI = 1;
     public static final int MOUSE_POSITION = 2;
     public static final int INIT_CLIPBOARD_NBT = 3;
 
+    public static final int UPDATE_UI = 10; // 10-36
     // Pump
     public static final int PUMP_HEAD_LEVEL = 200;
 

--- a/src/main/java/gregtech/api/net/NetworkHandler.java
+++ b/src/main/java/gregtech/api/net/NetworkHandler.java
@@ -39,6 +39,7 @@ public class NetworkHandler {
         registerPacket(CPacketFluidVeinList.class);
         registerPacket(SPacketNotifyCapeChange.class);
         registerPacket(SPacketReloadShaders.class);
+        registerPacket(CPacketClipboardNBTUpdate.class);
 
         initServer();
         if (FMLCommonHandler.instance().getSide().isClient()) {
@@ -53,6 +54,7 @@ public class NetworkHandler {
         registerServerExecutor(CPacketPluginSynced.class);
         registerServerExecutor(CPacketRecoverMTE.class);
         registerServerExecutor(CPacketKeysPressed.class);
+        registerServerExecutor(CPacketClipboardNBTUpdate.class);
     }
 
     // Register packets as "received on client" here

--- a/src/main/java/gregtech/api/net/packets/CPacketClipboardNBTUpdate.java
+++ b/src/main/java/gregtech/api/net/packets/CPacketClipboardNBTUpdate.java
@@ -1,0 +1,53 @@
+package gregtech.api.net.packets;
+
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.net.IPacket;
+import gregtech.api.net.NetworkUtils;
+import gregtech.common.metatileentities.MetaTileEntityClipboard;
+import lombok.NoArgsConstructor;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+
+@NoArgsConstructor
+public class CPacketClipboardNBTUpdate implements IPacket {
+    private int dimension;
+    private BlockPos pos;
+    private int id;
+    private PacketBuffer updateData;
+
+    public CPacketClipboardNBTUpdate(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
+        this.dimension = dimension;
+        this.pos = pos;
+        this.id = id;
+        this.updateData = updateData;
+    }
+
+    @Override
+    public void encode(PacketBuffer buf) {
+        NetworkUtils.writePacketBuffer(buf, updateData);
+        buf.writeVarInt(dimension);
+        buf.writeBlockPos(pos);
+        buf.writeVarInt(id);
+    }
+
+    @Override
+    public void decode(PacketBuffer buf) {
+        this.updateData = NetworkUtils.readPacketBuffer(buf);
+        this.dimension = buf.readVarInt();
+        this.pos = buf.readBlockPos();
+        this.id = buf.readVarInt();
+    }
+
+    // TODO This could still be cleaned up
+    @Override
+    public void executeServer(NetHandlerPlayServer handler) {
+        TileEntity te = NetworkUtils.getTileEntityServer(dimension, pos);
+        if (te instanceof IGregTechTileEntity && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MetaTileEntityClipboard) {
+            try {
+                ((MetaTileEntityClipboard) ((IGregTechTileEntity) te).getMetaTileEntity()).setClipboardNBT(updateData.readCompoundTag());
+            } catch (Exception ignored) {}
+        }
+    }
+}

--- a/src/main/java/gregtech/common/gui/impl/FakeModularUIContainerClipboard.java
+++ b/src/main/java/gregtech/common/gui/impl/FakeModularUIContainerClipboard.java
@@ -21,7 +21,6 @@ import java.util.function.Consumer;
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_UI;
 
 
-// Note: when porting the central monitor, please make this more generic.
 public class FakeModularUIContainerClipboard extends FakeModularGuiContainer {
     private final NonNullList<ItemStack> inventoryItemStacks = NonNullList.create();
     public final List<Slot> inventorySlots = Lists.newArrayList();
@@ -101,7 +100,7 @@ public class FakeModularUIContainerClipboard extends FakeModularGuiContainer {
 
     @Override
     public void writeUpdateInfo(Widget widget, int updateId, Consumer<PacketBuffer> payloadWriter) {
-        this.clipboard.writeCustomData(UPDATE_UI, buf -> {
+        this.clipboard.writeCustomData(UPDATE_UI + modularUI.guiWidgets.inverse().get(widget), buf -> {
             buf.writeVarInt(windowId);
             buf.writeVarInt(modularUI.guiWidgets.inverse().get(widget));
             buf.writeVarInt(updateId);

--- a/src/main/java/gregtech/common/items/behaviors/ClipboardBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ClipboardBehavior.java
@@ -109,7 +109,6 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
     private static NBTTagCompound getPageCompound(ItemStack stack) {
         if (!MetaItems.CLIPBOARD.isItemEqual(stack))
             return null;
-        assert stack.getTagCompound() != null;
         short pageNum = stack.getTagCompound().getShort("PageIndex");
         return stack.getTagCompound().getCompoundTag("Page" + pageNum);
     }
@@ -117,7 +116,6 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
     private static void setPageCompound(ItemStack stack, NBTTagCompound pageCompound) {
         if (!MetaItems.CLIPBOARD.isItemEqual(stack))
             return;
-        assert stack.getTagCompound() != null;
         short pageNum = stack.getTagCompound().getShort("PageIndex");
         stack.getTagCompound().setTag("Page" + pageNum, pageCompound);
     }
@@ -227,7 +225,6 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
         stack.setTagCompound(tagCompound);
     }
 
-
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack heldItem = player.getHeldItem(hand);
@@ -247,7 +244,7 @@ public class ClipboardBehavior implements IItemBehaviour, ItemUIFactory {
             IBlockState testState = world.getBlockState(pos);
             Block testBlock = testState.getBlock();
             if (!testBlock.isAir(world.getBlockState(pos), world, pos) && testState.isSideSolid(world, pos, facing)) {
-                // Step away from the block so you don't replace it, and then give it our fun blockstate
+                // Step away from the block so that you don't replace it, and then give it our fun blockstate
                 BlockPos shiftedPos = pos.offset(facing);
                 Block shiftedBlock = world.getBlockState(shiftedPos).getBlock();
                 if (shiftedBlock.isAir(world.getBlockState(shiftedPos), world, shiftedPos)) {

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -83,10 +83,9 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
         if (this.getWorld().isRemote) {
             if (guiCache != null)
                 guiCache.updateScreen();
-        } else {
-            if (guiContainerCache != null)
-                guiContainerCache.detectAndSendChanges();
         }
+        if (guiContainerCache != null)
+            guiContainerCache.detectAndSendChanges();
     }
 
     @Override
@@ -164,8 +163,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
             this.guiContainerCache = fakeModularUIContainer;
             if (getWorld().isRemote)
                 this.guiCache = new FakeModularGui(ui, fakeModularUIContainer);
-            this.writeCustomData(CREATE_FAKE_UI, buffer -> {
-            });
+            this.writeCustomData(CREATE_FAKE_UI, buffer -> {});
         } catch (Exception e) {
             GTLog.logger.error(e);
         }


### PR DESCRIPTION
## What
Previously, there was an issue where upon changing pages in-world, the checkbox buttons would not be updated to the page that the clipboard was now on. This clearly needed fixing. 

## Implementation Details
This PR allows for the NBT to be directly synced to the server upon any changes in the clipboard on the client side, preventing most issues with un-synced page indices. Furthermore, thanks to the changes with the use of the UPDATE_UI datacode, more than one update may be handled at a time, as now the ID of the widget is added to this code to diversify it.

## Outcome
Now, upon switching pages in any context, the in-world clipboard properly updates its buttons.

## Additional Information
Before, the checkboxes would not update their state, but now:
[Screencast from 08-21-2022 12:09:24 PM.webm](https://user-images.githubusercontent.com/80226372/185802762-f2d8bdfc-eecd-42eb-b76d-c5ebbdbf54a9.webm)

