### PR TITLE
Fix steel dupe with cleanroom glass and plascrete

### DIFF
--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -161,13 +161,13 @@ public class MaterialInfoLoader {
         ));
 
         OreDictUnifier.registerOre(MetaBlocks.CLEANROOM_CASING.getItemVariant(BlockCleanroomCasing.CasingType.PLASCRETE), new ItemMaterialInfo(
-                new MaterialStack(Materials.Steel, M * 2), // frame / 2
+                new MaterialStack(Materials.Steel, M), // frame / 2
                 new MaterialStack(Materials.Polyethylene, M * 3), // 6 sheets / 2
                 new MaterialStack(Materials.Concrete, M / 2) // 1 block / 2
         ));
 
         OreDictUnifier.registerOre(MetaBlocks.TRANSPARENT_CASING.getItemVariant(BlockGlassCasing.CasingType.CLEANROOM_GLASS), new ItemMaterialInfo(
-                new MaterialStack(Materials.Steel, M * 2), // frame / 2
+                new MaterialStack(Materials.Steel, M), // frame / 2
                 new MaterialStack(Materials.Polyethylene, M * 3), // 6 sheets / 2
                 new MaterialStack(Materials.Glass, M / 2) // 1 block / 2
         ));


### PR DESCRIPTION
## What
Fixes extra steel being returned when recycling cleanroom glass or plascrete



## Outcome
Fix 1 plascrete/glass giving back to 2 steel ingots

## Additional Information
1 steel frame (2 steel ingots => 4 steel rods) + 6 PE sheets + 1 glass = 2 cleanroom glass
Therefore, 1 cleanroom glass = 1 steel ingots + 3 PE sheets and 1/2 glass (2 small piles)

