### PR TITLE
Check against the CT ingredient's internal object

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -48,9 +48,15 @@ public class CTRecipeBuilder {
     @ZenMethod
     public CTRecipeBuilder inputs(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
-            if (ingredient.getInternal() instanceof IOreDictEntry) {
+            String oreDict = null;
+            if (ingredient instanceof IOreDictEntry) {
+                oreDict = ((IOreDictEntry) ingredient).getName();
+            } else if (ingredient.getInternal() instanceof IOreDictEntry) {
+                oreDict = ((IOreDictEntry) ingredient.getInternal()).getName();
+            }
+            if (oreDict != null) {
                 this.backingBuilder.input(
-                        GTRecipeOreInput.getOrCreate(((IOreDictEntry) ingredient.getInternal()).getName(), ingredient.getAmount()));
+                        GTRecipeOreInput.getOrCreate(oreDict, ingredient.getAmount()));
             } else {
                 this.backingBuilder.input(GTRecipeItemInput.getOrCreate(
                         new CraftTweakerItemInputWrapper(ingredient), ingredient.getAmount()));
@@ -62,13 +68,19 @@ public class CTRecipeBuilder {
     @ZenMethod
     public CTRecipeBuilder notConsumable(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
+            String oreDict = null;
             if (ingredient instanceof IOreDictEntry) {
+                oreDict = ((IOreDictEntry) ingredient).getName();
+            } else if (ingredient.getInternal() instanceof IOreDictEntry) {
+                oreDict = ((IOreDictEntry) ingredient.getInternal()).getName();
+            }
+            if (oreDict != null) {
                 this.backingBuilder.input(
-                        GTRecipeOreInput.getOrCreate(((IOreDictEntry) ingredient).getName(), ingredient.getAmount())
+                        GTRecipeOreInput.getOrCreate(oreDict, ingredient.getAmount())
                                 .setNonConsumable());
             } else {
                 this.backingBuilder.input(GTRecipeItemInput.getOrCreate(
-                        new CraftTweakerItemInputWrapper(ingredient), ingredient.getAmount())
+                                new CraftTweakerItemInputWrapper(ingredient), ingredient.getAmount())
                         .setNonConsumable());
             }
         }

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -52,11 +52,26 @@ public class CTRecipeBuilder {
             return ((IOreDictEntry) ingredient.getInternal()).getName();
         return null;
     }
+    private static void checkIfExists(IIngredient ingredient, String oreDict) {
+        if (ingredient == null){
+            throw new IllegalArgumentException("Invalid ingredient: is null");
+        }
+
+        if (ingredient.getItems().size() == 0) {
+            if (oreDict != null) {
+                throw new IllegalArgumentException("Invalid Ore Dictionary [" + oreDict + "]: contains no items");
+            } else {
+                throw new IllegalArgumentException("Invalid Item [" + ingredient.toString() + "]: item not found");
+            }
+        }
+    }
 
     @ZenMethod
     public CTRecipeBuilder inputs(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
             String oreDict = extractOreDictEntry(ingredient);
+            checkIfExists(ingredient, oreDict);
+
             if (oreDict != null) {
                 this.backingBuilder.input(
                         GTRecipeOreInput.getOrCreate(oreDict, ingredient.getAmount()));
@@ -72,6 +87,8 @@ public class CTRecipeBuilder {
     public CTRecipeBuilder notConsumable(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
             String oreDict = extractOreDictEntry(ingredient);
+            checkIfExists(ingredient, oreDict);
+
             if (oreDict != null) {
                 this.backingBuilder.input(
                         GTRecipeOreInput.getOrCreate(oreDict, ingredient.getAmount())

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -52,8 +52,9 @@ public class CTRecipeBuilder {
             return ((IOreDictEntry) ingredient.getInternal()).getName();
         return null;
     }
+    
     private static void checkIfExists(IIngredient ingredient, String oreDict) {
-        if (ingredient == null){
+        if (ingredient == null) {
             throw new IllegalArgumentException("Invalid ingredient: is null");
         }
 

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -45,15 +45,18 @@ public class CTRecipeBuilder {
         return this;
     }
 
+    private static String extractOreDictEntry(IIngredient ingredient) {
+        if (ingredient instanceof IOreDictEntry)
+            return ((IOreDictEntry) ingredient).getName();
+        if (ingredient.getInternal() instanceof IOreDictEntry)
+            return ((IOreDictEntry) ingredient.getInternal()).getName();
+        return null;
+    }
+
     @ZenMethod
     public CTRecipeBuilder inputs(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
-            String oreDict = null;
-            if (ingredient instanceof IOreDictEntry) {
-                oreDict = ((IOreDictEntry) ingredient).getName();
-            } else if (ingredient.getInternal() instanceof IOreDictEntry) {
-                oreDict = ((IOreDictEntry) ingredient.getInternal()).getName();
-            }
+            String oreDict = extractOreDictEntry(ingredient);
             if (oreDict != null) {
                 this.backingBuilder.input(
                         GTRecipeOreInput.getOrCreate(oreDict, ingredient.getAmount()));
@@ -68,12 +71,7 @@ public class CTRecipeBuilder {
     @ZenMethod
     public CTRecipeBuilder notConsumable(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
-            String oreDict = null;
-            if (ingredient instanceof IOreDictEntry) {
-                oreDict = ((IOreDictEntry) ingredient).getName();
-            } else if (ingredient.getInternal() instanceof IOreDictEntry) {
-                oreDict = ((IOreDictEntry) ingredient.getInternal()).getName();
-            }
+            String oreDict = extractOreDictEntry(ingredient);
             if (oreDict != null) {
                 this.backingBuilder.input(
                         GTRecipeOreInput.getOrCreate(oreDict, ingredient.getAmount())

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -48,9 +48,9 @@ public class CTRecipeBuilder {
     @ZenMethod
     public CTRecipeBuilder inputs(IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
-            if (ingredient instanceof IOreDictEntry) {
+            if (ingredient.getInternal() instanceof IOreDictEntry) {
                 this.backingBuilder.input(
-                        GTRecipeOreInput.getOrCreate(((IOreDictEntry) ingredient).getName(), ingredient.getAmount()));
+                        GTRecipeOreInput.getOrCreate(((IOreDictEntry) ingredient.getInternal()).getName(), ingredient.getAmount()));
             } else {
                 this.backingBuilder.input(GTRecipeItemInput.getOrCreate(
                         new CraftTweakerItemInputWrapper(ingredient), ingredient.getAmount()));


### PR DESCRIPTION
## What
See #1154

## Implementation Details
Check if the internal object of the `IIngredient` parameter is of type `IOreDictEntry`

## Outcome
Fixes #1154 

## Additional Information

https://user-images.githubusercontent.com/18713839/186188990-0ebb8672-8865-42dc-8430-778d1d50bccc.mp4



Testing scripts:
[test_zenscripts.zip](https://github.com/GregTechCEu/GregTech/files/9403578/test_zenscripts.zip)

