### PR TITLE
Useable Circuit Slot For Recipes

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -101,7 +101,11 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
 
     @Override
     public IItemHandlerModifiable getImportItems() {
-        return importItemsWithCircuit;
+        if (circuitInventory != null && IntCircuitIngredient.isIntegratedCircuit(circuitInventory.getStackInSlot(0))){
+            return importItemsWithCircuit;
+        }else {
+            return super.getImportItems();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -102,9 +102,9 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     @Override
     public IItemHandlerModifiable getImportItems() {
         ItemStack circStack = circuitInventory != null ? circuitInventory.getStackInSlot(0) : ItemStack.EMPTY;
-        if (circStack != ItemStack.EMPTY && IntCircuitIngredient.isIntegratedCircuit(circStack)){
+        if (circStack != ItemStack.EMPTY && IntCircuitIngredient.isIntegratedCircuit(circStack)) {
             return importItemsWithCircuit;
-        }else {
+        } else {
             return super.getImportItems();
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -470,7 +470,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         ItemStack stack;
         if (circuitInventory != null && IntCircuitIngredient.isIntegratedCircuit(stack = circuitInventory.getStackInSlot(0))) {
             IntCircuitIngredient.adjustConfiguration(stack, data.isShiftClick ? 5 : 1);
-            this.workable.forceRecipeRecheck();
+            this.notifiedItemInputList.add(circuitInventory);
         }
     }
 
@@ -478,7 +478,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         ItemStack stack;
         if (circuitInventory != null && IntCircuitIngredient.isIntegratedCircuit(stack = circuitInventory.getStackInSlot(0))) {
             IntCircuitIngredient.adjustConfiguration(stack, data.isShiftClick ? -5 : -1);
-            this.workable.forceRecipeRecheck();
+            this.notifiedItemInputList.add(circuitInventory);
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -101,7 +101,8 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
 
     @Override
     public IItemHandlerModifiable getImportItems() {
-        if (circuitInventory != null && IntCircuitIngredient.isIntegratedCircuit(circuitInventory.getStackInSlot(0))){
+        ItemStack circStack = circuitInventory != null ? circuitInventory.getStackInSlot(0) : ItemStack.EMPTY;
+        if (circStack != ItemStack.EMPTY && IntCircuitIngredient.isIntegratedCircuit(circStack)){
             return importItemsWithCircuit;
         }else {
             return super.getImportItems();

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -7,10 +7,7 @@ import codechicken.lib.vec.Matrix4;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IActiveOutputSide;
-import gregtech.api.capability.impl.EnergyContainerHandler;
-import gregtech.api.capability.impl.FluidHandlerProxy;
-import gregtech.api.capability.impl.FluidTankList;
-import gregtech.api.capability.impl.ItemHandlerProxy;
+import gregtech.api.capability.impl.*;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.ICoverable;
@@ -43,9 +40,11 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -56,7 +55,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     private final boolean hasFrontFacing;
 
     protected final ItemStackHandler chargerInventory;
-    protected final ItemStackHandler circuitInventory;
+    protected ItemStackHandler circuitInventory;
     private EnumFacing outputFacingItems;
     private EnumFacing outputFacingFluids;
 
@@ -67,6 +66,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
 
     protected IItemHandler outputItemInventory;
     protected IFluidHandler outputFluidInventory;
+    protected IItemHandlerModifiable importItemsWithCircuit;
 
     private static final int FONT_HEIGHT = 9; // Minecraft's FontRenderer FONT_HEIGHT value
 
@@ -79,7 +79,6 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         super(metaTileEntityId, recipeMap, renderer, tier, tankScalingFunction);
         this.hasFrontFacing = hasFrontFacing;
         this.chargerInventory = new ItemStackHandler(1);
-        this.circuitInventory = new ItemStackHandler(1);
     }
 
     @Override
@@ -92,6 +91,17 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         super.initializeInventory();
         this.outputItemInventory = new ItemHandlerProxy(new ItemStackHandler(0), exportItems);
         this.outputFluidInventory = new FluidHandlerProxy(new FluidTankList(false), exportFluids);
+        this.circuitInventory = new NotifiableItemStackHandler(1, this, false);
+
+        List<IItemHandlerModifiable> temp = new ArrayList<>();
+        temp.add(importItems);
+        temp.add(circuitInventory);
+        this.importItemsWithCircuit = new ItemHandlerList(temp);
+    }
+
+    @Override
+    public IItemHandlerModifiable getImportItems() {
+        return importItemsWithCircuit;
     }
 
     @Override
@@ -455,6 +465,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         ItemStack stack;
         if (circuitInventory != null && IntCircuitIngredient.isIntegratedCircuit(stack = circuitInventory.getStackInSlot(0))) {
             IntCircuitIngredient.adjustConfiguration(stack, data.isShiftClick ? 5 : 1);
+            this.workable.forceRecipeRecheck();
         }
     }
 
@@ -462,6 +473,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         ItemStack stack;
         if (circuitInventory != null && IntCircuitIngredient.isIntegratedCircuit(stack = circuitInventory.getStackInSlot(0))) {
             IntCircuitIngredient.adjustConfiguration(stack, data.isShiftClick ? -5 : -1);
+            this.workable.forceRecipeRecheck();
         }
     }
 


### PR DESCRIPTION
## What
Have the circuit inventory slot count as being in the input inventory

## Implementation Details
Context: `SimpleMachineMetaTileEntity`  
* Combine `importItems` and `circuitInventory` into `importItemsWithCircuit` and return that with an overridden `getImportItems`  
* Change circuit inventory to a `NotifiableItemStackHandler` so the recipe is checked when that slot changes (and an IC is in the slot)  
* Notify machine item input when the circuit is changed via up and down buttons in the GUI

## Outcome
Removes the need to keep the circuit for a machine in the input inventory.


## Additional Information

https://user-images.githubusercontent.com/18713839/186527289-4258f419-fa64-4646-8f1a-5af4978e3dec.mp4




