### PR TITLE
Relax itemstack matching on the crafting result for recipes that add NBT data to their outputs

### DIFF
--- a/src/main/java/gregtech/common/gui/widget/craftingstation/CraftingSlotWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/CraftingSlotWidget.java
@@ -69,6 +69,7 @@ public class CraftingSlotWidget extends SlotWidget implements IRecipeTransferHan
                         int maxCrafts = this.slotReference.getStack().getMaxStackSize() / this.slotReference.getStack().getCount();
                         for (int i = 0; i < maxCrafts; i++) {
                             if (canMergeToInv(playerInventory, toMerge, crafts) && recipeResolver.performRecipe(gui.entityPlayer)) {
+                                this.recipeResolver.refreshOutputSlot();
                                 recipeResolver.handleItemCraft(this.slotReference.getStack(), gui.entityPlayer);
                                 totalCrafts += crafts;
                             }
@@ -79,6 +80,7 @@ public class CraftingSlotWidget extends SlotWidget implements IRecipeTransferHan
                     } else if (isRightClick) {
                         int totalCrafts = 0;
                         while (canMergeToInv(playerInventory, toMerge, crafts) && recipeResolver.performRecipe(gui.entityPlayer)) {
+                            this.recipeResolver.refreshOutputSlot();
                             recipeResolver.handleItemCraft(this.slotReference.getStack(), gui.entityPlayer);
                             totalCrafts += crafts;
                         }
@@ -89,18 +91,18 @@ public class CraftingSlotWidget extends SlotWidget implements IRecipeTransferHan
                 } else {
                     if (isLeftClick) {
                         if (canMerge(player.inventory.getItemStack(), this.slotReference.getStack()) && recipeResolver.performRecipe(gui.entityPlayer)) {
+                            this.recipeResolver.refreshOutputSlot();
                             recipeResolver.handleItemCraft(this.slotReference.getStack(), gui.entityPlayer);
                             //send slot changes now, both of consumed items in inventory and result slot
                             ItemStack result = this.slotReference.getStack();
                             mergeToHand(result);
-                            this.recipeResolver.refreshOutputSlot();
                         }
                     } else if (isRightClick) {
                         while (canMerge(player.inventory.getItemStack(), this.slotReference.getStack()) && recipeResolver.performRecipe(gui.entityPlayer)) {
+                            this.recipeResolver.refreshOutputSlot();
                             recipeResolver.handleItemCraft(this.slotReference.getStack(), gui.entityPlayer);
                             ItemStack result = this.slotReference.getStack();
                             mergeToHand(result);
-                            this.recipeResolver.refreshOutputSlot();
                         }
                     }
                 }

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -69,7 +69,6 @@ public class CachedRecipeData {
         if (currentStack.isEmpty()) {
             return true; //stack is empty, nothing to return
         }
-        ItemStack previousStack = recipe.getCraftingResult(inventory);
 
         if (simulateExtractItem(KeySharedStack.getRegisteredStack(currentStack))) {
             return true;
@@ -80,8 +79,7 @@ public class CachedRecipeData {
             ItemStack itemStack = itemStackKey.getItemStack();
             //update item in slot, and check that recipe matches and output item is equal to the expected one
             inventory.setInventorySlotContents(slot, itemStack);
-            if (recipe.matches(inventory, itemSources.getWorld()) &&
-                    ItemStack.areItemStacksEqual(previousStack, recipe.getCraftingResult(inventory))) {
+            if (recipe.matches(inventory, itemSources.getWorld())) {
                 //ingredient matched, attempt to extract it and return if successful
                 if (simulateExtractItem(itemStackKey)) {
                     return true;

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeLogic.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeLogic.java
@@ -34,6 +34,7 @@ public class CraftingRecipeLogic {
     private final ItemStackKey[] oldCraftingGrid = new ItemStackKey[9];
     private final InventoryCrafting inventoryCrafting = new InventoryCrafting(new DummyContainer(), 3, 3);
     private final IInventory craftingResultInventory = new InventoryCraftResult();
+    private ItemStack oldResult = ItemStack.EMPTY;
     private final CachedRecipeData cachedRecipeData;
     private final CraftingRecipeMemory recipeMemory;
     private IRecipe cachedRecipe = null;
@@ -162,12 +163,13 @@ public class CraftingRecipeLogic {
     }
 
     private void updateCurrentRecipe() {
-        if (!cachedRecipeData.matches(inventoryCrafting, world)) {
+        if (!cachedRecipeData.matches(inventoryCrafting, world) || !ItemStack.areItemStacksEqual(oldResult, cachedRecipe.getCraftingResult(inventoryCrafting))) {
             IRecipe newRecipe = CraftingManager.findMatchingRecipe(inventoryCrafting, world);
             this.cachedRecipe = newRecipe;
             ItemStack resultStack = ItemStack.EMPTY;
             if (newRecipe != null) {
                 resultStack = newRecipe.getCraftingResult(inventoryCrafting);
+                oldResult = resultStack.copy();
             }
             this.craftingResultInventory.setInventorySlotContents(0, resultStack);
             this.cachedRecipeData.setRecipe(newRecipe);


### PR DESCRIPTION
Refresh the crafting result slot with the result of the items consumed used in the actual 3x3 crafting grid

Fixes propector weird crafting and weird energy transfer