### PR TITLE
Rebalance and Fix Epoxy Chemistry

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -121,7 +121,7 @@ public class OrganicChemistryMaterials {
                 .ingot(1).fluid()
                 .color(0xC88C14)
                 .flags(STD_METAL, DISABLE_DECOMPOSITION, NO_SMASHING, FLAMMABLE)
-                .components(Carbon, 21, Hydrogen, 25, Chlorine, 1, Oxygen, 5)
+                .components(Carbon, 21, Hydrogen, 24, Oxygen, 4)
                 .fluidTemp(400)
                 .build();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/AcidRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/AcidRecipes.java
@@ -129,18 +129,17 @@ public class AcidRecipes {
     }
 
     private static void phosphoricAcidRecipes() {
-
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
-                .input(dust, Phosphorus, 4)
-                .fluidInputs(Oxygen.getFluid(10000))
+                .input(dust, Phosphorus, 2)
+                .fluidInputs(Oxygen.getFluid(5000))
                 .output(dust, PhosphorusPentoxide, 14)
                 .duration(40).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .input(dust, PhosphorusPentoxide, 14)
-                .fluidInputs(Water.getFluid(6000))
-                .fluidOutputs(PhosphoricAcid.getFluid(4000))
+                .input(dust, PhosphorusPentoxide, 7)
+                .fluidInputs(Water.getFluid(3000))
+                .fluidOutputs(PhosphoricAcid.getFluid(2000))
                 .duration(40).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
@@ -150,14 +149,6 @@ public class AcidRecipes {
                 .output(dust, Gypsum, 40)
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(PhosphoricAcid.getFluid(3000))
-                .duration(320).EUt(VA[LV]).buildAndRegister();
-
-        LARGE_CHEMICAL_RECIPES.recipeBuilder()
-                .notConsumable(new IntCircuitIngredient(24))
-                .input(dust, Phosphorus, 2)
-                .fluidInputs(Water.getFluid(3000))
-                .fluidInputs(Oxygen.getFluid(5000))
-                .fluidOutputs(PhosphoricAcid.getFluid(2000))
                 .duration(320).EUt(VA[LV]).buildAndRegister();
     }
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/LCRCombined.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/LCRCombined.java
@@ -32,17 +32,17 @@ public class LCRCombined {
                 .duration(160)
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder()
+        LARGE_CHEMICAL_RECIPES.recipeBuilder() // The Cumeme Process (Shortcut)
                 .notConsumable(new IntCircuitIngredient(24))
                 .fluidInputs(Propene.getFluid(1000))
                 .fluidInputs(Benzene.getFluid(1000))
-                .fluidInputs(Oxygen.getFluid(1000))
+                .fluidInputs(Oxygen.getFluid(2000))
                 .fluidInputs(PhosphoricAcid.getFluid(100))
                 .fluidOutputs(Phenol.getFluid(1000))
                 .fluidOutputs(Acetone.getFluid(1000))
-                .duration(480).EUt(VA[LV]).buildAndRegister();
+                .duration(480).EUt(VA[HV]).buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder()
+        LARGE_CHEMICAL_RECIPES.recipeBuilder() // The Raschig-Hooker Process
                 .notConsumable(new IntCircuitIngredient(24))
                 .fluidInputs(Benzene.getFluid(1000))
                 .fluidInputs(Chlorine.getFluid(2000))
@@ -50,17 +50,17 @@ public class LCRCombined {
                 .fluidOutputs(Phenol.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(DilutedHydrochloricAcid.getFluid(1000))
-                .duration(560).EUt(VA[LV]).buildAndRegister();
+                .duration(560).EUt(VA[HV]).buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder()
+        LARGE_CHEMICAL_RECIPES.recipeBuilder() // The Dow Process (shortcut)
                 .notConsumable(new IntCircuitIngredient(24))
-                .fluidInputs(Benzene.getFluid(2000))
-                .fluidInputs(Chlorine.getFluid(4000))
-                .input(dust, SodiumHydroxide, 6)
-                .output(dust, Salt, 4)
-                .fluidOutputs(Phenol.getFluid(2000))
-                .fluidOutputs(HydrochloricAcid.getFluid(2000))
-                .duration(1120).EUt(VA[LV]).buildAndRegister();
+                .fluidInputs(Benzene.getFluid(1000))
+                .fluidInputs(Chlorine.getFluid(1000))
+                .input(dust, SodiumHydroxide, 3)
+                .output(dust, Salt, 2)
+                .fluidOutputs(Phenol.getFluid(1000))
+                .fluidOutputs(Oxygen.getFluid(1000))
+                .duration(620).EUt(VA[HV]).buildAndRegister();
 
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(24))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -270,17 +270,6 @@ public class PolymerRecipes {
                 .duration(480).EUt(VA[LV]).buildAndRegister();
 
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
-                .notConsumable(new IntCircuitIngredient(23))
-                .fluidInputs(Chlorine.getFluid(4000))
-                .fluidInputs(Propene.getFluid(1000))
-                .fluidInputs(Water.getFluid(1000))
-                .input(dust, SodiumHydroxide, 3)
-                .fluidOutputs(Epichlorohydrin.getFluid(1000))
-                .fluidOutputs(HydrochloricAcid.getFluid(2000))
-                .fluidOutputs(SaltWater.getFluid(1000))
-                .duration(640).EUt(VA[LV]).buildAndRegister();
-
-        LARGE_CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(24))
                 .fluidInputs(Chlorine.getFluid(2000))
                 .fluidInputs(Propene.getFluid(1000))
@@ -289,9 +278,9 @@ public class PolymerRecipes {
                 .fluidOutputs(Epichlorohydrin.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(SaltWater.getFluid(1000))
-                .duration(640).EUt(VA[LV]).buildAndRegister();
+                .duration(640).EUt(VA[HV]).buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder()
+        CHEMICAL_RECIPES.recipeBuilder() // The Cumene Process
                 .fluidInputs(Oxygen.getFluid(2000))
                 .fluidInputs(Cumene.getFluid(1000))
                 .fluidOutputs(Phenol.getFluid(1000))
@@ -307,25 +296,26 @@ public class PolymerRecipes {
                 .fluidOutputs(DilutedHydrochloricAcid.getFluid(1000))
                 .duration(160).EUt(VA[LV]).buildAndRegister();
 
+        // 2NaOH + 2C3H5ClO + C15H16O2 -> C21H24O4 + 2NaCl + 2H2O
         CHEMICAL_RECIPES.recipeBuilder()
-                .input(dust, SodiumHydroxide, 3)
-                .fluidInputs(Epichlorohydrin.getFluid(1000))
+                .input(dust, SodiumHydroxide, 6)
+                .fluidInputs(Epichlorohydrin.getFluid(2000))
                 .fluidInputs(BisphenolA.getFluid(1000))
-                .fluidOutputs(Epoxy.getFluid(1000))
-                .fluidOutputs(SaltWater.getFluid(1000))
+                .fluidOutputs(Epoxy.getFluid(1008))
+                .fluidOutputs(SaltWater.getFluid(2000))
                 .duration(200).EUt(VA[LV]).buildAndRegister();
 
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(24))
-                .fluidInputs(Epichlorohydrin.getFluid(1000))
+                .fluidInputs(Epichlorohydrin.getFluid(2000))
                 .fluidInputs(Phenol.getFluid(2000))
                 .fluidInputs(Acetone.getFluid(1000))
                 .fluidInputs(HydrochloricAcid.getFluid(1000))
-                .input(dust, SodiumHydroxide, 3)
-                .fluidOutputs(Epoxy.getFluid(1000))
-                .fluidOutputs(SaltWater.getFluid(1000))
+                .input(dust, SodiumHydroxide, 6)
+                .fluidOutputs(Epoxy.getFluid(1008))
+                .fluidOutputs(SaltWater.getFluid(2000))
                 .fluidOutputs(DilutedHydrochloricAcid.getFluid(1000))
-                .duration(480).EUt(VA[LV]).buildAndRegister();
+                .duration(680).EUt(VA[HV]).buildAndRegister();
     }
 
     private static void styreneButadieneProcess() {

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -262,18 +262,17 @@ public class ReactorRecipes {
                 .duration(320).EUt(96).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .fluidInputs(Mercury.getFluid(1000))
-                .fluidInputs(Water.getFluid(10000))
-                .fluidInputs(Chlorine.getFluid(10000))
-                .fluidOutputs(HypochlorousAcid.getFluid(10000))
-                .duration(600).EUt(VA[ULV]).buildAndRegister();
+                .fluidInputs(Mercury.getFluid(100))
+                .fluidInputs(Water.getFluid(1000))
+                .fluidInputs(Chlorine.getFluid(1000))
+                .fluidOutputs(HypochlorousAcid.getFluid(1000))
+                .duration(60).EUt(VA[ULV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .notConsumable(new IntCircuitIngredient(1))
                 .fluidInputs(Water.getFluid(1000))
                 .fluidInputs(Chlorine.getFluid(2000))
-                .fluidOutputs(DilutedHydrochloricAcid.getFluid(1000))
-                .fluidOutputs(HypochlorousAcid.getFluid(1000))
+                .fluidInputs(Oxygen.getFluid(1000))
+                .fluidOutputs(HypochlorousAcid.getFluid(2000))
                 .duration(120).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
@@ -299,11 +298,11 @@ public class ReactorRecipes {
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))
-                .fluidInputs(PhosphoricAcid.getFluid(1000))
-                .fluidInputs(Benzene.getFluid(8000))
-                .fluidInputs(Propene.getFluid(8000))
-                .fluidOutputs(Cumene.getFluid(8000))
-                .duration(1920).EUt(VA[LV]).buildAndRegister();
+                .fluidInputs(PhosphoricAcid.getFluid(100))
+                .fluidInputs(Benzene.getFluid(1000))
+                .fluidInputs(Propene.getFluid(1000))
+                .fluidOutputs(Cumene.getFluid(1000))
+                .duration(160).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, Silicon)
@@ -590,13 +589,13 @@ public class ReactorRecipes {
                 .outputs(new ItemStack(Blocks.TNT))
                 .duration(200).EUt(24).buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder()
-                .input(dust, SodiumHydroxide, 6)
-                .fluidInputs(Dichlorobenzene.getFluid(1000))
-                .output(dust, Salt, 4)
+        CHEMICAL_RECIPES.recipeBuilder() // The Dow Process
+                .input(dust, SodiumHydroxide, 3)
+                .fluidInputs(Chlorobenzene.getFluid(1000))
+                .output(dust, Salt, 2)
                 .fluidOutputs(Phenol.getFluid(1000))
                 .fluidOutputs(Oxygen.getFluid(1000))
-                .duration(120).EUt(VA[LV]).buildAndRegister();
+                .duration(220).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .fluidInputs(MethylAcetate.getFluid(1000))


### PR DESCRIPTION
## What
This PR fixes Epoxy's chemistry and rebalances the recipes for producing it.

## Implementation Details
Phosphorus Pentoxide and Phosphoric Acid have had their recipes divided by 2, but durations remain the same. This shouldn't cause many issues duration wise, and it makes the recipes use a lot less oxygen per time now. The LCR shortcut for Phosphoric Acid was removed.

The recipe for Cumene was divided by 8, excluding the Phosphoric Acid consumed catalyst which was divided by 10. Fixed the recipe for Phenol using too little Oxygen from Cumene, and moves this recipe's LCR shortcut to HV.

The Dow Process was corrected to use Chlorobenzene instead of Dichlorobenzene, and was rebalanced as such. Additionally, it was made longer than the Cumene process as the Cumene Process should be preferred.

The LCR shortcut for the Dow Process has been divided by two and had its chemistry fixed. The Dow and Raschig-Hooker Processes' LCR shortcuts were also moved to HV.

The Mercury recipe for Hypochlorous Acid has been divided by 10, and the alternative route updated to no longer produce Dilute Hydrochloric Acid.

The LCR shortcut for Epichlorohydrin which skips the Hypochlorous Acid step has been removed, and the one including the step has been moved to HV.

The chemical formula for the Epoxy used in CEu has been corrected, and the recipe rebalanced. The LCR shortcut was moved to HV, and given a longer duration.

## Outcome
Fixes and Rebalances Epoxy production.

## Potential Compatibility Issues
These recipe changes will break existing setups.