### PR TITLE
LCR TFE fix

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -146,7 +146,7 @@ public class PolymerRecipes {
                 .fluidInputs(Chlorine.getFluid(12000))
                 .fluidOutputs(Tetrafluoroethylene.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(12000))
-                .duration(540).EUt(VA[IV] * 2).buildAndRegister();
+                .duration(540).EUt(VA[IV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -145,9 +145,8 @@ public class PolymerRecipes {
                 .fluidInputs(Methane.getFluid(2000))
                 .fluidInputs(Chlorine.getFluid(12000))
                 .fluidOutputs(Tetrafluoroethylene.getFluid(1000))
-                .fluidOutputs(HydrochloricAcid.getFluid(6000))
-                .fluidOutputs(DilutedHydrochloricAcid.getFluid(6000))
-                .duration(540).EUt(240).buildAndRegister();
+                .fluidOutputs(HydrochloricAcid.getFluid(12000))
+                .duration(540).EUt(VA[IV] * 2).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(1))


### PR DESCRIPTION
## What
fix shortcut Tetrafluoroethylene recipe in LCR being Chlorine negative, and increases power usage to 15360 EU/t

## Outcome
resolves bugs described in https://discord.com/channels/701354865217110096/704380911206006855/984270211802869770 (CEu) and https://discord.com/channels/927050775073534012/954620685848825886/1018121323790204999 (nomi)

## Potential Compatibility Issues
Recipe change which will break certain setups
