### PR TITLE
Configurable maintenance fix

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.IHeatingCoil;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
+import net.minecraft.util.Tuple;
 
 import javax.annotation.Nonnull;
 
@@ -21,9 +22,12 @@ public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
 
     @Override
     protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int maxOverclocks) {
+        // apply maintenance penalties
+        Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+
         return heatingCoilOverclockingLogic(Math.abs(recipeEUt),
                 maxVoltage,
-                duration,
+                (int) Math.round(duration * maintenanceValues.getSecond()),
                 maxOverclocks,
                 ((IHeatingCoil) metaTileEntity).getCurrentTemperature(),
                 propertyStorage.getRecipePropertyValue(TemperatureProperty.getInstance(), 0)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -29,6 +29,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraft.util.Tuple;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -268,10 +269,14 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                 return new int[]{recipeEUt, recipeDuration};
             }
 
+            // apply maintenance penalties
+            Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+
             int originalTier = Math.max(1, GTUtility.getTierByVoltage(recipeEUt / Math.max(1, this.parallelRecipesPerformed)));
             int numOverclocks = Math.min(this.machineTier, GTUtility.getTierByVoltage(getMaxVoltage())) - originalTier;
             return unlockedVoltageOverclockingLogic(
-                    recipeEUt, getMaxVoltage(), recipeDuration,
+                    recipeEUt, getMaxVoltage(),
+                    (int) Math.round(recipeDuration * maintenanceValues.getSecond()),
                     getOverclockingDurationDivisor(),
                     getOverclockingVoltageMultiplier(),
                     numOverclocks


### PR DESCRIPTION
## What
#1178

## Implementation Details
Added configurable maintenance bonuses to machines that overrode the base overclock calculations and did not account for the bonuses.

## Outcome
Fixes #1178 