### PR TITLE
Fix Recipe Logic not Validating Cached Recipe Voltage Before Running

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -302,7 +302,9 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return true if the previous recipe is valid and can be run again
      */
     protected boolean checkPreviousRecipe() {
-        return this.previousRecipe != null && this.previousRecipe.matches(false, getInputInventory(), getInputTank());
+        if (this.previousRecipe == null) return false;
+        if (this.previousRecipe.getEUt() > this.getMaxVoltage()) return false;
+        return this.previousRecipe.matches(false, getInputInventory(), getInputTank());
     }
 
     /**


### PR DESCRIPTION
## What
This PR fixes recipe logic not validating that the voltage is correct on cached recipes. This could lead to multiblocks running a recipe with adequate power, having energy hatches swapped to be inadequate, and then immediately running the cached recipe again even though there is not enough power to do so.

## Outcome
Fixed recipe logic not validating minimum energy on cached recipes.