### PR TITLE
Convert to Jetbrains annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,8 @@ repositories {
 }
 
 dependencies {
+    "compileOnly"("org.jetbrains:annotations:23.0.0")
+
     "deobfCompile"("curse.maven:codechicken-lib-1-8-242818:2779848")
 
     "deobfCompile"("curse.maven:ae2-extended-life-570458:3649419")

--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -25,7 +25,7 @@ import net.minecraftforge.fml.common.eventhandler.GenericEvent;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/gregtech/api/block/BlockCustomParticle.java
+++ b/src/main/java/gregtech/api/block/BlockCustomParticle.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class BlockCustomParticle extends Block implements ICustomParticleBlock {
 
@@ -38,7 +38,7 @@ public abstract class BlockCustomParticle extends Block implements ICustomPartic
 
     @Override
     @SideOnly(Side.CLIENT)
-    public boolean addHitEffects(@Nonnull IBlockState state, @Nonnull World worldObj, RayTraceResult target, @Nonnull ParticleManager manager) {
+    public boolean addHitEffects(@NotNull IBlockState state, @NotNull World worldObj, RayTraceResult target, @NotNull ParticleManager manager) {
         Pair<TextureAtlasSprite, Integer> atlasSprite = getParticleTexture(worldObj, target.getBlockPos());
         ParticleHandlerUtil.addHitEffects(state, worldObj, target, atlasSprite.getLeft(), atlasSprite.getRight(), manager);
         return true;
@@ -46,7 +46,7 @@ public abstract class BlockCustomParticle extends Block implements ICustomPartic
 
     @Override
     @SideOnly(Side.CLIENT)
-    public boolean addDestroyEffects(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull ParticleManager manager) {
+    public boolean addDestroyEffects(@NotNull World world, @NotNull BlockPos pos, @NotNull ParticleManager manager) {
         Pair<TextureAtlasSprite, Integer> atlasSprite = getParticleTexture(world, pos);
         ParticleHandlerUtil.addBlockDestroyEffects(world.getBlockState(pos), world, pos, atlasSprite.getLeft(), atlasSprite.getRight(), manager);
         return true;
@@ -60,7 +60,7 @@ public abstract class BlockCustomParticle extends Block implements ICustomPartic
     }
 
     @Override
-    public boolean addRunningEffects(@Nonnull IBlockState state, World world, @Nonnull BlockPos pos, @Nonnull Entity entity) {
+    public boolean addRunningEffects(@NotNull IBlockState state, World world, @NotNull BlockPos pos, @NotNull Entity entity) {
         if (world.isRemote) {
             Pair<TextureAtlasSprite, Integer> atlasSprite = getParticleTexture(world, pos);
             ParticleHandlerUtil.addBlockRunningEffects(world, entity, atlasSprite.getLeft(), atlasSprite.getRight());
@@ -69,7 +69,7 @@ public abstract class BlockCustomParticle extends Block implements ICustomPartic
     }
 
     @Override
-    public boolean addLandingEffects(@Nonnull IBlockState state, @Nonnull WorldServer worldObj, @Nonnull BlockPos blockPosition, @Nonnull IBlockState iblockstate, EntityLivingBase entity, int numberOfParticles) {
+    public boolean addLandingEffects(@NotNull IBlockState state, @NotNull WorldServer worldObj, @NotNull BlockPos blockPosition, @NotNull IBlockState iblockstate, EntityLivingBase entity, int numberOfParticles) {
         SPacketBlockParticle
                 packet = new SPacketBlockParticle(blockPosition, new Vector3(entity.posX, entity.posY, entity.posZ), numberOfParticles);
         NetworkHandler.channel.sendToAllTracking(packet.toFMLPacket(), NetworkUtils.blockPoint(worldObj, blockPosition));

--- a/src/main/java/gregtech/api/block/BuiltInRenderBlock.java
+++ b/src/main/java/gregtech/api/block/BuiltInRenderBlock.java
@@ -4,7 +4,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.BlockRenderLayer;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class BuiltInRenderBlock extends BlockCustomParticle {
 
@@ -12,7 +12,7 @@ public abstract class BuiltInRenderBlock extends BlockCustomParticle {
         super(materialIn);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
@@ -20,13 +20,13 @@ public abstract class BuiltInRenderBlock extends BlockCustomParticle {
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isOpaqueCube(@Nonnull IBlockState state) {
+    public boolean isOpaqueCube(@NotNull IBlockState state) {
         return false;
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isFullCube(@Nonnull IBlockState state) {
+    public boolean isFullCube(@NotNull IBlockState state) {
         return false;
     }
 

--- a/src/main/java/gregtech/api/block/CTHeatingCoilBlockStats.java
+++ b/src/main/java/gregtech/api/block/CTHeatingCoilBlockStats.java
@@ -8,8 +8,8 @@ import gregtech.api.unification.material.Material;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ZenClass("mods.gregtech.blocks.HeatingCoils")
 @ZenRegister
@@ -40,7 +40,7 @@ public class CTHeatingCoilBlockStats implements IHeatingCoilBlockStats {
         this.material = material;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return this.name;
@@ -73,12 +73,12 @@ public class CTHeatingCoilBlockStats implements IHeatingCoilBlockStats {
     }
 
     @ZenMethod
-    public static void add(@Nonnull IBlockState state, @Nonnull String name, int coilTemperature, int level, int energyDiscount, int tier, @Nullable Material material) {
+    public static void add(@NotNull IBlockState state, @NotNull String name, int coilTemperature, int level, int energyDiscount, int tier, @Nullable Material material) {
         GregTechAPI.HEATING_COILS.put(CraftTweakerMC.getBlockState(state), new CTHeatingCoilBlockStats(name, coilTemperature, level, energyDiscount, tier, material));
     }
 
     @ZenMethod
-    public static void remove(@Nonnull IBlockState state) {
+    public static void remove(@NotNull IBlockState state) {
         GregTechAPI.HEATING_COILS.remove(CraftTweakerMC.getBlockState(state));
     }
 }

--- a/src/main/java/gregtech/api/block/DelayedStateBlock.java
+++ b/src/main/java/gregtech/api/block/DelayedStateBlock.java
@@ -5,7 +5,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This class allows lazy initialization of block state of block
@@ -18,7 +18,7 @@ public abstract class DelayedStateBlock extends Block {
         super(materialIn);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected final BlockStateContainer createBlockState() {
         return new BlockStateContainer(this);

--- a/src/main/java/gregtech/api/block/IHeatingCoilBlockStats.java
+++ b/src/main/java/gregtech/api/block/IHeatingCoilBlockStats.java
@@ -3,8 +3,8 @@ package gregtech.api.block;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 import gregtech.api.unification.material.Material;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Implement this interface on the Block Enum for your Heating Coil block
@@ -16,7 +16,7 @@ public interface IHeatingCoilBlockStats {
     /**
      * @return The Unique Name of the Heating Coil
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**

--- a/src/main/java/gregtech/api/block/UnlistedIntegerProperty.java
+++ b/src/main/java/gregtech/api/block/UnlistedIntegerProperty.java
@@ -2,17 +2,17 @@ package gregtech.api.block;
 
 import net.minecraftforge.common.property.IUnlistedProperty;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class UnlistedIntegerProperty implements IUnlistedProperty<Integer> {
 
     private final String name;
 
-    public UnlistedIntegerProperty(@Nonnull String name) {
+    public UnlistedIntegerProperty(@NotNull String name) {
         this.name = name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return this.name;
@@ -23,14 +23,14 @@ public class UnlistedIntegerProperty implements IUnlistedProperty<Integer> {
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<Integer> getType() {
         return Integer.class;
     }
 
     @Override
-    public String valueToString(@Nonnull Integer integer) {
+    public String valueToString(@NotNull Integer integer) {
         return integer.toString();
     }
 }

--- a/src/main/java/gregtech/api/block/UnlistedStringProperty.java
+++ b/src/main/java/gregtech/api/block/UnlistedStringProperty.java
@@ -2,17 +2,17 @@ package gregtech.api.block;
 
 import net.minecraftforge.common.property.IUnlistedProperty;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class UnlistedStringProperty implements IUnlistedProperty<String> {
 
     private final String name;
 
-    public UnlistedStringProperty(@Nonnull String name) {
+    public UnlistedStringProperty(@NotNull String name) {
         this.name = name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return this.name;
@@ -23,7 +23,7 @@ public class UnlistedStringProperty implements IUnlistedProperty<String> {
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<String> getType() {
         return String.class;

--- a/src/main/java/gregtech/api/block/VariantActiveBlock.java
+++ b/src/main/java/gregtech/api/block/VariantActiveBlock.java
@@ -9,7 +9,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends VariantBlock<T>{
     public static final PropertyBool ACTIVE = PropertyBool.create("active");
@@ -41,7 +41,7 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
         Class<T> enumClass = GTUtility.getActualTypeParameter(getClass(), VariantActiveBlock.class, 0);
@@ -51,11 +51,11 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
     }
 
     @Override
-    public int damageDropped(@Nonnull IBlockState state) {
+    public int damageDropped(@NotNull IBlockState state) {
         return getMetaFromState(state) - (state.getValue(ACTIVE) ? 8 : 0);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IBlockState getStateFromMeta(int meta) {
         return super.getStateFromMeta(meta).withProperty(ACTIVE, meta / 8 >= 1);

--- a/src/main/java/gregtech/api/block/VariantBlock.java
+++ b/src/main/java/gregtech/api/block/VariantBlock.java
@@ -17,8 +17,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> list) {
+    public void getSubBlocks(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> list) {
         for (T variant : VALUES) {
             list.add(getItemVariant(variant));
         }
@@ -66,7 +66,7 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
         return new ItemStack(this, amount, variant.ordinal());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
         Class<T> enumClass = GTUtility.getActualTypeParameter(getClass(), VariantBlock.class, 0);
@@ -77,7 +77,7 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World player, List<String> tooltip, @Nonnull ITooltipFlag advanced) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World player, List<String> tooltip, @NotNull ITooltipFlag advanced) {
         //basic tooltip for all variant blocks
         tooltip.add(I18n.format("tile.machine_casing.tooltip1"));
         tooltip.add(I18n.format("tile.machine_casing.tooltip2"));
@@ -92,11 +92,11 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
     }
 
     @Override
-    public int damageDropped(@Nonnull IBlockState state) {
+    public int damageDropped(@NotNull IBlockState state) {
         return getMetaFromState(state);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
     public IBlockState getStateFromMeta(int meta) {

--- a/src/main/java/gregtech/api/block/VariantItemBlock.java
+++ b/src/main/java/gregtech/api/block/VariantItemBlock.java
@@ -5,7 +5,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class VariantItemBlock<R extends Enum<R> & IStringSerializable, T extends VariantBlock<R>> extends ItemBlock {
 
@@ -27,9 +27,9 @@ public class VariantItemBlock<R extends Enum<R> & IStringSerializable, T extends
         return block.getStateFromMeta(getMetadata(stack.getItemDamage()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getTranslationKey(@Nonnull ItemStack stack) {
+    public String getTranslationKey(@NotNull ItemStack stack) {
         return super.getTranslationKey(stack) + '.' + genericBlock.getState(getBlockState(stack)).getName();
     }
 

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -61,8 +61,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 import static gregtech.api.util.GTUtility.getMetaTileEntity;
@@ -87,7 +87,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean canHarvestBlock(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityPlayer player) {
+    public boolean canHarvestBlock(@NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityPlayer player) {
         if (ConfigHolder.machines.requireWrenchForMachines) {
             return player.getHeldItemMainhand().hasCapability(GregtechCapabilities.CAPABILITY_WRENCH, null);
         }
@@ -96,13 +96,13 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Nullable
     @Override
-    public String getHarvestTool(@Nonnull IBlockState state) {
+    public String getHarvestTool(@NotNull IBlockState state) {
         String value = ((IExtendedBlockState) state).getValue(HARVEST_TOOL);
         return value == null ? "wrench" : value; //safety check for mods who don't handle state properly
     }
 
     @Override
-    public int getHarvestLevel(@Nonnull IBlockState state) {
+    public int getHarvestLevel(@NotNull IBlockState state) {
         Integer value = ((IExtendedBlockState) state).getValue(HARVEST_LEVEL);
         return value == null ? 0 : value; //safety check for mods who don't handle state properly
     }
@@ -112,9 +112,9 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         return state.getValue(OPAQUE);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getActualState(@Nonnull IBlockState state, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {
+    public IBlockState getActualState(@NotNull IBlockState state, @NotNull IBlockAccess worldIn, @NotNull BlockPos pos) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         if (metaTileEntity == null)
             return state;
@@ -124,13 +124,13 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                 .withProperty(HARVEST_LEVEL, metaTileEntity.getHarvestLevel());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
         return new ExtendedBlockState(this, new IProperty[]{OPAQUE}, new IUnlistedProperty[]{HARVEST_TOOL, HARVEST_LEVEL});
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IBlockState getStateFromMeta(int meta) {
         return getDefaultState().withProperty(OPAQUE, meta % 2 == 0);
@@ -142,18 +142,18 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
     @Override
-    public float getBlockHardness(@Nonnull IBlockState blockState, @Nonnull World worldIn, @Nonnull BlockPos pos) {
+    public float getBlockHardness(@NotNull IBlockState blockState, @NotNull World worldIn, @NotNull BlockPos pos) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         return metaTileEntity == null ? 1.0f : metaTileEntity.getBlockHardness();
     }
 
     @Override
-    public float getExplosionResistance(@Nonnull World world, @Nonnull BlockPos pos, @Nullable Entity exploder, @Nonnull Explosion explosion) {
+    public float getExplosionResistance(@NotNull World world, @NotNull BlockPos pos, @Nullable Entity exploder, @NotNull Explosion explosion) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         return metaTileEntity == null ? 1.0f : metaTileEntity.getBlockResistance();
     }
@@ -169,13 +169,13 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean doesSideBlockRendering(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+    public boolean doesSideBlockRendering(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EnumFacing face) {
         return state.isOpaqueCube() && getMetaTileEntity(world, pos) != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getPickBlock(@Nonnull IBlockState state, @Nonnull RayTraceResult target, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EntityPlayer player) {
+    public ItemStack getPickBlock(@NotNull IBlockState state, @NotNull RayTraceResult target, @NotNull World world, @NotNull BlockPos pos, @NotNull EntityPlayer player) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         if (metaTileEntity == null)
             return ItemStack.EMPTY;
@@ -186,7 +186,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public void addCollisionBoxToList(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull AxisAlignedBB entityBox, @Nonnull List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
+    public void addCollisionBoxToList(@NotNull IBlockState state, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull AxisAlignedBB entityBox, @NotNull List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
         for (Cuboid6 axisAlignedBB : getCollisionBox(worldIn, pos)) {
             AxisAlignedBB offsetBox = axisAlignedBB.aabb().offset(pos);
             if (offsetBox.intersects(entityBox)) collidingBoxes.add(offsetBox);
@@ -195,12 +195,12 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Nullable
     @Override
-    public RayTraceResult collisionRayTrace(@Nonnull IBlockState blockState, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Vec3d start, @Nonnull Vec3d end) {
+    public RayTraceResult collisionRayTrace(@NotNull IBlockState blockState, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull Vec3d start, @NotNull Vec3d end) {
         return RayTracer.rayTraceCuboidsClosest(start, end, pos, getCollisionBox(worldIn, pos));
     }
 
     @Override
-    public boolean rotateBlock(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing axis) {
+    public boolean rotateBlock(@NotNull World world, @NotNull BlockPos pos, @NotNull EnumFacing axis) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         if (metaTileEntity == null ||
                 !metaTileEntity.isValidFrontFacing(axis) ||
@@ -213,7 +213,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Nullable
     @Override
-    public EnumFacing[] getValidRotations(@Nonnull World world, @Nonnull BlockPos pos) {
+    public EnumFacing[] getValidRotations(@NotNull World world, @NotNull BlockPos pos) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         if (metaTileEntity == null || !metaTileEntity.hasFrontFacing()) return null;
         return Arrays.stream(EnumFacing.VALUES)
@@ -222,7 +222,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean recolorBlock(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, @Nonnull EnumDyeColor color) {
+    public boolean recolorBlock(@NotNull World world, @NotNull BlockPos pos, @NotNull EnumFacing side, @NotNull EnumDyeColor color) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         if (metaTileEntity == null ||
                 metaTileEntity.getPaintingColor() == color.colorValue)
@@ -232,7 +232,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public void onBlockPlacedBy(World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull EntityLivingBase placer, ItemStack stack) {
+    public void onBlockPlacedBy(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull EntityLivingBase placer, ItemStack stack) {
         IGregTechTileEntity holder = (IGregTechTileEntity) worldIn.getTileEntity(pos);
         MetaTileEntity sampleMetaTileEntity = GregTechAPI.MTE_REGISTRY.getObjectById(stack.getItemDamage());
         if (holder != null && sampleMetaTileEntity != null) {
@@ -259,7 +259,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public void breakBlock(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public void breakBlock(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         if (metaTileEntity != null) {
             if (!metaTileEntity.keepsInventory()) {
@@ -278,7 +278,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
+    public void getDrops(@NotNull NonNullList<ItemStack> drops, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull IBlockState state, int fortune) {
         MetaTileEntity metaTileEntity = tileEntities.get() == null ? getMetaTileEntity(world, pos) : tileEntities.get();
         if (metaTileEntity == null) return;
         if (!metaTileEntity.shouldDropWhenDestroyed())
@@ -301,7 +301,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean onBlockActivated(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull EntityPlayer playerIn, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
+    public boolean onBlockActivated(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull EntityPlayer playerIn, @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         CuboidRayTraceResult rayTraceResult = (CuboidRayTraceResult) RayTracer.retraceBlock(worldIn, playerIn, pos);
         ItemStack itemStack = playerIn.getHeldItem(hand);
@@ -339,7 +339,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public void onBlockClicked(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull EntityPlayer playerIn) {
+    public void onBlockClicked(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull EntityPlayer playerIn) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         if (metaTileEntity == null) return;
         CuboidRayTraceResult rayTraceResult = (CuboidRayTraceResult) RayTracer.retraceBlock(worldIn, playerIn, pos);
@@ -349,26 +349,26 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean canConnectRedstone(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nullable EnumFacing side) {
+    public boolean canConnectRedstone(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @Nullable EnumFacing side) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         return metaTileEntity != null && metaTileEntity.canConnectRedstone(side == null ? null : side.getOpposite());
     }
 
     @Override
-    public boolean shouldCheckWeakPower(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public boolean shouldCheckWeakPower(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
         // actually cause getWeakPower to be called, rather than prevent it.
         return false;
     }
 
     @Override
-    public int getWeakPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public int getWeakPower(@NotNull IBlockState blockState, @NotNull IBlockAccess blockAccess, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(blockAccess, pos);
         return metaTileEntity == null ? 0 : metaTileEntity.getOutputRedstoneSignal(side == null ? null : side.getOpposite());
     }
 
     @Override
-    public void neighborChanged(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Block blockIn, @Nonnull BlockPos fromPos) {
+    public void neighborChanged(@NotNull IBlockState state, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull Block blockIn, @NotNull BlockPos fromPos) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         if (metaTileEntity != null) {
             metaTileEntity.updateInputRedstoneSignals();
@@ -377,7 +377,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public int getComparatorInputOverride(@Nonnull IBlockState blockState, @Nonnull World worldIn, @Nonnull BlockPos pos) {
+    public int getComparatorInputOverride(@NotNull IBlockState blockState, @NotNull World worldIn, @NotNull BlockPos pos) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         return metaTileEntity == null ? 0 : metaTileEntity.getComparatorValue();
     }
@@ -385,14 +385,14 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     protected final ThreadLocal<MetaTileEntity> tileEntities = new ThreadLocal<>();
 
     @Override
-    public void harvestBlock(@Nonnull World worldIn, @Nonnull EntityPlayer player, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nullable TileEntity te, @Nonnull ItemStack stack) {
+    public void harvestBlock(@NotNull World worldIn, @NotNull EntityPlayer player, @NotNull BlockPos pos, @NotNull IBlockState state, @Nullable TileEntity te, @NotNull ItemStack stack) {
         tileEntities.set(te == null ? tileEntities.get() : ((IGregTechTileEntity) te).getMetaTileEntity());
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
     }
 
     @Override
-    public boolean hasComparatorInputOverride(@Nonnull IBlockState state) {
+    public boolean hasComparatorInputOverride(@NotNull IBlockState state) {
         return true;
     }
 
@@ -402,15 +402,15 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         return new MetaTileEntityHolder();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SideOnly(Side.CLIENT)
-    public EnumBlockRenderType getRenderType(@Nonnull IBlockState state) {
+    public EnumBlockRenderType getRenderType(@NotNull IBlockState state) {
         return MetaTileEntityRenderer.BLOCK_RENDER_TYPE;
     }
 
     @Override
-    public boolean canRenderInLayer(@Nonnull IBlockState state, @Nonnull BlockRenderLayer layer) {
+    public boolean canRenderInLayer(@NotNull IBlockState state, @NotNull BlockRenderLayer layer) {
         return true;
     }
 
@@ -424,43 +424,43 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         return state.getValue(OPAQUE);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public BlockFaceShape getBlockFaceShape(@Nonnull IBlockAccess worldIn, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+    public BlockFaceShape getBlockFaceShape(@NotNull IBlockAccess worldIn, @NotNull IBlockState state, @NotNull BlockPos pos, @NotNull EnumFacing face) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         return metaTileEntity == null ? BlockFaceShape.SOLID : metaTileEntity.getCoverFaceShape(face);
     }
 
     @Override
-    public int getLightValue(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos) {
+    public int getLightValue(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos) {
         //why mc is so fucking retarded to call this method on fucking NEIGHBOUR BLOCKS!
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         return metaTileEntity == null ? 0 : metaTileEntity.getLightValue();
     }
 
     @Override
-    public int getLightOpacity(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos) {
+    public int getLightOpacity(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos) {
         //why mc is so fucking retarded to call this method on fucking NEIGHBOUR BLOCKS!
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         return metaTileEntity == null ? 0 : metaTileEntity.getLightOpacity();
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> items) {
+    public void getSubBlocks(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> items) {
         for (MetaTileEntity metaTileEntity : GregTechAPI.MTE_REGISTRY) {
             metaTileEntity.getSubItems(tab, items);
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getFacade(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nullable EnumFacing side, @Nonnull BlockPos otherPos) {
+    public IBlockState getFacade(@NotNull IBlockAccess world, @NotNull BlockPos pos, @Nullable EnumFacing side, @NotNull BlockPos otherPos) {
         return getFacade(world, pos, side);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getFacade(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, EnumFacing side) {
+    public IBlockState getFacade(@NotNull IBlockAccess world, @NotNull BlockPos pos, EnumFacing side) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         if (metaTileEntity != null && side != null) {
             CoverBehavior coverBehavior = metaTileEntity.getCoverAtSide(side);
@@ -471,9 +471,9 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         return world.getBlockState(pos);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getVisualState(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public IBlockState getVisualState(@NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         return getFacade(world, pos, side);
     }
 
@@ -489,7 +489,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     }
 
     @Override
-    public boolean canEntityDestroy(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull Entity entity) {
+    public boolean canEntityDestroy(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull Entity entity) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
         if(metaTileEntity == null) {
             return super.canEntityDestroy(state, world, pos, entity);
@@ -499,7 +499,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void randomDisplayTick(@Nonnull IBlockState stateIn, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Random rand) {
+    public void randomDisplayTick(@NotNull IBlockState stateIn, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull Random rand) {
         super.randomDisplayTick(stateIn, worldIn, pos, rand);
         MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
         if (metaTileEntity != null) metaTileEntity.randomDisplayTick();

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -25,8 +25,8 @@ import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,15 +37,15 @@ public class MachineItemBlock extends ItemBlock {
         setHasSubtypes(true);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getTranslationKey(@Nonnull ItemStack stack) {
+    public String getTranslationKey(@NotNull ItemStack stack) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(stack);
         return metaTileEntity == null ? "unnamed" : metaTileEntity.getMetaName();
     }
 
     @Override
-    public boolean placeBlockAt(@Nonnull ItemStack stack, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, float hitX, float hitY, float hitZ, IBlockState newState) {
+    public boolean placeBlockAt(@NotNull ItemStack stack, @NotNull EntityPlayer player, @NotNull World world, @NotNull BlockPos pos, @NotNull EnumFacing side, float hitX, float hitY, float hitZ, IBlockState newState) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(stack);
         //prevent rendering glitch before meta tile entity sync to client, but after block placement
         //set opaque property on the placing on block, instead during set of meta tile entity
@@ -66,7 +66,7 @@ public class MachineItemBlock extends ItemBlock {
 
     @Nullable
     @Override
-    public String getCreatorModId(@Nonnull ItemStack itemStack) {
+    public String getCreatorModId(@NotNull ItemStack itemStack) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(itemStack);
         if (metaTileEntity == null) {
             return GTValues.MODID;
@@ -77,7 +77,7 @@ public class MachineItemBlock extends ItemBlock {
 
     @Nullable
     @Override
-    public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt) {
+    public ICapabilityProvider initCapabilities(@NotNull ItemStack stack, @Nullable NBTTagCompound nbt) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(stack);
         return metaTileEntity == null ? null : metaTileEntity.initItemStackCapabilities(stack);
     }
@@ -88,7 +88,7 @@ public class MachineItemBlock extends ItemBlock {
     }
 
     @Override
-    public @Nonnull ItemStack getContainerItem(@Nonnull ItemStack itemStack) {
+    public @NotNull ItemStack getContainerItem(@NotNull ItemStack itemStack) {
         if (!hasContainerItem(itemStack)) {
             return ItemStack.EMPTY;
         }
@@ -107,7 +107,7 @@ public class MachineItemBlock extends ItemBlock {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World worldIn, @NotNull List<String> tooltip, @NotNull ITooltipFlag flagIn) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(stack);
         if (metaTileEntity == null) return;
 

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -313,7 +313,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @param recipe the recipe to check
      * @return true if the recipe is allowed to be used, else false
      */
-    protected boolean checkRecipe(@Nonnull Recipe recipe) {
+    protected boolean checkRecipe(@NotNull Recipe recipe) {
         CleanroomType requiredType = null;
         if (recipe.hasProperty(CleanroomProperty.getInstance())) {
             requiredType = recipe.getProperty(CleanroomProperty.getInstance(), null);
@@ -380,7 +380,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         return ParallelLogicType.MULTIPLY;
     }
 
-    protected int getMinTankCapacity(@Nonnull IMultipleTankHandler tanks) {
+    protected int getMinTankCapacity(@NotNull IMultipleTankHandler tanks) {
         if (tanks.getTanks() == 0) {
             return 0;
         }
@@ -457,7 +457,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         return false;
     }
 
-    protected boolean hasEnoughPower(@Nonnull int[] resultOverclock) {
+    protected boolean hasEnoughPower(@NotNull int[] resultOverclock) {
         // Format of resultOverclock: EU/t, duration
         int totalEUt = resultOverclock[0] * resultOverclock[1];
 
@@ -504,7 +504,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      *
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
-    protected int[] calculateOverclock(@Nonnull Recipe recipe) {
+    protected int[] calculateOverclock(@NotNull Recipe recipe) {
 
         int recipeEUt = recipe.getEUt();
         int recipeDuration = recipe.getDuration();
@@ -815,13 +815,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     @Override
-    public void writeInitialData(@Nonnull PacketBuffer buf) {
+    public void writeInitialData(@NotNull PacketBuffer buf) {
         buf.writeBoolean(this.isActive);
         buf.writeBoolean(this.workingEnabled);
     }
 
     @Override
-    public void receiveInitialData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialData(@NotNull PacketBuffer buf) {
         this.isActive = buf.readBoolean();
         this.workingEnabled = buf.readBoolean();
     }
@@ -852,7 +852,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     @Override
-    public void deserializeNBT(@Nonnull NBTTagCompound compound) {
+    public void deserializeNBT(@NotNull NBTTagCompound compound) {
         this.workingEnabled = compound.getBoolean("WorkEnabled");
         this.canRecipeProgress = compound.getBoolean("CanRecipeProgress");
         this.progressTime = compound.getInteger("Progress");

--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 
@@ -234,7 +234,7 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public void deserializeNBT(@Nonnull NBTTagCompound compound) {
+    public void deserializeNBT(@NotNull NBTTagCompound compound) {
         super.deserializeNBT(compound);
         this.currentHeat = compound.getInteger("Heat");
         this.excessFuel = compound.getInteger("ExcessFuel");
@@ -243,14 +243,14 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public void writeInitialData(@Nonnull PacketBuffer buf) {
+    public void writeInitialData(@NotNull PacketBuffer buf) {
         super.writeInitialData(buf);
         buf.writeVarInt(currentHeat);
         buf.writeVarInt(lastTickSteamOutput);
     }
 
     @Override
-    public void receiveInitialData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialData(@NotNull PacketBuffer buf) {
         super.receiveInitialData(buf);
         this.currentHeat = buf.readVarInt();
         this.lastTickSteamOutput = buf.readVarInt();

--- a/src/main/java/gregtech/api/capability/impl/CapabilityCompatProvider.java
+++ b/src/main/java/gregtech/api/capability/impl/CapabilityCompatProvider.java
@@ -4,7 +4,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class CapabilityCompatProvider implements ICapabilityProvider {
 

--- a/src/main/java/gregtech/api/capability/impl/CleanroomLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/CleanroomLogic.java
@@ -9,7 +9,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CleanroomLogic {
 
@@ -166,7 +166,7 @@ public class CleanroomLogic {
      * writes all needed values to NBT
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeToNBT(NBTTagCompound)} method
      */
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound data) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound data) {
         data.setBoolean("isActive", this.isActive);
         data.setBoolean("isWorkingEnabled", this.isWorkingEnabled);
         data.setBoolean("wasActiveAndNeedsUpdate", this.wasActiveAndNeedsUpdate);
@@ -179,7 +179,7 @@ public class CleanroomLogic {
      * reads all needed values from NBT
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#readFromNBT(NBTTagCompound)} method
      */
-    public void readFromNBT(@Nonnull NBTTagCompound data) {
+    public void readFromNBT(@NotNull NBTTagCompound data) {
         this.isActive = data.getBoolean("isActive");
         this.isWorkingEnabled = data.getBoolean("isWorkingEnabled");
         this.wasActiveAndNeedsUpdate = data.getBoolean("wasActiveAndNeedsUpdate");
@@ -191,7 +191,7 @@ public class CleanroomLogic {
      * writes all needed values to InitialSyncData
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeInitialSyncData(PacketBuffer)} method
      */
-    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
         buf.writeBoolean(this.isActive);
         buf.writeBoolean(this.isWorkingEnabled);
         buf.writeBoolean(this.wasActiveAndNeedsUpdate);
@@ -203,7 +203,7 @@ public class CleanroomLogic {
      * reads all needed values from InitialSyncData
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#receiveInitialSyncData(PacketBuffer)} method
      */
-    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
         setActive(buf.readBoolean());
         setWorkingEnabled(buf.readBoolean());
         setWasActiveAndNeedsUpdate(buf.readBoolean());

--- a/src/main/java/gregtech/api/capability/impl/CombinedCapabilityProvider.java
+++ b/src/main/java/gregtech/api/capability/impl/CombinedCapabilityProvider.java
@@ -4,8 +4,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class CombinedCapabilityProvider implements ICapabilityProvider {
@@ -21,7 +21,7 @@ public class CombinedCapabilityProvider implements ICapabilityProvider {
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         for (ICapabilityProvider provider : providers) {
             if (provider.hasCapability(capability, facing)) {
                 return true;
@@ -32,7 +32,7 @@ public class CombinedCapabilityProvider implements ICapabilityProvider {
 
     @Nullable
     @Override
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+    public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
         for (ICapabilityProvider provider : providers) {
             T cap = provider.getCapability(capability, facing);
             if (cap != null) {

--- a/src/main/java/gregtech/api/capability/impl/EUToFEProvider.java
+++ b/src/main/java/gregtech/api/capability/impl/EUToFEProvider.java
@@ -12,7 +12,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class EUToFEProvider extends CapabilityCompatProvider {
 
@@ -28,14 +28,14 @@ public class EUToFEProvider extends CapabilityCompatProvider {
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing facing) {
+    public boolean hasCapability(@NotNull Capability<?> capability, EnumFacing facing) {
         return ConfigHolder.compat.energy.nativeEUToFE &&
                 capability == GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER &&
                 hasUpvalueCapability(CapabilityEnergy.ENERGY, facing);
     }
 
     @Override
-    public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
+    public <T> T getCapability(@NotNull Capability<T> capability, EnumFacing facing) {
         if (!ConfigHolder.compat.energy.nativeEUToFE || capability != GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER)
             return null;
 

--- a/src/main/java/gregtech/api/capability/impl/ElectricItem.java
+++ b/src/main/java/gregtech/api/capability/impl/ElectricItem.java
@@ -10,8 +10,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.Constants.NBT;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -145,13 +145,13 @@ public class ElectricItem implements IElectricItem, ICapabilityProvider {
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         return capability == GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM;
     }
 
     @Nullable
     @Override
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+    public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
         return capability == GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM ? (T) this : null;
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/FilteredFluidHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/FilteredFluidHandler.java
@@ -4,7 +4,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.function.Predicate;
 
 public class FilteredFluidHandler extends FluidTank {

--- a/src/main/java/gregtech/api/capability/impl/FilteredItemHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/FilteredItemHandler.java
@@ -5,7 +5,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Predicate;
 
 public class FilteredItemHandler extends ItemStackHandler {
@@ -34,7 +34,7 @@ public class FilteredItemHandler extends ItemStackHandler {
     }
 
     @Override
-    public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
         return fillPredicate == null || fillPredicate.test(stack);
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/FluidDrillLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidDrillLogic.java
@@ -11,7 +11,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class FluidDrillLogic {
 
@@ -245,7 +245,7 @@ public class FluidDrillLogic {
      * writes all needed values to NBT
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeToNBT(NBTTagCompound)} method
      */
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound data) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound data) {
         data.setBoolean("isActive", this.isActive);
         data.setBoolean("isWorkingEnabled", this.isWorkingEnabled);
         data.setBoolean("wasActiveAndNeedsUpdate", this.wasActiveAndNeedsUpdate);
@@ -259,7 +259,7 @@ public class FluidDrillLogic {
      * reads all needed values from NBT
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#readFromNBT(NBTTagCompound)} method
      */
-    public void readFromNBT(@Nonnull NBTTagCompound data) {
+    public void readFromNBT(@NotNull NBTTagCompound data) {
         this.isActive = data.getBoolean("isActive");
         this.isWorkingEnabled = data.getBoolean("isWorkingEnabled");
         this.wasActiveAndNeedsUpdate = data.getBoolean("wasActiveAndNeedsUpdate");
@@ -272,7 +272,7 @@ public class FluidDrillLogic {
      * writes all needed values to InitialSyncData
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeInitialSyncData(PacketBuffer)} method
      */
-    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
         buf.writeBoolean(this.isActive);
         buf.writeBoolean(this.isWorkingEnabled);
         buf.writeBoolean(this.wasActiveAndNeedsUpdate);
@@ -284,7 +284,7 @@ public class FluidDrillLogic {
      * reads all needed values from InitialSyncData
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#receiveInitialSyncData(PacketBuffer)} method
      */
-    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
         setActive(buf.readBoolean());
         setWorkingEnabled(buf.readBoolean());
         setWasActiveAndNeedsUpdate(buf.readBoolean());

--- a/src/main/java/gregtech/api/capability/impl/FluidHandlerDelegate.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidHandlerDelegate.java
@@ -4,7 +4,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class FluidHandlerDelegate implements IFluidHandler {
 

--- a/src/main/java/gregtech/api/capability/impl/FluidHandlerProxy.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidHandlerProxy.java
@@ -5,7 +5,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/gregtech/api/capability/impl/FluidTankList.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidTankList.java
@@ -12,8 +12,8 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 /**
@@ -48,7 +48,7 @@ public class FluidTankList implements IFluidHandler, IMultipleTankHandler, INBTS
         return Collections.unmodifiableList(fluidTanks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<IFluidTank> iterator() {
         return getFluidTanks().iterator();

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -10,7 +10,7 @@ import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Supplier;
 
 public class FuelRecipeLogic extends RecipeLogicEnergy {
@@ -32,13 +32,13 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
     }
 
     @Override
-    protected boolean hasEnoughPower(@Nonnull int[] resultOverclock) {
+    protected boolean hasEnoughPower(@NotNull int[] resultOverclock) {
         // generators always have enough power to run recipes
         return true;
     }
 
     @Override
-    public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
+    public void applyParallelBonus(@NotNull RecipeBuilder<?> builder) {
         // the builder automatically multiplies by -1, so nothing extra is needed here
         builder.EUt(builder.getEUt());
     }

--- a/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java
@@ -4,7 +4,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class GTFluidHandlerItemStack extends FluidHandlerItemStack {
 
@@ -12,7 +12,7 @@ public class GTFluidHandlerItemStack extends FluidHandlerItemStack {
      * @param container The container itemStack, data is stored on it directly as NBT.
      * @param capacity  The maximum capacity of this fluid tank.
      */
-    public GTFluidHandlerItemStack(@Nonnull ItemStack container, int capacity) {
+    public GTFluidHandlerItemStack(@NotNull ItemStack container, int capacity) {
         super(container, capacity);
     }
 

--- a/src/main/java/gregtech/api/capability/impl/GTSimpleFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/GTSimpleFluidHandlerItemStack.java
@@ -4,7 +4,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStackSimple;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class GTSimpleFluidHandlerItemStack extends FluidHandlerItemStackSimple {
 
@@ -12,7 +12,7 @@ public class GTSimpleFluidHandlerItemStack extends FluidHandlerItemStackSimple {
      * @param container The container itemStack, data is stored on it directly as NBT.
      * @param capacity  The maximum capacity of this fluid tank.
      */
-    public GTSimpleFluidHandlerItemStack(@Nonnull ItemStack container, int capacity) {
+    public GTSimpleFluidHandlerItemStack(@NotNull ItemStack container, int capacity) {
         super(container, capacity);
     }
 

--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -5,7 +5,7 @@ import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import static gregtech.api.recipes.logic.OverclockingLogic.heatingCoilOverclockingLogic;
 
@@ -20,7 +20,7 @@ public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int maxOverclocks) {
+    protected int[] runOverclockingLogic(@NotNull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int maxOverclocks) {
         return heatingCoilOverclockingLogic(Math.abs(recipeEUt),
                 maxVoltage,
                 duration,

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerDelegate.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerDelegate.java
@@ -3,7 +3,7 @@ package gregtech.api.capability.impl;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemHandlerDelegate implements IItemHandler {
 
@@ -18,19 +18,19 @@ public class ItemHandlerDelegate implements IItemHandler {
         return delegate.getSlots();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getStackInSlot(int slot) {
         return delegate.getStackInSlot(slot);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         return delegate.insertItem(slot, stack, simulate);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         return delegate.extractItem(slot, amount, simulate);

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -6,7 +6,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,14 +40,14 @@ public class ItemHandlerList implements IItemHandlerModifiable {
     }
 
     @Override
-    public void setStackInSlot(int slot, @Nonnull ItemStack stack) {
+    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
         IItemHandler itemHandler = handlerBySlotIndex.get(slot);
         if (!(itemHandler instanceof IItemHandlerModifiable))
             throw new UnsupportedOperationException("Handler " + itemHandler + " does not support this method");
         ((IItemHandlerModifiable) itemHandler).setStackInSlot(slot - baseIndexOffset.get(itemHandler), stack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getStackInSlot(int slot) {
         IItemHandler itemHandler = handlerBySlotIndex.get(slot);
@@ -61,14 +61,14 @@ public class ItemHandlerList implements IItemHandlerModifiable {
         return itemHandler.getSlotLimit(slot - baseIndexOffset.get(itemHandler));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         IItemHandler itemHandler = handlerBySlotIndex.get(slot);
         return itemHandler.insertItem(slot - baseIndexOffset.get(itemHandler), stack, simulate);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         IItemHandler itemHandler = handlerBySlotIndex.get(slot);

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerProxy.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerProxy.java
@@ -3,7 +3,7 @@ package gregtech.api.capability.impl;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemHandlerProxy implements IItemHandler {
 
@@ -20,19 +20,19 @@ public class ItemHandlerProxy implements IItemHandler {
         return insertHandler.getSlots() + extractHandler.getSlots();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getStackInSlot(int slot) {
         return slot < insertHandler.getSlots() ? insertHandler.getStackInSlot(slot) : extractHandler.getStackInSlot(slot - insertHandler.getSlots());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         return slot < insertHandler.getSlots() ? insertHandler.insertItem(slot, stack, simulate) : stack;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         return slot >= insertHandler.getSlots() ? extractHandler.extractItem(slot - insertHandler.getSlots(), amount, simulate) : ItemStack.EMPTY;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -9,7 +9,7 @@ import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.common.ConfigHolder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
 
@@ -50,13 +50,13 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected boolean hasEnoughPower(@Nonnull int[] resultOverclock) {
+    protected boolean hasEnoughPower(@NotNull int[] resultOverclock) {
         // generators always have enough power to run recipes
         return true;
     }
 
     @Override
-    public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
+    public void applyParallelBonus(@NotNull RecipeBuilder<?> builder) {
         // the builder automatically multiplies by -1, so nothing extra is needed here
         builder.EUt(builder.getEUt());
     }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -11,7 +11,7 @@ import gregtech.common.ConfigHolder;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -296,7 +296,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean checkRecipe(@Nonnull Recipe recipe) {
+    protected boolean checkRecipe(@NotNull Recipe recipe) {
         RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
         if (controller.checkRecipe(recipe, false)) {
             controller.checkRecipe(recipe, true);

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -27,7 +27,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.fluids.IFluidTank;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
 
@@ -108,7 +108,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    public void writeInitialData(@Nonnull PacketBuffer buf) {
+    public void writeInitialData(@NotNull PacketBuffer buf) {
         super.writeInitialData(buf);
         buf.writeByte(getVentingSide().getIndex());
         buf.writeBoolean(needsVenting);
@@ -116,7 +116,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    public void receiveInitialData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialData(@NotNull PacketBuffer buf) {
         super.receiveInitialData(buf);
         this.ventingSide = EnumFacing.VALUES[buf.readByte()];
         this.needsVenting = buf.readBoolean();
@@ -178,7 +178,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    protected boolean checkRecipe(@Nonnull Recipe recipe) {
+    protected boolean checkRecipe(@NotNull Recipe recipe) {
         return super.checkRecipe(recipe) && !this.needsVenting;
     }
 
@@ -190,7 +190,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    protected int[] calculateOverclock(@Nonnull Recipe recipe) {
+    protected int[] calculateOverclock(@NotNull Recipe recipe) {
 
         //EUt, Duration
         int[] result = new int[2];
@@ -238,7 +238,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    public void deserializeNBT(@Nonnull NBTTagCompound compound) {
+    public void deserializeNBT(@NotNull NBTTagCompound compound) {
         super.deserializeNBT(compound);
         this.ventingSide = EnumFacing.VALUES[compound.getInteger("VentingSide")];
         this.needsVenting = compound.getBoolean("NeedsVenting");

--- a/src/main/java/gregtech/api/capability/impl/SimpleThermalFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/SimpleThermalFluidHandlerItemStack.java
@@ -4,7 +4,7 @@ import gregtech.api.capability.IThermalFluidHandlerItemStack;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class SimpleThermalFluidHandlerItemStack extends GTSimpleFluidHandlerItemStack implements IThermalFluidHandlerItemStack {
 
@@ -18,7 +18,7 @@ public class SimpleThermalFluidHandlerItemStack extends GTSimpleFluidHandlerItem
      * @param container The container itemStack, data is stored on it directly as NBT.
      * @param capacity  The maximum capacity of this fluid tank.
      */
-    public SimpleThermalFluidHandlerItemStack(@Nonnull ItemStack container, int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
+    public SimpleThermalFluidHandlerItemStack(@NotNull ItemStack container, int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
         super(container, capacity);
         this.maxFluidTemperature = maxFluidTemperature;
         this.gasProof = gasProof;

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -4,7 +4,7 @@ import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.recipes.RecipeBuilder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 
 /**
@@ -25,7 +25,7 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     }
 
     @Override
-    public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
+    public void applyParallelBonus(@NotNull RecipeBuilder<?> builder) {
         int currentRecipeEU = builder.getEUt();
         int currentRecipeDuration = builder.getDuration() / getParallelLimit();
         builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU) * 1.33))

--- a/src/main/java/gregtech/api/capability/impl/ThermalFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/ThermalFluidHandlerItemStack.java
@@ -4,7 +4,7 @@ import gregtech.api.capability.IThermalFluidHandlerItemStack;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ThermalFluidHandlerItemStack extends GTFluidHandlerItemStack implements IThermalFluidHandlerItemStack {
 
@@ -18,7 +18,7 @@ public class ThermalFluidHandlerItemStack extends GTFluidHandlerItemStack implem
      * @param container The container itemStack, data is stored on it directly as NBT.
      * @param capacity  The maximum capacity of this fluid tank.
      */
-    public ThermalFluidHandlerItemStack(@Nonnull ItemStack container, int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
+    public ThermalFluidHandlerItemStack(@NotNull ItemStack container, int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
         super(container, capacity);
         this.maxFluidTemperature = maxFluidTemperature;
         this.gasProof = gasProof;

--- a/src/main/java/gregtech/api/capability/impl/VoidFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/VoidFluidHandlerItemStack.java
@@ -5,7 +5,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import static net.minecraftforge.fluids.capability.templates.EmptyFluidHandler.EMPTY_TANK_PROPERTIES_ARRAY;
 
@@ -19,7 +19,7 @@ public class VoidFluidHandlerItemStack extends FluidHandlerItemStack {
      *
      * @param container The container itemStack.
      */
-    public VoidFluidHandlerItemStack(@Nonnull ItemStack container) {
+    public VoidFluidHandlerItemStack(@NotNull ItemStack container) {
         this(container, Integer.MAX_VALUE);
     }
 
@@ -29,7 +29,7 @@ public class VoidFluidHandlerItemStack extends FluidHandlerItemStack {
      * @param container The container itemStack.
      * @param capacity  max amount to void in each operation
      */
-    public VoidFluidHandlerItemStack(@Nonnull ItemStack container, final int capacity) {
+    public VoidFluidHandlerItemStack(@NotNull ItemStack container, final int capacity) {
         super(container, capacity);
     }
 

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -26,7 +26,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -76,7 +76,7 @@ public class MinerLogic {
      * @param speed the speed in ticks per block mined
      * @param maximumRadius the maximum radius (square shaped) the miner can mine in
      */
-    public MinerLogic(@Nonnull MetaTileEntity metaTileEntity, int fortune, int speed, int maximumRadius, ICubeRenderer pipeTexture) {
+    public MinerLogic(@NotNull MetaTileEntity metaTileEntity, int fortune, int speed, int maximumRadius, ICubeRenderer pipeTexture) {
         this.metaTileEntity = metaTileEntity;
         this.miner = (IMiner) metaTileEntity;
         this.fortune = fortune;
@@ -224,7 +224,7 @@ public class MinerLogic {
      * @param blockToMine the {@link BlockPos} of the block being mined
      * @param blockState the {@link IBlockState} of the block being mined
      */
-    protected void getRegularBlockDrops(NonNullList<ItemStack> blockDrops, WorldServer world, BlockPos blockToMine, @Nonnull IBlockState blockState) {
+    protected void getRegularBlockDrops(NonNullList<ItemStack> blockDrops, WorldServer world, BlockPos blockToMine, @NotNull IBlockState blockState) {
         blockState.getBlock().getDrops(blockDrops, world, blockToMine, blockState, 0); // regular ores do not get fortune applied
     }
 
@@ -263,7 +263,7 @@ public class MinerLogic {
      * @param pos the {@link BlockPos} of the miner itself
      * @param currentRadius the currently set mining radius
      */
-    public void initPos(@Nonnull BlockPos pos, int currentRadius) {
+    public void initPos(@NotNull BlockPos pos, int currentRadius) {
         x.set(pos.getX() - currentRadius);
         z.set(pos.getZ() - currentRadius);
         y.set(pos.getY() - 1);
@@ -283,7 +283,7 @@ public class MinerLogic {
      * @param z the z coordinate
      * @return {@code true} if the coordinates are invalid, else false
      */
-    private static boolean checkCoordinatesInvalid(@Nonnull AtomicInteger x, @Nonnull AtomicInteger y, @Nonnull AtomicInteger z) {
+    private static boolean checkCoordinatesInvalid(@NotNull AtomicInteger x, @NotNull AtomicInteger y, @NotNull AtomicInteger z) {
         return x.get() == Integer.MAX_VALUE && y.get() == Integer.MAX_VALUE && z.get() == Integer.MAX_VALUE;
     }
 
@@ -359,7 +359,7 @@ public class MinerLogic {
      * @param map the recipemap from which to get the drops
      * @param tier the tier at which the operation is performed, used for calculating the chanced output boost
      */
-    protected static void applyTieredHammerNoRandomDrops(@Nonnull IBlockState blockState, List<ItemStack> drops, int fortuneLevel, @Nonnull RecipeMap<?> map, int tier) {
+    protected static void applyTieredHammerNoRandomDrops(@NotNull IBlockState blockState, List<ItemStack> drops, int fortuneLevel, @NotNull RecipeMap<?> map, int tier) {
         ItemStack itemStack = GTUtility.toItem(blockState);
         Recipe recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(itemStack), Collections.emptyList(), 0);
         if (recipe != null && !recipe.getOutputs().isEmpty()) {
@@ -400,7 +400,7 @@ public class MinerLogic {
      * writes all needed values to NBT
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeToNBT(NBTTagCompound)} method
      */
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound data) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound data) {
         data.setTag("xPos", new NBTTagInt(x.get()));
         data.setTag("yPos", new NBTTagInt(y.get()));
         data.setTag("zPos", new NBTTagInt(z.get()));
@@ -424,7 +424,7 @@ public class MinerLogic {
      * reads all needed values from NBT
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#readFromNBT(NBTTagCompound)} method
      */
-    public void readFromNBT(@Nonnull NBTTagCompound data) {
+    public void readFromNBT(@NotNull NBTTagCompound data) {
         x.set(data.getInteger("xPos"));
         y.set(data.getInteger("yPos"));
         z.set(data.getInteger("zPos"));
@@ -447,7 +447,7 @@ public class MinerLogic {
      * writes all needed values to InitialSyncData
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#writeInitialSyncData(PacketBuffer)} method
      */
-    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
         buf.writeInt(pipeLength);
         buf.writeBoolean(this.isActive);
         buf.writeBoolean(this.isWorkingEnabled);
@@ -458,7 +458,7 @@ public class MinerLogic {
      * reads all needed values from InitialSyncData
      * This MUST be called and returned in the MetaTileEntity's {@link MetaTileEntity#receiveInitialSyncData(PacketBuffer)} method
      */
-    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
         this.pipeLength = buf.readInt();
         setActive(buf.readBoolean());
         setWorkingEnabled(buf.readBoolean());

--- a/src/main/java/gregtech/api/capability/impl/miner/MultiblockMinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MultiblockMinerLogic.java
@@ -13,7 +13,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MultiblockMinerLogic extends MinerLogic {
 
@@ -52,7 +52,7 @@ public class MultiblockMinerLogic extends MinerLogic {
     }
 
     @Override
-    protected void getRegularBlockDrops(NonNullList<ItemStack> blockDrops, WorldServer world, BlockPos blockToMine, @Nonnull IBlockState blockState) {
+    protected void getRegularBlockDrops(NonNullList<ItemStack> blockDrops, WorldServer world, BlockPos blockToMine, @NotNull IBlockState blockState) {
         if (!isSilkTouchMode) // 3X the ore compared to the single blocks
             applyTieredHammerNoRandomDrops(blockState, blockDrops, 3, this.blockDropRecipeMap, this.voltageTier);
         else
@@ -60,7 +60,7 @@ public class MultiblockMinerLogic extends MinerLogic {
     }
 
     @Override
-    public void initPos(@Nonnull BlockPos pos, int currentRadius) {
+    public void initPos(@NotNull BlockPos pos, int currentRadius) {
         if (!isChunkMode) {
             super.initPos(pos, currentRadius);
         } else {
@@ -115,28 +115,28 @@ public class MultiblockMinerLogic extends MinerLogic {
     }
 
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound data) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound data) {
         data.setBoolean("isChunkMode", isChunkMode);
         data.setBoolean("isSilkTouchMode", isSilkTouchMode);
         return super.writeToNBT(data);
     }
 
     @Override
-    public void readFromNBT(@Nonnull NBTTagCompound data) {
+    public void readFromNBT(@NotNull NBTTagCompound data) {
         this.isChunkMode = data.getBoolean("isChunkMode");
         this.isSilkTouchMode = data.getBoolean("isSilkTouchMode");
         super.readFromNBT(data);
     }
 
     @Override
-    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
         super.writeInitialSyncData(buf);
         buf.writeBoolean(this.isChunkMode);
         buf.writeBoolean(this.isSilkTouchMode);
     }
 
     @Override
-    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
         super.receiveInitialSyncData(buf);
         this.isChunkMode = buf.readBoolean();
         this.isSilkTouchMode = buf.readBoolean();

--- a/src/main/java/gregtech/api/enchants/EnchantmentEnderDamage.java
+++ b/src/main/java/gregtech/api/enchants/EnchantmentEnderDamage.java
@@ -15,7 +15,7 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class EnchantmentEnderDamage extends Enchantment {
 
@@ -47,7 +47,7 @@ public class EnchantmentEnderDamage extends Enchantment {
     }
 
     @Override
-    public void onEntityDamaged(@Nonnull EntityLivingBase user, @Nonnull Entity target, int level) {
+    public void onEntityDamaged(@NotNull EntityLivingBase user, @NotNull Entity target, int level) {
         String entityName = EntityList.getEntityString(target);
         if (target instanceof EntityLivingBase && (target instanceof EntityEnderman || target instanceof EntityDragon || target instanceof EntityEndermite || (entityName != null && entityName.toLowerCase().contains("ender")))) {
             ((EntityLivingBase) target).addPotionEffect(new PotionEffect(MobEffects.WEAKNESS, level * 200, Math.max(1, (5 * level) / 7)));

--- a/src/main/java/gregtech/api/enchants/EnchantmentHardHammer.java
+++ b/src/main/java/gregtech/api/enchants/EnchantmentHardHammer.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class EnchantmentHardHammer extends Enchantment {
     public static final EnchantmentHardHammer INSTANCE = new EnchantmentHardHammer();
@@ -65,7 +65,7 @@ public class EnchantmentHardHammer extends Enchantment {
     }
 
     @Override
-    protected boolean canApplyTogether(@Nonnull Enchantment ench) {
+    protected boolean canApplyTogether(@NotNull Enchantment ench) {
             return ench != Enchantments.SILK_TOUCH && super.canApplyTogether(ench);
     }
 }

--- a/src/main/java/gregtech/api/fluids/MaterialFluid.java
+++ b/src/main/java/gregtech/api/fluids/MaterialFluid.java
@@ -12,14 +12,14 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MaterialFluid extends Fluid {
 
     private final Material material;
     private final FluidType fluidType;
 
-    public MaterialFluid(String fluidName, @Nonnull Material material, @Nonnull FluidType fluidType, ResourceLocation texture) {
+    public MaterialFluid(String fluidName, @NotNull Material material, @NotNull FluidType fluidType, ResourceLocation texture) {
         super(fluidName, texture, texture, GTUtility.convertRGBtoOpaqueRGBA_MC(material.getMaterialRGB()));
         this.material = material;
         this.fluidType = fluidType;
@@ -29,12 +29,12 @@ public class MaterialFluid extends Fluid {
         FluidTooltipUtil.registerTooltip(this, FluidTooltipUtil.getMaterialTooltip(material, getTemperature(), fluidType.equals(FluidTypes.PLASMA)));
     }
 
-    @Nonnull
+    @NotNull
     public Material getMaterial() {
         return this.material;
     }
 
-    @Nonnull
+    @NotNull
     public FluidType getFluidType() {
         return this.fluidType;
     }

--- a/src/main/java/gregtech/api/fluids/MetaFluids.java
+++ b/src/main/java/gregtech/api/fluids/MetaFluids.java
@@ -25,8 +25,8 @@ import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +81,7 @@ public class MetaFluids {
         }
     }
 
-    public static void handleNonMaterialFluids(@Nonnull Material material, @Nonnull Fluid fluid) {
+    public static void handleNonMaterialFluids(@NotNull Material material, @NotNull Fluid fluid) {
         material.getProperty(PropertyKey.FLUID).setFluid(fluid);
         material.getProperty(PropertyKey.FLUID).setFluidTemperature(fluid.getTemperature());
         List<String> tooltip = new ArrayList<>();
@@ -171,7 +171,7 @@ public class MetaFluids {
      * @param material  the material whose texture to change
      * @param fluidType the type of the fluid
      */
-    public static void setMaterialFluidTexture(@Nonnull Material material, @Nonnull FluidType fluidType) {
+    public static void setMaterialFluidTexture(@NotNull Material material, @NotNull FluidType fluidType) {
         String path = "blocks/fluids/fluid." + material.toString();
         if (fluidType.equals(FluidTypes.PLASMA))
             path += ".plasma";
@@ -200,12 +200,12 @@ public class MetaFluids {
         fluidSprites.add(textureLocation);
     }
 
-    public static void setAlternativeFluidName(Material material, @Nonnull FluidType fluidType, String alternativeName) {
+    public static void setAlternativeFluidName(Material material, @NotNull FluidType fluidType, String alternativeName) {
         alternativeFluidNames.put(fluidType.getNameForMaterial(material), alternativeName);
     }
 
-    @Nonnull
-    public static Fluid registerFluid(@Nonnull Material material, @Nonnull FluidType fluidType, int temperature, boolean generateBlock) {
+    @NotNull
+    public static Fluid registerFluid(@NotNull Material material, @NotNull FluidType fluidType, int temperature, boolean generateBlock) {
         String materialName = material.toString();
         String fluidName = fluidType.getNameForMaterial(material);
         Fluid fluid = FluidRegistry.getFluid(fluidName);
@@ -264,7 +264,7 @@ public class MetaFluids {
     }
 
     @Nullable
-    public static Material getMaterialFromFluid(@Nonnull Fluid fluid) {
+    public static Material getMaterialFromFluid(@NotNull Fluid fluid) {
         Material material = fluidToMaterialMappings.get(fluid.getName());
         if (material.hasFluid())
             return material;

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidType.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidType.java
@@ -9,8 +9,8 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +27,7 @@ public abstract class FluidType {
     private final String suffix;
     protected final String localization;
 
-    public FluidType(@Nonnull String name, @Nullable String prefix, @Nullable String suffix, @Nonnull String localization) {
+    public FluidType(@NotNull String name, @Nullable String prefix, @Nullable String suffix, @NotNull String localization) {
         if (FLUID_TYPES.get(name) != null)
             throw new IllegalArgumentException("Cannot register FluidType with duplicate name: " + name);
 
@@ -38,7 +38,7 @@ public abstract class FluidType {
         FLUID_TYPES.put(name, this);
     }
 
-    public String getNameForMaterial(@Nonnull Material material) {
+    public String getNameForMaterial(@NotNull Material material) {
         StringBuilder builder = new StringBuilder();
 
         if (this.prefix != null)
@@ -52,11 +52,11 @@ public abstract class FluidType {
         return builder.toString();
     }
 
-    public static void setFluidProperties(@Nonnull FluidType fluidType, @Nonnull Fluid fluid) {
+    public static void setFluidProperties(@NotNull FluidType fluidType, @NotNull Fluid fluid) {
         fluidType.setFluidProperties(fluid);
     }
 
-    protected abstract void setFluidProperties(@Nonnull Fluid fluid);
+    protected abstract void setFluidProperties(@NotNull Fluid fluid);
 
     @ZenMethod("setFluidProperties")
     public void setFluidPropertiesCT(FluidType fluidType, Material material) {
@@ -97,7 +97,7 @@ public abstract class FluidType {
 
     @Nullable
     @ZenMethod
-    public static FluidType getByName(@Nonnull String name) {
+    public static FluidType getByName(@NotNull String name) {
         return FLUID_TYPES.get(name);
     }
 }

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidTypeAcid.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidTypeAcid.java
@@ -2,15 +2,15 @@ package gregtech.api.fluids.fluidType;
 
 import gregtech.api.util.LocalizationUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class FluidTypeAcid extends FluidTypeLiquid {
 
     private static final String TOOLTIP_NAME = "gregtech.fluid.state_liquid";
 
-    public FluidTypeAcid(@Nonnull String name, @Nullable String prefix, @Nullable String suffix, @Nonnull String localization) {
+    public FluidTypeAcid(@NotNull String name, @Nullable String prefix, @Nullable String suffix, @NotNull String localization) {
         super(name, prefix, suffix, localization);
     }
 

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidTypeGas.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidTypeGas.java
@@ -2,19 +2,19 @@ package gregtech.api.fluids.fluidType;
 
 import net.minecraftforge.fluids.Fluid;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FluidTypeGas extends FluidType {
 
     private static final String TOOLTIP_NAME = "gregtech.fluid.state_gas";
 
-    public FluidTypeGas(@Nonnull String name, @Nullable String prefix, @Nullable String suffix, @Nonnull String localization) {
+    public FluidTypeGas(@NotNull String name, @Nullable String prefix, @Nullable String suffix, @NotNull String localization) {
         super(name, prefix, suffix, localization);
     }
 
     @Override
-    protected void setFluidProperties(@Nonnull Fluid fluid) {
+    protected void setFluidProperties(@NotNull Fluid fluid) {
         fluid.setGaseous(true);
         fluid.setDensity(-100);
         fluid.setViscosity(200);

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidTypeLiquid.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidTypeLiquid.java
@@ -2,19 +2,19 @@ package gregtech.api.fluids.fluidType;
 
 import net.minecraftforge.fluids.Fluid;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FluidTypeLiquid extends FluidType {
 
     private static final String TOOLTIP_NAME = "gregtech.fluid.state_liquid";
 
-    public FluidTypeLiquid(@Nonnull String name, @Nullable String prefix, @Nullable String suffix, @Nonnull String localization) {
+    public FluidTypeLiquid(@NotNull String name, @Nullable String prefix, @Nullable String suffix, @NotNull String localization) {
         super(name, prefix, suffix, localization);
     }
 
     @Override
-    protected void setFluidProperties(@Nonnull Fluid fluid) {
+    protected void setFluidProperties(@NotNull Fluid fluid) {
         fluid.setGaseous(false);
         fluid.setViscosity(1000);
     }

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidTypePlasma.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidTypePlasma.java
@@ -2,19 +2,19 @@ package gregtech.api.fluids.fluidType;
 
 import net.minecraftforge.fluids.Fluid;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FluidTypePlasma extends FluidType {
 
     private static final String TOOLTIP_NAME = "gregtech.fluid.state_plasma";
 
-    public FluidTypePlasma(@Nonnull String name, @Nullable String prefix, @Nullable String suffix, @Nonnull String localization) {
+    public FluidTypePlasma(@NotNull String name, @Nullable String prefix, @Nullable String suffix, @NotNull String localization) {
         super(name, prefix, suffix, localization);
     }
 
     @Override
-    protected void setFluidProperties(@Nonnull Fluid fluid) {
+    protected void setFluidProperties(@NotNull Fluid fluid) {
         fluid.setGaseous(true);
         fluid.setDensity(-100000);
         fluid.setViscosity(10);

--- a/src/main/java/gregtech/api/gui/Widget.java
+++ b/src/main/java/gregtech/api/gui/Widget.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/gregtech/api/gui/impl/ModularUIContainer.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIContainer.java
@@ -19,7 +19,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SPacketSetSlot;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -101,13 +101,13 @@ public class ModularUIContainer extends Container implements WidgetUIAccess {
     }
 
     @Override
-    public void onContainerClosed(@Nonnull EntityPlayer playerIn) {
+    public void onContainerClosed(@NotNull EntityPlayer playerIn) {
         super.onContainerClosed(playerIn);
         modularUI.triggerCloseListeners();
     }
 
     @Override
-    public void addListener(@Nonnull IContainerListener listener) {
+    public void addListener(@NotNull IContainerListener listener) {
         super.addListener(listener);
         modularUI.guiWidgets.values().forEach(Widget::detectAndSendChanges);
     }
@@ -138,9 +138,9 @@ public class ModularUIContainer extends Container implements WidgetUIAccess {
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack slotClick(int slotId, int dragType, @Nonnull ClickType clickTypeIn, @Nonnull EntityPlayer player) {
+    public ItemStack slotClick(int slotId, int dragType, @NotNull ClickType clickTypeIn, @NotNull EntityPlayer player) {
         if (slotId >= 0 && slotId < inventorySlots.size()) {
             Slot slot = getSlot(slotId);
             ItemStack result = slotMap.get(slot).slotClick(dragType, clickTypeIn, player);
@@ -179,9 +179,9 @@ public class ModularUIContainer extends Container implements WidgetUIAccess {
         return GTUtility.mergeItemStack(itemStack, inventorySlots, simulate);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack transferStackInSlot(@Nonnull EntityPlayer player, int index) {
+    public ItemStack transferStackInSlot(@NotNull EntityPlayer player, int index) {
         Slot slot = inventorySlots.get(index);
         if (!slot.canTakeStack(player)) {
             return ItemStack.EMPTY;
@@ -230,12 +230,12 @@ public class ModularUIContainer extends Container implements WidgetUIAccess {
     }
 
     @Override
-    public boolean canMergeSlot(@Nonnull ItemStack stack, @Nonnull Slot slotIn) {
+    public boolean canMergeSlot(@NotNull ItemStack stack, @NotNull Slot slotIn) {
         return slotMap.get(slotIn).canMergeSlot(stack);
     }
 
     @Override
-    public boolean canInteractWith(@Nonnull EntityPlayer playerIn) {
+    public boolean canInteractWith(@NotNull EntityPlayer playerIn) {
         return playerIn == this.modularUI.entityPlayer && this.modularUI.holder.isValid();
     }
 
@@ -274,23 +274,23 @@ public class ModularUIContainer extends Container implements WidgetUIAccess {
             super(EMPTY_INVENTORY, 0, -100000, -100000);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack getStack() {
             return ItemStack.EMPTY;
         }
 
         @Override
-        public void putStack(@Nonnull ItemStack stack) {
+        public void putStack(@NotNull ItemStack stack) {
         }
 
         @Override
-        public boolean isItemValid(@Nonnull ItemStack stack) {
+        public boolean isItemValid(@NotNull ItemStack stack) {
             return false;
         }
 
         @Override
-        public boolean canTakeStack(@Nonnull EntityPlayer playerIn) {
+        public boolean canTakeStack(@NotNull EntityPlayer playerIn) {
             return false;
         }
 

--- a/src/main/java/gregtech/api/gui/widgets/AdvancedTextWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/AdvancedTextWidget.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.input.Mouse;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -255,17 +255,17 @@ public class AdvancedTextWidget extends Widget {
     @SideOnly(Side.CLIENT)
     private static class WrapScreen extends GuiScreen {
         @Override
-        public void handleComponentHover(@Nonnull ITextComponent component, int x, int y) {
+        public void handleComponentHover(@NotNull ITextComponent component, int x, int y) {
             super.handleComponentHover(component, x, y);
         }
 
         @Override
-        public boolean handleComponentClick(@Nonnull ITextComponent component) {
+        public boolean handleComponentClick(@NotNull ITextComponent component) {
             return super.handleComponentClick(component);
         }
 
         @Override
-        protected void drawHoveringText(@Nonnull List<String> textLines, int x, int y, @Nonnull FontRenderer font) {
+        protected void drawHoveringText(@NotNull List<String> textLines, int x, int y, @NotNull FontRenderer font) {
             GuiUtils.drawHoveringText(textLines, x, y, width, height, 256, font);
         }
     }

--- a/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
+++ b/src/main/java/gregtech/api/gui/widgets/OreDictFilterTestSlot.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fml.client.config.GuiUtils;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 import java.util.Arrays;
 import java.util.Collections;
@@ -124,14 +124,14 @@ public class OreDictFilterTestSlot extends Widget implements IGhostIngredientTar
         }
         Rectangle rectangle = toRectangleBox();
         return Lists.newArrayList(new IGhostIngredientHandler.Target<Object>() {
-            @Nonnull
+            @NotNull
             @Override
             public Rectangle getArea() {
                 return rectangle;
             }
 
             @Override
-            public void accept(@Nonnull Object ingredient) {
+            public void accept(@NotNull Object ingredient) {
                 if (ingredient instanceof ItemStack) {
                     putItem((ItemStack) ingredient);
                 }

--- a/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
@@ -26,7 +26,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -101,14 +101,14 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
 
         Rectangle rectangle = toRectangleBox();
         return Lists.newArrayList(new Target<Object>() {
-            @Nonnull
+            @NotNull
             @Override
             public Rectangle getArea() {
                 return rectangle;
             }
 
             @Override
-            public void accept(@Nonnull Object ingredient) {
+            public void accept(@NotNull Object ingredient) {
                 FluidStack ingredientStack;
                 if (ingredient instanceof FluidStack)
                     ingredientStack = (FluidStack) ingredient;

--- a/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
@@ -12,7 +12,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 import java.io.IOException;
 import java.util.Collections;
@@ -82,14 +82,14 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
         }
         Rectangle rectangle = toRectangleBox();
         return Lists.newArrayList(new Target<Object>() {
-            @Nonnull
+            @NotNull
             @Override
             public Rectangle getArea() {
                 return rectangle;
             }
 
             @Override
-            public void accept(@Nonnull Object ingredient) {
+            public void accept(@NotNull Object ingredient) {
                 if (ingredient instanceof ItemStack) {
                     int mouseButton = Mouse.getEventButton();
                     boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);

--- a/src/main/java/gregtech/api/gui/widgets/PhantomTankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomTankWidget.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 import java.io.IOException;
 import java.util.Collections;
@@ -56,14 +56,14 @@ public class PhantomTankWidget extends TankWidget implements IGhostIngredientTar
         Rectangle rectangle = toRectangleBox();
         return Lists.newArrayList(new Target<Object>() {
 
-            @Nonnull
+            @NotNull
             @Override
             public Rectangle getArea() {
                 return rectangle;
             }
 
             @Override
-            public void accept(@Nonnull Object ingredient) {
+            public void accept(@NotNull Object ingredient) {
                 FluidStack stack;
                 if (ingredient instanceof FluidStack) {
                     stack = (FluidStack) ingredient;

--- a/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
@@ -14,8 +14,8 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.math.MathHelper;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.function.BiFunction;
 
 public class SliderWidget extends Widget {
@@ -50,7 +50,7 @@ public class SliderWidget extends Widget {
         this.sliderPosition = (currentValue - min) / (max - min);
     }
 
-    public SliderWidget setSliderIcon(@Nonnull TextureArea sliderIcon) {
+    public SliderWidget setSliderIcon(@NotNull TextureArea sliderIcon) {
         Preconditions.checkNotNull(sliderIcon, "sliderIcon");
         this.sliderIcon = sliderIcon;
         return this;

--- a/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SlotWidget.java
@@ -26,7 +26,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.SlotItemHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
 
@@ -291,26 +291,26 @@ public class SlotWidget extends Widget implements INativeWidget {
         }
 
         @Override
-        public boolean isItemValid(@Nonnull ItemStack stack) {
+        public boolean isItemValid(@NotNull ItemStack stack) {
             return SlotWidget.this.canPutStack(stack) && super.isItemValid(stack);
         }
 
         @Override
-        public boolean canTakeStack(@Nonnull EntityPlayer playerIn) {
+        public boolean canTakeStack(@NotNull EntityPlayer playerIn) {
             return SlotWidget.this.canTakeStack(playerIn) && super.canTakeStack(playerIn);
         }
 
         @Override
-        public void putStack(@Nonnull ItemStack stack) {
+        public void putStack(@NotNull ItemStack stack) {
             super.putStack(stack);
             if (changeListener != null) {
                 changeListener.run();
             }
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public final ItemStack onTake(@Nonnull EntityPlayer thePlayer, @Nonnull ItemStack stack) {
+        public final ItemStack onTake(@NotNull EntityPlayer thePlayer, @NotNull ItemStack stack) {
             return onItemTake(thePlayer, super.onTake(thePlayer, stack), false);
         }
 
@@ -345,7 +345,7 @@ public class SlotWidget extends Widget implements INativeWidget {
         }
 
         @Override
-        public boolean isItemValid(@Nonnull ItemStack stack) {
+        public boolean isItemValid(@NotNull ItemStack stack) {
             return SlotWidget.this.canPutStack(stack) && super.isItemValid(stack);
         }
 
@@ -355,16 +355,16 @@ public class SlotWidget extends Widget implements INativeWidget {
         }
 
         @Override
-        public void putStack(@Nonnull ItemStack stack) {
+        public void putStack(@NotNull ItemStack stack) {
             super.putStack(stack);
             if (changeListener != null) {
                 changeListener.run();
             }
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public final ItemStack onTake(@Nonnull EntityPlayer thePlayer, @Nonnull ItemStack stack) {
+        public final ItemStack onTake(@NotNull EntityPlayer thePlayer, @NotNull ItemStack stack) {
             return onItemTake(thePlayer, super.onTake(thePlayer, stack), false);
         }
 

--- a/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
@@ -20,7 +20,7 @@ import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public abstract class ArmorLogicSuite implements ISpecialArmorLogic {
@@ -52,7 +52,7 @@ public abstract class ArmorLogicSuite implements ISpecialArmorLogic {
     }
 
     @Override
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         IElectricItem item = armor.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if(item == null) {
             return new ArmorProperties(0, 0.0, 0);

--- a/src/main/java/gregtech/api/items/armor/ArmorMetaItem.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorMetaItem.java
@@ -22,8 +22,8 @@ import net.minecraftforge.common.ISpecialArmor;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extends MetaItem<T> implements IArmorItem, ISpecialArmor, IEnchantabilityHelper {
 
@@ -37,15 +37,15 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
         return (T) new ArmorMetaValueItem(metaValue, unlocalizedName);
     }
 
-    @Nonnull
+    @NotNull
     private IArmorLogic getArmorLogic(ItemStack itemStack) {
         T metaValueItem = getItem(itemStack);
         return metaValueItem == null ? new DummyArmorLogic() : metaValueItem.getArmorLogic();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Multimap<String, AttributeModifier> getAttributeModifiers(@Nonnull EntityEquipmentSlot slot, @Nonnull ItemStack stack) {
+    public Multimap<String, AttributeModifier> getAttributeModifiers(@NotNull EntityEquipmentSlot slot, @NotNull ItemStack stack) {
         Multimap<String, AttributeModifier> multimap = super.getAttributeModifiers(slot, stack);
         IArmorLogic armorLogic = getArmorLogic(stack);
         multimap.putAll(armorLogic.getAttributeModifiers(slot, stack));
@@ -53,7 +53,7 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     }
 
     @Override
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, int slot) {
+    public ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, int slot) {
         IArmorLogic armorLogic = getArmorLogic(armor);
         if (armorLogic instanceof ISpecialArmorLogic) {
             return ((ISpecialArmorLogic) armorLogic).getProperties(player, armor, source, damage, getSlotByIndex(slot));
@@ -62,7 +62,7 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     }
 
     @Override
-    public int getArmorDisplay(EntityPlayer player, @Nonnull ItemStack armor, int slot) {
+    public int getArmorDisplay(EntityPlayer player, @NotNull ItemStack armor, int slot) {
         IArmorLogic armorLogic = getArmorLogic(armor);
         if (armorLogic instanceof ISpecialArmorLogic) {
             return ((ISpecialArmorLogic) armorLogic).getArmorDisplay(player, armor, slot);
@@ -71,13 +71,13 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     }
 
     @Override
-    public void damageArmor(EntityLivingBase entity, @Nonnull ItemStack stack, DamageSource source, int damage, int slot) {
+    public void damageArmor(EntityLivingBase entity, @NotNull ItemStack stack, DamageSource source, int damage, int slot) {
         IArmorLogic armorLogic = getArmorLogic(stack);
         armorLogic.damageArmor(entity, stack, source, damage, getSlotByIndex(slot));
     }
 
     @Override
-    public boolean handleUnblockableDamage(EntityLivingBase entity, @Nonnull ItemStack armor, DamageSource source, double damage, int slot) {
+    public boolean handleUnblockableDamage(EntityLivingBase entity, @NotNull ItemStack armor, DamageSource source, double damage, int slot) {
         IArmorLogic armorLogic = getArmorLogic(armor);
         if (armorLogic instanceof ISpecialArmorLogic) {
             return ((ISpecialArmorLogic) armorLogic).handleUnblockableDamage(entity, armor, source, damage, getSlotByIndex(slot));
@@ -86,13 +86,13 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     }
 
     @Override
-    public void onArmorTick(@Nonnull World world, @Nonnull EntityPlayer player, @Nonnull ItemStack itemStack) {
+    public void onArmorTick(@NotNull World world, @NotNull EntityPlayer player, @NotNull ItemStack itemStack) {
         IArmorLogic armorLogic = getArmorLogic(itemStack);
         armorLogic.onArmorTick(world, player, itemStack);
     }
 
     @Override
-    public boolean isValidArmor(@Nonnull ItemStack stack, @Nonnull EntityEquipmentSlot armorType, @Nonnull Entity entity) {
+    public boolean isValidArmor(@NotNull ItemStack stack, @NotNull EntityEquipmentSlot armorType, @NotNull Entity entity) {
         IArmorLogic armorLogic = getArmorLogic(stack);
         return super.isValidArmor(stack, armorType, entity) &&
                 armorLogic.isValidArmor(stack, entity, armorType);
@@ -100,14 +100,14 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
 
     @Nullable
     @Override
-    public EntityEquipmentSlot getEquipmentSlot(@Nonnull ItemStack stack) {
+    public EntityEquipmentSlot getEquipmentSlot(@NotNull ItemStack stack) {
         IArmorLogic armorLogic = getArmorLogic(stack);
         return armorLogic.getEquipmentSlot(stack);
     }
 
     @Nullable
     @Override
-    public String getArmorTexture(@Nonnull ItemStack stack, @Nonnull Entity entity, @Nonnull EntityEquipmentSlot slot, @Nonnull String type) {
+    public String getArmorTexture(@NotNull ItemStack stack, @NotNull Entity entity, @NotNull EntityEquipmentSlot slot, @NotNull String type) {
         IArmorLogic armorLogic = getArmorLogic(stack);
         return armorLogic.getArmorTexture(stack, entity, slot, type);
     }
@@ -115,7 +115,7 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     @Nullable
     @Override
     @SideOnly(Side.CLIENT)
-    public ModelBiped getArmorModel(@Nonnull EntityLivingBase entityLiving, @Nonnull ItemStack itemStack, @Nonnull EntityEquipmentSlot armorSlot, @Nonnull ModelBiped _default) {
+    public ModelBiped getArmorModel(@NotNull EntityLivingBase entityLiving, @NotNull ItemStack itemStack, @NotNull EntityEquipmentSlot armorSlot, @NotNull ModelBiped _default) {
         IArmorLogic armorLogic = getArmorLogic(itemStack);
         return armorLogic.getArmorModel(entityLiving, itemStack, armorSlot, _default);
     }
@@ -133,7 +133,7 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     }
 
     @Override
-    public void renderHelmetOverlay(@Nonnull ItemStack stack, @Nonnull EntityPlayer player, @Nonnull ScaledResolution resolution, float partialTicks) {
+    public void renderHelmetOverlay(@NotNull ItemStack stack, @NotNull EntityPlayer player, @NotNull ScaledResolution resolution, float partialTicks) {
         IArmorLogic armorLogic = getArmorLogic(stack);
         armorLogic.renderHelmetOverlay(stack, player, resolution, partialTicks);
     }
@@ -160,7 +160,7 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
             setMaxStackSize(1);
         }
 
-        @Nonnull
+        @NotNull
         public IArmorLogic getArmorLogic() {
             return armorLogic;
         }
@@ -191,17 +191,17 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     }
 
     @Override
-    public boolean isEnchantable(@Nonnull ItemStack stack) {
+    public boolean isEnchantable(@NotNull ItemStack stack) {
         return true;
     }
 
     @Override
-    public int getItemEnchantability(@Nonnull ItemStack stack) {
+    public int getItemEnchantability(@NotNull ItemStack stack) {
         return 50;
     }
 
     @Override
-    public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
+    public boolean canApplyAtEnchantingTable(@NotNull ItemStack stack, @NotNull Enchantment enchantment) {
         EntityEquipmentSlot slot = this.getEquipmentSlot(stack);
         if(slot == null || enchantment.type == null) {
             return false;

--- a/src/main/java/gregtech/api/items/armor/ArmorUtils.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorUtils.java
@@ -23,7 +23,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.Map.Entry;
@@ -109,7 +109,7 @@ public class ArmorUtils {
         }
     }
 
-    public static void playJetpackSound(@Nonnull EntityPlayer player) {
+    public static void playJetpackSound(@NotNull EntityPlayer player) {
         if (player.world.isRemote) {
             float cons = (float) player.motionY + player.moveForward;
             cons = MathHelper.clamp(cons, 0.6F, 1.0F);
@@ -219,7 +219,7 @@ public class ArmorUtils {
             }
         }
 
-        @Nonnull
+        @NotNull
         private Pair<Integer, Integer> getStringCoord(int index) {
             int posX;
             int posY;

--- a/src/main/java/gregtech/api/items/armor/IArmorLogic.java
+++ b/src/main/java/gregtech/api/items/armor/IArmorLogic.java
@@ -16,7 +16,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 /**

--- a/src/main/java/gregtech/api/items/armor/ISpecialArmorLogic.java
+++ b/src/main/java/gregtech/api/items/armor/ISpecialArmorLogic.java
@@ -7,7 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Armor logic that wraps {@link net.minecraftforge.common.ISpecialArmor} methods
@@ -23,14 +23,14 @@ public interface ISpecialArmorLogic extends IArmorLogic {
      * same priority, damage will be distributed between them based on there
      * absorption ratio.
      */
-    ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot);
+    ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot);
 
     /**
      * Get the displayed effective armor.
      *
      * @return The number of armor points for display, 2 per shield.
      */
-    int getArmorDisplay(EntityPlayer player, @Nonnull ItemStack armor, int slot);
+    int getArmorDisplay(EntityPlayer player, @NotNull ItemStack armor, int slot);
 
     /**
      * Simple check to see if the armor should interact with "Unblockable" damage
@@ -40,7 +40,7 @@ public interface ISpecialArmorLogic extends IArmorLogic {
      * Returning true here means that the armor is able to meaningfully respond
      * to this damage source. Otherwise, no interaction is allowed.
      */
-    default boolean handleUnblockableDamage(EntityLivingBase entity, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    default boolean handleUnblockableDamage(EntityLivingBase entity, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         return false;
     }
 }

--- a/src/main/java/gregtech/api/items/behavior/MonitorPluginBaseBehavior.java
+++ b/src/main/java/gregtech/api/items/behavior/MonitorPluginBaseBehavior.java
@@ -29,7 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -93,7 +93,7 @@ public abstract class MonitorPluginBaseBehavior implements IItemBehaviour, ItemU
      * @param id PacketID
      * @param buf PacketBuffer
      */
-    public final void writePluginData(int id, @Nonnull Consumer<PacketBuffer> buf) {
+    public final void writePluginData(int id, @NotNull Consumer<PacketBuffer> buf) {
         if (screen != null && this.screen.getWorld() != null && !this.screen.getWorld().isRemote) {
             screen.writeCustomData(GregtechDataCodes.UPDATE_PLUGIN_DATA, packetBuffer -> {
                 packetBuffer.writeVarInt(id);
@@ -116,7 +116,7 @@ public abstract class MonitorPluginBaseBehavior implements IItemBehaviour, ItemU
      * @param id PacketID
      * @param buf PacketBuffer
      */
-    public final void writePluginAction(int id, @Nonnull Consumer<PacketBuffer> dataWriter) {
+    public final void writePluginAction(int id, @NotNull Consumer<PacketBuffer> dataWriter) {
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
         dataWriter.accept(buffer);
         NetworkHandler.channel.sendToServer(new CPacketPluginSynced(

--- a/src/main/java/gregtech/api/items/itemhandlers/InaccessibleItemStackHandler.java
+++ b/src/main/java/gregtech/api/items/itemhandlers/InaccessibleItemStackHandler.java
@@ -3,20 +3,20 @@ package gregtech.api.items.itemhandlers;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class InaccessibleItemStackHandler extends ItemStackHandler {
-    @Nonnull
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         return stack;
     }
 
-    @Nonnull
+    @NotNull
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         return ItemStack.EMPTY;
     }
 
-    public void setStackInSlot(int slot, @Nonnull ItemStack stack) {
+    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
         this.stacks.set(slot, stack);
     }
 }

--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -31,8 +31,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +89,7 @@ public class MetaPrefixItem extends StandardMetaItem {
         return orePrefix.doGenerateItem(material);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getItemStackDisplayName(ItemStack itemStack) {
         Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(itemStack.getItemDamage());
@@ -136,7 +136,7 @@ public class MetaPrefixItem extends StandardMetaItem {
     }
 
     @Override
-    public int getItemStackLimit(@Nonnull ItemStack stack) {
+    public int getItemStackLimit(@NotNull ItemStack stack) {
         if (prefix == null)
             return 64;
         return prefix.maxStackSize;
@@ -144,7 +144,7 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
+    public void getSubItems(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> subItems) {
         if (tab == GregTechAPI.TAB_GREGTECH_MATERIALS || tab == CreativeTabs.SEARCH) {
             for (MetaItem<?>.MetaValueItem enabledItem : metaItems.values()) {
                 if (!enabledItem.isVisible())
@@ -156,7 +156,7 @@ public class MetaPrefixItem extends StandardMetaItem {
     }
 
     @Override
-    public void onUpdate(@Nonnull ItemStack itemStack, @Nonnull World worldIn, @Nonnull Entity entityIn, int itemSlot, boolean isSelected) {
+    public void onUpdate(@NotNull ItemStack itemStack, @NotNull World worldIn, @NotNull Entity entityIn, int itemSlot, boolean isSelected) {
         super.onUpdate(itemStack, worldIn, entityIn, itemSlot, isSelected);
         if (metaItems.containsKey((short) itemStack.getItemDamage()) && entityIn instanceof EntityLivingBase) {
             EntityLivingBase entity = (EntityLivingBase) entityIn;
@@ -172,7 +172,7 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack itemStack, @Nullable World worldIn, @Nonnull List<String> lines, @Nonnull ITooltipFlag tooltipFlag) {
+    public void addInformation(@NotNull ItemStack itemStack, @Nullable World worldIn, @NotNull List<String> lines, @NotNull ITooltipFlag tooltipFlag) {
         super.addInformation(itemStack, worldIn, lines, tooltipFlag);
         int damage = itemStack.getItemDamage();
         Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
@@ -190,7 +190,7 @@ public class MetaPrefixItem extends StandardMetaItem {
     }
 
     @Override
-    public int getItemBurnTime(@Nonnull ItemStack itemStack) {
+    public int getItemBurnTime(@NotNull ItemStack itemStack) {
         int damage = itemStack.getItemDamage();
         Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
         DustProperty property = material == null ? null : material.getProperty(PropertyKey.DUST);

--- a/src/main/java/gregtech/api/items/metaitem/FoodStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/FoodStats.java
@@ -9,7 +9,7 @@ import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -60,8 +60,8 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -177,7 +177,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public boolean showDurabilityBar(@Nonnull ItemStack stack) {
+    public boolean showDurabilityBar(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null && metaValueItem.getDurabilityManager() != null) {
             return metaValueItem.getDurabilityManager().showsDurabilityBar(stack);
@@ -187,7 +187,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public double getDurabilityForDisplay(@Nonnull ItemStack stack) {
+    public double getDurabilityForDisplay(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null && metaValueItem.getDurabilityManager() != null) {
             return metaValueItem.getDurabilityManager().getDurabilityForDisplay(stack);
@@ -200,7 +200,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public int getRGBDurabilityForDisplay(@Nonnull ItemStack stack) {
+    public int getRGBDurabilityForDisplay(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null && metaValueItem.getDurabilityManager() != null) {
             return metaValueItem.getDurabilityManager().getRGBDurabilityForDisplay(stack);
@@ -208,10 +208,10 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return MathHelper.hsvToRGB(0.33f, 1.0f, 1.0f);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public EnumRarity getRarity(@Nonnull ItemStack stack) {
+    public EnumRarity getRarity(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null && metaValueItem.getRarity() != null) return metaValueItem.getRarity();
         else return super.getRarity(stack);
@@ -255,7 +255,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt) {
+    public ICapabilityProvider initCapabilities(@NotNull ItemStack stack, @Nullable NBTTagCompound nbt) {
         T metaValueItem = getItem(stack);
         if (metaValueItem == null) {
             return null;
@@ -273,7 +273,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     //////////////////////////////////////////////////////////////////
 
     @Override
-    public int getItemBurnTime(@Nonnull ItemStack itemStack) {
+    public int getItemBurnTime(@NotNull ItemStack itemStack) {
         T metaValueItem = getItem(itemStack);
         if (metaValueItem == null) {
             return super.getItemBurnTime(itemStack);
@@ -302,7 +302,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public int getItemStackLimit(@Nonnull ItemStack stack) {
+    public int getItemStackLimit(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem == null) {
             return 64;
@@ -310,9 +310,9 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return metaValueItem.getMaxStackSize(stack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumAction getItemUseAction(@Nonnull ItemStack stack) {
+    public EnumAction getItemUseAction(@NotNull ItemStack stack) {
         IItemUseManager useManager = getUseManager(stack);
         if (useManager != null) {
             return useManager.getUseAction(stack);
@@ -321,7 +321,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public int getMaxItemUseDuration(@Nonnull ItemStack stack) {
+    public int getMaxItemUseDuration(@NotNull ItemStack stack) {
         IItemUseManager useManager = getUseManager(stack);
         if (useManager != null) {
             return useManager.getMaxItemUseDuration(stack);
@@ -330,7 +330,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public void onUsingTick(@Nonnull ItemStack stack, @Nonnull EntityLivingBase player, int count) {
+    public void onUsingTick(@NotNull ItemStack stack, @NotNull EntityLivingBase player, int count) {
         if (player instanceof EntityPlayer) {
             IItemUseManager useManager = getUseManager(stack);
             if (useManager != null) {
@@ -340,7 +340,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public void onPlayerStoppedUsing(@Nonnull ItemStack stack, @Nonnull World world, @Nonnull EntityLivingBase player, int timeLeft) {
+    public void onPlayerStoppedUsing(@NotNull ItemStack stack, @NotNull World world, @NotNull EntityLivingBase player, int timeLeft) {
         if (player instanceof EntityPlayer) {
             IItemUseManager useManager = getUseManager(stack);
             if (useManager != null) {
@@ -351,7 +351,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
 
     @Nullable
     @Override
-    public ItemStack onItemUseFinish(@Nonnull ItemStack stack, @Nonnull World world, @Nonnull EntityLivingBase player) {
+    public ItemStack onItemUseFinish(@NotNull ItemStack stack, @NotNull World world, @NotNull EntityLivingBase player) {
         if (player instanceof EntityPlayer) {
             IItemUseManager useManager = getUseManager(stack);
             if (useManager != null) {
@@ -362,7 +362,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public boolean onLeftClickEntity(@Nonnull ItemStack stack, @Nonnull EntityPlayer player, @Nonnull Entity entity) {
+    public boolean onLeftClickEntity(@NotNull ItemStack stack, @NotNull EntityPlayer player, @NotNull Entity entity) {
         boolean returnValue = false;
         for (IItemBehaviour behaviour : getBehaviours(stack)) {
             if (behaviour.onLeftClickEntity(stack, player, entity)) {
@@ -373,7 +373,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public boolean itemInteractionForEntity(@Nonnull ItemStack stack, @Nonnull EntityPlayer playerIn, @Nonnull EntityLivingBase target, @Nonnull EnumHand hand) {
+    public boolean itemInteractionForEntity(@NotNull ItemStack stack, @NotNull EntityPlayer playerIn, @NotNull EntityLivingBase target, @NotNull EnumHand hand) {
         boolean returnValue = false;
         for (IItemBehaviour behaviour : getBehaviours(stack)) {
             if (behaviour.itemInteractionForEntity(stack, playerIn, target, hand)) {
@@ -383,9 +383,9 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return returnValue;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ActionResult<ItemStack> onItemRightClick(@Nonnull World world, EntityPlayer player, @Nonnull EnumHand hand) {
+    public ActionResult<ItemStack> onItemRightClick(@NotNull World world, EntityPlayer player, @NotNull EnumHand hand) {
         ItemStack itemStack = player.getHeldItem(hand);
         for (IItemBehaviour behaviour : getBehaviours(itemStack)) {
             ActionResult<ItemStack> behaviourResult = behaviour.onItemRightClick(world, player, hand);
@@ -405,9 +405,9 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return ActionResult.newResult(EnumActionResult.PASS, itemStack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumActionResult onItemUseFirst(EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, float hitX, float hitY, float hitZ, @Nonnull EnumHand hand) {
+    public EnumActionResult onItemUseFirst(EntityPlayer player, @NotNull World world, @NotNull BlockPos pos, @NotNull EnumFacing side, float hitX, float hitY, float hitZ, @NotNull EnumHand hand) {
         ItemStack itemStack = player.getHeldItem(hand);
         for (IItemBehaviour behaviour : getBehaviours(itemStack)) {
             EnumActionResult behaviourResult = behaviour.onItemUseFirst(player, world, pos, side, hitX, hitY, hitZ, hand);
@@ -420,9 +420,9 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return EnumActionResult.PASS;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumActionResult onItemUse(EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
+    public EnumActionResult onItemUse(EntityPlayer player, @NotNull World world, @NotNull BlockPos pos, @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
         ItemStack stack = player.getHeldItem(hand);
         ItemStack originalStack = stack.copy();
         for (IItemBehaviour behaviour : getBehaviours(stack)) {
@@ -440,9 +440,9 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return EnumActionResult.PASS;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Multimap<String, AttributeModifier> getAttributeModifiers(@Nonnull EntityEquipmentSlot slot, @Nonnull ItemStack stack) {
+    public Multimap<String, AttributeModifier> getAttributeModifiers(@NotNull EntityEquipmentSlot slot, @NotNull ItemStack stack) {
         HashMultimap<String, AttributeModifier> modifiers = HashMultimap.create();
         T metaValueItem = getItem(stack);
         if (metaValueItem != null) {
@@ -454,7 +454,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public boolean isEnchantable(@Nonnull ItemStack stack) {
+    public boolean isEnchantable(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null) {
             IEnchantabilityHelper helper = metaValueItem.getEnchantabilityHelper();
@@ -464,7 +464,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public int getItemEnchantability(@Nonnull ItemStack stack) {
+    public int getItemEnchantability(@NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null) {
             IEnchantabilityHelper helper = metaValueItem.getEnchantabilityHelper();
@@ -474,7 +474,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
+    public boolean canApplyAtEnchantingTable(@NotNull ItemStack stack, @NotNull Enchantment enchantment) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null) {
             IEnchantabilityHelper helper = metaValueItem.getEnchantabilityHelper();
@@ -484,14 +484,14 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public void onUpdate(@Nonnull ItemStack stack, @Nonnull World worldIn, @Nonnull Entity entityIn, int itemSlot, boolean isSelected) {
+    public void onUpdate(@NotNull ItemStack stack, @NotNull World worldIn, @NotNull Entity entityIn, int itemSlot, boolean isSelected) {
         for (IItemBehaviour behaviour : getBehaviours(stack)) {
             behaviour.onUpdate(stack, entityIn);
         }
     }
 
     @Override
-    public boolean shouldCauseReequipAnimation(@Nonnull ItemStack oldStack, @Nonnull ItemStack newStack, boolean slotChanged) {
+    public boolean shouldCauseReequipAnimation(@NotNull ItemStack oldStack, @NotNull ItemStack newStack, boolean slotChanged) {
         //if item is equal, and old item has electric item capability, remove charge tags to stop reequip animation when charge is altered
         if (ItemStack.areItemsEqual(oldStack, newStack) && oldStack.hasCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null) &&
                 oldStack.hasTagCompound() && newStack.hasTagCompound()) {
@@ -513,7 +513,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return metaItem == null ? getTranslationKey() : getTranslationKey() + "." + metaItem.unlocalizedName;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
         if (stack.getItemDamage() >= metaItemOffset) {
@@ -540,7 +540,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack itemStack, @Nullable World worldIn, @Nonnull List<String> lines, @Nonnull ITooltipFlag tooltipFlag) {
+    public void addInformation(@NotNull ItemStack itemStack, @Nullable World worldIn, @NotNull List<String> lines, @NotNull ITooltipFlag tooltipFlag) {
         T item = getItem(itemStack);
         if (item == null) return;
         String unlocalizedTooltip = "metaitem." + item.unlocalizedName + ".tooltip";
@@ -622,7 +622,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    public boolean hasContainerItem(@Nonnull ItemStack itemStack) {
+    public boolean hasContainerItem(@NotNull ItemStack itemStack) {
         T item = getItem(itemStack);
         if (item == null) {
             return false;
@@ -630,9 +630,9 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return item.getContainerItemProvider() != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getContainerItem(@Nonnull ItemStack itemStack) {
+    public ItemStack getContainerItem(@NotNull ItemStack itemStack) {
         T item = getItem(itemStack);
         if (item == null) {
             return ItemStack.EMPTY;
@@ -643,7 +643,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return provider == null ? ItemStack.EMPTY : provider.getContainerItem(itemStack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CreativeTabs[] getCreativeTabs() {
         return new CreativeTabs[]{GregTechAPI.TAB_GREGTECH, GregTechAPI.TAB_GREGTECH_MATERIALS};
@@ -651,7 +651,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
+    public void getSubItems(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> subItems) {
         if (tab != GregTechAPI.TAB_GREGTECH && tab != CreativeTabs.SEARCH) {
             return;
         }

--- a/src/main/java/gregtech/api/items/metaitem/stats/IFoodBehavior.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/IFoodBehavior.java
@@ -4,7 +4,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumAction;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public interface IFoodBehavior extends IItemComponent {

--- a/src/main/java/gregtech/api/items/toolitem/AbstractToolItemCapabilityProvider.java
+++ b/src/main/java/gregtech/api/items/toolitem/AbstractToolItemCapabilityProvider.java
@@ -6,8 +6,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractToolItemCapabilityProvider<T> implements ICapabilityProvider {
 
@@ -24,14 +24,14 @@ public abstract class AbstractToolItemCapabilityProvider<T> implements ICapabili
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         return capability == getCapability();
     }
 
     @Nullable
     @Override
     @SuppressWarnings("unchecked")
-    public <R> R getCapability(@Nonnull Capability<R> capability, @Nullable EnumFacing facing) {
+    public <R> R getCapability(@NotNull Capability<R> capability, @Nullable EnumFacing facing) {
         if (capability == getCapability()) {
             return getCapability().cast((T) this);
         }

--- a/src/main/java/gregtech/api/items/toolitem/IToolStats.java
+++ b/src/main/java/gregtech/api/items/toolitem/IToolStats.java
@@ -14,7 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -193,7 +193,7 @@ public interface IToolStats {
             world.playSound(null, pos, ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getSound(), SoundCategory.PLAYERS, 1, 1);
     }
 
-    static void onOtherUse(@Nonnull ItemStack stack, World world, BlockPos pos) {
+    static void onOtherUse(@NotNull ItemStack stack, World world, BlockPos pos) {
         if (stack.getItem() instanceof ToolMetaItem<?>) {
             IToolStats stats = ((ToolMetaItem<?>) stack.getItem()).getItem(stack).getToolStats();
             if (ConfigHolder.client.toolUseSounds && stack.getItem() instanceof ToolMetaItem<?>)

--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -62,8 +62,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.Validate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -123,12 +123,12 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean doesSneakBypassUse(@Nonnull ItemStack stack, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityPlayer player) {
+    public boolean doesSneakBypassUse(@NotNull ItemStack stack, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityPlayer player) {
         return true; //required for machine wrenching
     }
 
     @Override
-    public boolean showDurabilityBar(@Nonnull ItemStack stack) {
+    public boolean showDurabilityBar(@NotNull ItemStack stack) {
         T item = getItem(stack);
         if (item != null && item.getDurabilityManager() != null) {
             return item.getDurabilityManager().showsDurabilityBar(stack);
@@ -138,7 +138,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public double getDurabilityForDisplay(@Nonnull ItemStack stack) {
+    public double getDurabilityForDisplay(@NotNull ItemStack stack) {
         T item = getItem(stack);
         if (item != null && item.getDurabilityManager() != null) {
             return item.getDurabilityManager().getDurabilityForDisplay(stack);
@@ -154,14 +154,14 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public int getRGBDurabilityForDisplay(@Nonnull ItemStack stack) {
+    public int getRGBDurabilityForDisplay(@NotNull ItemStack stack) {
         //always color durability bar as item internal damage
         double internalDamage = getItemDamage(stack) / (getMaxItemDamage(stack) * 1.0);
         return MathHelper.hsvToRGB(Math.max(0.0F, (float) (1.0 - internalDamage)) / 3.0F, 1.0F, 1.0F);
     }
 
     @Override
-    public void onCreated(@Nonnull ItemStack stack, @Nonnull World worldIn, @Nonnull EntityPlayer playerIn) {
+    public void onCreated(@NotNull ItemStack stack, @NotNull World worldIn, @NotNull EntityPlayer playerIn) {
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
             IToolStats toolStats = metaToolValueItem.getToolStats();
@@ -170,13 +170,13 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean hasContainerItem(@Nonnull ItemStack stack) {
+    public boolean hasContainerItem(@NotNull ItemStack stack) {
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getContainerItem(@Nonnull ItemStack stack) {
+    public ItemStack getContainerItem(@NotNull ItemStack stack) {
         stack = stack.copy();
         stack.setCount(1);
         T metaToolValueItem = getItem(stack);
@@ -208,7 +208,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public float getSaplingModifier(@Nonnull ItemStack stack, @Nonnull World world, @Nonnull EntityPlayer player, @Nonnull BlockPos pos) {
+    public float getSaplingModifier(@NotNull ItemStack stack, @NotNull World world, @NotNull EntityPlayer player, @NotNull BlockPos pos) {
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
             IToolStats toolStats = metaToolValueItem.getToolStats();
@@ -219,7 +219,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean onBlockStartBreak(@Nonnull ItemStack itemStack, @Nonnull BlockPos pos, @Nonnull EntityPlayer player) {
+    public boolean onBlockStartBreak(@NotNull ItemStack itemStack, @NotNull BlockPos pos, @NotNull EntityPlayer player) {
         T metaToolValueItem = getItem(itemStack);
         if (metaToolValueItem != null) {
             IToolStats toolStats = metaToolValueItem.getToolStats();
@@ -229,7 +229,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean onBlockDestroyed(@Nonnull ItemStack stack, @Nonnull World world, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EntityLivingBase entity) {
+    public boolean onBlockDestroyed(@NotNull ItemStack stack, @NotNull World world, @NotNull IBlockState state, @NotNull BlockPos pos, @NotNull EntityLivingBase entity) {
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
             IToolStats toolStats = metaToolValueItem.getToolStats();
@@ -249,7 +249,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public float getDestroySpeed(@Nonnull ItemStack stack, @Nonnull IBlockState state) {
+    public float getDestroySpeed(@NotNull ItemStack stack, @NotNull IBlockState state) {
         Preconditions.checkNotNull(state, "null blockState");
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
@@ -262,7 +262,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean canHarvestBlock(@Nonnull IBlockState state, @Nonnull ItemStack stack) {
+    public boolean canHarvestBlock(@NotNull IBlockState state, @NotNull ItemStack stack) {
         Preconditions.checkNotNull(state, "null blockState");
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
@@ -273,7 +273,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public int getHarvestLevel(@Nonnull ItemStack stack, @Nonnull String toolClass, EntityPlayer player, IBlockState blockState) {
+    public int getHarvestLevel(@NotNull ItemStack stack, @NotNull String toolClass, EntityPlayer player, IBlockState blockState) {
         if (blockState == null) {
             GTLog.logger.warn("ToolMetaItem.getHarvestLevel called for tool '{}' without providing IBlockState. Offending stack trace:\n    {}",
                     toolClass, Arrays.stream(Thread.currentThread().getStackTrace()).skip(1).map(StackTraceElement::toString).collect(Collectors.joining("\n    ")));
@@ -290,9 +290,9 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
         return -1;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Multimap<String, AttributeModifier> getAttributeModifiers(@Nonnull EntityEquipmentSlot slot, @Nonnull ItemStack stack) {
+    public Multimap<String, AttributeModifier> getAttributeModifiers(@NotNull EntityEquipmentSlot slot, @NotNull ItemStack stack) {
         T metaValueItem = getItem(stack);
         HashMultimap<String, AttributeModifier> modifiers = HashMultimap.create();
         modifiers.putAll(super.getAttributeModifiers(slot, stack));
@@ -308,7 +308,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean onLeftClickEntity(@Nonnull ItemStack stack, @Nonnull EntityPlayer player, @Nonnull Entity entity) {
+    public boolean onLeftClickEntity(@NotNull ItemStack stack, @NotNull EntityPlayer player, @NotNull Entity entity) {
         //cancel attack if broken or out of charge
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
@@ -321,7 +321,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean hitEntity(@Nonnull ItemStack stack, @Nonnull EntityLivingBase target, @Nonnull EntityLivingBase attacker) {
+    public boolean hitEntity(@NotNull ItemStack stack, @NotNull EntityLivingBase target, @NotNull EntityLivingBase attacker) {
         T metaValueItem = getItem(stack);
         if (metaValueItem != null) {
             IToolStats toolStats = metaValueItem.getToolStats();
@@ -413,7 +413,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt) {
+    public ICapabilityProvider initCapabilities(@NotNull ItemStack stack, @Nullable NBTTagCompound nbt) {
         ICapabilityProvider capabilityProvider = super.initCapabilities(stack, nbt);
         if (capabilityProvider != null && capabilityProvider.hasCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null)) {
             IElectricItem electricItem = capabilityProvider.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
@@ -428,7 +428,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
         return capabilityProvider;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
         if (stack.getItemDamage() >= metaItemOffset) {
@@ -445,7 +445,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack itemStack, @Nullable World worldIn, @Nonnull List<String> lines, @Nonnull ITooltipFlag tooltipFlag) {
+    public void addInformation(@NotNull ItemStack itemStack, @Nullable World worldIn, @NotNull List<String> lines, @NotNull ITooltipFlag tooltipFlag) {
         T item = getItem(itemStack);
         if (item == null) {
             return;
@@ -464,17 +464,17 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public boolean isEnchantable(@Nonnull ItemStack stack) {
+    public boolean isEnchantable(@NotNull ItemStack stack) {
         return true;
     }
 
     @Override
-    public int getItemEnchantability(@Nonnull ItemStack stack) {
+    public int getItemEnchantability(@NotNull ItemStack stack) {
         return getToolMaterial(stack).getProperty(PropertyKey.TOOL).getToolEnchantability();
     }
 
     @Override
-    public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
+    public boolean canApplyAtEnchantingTable(@NotNull ItemStack stack, @NotNull Enchantment enchantment) {
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null && metaToolValueItem.toolStats != null) {
             return metaToolValueItem.toolStats.canApplyEnchantment(stack, enchantment);
@@ -615,8 +615,8 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    @Nonnull
-    public Set<String> getToolClasses(@Nonnull ItemStack stack) {
+    @NotNull
+    public Set<String> getToolClasses(@NotNull ItemStack stack) {
         T metaToolValueItem = getItem(stack);
         if (metaToolValueItem != null) {
             IToolStats toolStats = metaToolValueItem.getToolStats();
@@ -671,12 +671,12 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
 
     // EIO Wrench Compat
     @Override
-    public boolean shouldHideFacades(@Nonnull ItemStack stack, @Nonnull EntityPlayer player) {
+    public boolean shouldHideFacades(@NotNull ItemStack stack, @NotNull EntityPlayer player) {
         return false;
     }
 
     @Override
-    public boolean canUse(@Nonnull EnumHand stack, @Nonnull EntityPlayer player, @Nonnull BlockPos pos) {
+    public boolean canUse(@NotNull EnumHand stack, @NotNull EntityPlayer player, @NotNull BlockPos pos) {
         T metaToolValueItem = getItem(player.getHeldItem(stack));
         if (metaToolValueItem != null) {
             return metaToolValueItem.getToolStats() instanceof ToolWrench;
@@ -685,7 +685,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
     }
 
     @Override
-    public void used(@Nonnull EnumHand stack, @Nonnull EntityPlayer player, @Nonnull BlockPos pos) {
+    public void used(@NotNull EnumHand stack, @NotNull EntityPlayer player, @NotNull BlockPos pos) {
         this.damageItem(player.getHeldItem(stack), player, DamageValues.DAMAGE_FOR_WRENCH, false);
     }
 
@@ -766,7 +766,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
             return this;
         }
 
-        @Nonnull
+        @NotNull
         public IToolStats getToolStats() {
             return toolStats;
         }

--- a/src/main/java/gregtech/api/metatileentity/IDataInfoProvider.java
+++ b/src/main/java/gregtech/api/metatileentity/IDataInfoProvider.java
@@ -3,11 +3,11 @@ package gregtech.api.metatileentity;
 
 import net.minecraft.util.text.ITextComponent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public interface IDataInfoProvider {
 
-    @Nonnull
+    @NotNull
     List<ITextComponent> getDataInfo();
 }

--- a/src/main/java/gregtech/api/metatileentity/IVoidable.java
+++ b/src/main/java/gregtech/api/metatileentity/IVoidable.java
@@ -2,7 +2,7 @@ package gregtech.api.metatileentity;
 
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public interface IVoidable {
 
@@ -33,7 +33,7 @@ public interface IVoidable {
             this.localeName = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return localeName;

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -65,8 +65,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -1377,9 +1377,9 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Method(modid = GTValues.MODID_APPENG)
-    public AECableType getCableConnectionType(@Nonnull AEPartLocation part) {
+    public AECableType getCableConnectionType(@NotNull AEPartLocation part) {
         return AECableType.NONE;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -42,8 +42,8 @@ import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 
@@ -114,7 +114,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
-    public void readFromNBT(@Nonnull NBTTagCompound compound) {
+    public void readFromNBT(@NotNull NBTTagCompound compound) {
         super.readFromNBT(compound);
         customName = compound.getString("CustomName");
         if (compound.hasKey("MetaId", NBT.TAG_STRING)) {
@@ -137,9 +137,9 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound compound) {
         super.writeToNBT(compound);
         compound.setString("CustomName", getName());
         if (metaTileEntity != null) {
@@ -166,14 +166,14 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         Object metaTileEntityValue = metaTileEntity == null ? null : metaTileEntity.getCoverCapability(capability, facing);
         return metaTileEntityValue != null || super.hasCapability(capability, facing);
     }
 
     @Nullable
     @Override
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+    public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
         T metaTileEntityValue = metaTileEntity == null ? null : metaTileEntity.getCoverCapability(capability, facing);
         return metaTileEntityValue != null ? metaTileEntityValue : super.getCapability(capability, facing);
     }
@@ -341,19 +341,19 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
-    public boolean shouldRefresh(@Nonnull World world, @Nonnull BlockPos pos, IBlockState oldState, IBlockState newState) {
+    public boolean shouldRefresh(@NotNull World world, @NotNull BlockPos pos, IBlockState oldState, IBlockState newState) {
         return oldState.getBlock() != newState.getBlock(); //MetaTileEntityHolder should never refresh (until block changes)
     }
 
     @Override
-    public void rotate(@Nonnull Rotation rotationIn) {
+    public void rotate(@NotNull Rotation rotationIn) {
         if (metaTileEntity != null) {
             metaTileEntity.setFrontFacing(rotationIn.rotate(metaTileEntity.getFrontFacing()));
         }
     }
 
     @Override
-    public void mirror(@Nonnull Mirror mirrorIn) {
+    public void mirror(@NotNull Mirror mirrorIn) {
         if (metaTileEntity != null) {
             rotate(mirrorIn.toRotation(metaTileEntity.getFrontFacing()));
         }
@@ -374,7 +374,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AxisAlignedBB getRenderBoundingBox() {
         if (metaTileEntity instanceof IFastRenderMetaTileEntity) {
@@ -433,7 +433,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return this.customName == null ? "" : this.customName;
@@ -444,7 +444,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         return this.customName != null && !this.customName.isEmpty();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ITextComponent getDisplayName() {
         return this.hasCustomName() ? new TextComponentString(this.getName()) : metaTileEntity != null ? new TextComponentTranslation(metaTileEntity.getMetaFullName()) : new TextComponentString(this.getName());
@@ -453,15 +453,15 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     @Nullable
     @Override
     @Method(modid = GTValues.MODID_APPENG)
-    public IGridNode getGridNode(@Nonnull AEPartLocation part) {
+    public IGridNode getGridNode(@NotNull AEPartLocation part) {
         AENetworkProxy proxy = getProxy();
         return proxy == null ? null : proxy.getNode();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @Method(modid = GTValues.MODID_APPENG)
-    public AECableType getCableConnectionType(@Nonnull AEPartLocation part) {
+    public AECableType getCableConnectionType(@NotNull AEPartLocation part) {
         return metaTileEntity == null ? AECableType.NONE : metaTileEntity.getCableConnectionType(part);
     }
 
@@ -469,7 +469,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     @Method(modid = GTValues.MODID_APPENG)
     public void securityBreak() {}
 
-    @Nonnull
+    @NotNull
     @Override
     @Method(modid = GTValues.MODID_APPENG)
     public IGridNode getActionableNode() {

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -28,8 +28,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.function.Function;
 
@@ -126,7 +126,7 @@ public class SimpleGeneratorMetaTileEntity extends WorkableTieredMetaTileEntity 
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @NotNull List<String> tooltip, boolean advanced) {
         String key = this.metaTileEntityId.getPath().split("\\.")[0];
         String mainKey = String.format("gregtech.machine.%s.tooltip", key);
         if (I18n.hasKey(mainKey)) {

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -45,7 +45,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.function.Function;
 

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -14,7 +14,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraftforge.common.util.Constants;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
@@ -56,7 +56,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     }
 
     @Override
-    public void onDataPacket(@Nonnull NetworkManager net, SPacketUpdateTileEntity pkt) {
+    public void onDataPacket(@NotNull NetworkManager net, SPacketUpdateTileEntity pkt) {
         NBTTagCompound updateTag = pkt.getNbtCompound();
         NBTTagList listTag = updateTag.getTagList("d", Constants.NBT.TAG_COMPOUND);
         for (NBTBase entryBase : listTag) {
@@ -68,7 +68,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public NBTTagCompound getUpdateTag() {
         NBTTagCompound updateTag = super.getUpdateTag();
@@ -80,7 +80,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     }
 
     @Override
-    public void handleUpdateTag(@Nonnull NBTTagCompound tag) {
+    public void handleUpdateTag(@NotNull NBTTagCompound tag) {
         super.readFromNBT(tag); // deserializes Forge data and capabilities
         byte[] updateData = tag.getByteArray("d");
         ByteBuf backedBuffer = Unpooled.copiedBuffer(updateData);

--- a/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
@@ -26,8 +26,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public abstract class TieredMetaTileEntity extends MetaTileEntity implements IEnergyChangeListener, ITieredMetaTileEntity {
@@ -68,7 +68,7 @@ public abstract class TieredMetaTileEntity extends MetaTileEntity implements IEn
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @NotNull List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         if (ConfigHolder.machines.doTerrainExplosion && getIsWeatherOrTerrainResistant())
             tooltip.add(I18n.format("gregtech.universal.tooltip.terrain_resist"));

--- a/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
@@ -24,8 +24,8 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -147,7 +147,7 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity 
         return workable.getRecipeMap().getSound();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = new ArrayList<>();

--- a/src/main/java/gregtech/api/metatileentity/multiblock/CleanroomType.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/CleanroomType.java
@@ -2,8 +2,8 @@ package gregtech.api.metatileentity.multiblock;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 
 public class CleanroomType {
@@ -17,7 +17,7 @@ public class CleanroomType {
     private final String name;
     private final String translationKey;
 
-    public CleanroomType(@Nonnull String name, @Nonnull String translationKey) {
+    public CleanroomType(@NotNull String name, @NotNull String translationKey) {
         if (CLEANROOM_TYPES.get(name) != null)
             throw new IllegalArgumentException(String.format("CleanroomType with name %s is already registered!", name));
 
@@ -26,18 +26,18 @@ public class CleanroomType {
         CLEANROOM_TYPES.put(name, this);
     }
 
-    @Nonnull
+    @NotNull
     public String getName() {
         return this.name;
     }
 
-    @Nonnull
+    @NotNull
     public String getTranslationKey() {
         return this.translationKey;
     }
 
     @Nullable
-    public static CleanroomType getByName(@Nonnull String name) {
+    public static CleanroomType getByName(@NotNull String name) {
         return CLEANROOM_TYPES.get(name);
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -14,7 +14,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.HoverEvent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,7 +69,7 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = new ArrayList<>();

--- a/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomReceiver.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomReceiver.java
@@ -1,6 +1,6 @@
 package gregtech.api.metatileentity.multiblock;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Implement this interface in order to make a TileEntity into a block that recieves a cleanroom from other blocks

--- a/src/main/java/gregtech/api/metatileentity/multiblock/IPassthroughHatch.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IPassthroughHatch.java
@@ -1,6 +1,6 @@
 package gregtech.api.metatileentity.multiblock;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Used with {@link IMultiblockAbilityPart} for hatches allowed in cleanroom-like structures for pass-through
@@ -12,6 +12,6 @@ public interface IPassthroughHatch {
      * @return the type of data passed into/out of the hatch
      */
     @SuppressWarnings("unused")
-    @Nonnull
+    @NotNull
     Class<?> getPassthroughType();
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
@@ -24,7 +24,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 @SuppressWarnings("unused")

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -39,8 +39,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -106,7 +106,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
      *
      * @return The overlay to render on the Multiblock Controller
      */
-    @Nonnull
+    @NotNull
     protected ICubeRenderer getFrontOverlay() {
         return Textures.MULTIBLOCK_WORKABLE_OVERLAY;
     }
@@ -125,7 +125,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
         return getLightValueForPart(null);
     }
 
-    public static TraceabilityPredicate tilePredicate(@Nonnull BiFunction<BlockWorldState, MetaTileEntity, Boolean> predicate, @Nullable Supplier<BlockInfo[]> candidates) {
+    public static TraceabilityPredicate tilePredicate(@NotNull BiFunction<BlockWorldState, MetaTileEntity, Boolean> predicate, @Nullable Supplier<BlockInfo[]> candidates) {
         return new TraceabilityPredicate(blockWorldState -> {
             TileEntity tileEntity = blockWorldState.getTileEntity();
             if (!(tileEntity instanceof IGregTechTileEntity))

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -35,8 +35,8 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -93,7 +93,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
      * Performs extra checks for validity of given recipe before multiblock
      * will start it's processing.
      */
-    public boolean checkRecipe(@Nonnull Recipe recipe, boolean consumeIfSuccess) {
+    public boolean checkRecipe(@NotNull Recipe recipe, boolean consumeIfSuccess) {
         return true;
     }
 
@@ -329,7 +329,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
         return recipeMap.getSound();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = new ArrayList<>();

--- a/src/main/java/gregtech/api/pattern/BlockWorldState.java
+++ b/src/main/java/gregtech/api/pattern/BlockWorldState.java
@@ -7,7 +7,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockPos.MutableBlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 
 public class BlockWorldState {

--- a/src/main/java/gregtech/api/pipenet/IBlockAppearance.java
+++ b/src/main/java/gregtech/api/pipenet/IBlockAppearance.java
@@ -5,7 +5,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Implement this interface on blocks that can mimic the appearance of other blocks. Note that this is meant to be available server-side, so ensure the code is
@@ -23,8 +23,8 @@ public interface IBlockAppearance {
      * @param pos   The Position of the block.
      * @param side  The side of the block.
      */
-    @Nonnull
-    IBlockState getVisualState(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side);
+    @NotNull
+    IBlockState getVisualState(@NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EnumFacing side);
 
     /**
      * This function returns whether the block's renderer will visually connect to other blocks implementing IBlockAppearance.

--- a/src/main/java/gregtech/api/pipenet/PipeGatherer.java
+++ b/src/main/java/gregtech/api/pipenet/PipeGatherer.java
@@ -6,7 +6,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;

--- a/src/main/java/gregtech/api/pipenet/PipeNetWalker.java
+++ b/src/main/java/gregtech/api/pipenet/PipeNetWalker.java
@@ -8,7 +8,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 /**

--- a/src/main/java/gregtech/api/pipenet/WorldPipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/WorldPipeNet.java
@@ -9,7 +9,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.common.util.Constants.NBT;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.lang.ref.WeakReference;
 import java.util.*;
 
@@ -142,9 +142,9 @@ public abstract class WorldPipeNet<NodeDataType, T extends PipeNet<NodeDataType>
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound compound) {
         NBTTagList allPipeNets = new NBTTagList();
         for (T pipeNet : pipeNets) {
             NBTTagCompound pNetTag = pipeNet.serializeNBT();

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -52,8 +52,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -139,10 +139,10 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     public abstract void setTileEntityData(TileEntityPipeBase<PipeType, NodeDataType> pipeTile, ItemStack itemStack);
 
     @Override
-    public abstract void getSubBlocks(@Nonnull CreativeTabs itemIn, @Nonnull NonNullList<ItemStack> items);
+    public abstract void getSubBlocks(@NotNull CreativeTabs itemIn, @NotNull NonNullList<ItemStack> items);
 
     @Override
-    public void breakBlock(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public void breakBlock(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         if (pipeTile != null) {
             pipeTile.getCoverableImplementation().dropAllCovers();
@@ -153,12 +153,12 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public void onBlockAdded(World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public void onBlockAdded(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state) {
         worldIn.scheduleUpdate(pos, this, 1);
     }
 
     @Override
-    public void updateTick(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Random rand) {
+    public void updateTick(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull Random rand) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         if (pipeTile != null) {
             int activeConnections = pipeTile.getConnections();
@@ -169,7 +169,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public void onBlockPlacedBy(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull EntityLivingBase placer, @Nonnull ItemStack stack) {
+    public void onBlockPlacedBy(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull EntityLivingBase placer, @NotNull ItemStack stack) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         if (pipeTile != null) {
             setTileEntityData((TileEntityPipeBase<PipeType, NodeDataType>) pipeTile, stack);
@@ -177,7 +177,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public void neighborChanged(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Block blockIn, @Nonnull BlockPos fromPos) {
+    public void neighborChanged(@NotNull IBlockState state, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull Block blockIn, @NotNull BlockPos fromPos) {
         if (worldIn.isRemote) return;
         if (!ConfigHolder.machines.gt6StylePipesCables) {
             IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
@@ -204,7 +204,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public void observedNeighborChange(@Nonnull IBlockState observerState, @Nonnull World world, @Nonnull BlockPos observerPos, @Nonnull Block changedBlock, @Nonnull BlockPos changedBlockPos) {
+    public void observedNeighborChange(@NotNull IBlockState observerState, @NotNull World world, @NotNull BlockPos observerPos, @NotNull Block changedBlock, @NotNull BlockPos changedBlockPos) {
         PipeNet<NodeDataType> net = getWorldPipeNet(world).getNetFromPos(observerPos);
         if (net != null) {
             net.onNeighbourUpdate(changedBlockPos);
@@ -212,20 +212,20 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public boolean canConnectRedstone(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nullable EnumFacing side) {
+    public boolean canConnectRedstone(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @Nullable EnumFacing side) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(world, pos);
         return pipeTile != null && pipeTile.getCoverableImplementation().canConnectRedstone(side);
     }
 
     @Override
-    public boolean shouldCheckWeakPower(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public boolean shouldCheckWeakPower(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         // The check in World::getRedstonePower in the vanilla code base is reversed. Setting this to false will
         // actually cause getWeakPower to be called, rather than prevent it.
         return false;
     }
 
     @Override
-    public int getWeakPower(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public int getWeakPower(@NotNull IBlockState blockState, @NotNull IBlockAccess blockAccess, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(blockAccess, pos);
         return pipeTile == null ? 0 : pipeTile.getCoverableImplementation().getOutputRedstoneSignal(side.getOpposite());
     }
@@ -244,7 +244,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
     @Nullable
     @Override
-    public TileEntity createNewTileEntity(@Nonnull World worldIn, int meta) {
+    public TileEntity createNewTileEntity(@NotNull World worldIn, int meta) {
         return createNewTileEntity(false);
     }
 
@@ -255,9 +255,9 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     protected void onActiveModeChange(World world, BlockPos pos, boolean isActiveNow, boolean isInitialChange) {
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getPickBlock(@Nonnull IBlockState state, @Nonnull RayTraceResult target, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EntityPlayer player) {
+    public ItemStack getPickBlock(@NotNull IBlockState state, @NotNull RayTraceResult target, @NotNull World world, @NotNull BlockPos pos, @NotNull EntityPlayer player) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(world, pos);
         if (pipeTile == null) {
             return ItemStack.EMPTY;
@@ -274,7 +274,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public boolean onBlockActivated(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull EntityPlayer playerIn, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
+    public boolean onBlockActivated(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull EntityPlayer playerIn, @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         CuboidRayTraceResult rayTraceResult = (CuboidRayTraceResult) RayTracer.retraceBlock(worldIn, playerIn, pos);
         if (rayTraceResult == null || pipeTile == null) {
@@ -370,7 +370,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public void onBlockClicked(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull EntityPlayer playerIn) {
+    public void onBlockClicked(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull EntityPlayer playerIn) {
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         CuboidRayTraceResult rayTraceResult = (CuboidRayTraceResult) RayTracer.retraceBlock(worldIn, playerIn, pos);
         if (pipeTile == null || rayTraceResult == null) {
@@ -396,14 +396,14 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
     @SuppressWarnings("unchecked")
     @Override
-    public void harvestBlock(@Nonnull World worldIn, @Nonnull EntityPlayer player, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nullable TileEntity te, @Nonnull ItemStack stack) {
+    public void harvestBlock(@NotNull World worldIn, @NotNull EntityPlayer player, @NotNull BlockPos pos, @NotNull IBlockState state, @Nullable TileEntity te, @NotNull ItemStack stack) {
         tileEntities.set(te == null ? tileEntities.get() : (IPipeTile<PipeType, NodeDataType>) te);
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
     }
 
     @Override
-    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
+    public void getDrops(@NotNull NonNullList<ItemStack> drops, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull IBlockState state, int fortune) {
         IPipeTile<PipeType, NodeDataType> pipeTile = tileEntities.get() == null ? getPipeTileEntity(world, pos) : tileEntities.get();
         if (pipeTile == null) return;
         if (pipeTile.getFrameMaterial() != null) {
@@ -414,7 +414,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public void addCollisionBoxToList(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull AxisAlignedBB entityBox, @Nonnull List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
+    public void addCollisionBoxToList(@NotNull IBlockState state, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull AxisAlignedBB entityBox, @NotNull List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
         // This iterator causes some heap memory overhead
         IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
         if (pipeTile != null && pipeTile.getFrameMaterial() != null) {
@@ -432,7 +432,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
 
     @Nullable
     @Override
-    public RayTraceResult collisionRayTrace(@Nonnull IBlockState blockState, World worldIn, @Nonnull BlockPos pos, @Nonnull Vec3d start, @Nonnull Vec3d end) {
+    public RayTraceResult collisionRayTrace(@NotNull IBlockState blockState, World worldIn, @NotNull BlockPos pos, @NotNull Vec3d start, @NotNull Vec3d end) {
         if (worldIn.isRemote) {
             return getClientCollisionRayTrace(worldIn, pos, start, end);
         }
@@ -440,18 +440,18 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @SideOnly(Side.CLIENT)
-    public RayTraceResult getClientCollisionRayTrace(World worldIn, @Nonnull BlockPos pos, @Nonnull Vec3d start, @Nonnull Vec3d end) {
+    public RayTraceResult getClientCollisionRayTrace(World worldIn, @NotNull BlockPos pos, @NotNull Vec3d start, @NotNull Vec3d end) {
         return RayTracer.rayTraceCuboidsClosest(start, end, pos, getCollisionBox(worldIn, pos, Minecraft.getMinecraft().player));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public BlockFaceShape getBlockFaceShape(@Nonnull IBlockAccess worldIn, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+    public BlockFaceShape getBlockFaceShape(@NotNull IBlockAccess worldIn, @NotNull IBlockState state, @NotNull BlockPos pos, @NotNull EnumFacing face) {
         return BlockFaceShape.UNDEFINED;
     }
 
     @Override
-    public boolean recolorBlock(World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, @Nonnull EnumDyeColor color) {
+    public boolean recolorBlock(World world, @NotNull BlockPos pos, @NotNull EnumFacing side, @NotNull EnumDyeColor color) {
         IPipeTile<PipeType, NodeDataType> tileEntityPipe = (IPipeTile<PipeType, NodeDataType>) world.getTileEntity(pos);
         if (tileEntityPipe != null && tileEntityPipe.getPipeType() != null &&
                 tileEntityPipe.getPipeType().isPaintable() &&
@@ -566,19 +566,19 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public boolean canRenderInLayer(@Nonnull IBlockState state, @Nonnull BlockRenderLayer layer) {
+    public boolean canRenderInLayer(@NotNull IBlockState state, @NotNull BlockRenderLayer layer) {
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getFacade(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nullable EnumFacing side, @Nonnull BlockPos otherPos) {
+    public IBlockState getFacade(@NotNull IBlockAccess world, @NotNull BlockPos pos, @Nullable EnumFacing side, @NotNull BlockPos otherPos) {
         return getFacade(world, pos, side);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getFacade(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, EnumFacing side) {
+    public IBlockState getFacade(@NotNull IBlockAccess world, @NotNull BlockPos pos, EnumFacing side) {
         IPipeTile<?, ?> pipeTileEntity = getPipeTileEntity(world, pos);
         if (pipeTileEntity != null && side != null) {
             CoverBehavior coverBehavior = pipeTileEntity.getCoverableImplementation().getCoverAtSide(side);
@@ -589,9 +589,9 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         return world.getBlockState(pos);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getVisualState(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public IBlockState getVisualState(@NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         return getFacade(world, pos, side);
     }
 

--- a/src/main/java/gregtech/api/pipenet/block/ItemBlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/ItemBlockPipe.java
@@ -11,7 +11,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemBlockPipe<PipeType extends Enum<PipeType> & IPipeType<NodeDataType>, NodeDataType> extends ItemBlock {
 
@@ -30,7 +30,7 @@ public class ItemBlockPipe<PipeType extends Enum<PipeType> & IPipeType<NodeDataT
 
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public boolean placeBlockAt(@Nonnull ItemStack stack, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, float hitX, float hitY, float hitZ, @Nonnull IBlockState newState) {
+    public boolean placeBlockAt(@NotNull ItemStack stack, @NotNull EntityPlayer player, @NotNull World world, @NotNull BlockPos pos, @NotNull EnumFacing side, float hitX, float hitY, float hitZ, @NotNull IBlockState newState) {
         boolean superVal = super.placeBlockAt(stack, player, world, pos, side, hitX, hitY, hitZ, newState);
         if (superVal && !world.isRemote) {
             IPipeTile selfTile = (IPipeTile) world.getTileEntity(pos);

--- a/src/main/java/gregtech/api/pipenet/block/material/ItemBlockMaterialPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/material/ItemBlockMaterialPipe.java
@@ -4,7 +4,7 @@ import gregtech.api.pipenet.block.ItemBlockPipe;
 import gregtech.api.unification.material.Material;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ItemBlockMaterialPipe<PipeType extends Enum<PipeType> & IMaterialPipeType<NodeDataType>, NodeDataType> extends ItemBlockPipe<PipeType, NodeDataType> {
 
@@ -12,10 +12,10 @@ public class ItemBlockMaterialPipe<PipeType extends Enum<PipeType> & IMaterialPi
         super(block);
     }
 
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
     @Override
-    public String getItemStackDisplayName(@Nonnull ItemStack stack) {
+    public String getItemStackDisplayName(@NotNull ItemStack stack) {
         PipeType pipeType = blockPipe.getItemPipeType(stack);
         Material material = ((BlockMaterialPipe<PipeType, NodeDataType, ?>) blockPipe).getItemMaterial(stack);
         return material == null ? " " : pipeType.getOrePrefix().getLocalNameForItem(material);

--- a/src/main/java/gregtech/api/pipenet/block/material/TileEntityMaterialPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/block/material/TileEntityMaterialPipeBase.java
@@ -10,7 +10,7 @@ import gregtech.api.unification.material.Materials;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_PIPE_MATERIAL;
 
@@ -47,16 +47,16 @@ public abstract class TileEntityMaterialPipeBase<PipeType extends Enum<PipeType>
         this.pipeMaterial = ((IMaterialPipeTile<PipeType, NodeDataType>) tileEntity).getPipeMaterial();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound compound) {
         super.writeToNBT(compound);
         compound.setString("PipeMaterial", pipeMaterial.toString());
         return compound;
     }
 
     @Override
-    public void readFromNBT(@Nonnull NBTTagCompound compound) {
+    public void readFromNBT(@NotNull NBTTagCompound compound) {
         super.readFromNBT(compound);
         this.pipeMaterial = GregTechAPI.MATERIAL_REGISTRY.getObject(compound.getString("PipeMaterial"));
         if (this.pipeMaterial == null) {

--- a/src/main/java/gregtech/api/pipenet/tile/IPipeTile.java
+++ b/src/main/java/gregtech/api/pipenet/tile/IPipeTile.java
@@ -9,7 +9,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 
 public interface IPipeTile<PipeType extends Enum<PipeType> & IPipeType<NodeDataType>, NodeDataType> {

--- a/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
+++ b/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
@@ -23,7 +23,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -24,8 +24,8 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 
 import static gregtech.api.capability.GregtechDataCodes.*;
@@ -289,7 +289,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
 
     @Nullable
     @Override
-    public final <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+    public final <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
         boolean isCoverable = capability == GregtechTileCapabilities.CAPABILITY_COVERABLE;
         CoverBehavior coverBehavior = facing == null ? null : coverableImplementation.getCoverAtSide(facing);
         T defaultValue;
@@ -311,13 +311,13 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     }
 
     @Override
-    public final boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+    public final boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         return getCapability(capability, facing) != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound compound) {
         super.writeToNBT(compound);
         BlockPipe<PipeType, NodeDataType, ?> pipeBlock = getPipeBlock();
         if (pipeBlock != null) {
@@ -336,7 +336,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     }
 
     @Override
-    public void readFromNBT(@Nonnull NBTTagCompound compound) {
+    public void readFromNBT(@NotNull NBTTagCompound compound) {
         super.readFromNBT(compound);
         if (compound.hasKey("PipeBlock", NBT.TAG_STRING)) {
             Block block = Block.REGISTRY.getObject(new ResourceLocation(compound.getString("PipeBlock")));
@@ -458,7 +458,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     }
 
     @Override
-    public boolean shouldRefresh(@Nonnull World world, @Nonnull BlockPos pos, IBlockState oldState, IBlockState newSate) {
+    public boolean shouldRefresh(@NotNull World world, @NotNull BlockPos pos, IBlockState oldState, IBlockState newSate) {
         return oldState.getBlock() != newSate.getBlock();
     }
 

--- a/src/main/java/gregtech/api/recipes/FluidCellInput.java
+++ b/src/main/java/gregtech/api/recipes/FluidCellInput.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class FluidCellInput extends GTRecipeItemInput {
 

--- a/src/main/java/gregtech/api/recipes/KeySharedStack.java
+++ b/src/main/java/gregtech/api/recipes/KeySharedStack.java
@@ -3,7 +3,7 @@ package gregtech.api.recipes;
 import gregtech.api.util.ItemStackKey;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
 
@@ -16,7 +16,7 @@ public class KeySharedStack {
 
     }
 
-    public static synchronized ItemStackKey getRegisteredStack(final @Nonnull ItemStack itemStack) {
+    public static synchronized ItemStackKey getRegisteredStack(final @NotNull ItemStack itemStack) {
         if (itemStack.isEmpty()) {
             return EMPTY;
         }

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -51,8 +51,8 @@ import net.minecraftforge.registries.IForgeRegistry;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -77,11 +77,11 @@ public class ModHandler {
         return false;
     }
 
-    public static FluidStack getBoilerFluidFromContainer(@Nonnull IFluidHandler fluidHandler, boolean doDrain) {
+    public static FluidStack getBoilerFluidFromContainer(@NotNull IFluidHandler fluidHandler, boolean doDrain) {
         return getBoilerFluidFromContainer(fluidHandler, 1, doDrain);
     }
 
-    public static FluidStack getBoilerFluidFromContainer(@Nonnull IFluidHandler fluidHandler, int amount, boolean doDrain) {
+    public static FluidStack getBoilerFluidFromContainer(@NotNull IFluidHandler fluidHandler, int amount, boolean doDrain) {
         if (amount == 0) return null;
         FluidStack drainedWater = fluidHandler.drain(Materials.Water.getFluid(amount), doDrain);
         if (drainedWater == null || drainedWater.amount == 0) {

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -29,8 +29,8 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -115,7 +115,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
-    public boolean applyProperty(@Nonnull String key, @Nullable Object value) {
+    public boolean applyProperty(@NotNull String key, @Nullable Object value) {
         if (key.equals(CleanroomProperty.KEY)) {
             if (value instanceof CleanroomType) {
                 this.cleanroom((CleanroomType) value);
@@ -129,7 +129,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return false;
     }
 
-    public boolean applyProperty(@Nonnull RecipeProperty<?> property, @Nullable Object value) {
+    public boolean applyProperty(@NotNull RecipeProperty<?> property, @Nullable Object value) {
         if (value == null) {
             if (this.recipePropertyStorage != null) {
                 return this.recipePropertyStorage.remove(property);

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -40,8 +40,8 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.function.Consumer;
@@ -288,7 +288,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     @Nullable
-    public Recipe find(@Nonnull List<ItemStack> items, @Nonnull List<FluidStack> fluids, @Nonnull Predicate<Recipe> canHandle) {
+    public Recipe find(@NotNull List<ItemStack> items, @NotNull List<FluidStack> fluids, @NotNull Predicate<Recipe> canHandle) {
         // First, check if items and fluids are valid.
         if (items.size() == Integer.MAX_VALUE || fluids.size() == Integer.MAX_VALUE) {
             return null;
@@ -379,7 +379,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * @param branchRoot  the root branch to search from.
      * @return a recipe
      */
-    private Recipe recurseIngredientTreeFindRecipe(@Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch branchRoot, @Nonnull Predicate<Recipe> canHandle) {
+    private Recipe recurseIngredientTreeFindRecipe(@NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch branchRoot, @NotNull Predicate<Recipe> canHandle) {
         // Try each ingredient as a starting point, adding it to the skiplist.
         for (int i = 0; i < ingredients.size(); i++) {
             Recipe r = recurseIngredientTreeFindRecipe(ingredients, branchRoot, canHandle, i, 0, (1L << i));
@@ -402,7 +402,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      *                    recursion.
      * @return a recipe
      */
-    private Recipe recurseIngredientTreeFindRecipe(@Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch branchMap, @Nonnull Predicate<Recipe> canHandle, int index, int count, long skip) {
+    private Recipe recurseIngredientTreeFindRecipe(@NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch branchMap, @NotNull Predicate<Recipe> canHandle, int index, int count, long skip) {
         if (count == ingredients.size()) {
             return null;
         }
@@ -428,7 +428,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return null;
     }
 
-    private Recipe diveIngredientTreeFindRecipe(@Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch map, Predicate<Recipe> canHandle, int index, int count, long skip) {
+    private Recipe diveIngredientTreeFindRecipe(@NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch map, Predicate<Recipe> canHandle, int index, int count, long skip) {
         // We loop around ingredients.size() if we reach the end.
         int counter = (index + 1) % ingredients.size();
         while (counter != index) {
@@ -487,7 +487,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return recurseIngredientTreeFindRecipeCollisions(list, lookup, collidingRecipes);
     }
 
-    private Set<Recipe> recurseIngredientTreeFindRecipeCollisions(@Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch branchRoot, Set<Recipe> collidingRecipes) {
+    private Set<Recipe> recurseIngredientTreeFindRecipeCollisions(@NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch branchRoot, Set<Recipe> collidingRecipes) {
         // Try each ingredient as a starting point, adding it to the skiplist.
         for (int i = 0; i < ingredients.size(); i++) {
             recurseIngredientTreeFindRecipeCollisions(ingredients, branchRoot, i, 0, (1L << i), collidingRecipes);
@@ -495,7 +495,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return collidingRecipes;
     }
 
-    private Recipe recurseIngredientTreeFindRecipeCollisions(@Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch branchMap, int index, int count, long skip, Set<Recipe> collidingRecipes) {
+    private Recipe recurseIngredientTreeFindRecipeCollisions(@NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch branchMap, int index, int count, long skip, Set<Recipe> collidingRecipes) {
         if (count == ingredients.size()) {
             return null;
         }
@@ -521,7 +521,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return null;
     }
 
-    private Recipe diveIngredientTreeFindRecipeCollisions(@Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch map, int index, int count, long skip, Set<Recipe> collidingRecipes) {
+    private Recipe diveIngredientTreeFindRecipeCollisions(@NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch map, int index, int count, long skip, Set<Recipe> collidingRecipes) {
         // We loop around ingredients.size() if we reach the end.
         int counter = (index + 1) % ingredients.size();
         while (counter != index) {
@@ -663,7 +663,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * @param index       where in the ingredients list we are.
      * @param count       how many added already.
      */
-    boolean recurseIngredientTreeAdd(@Nonnull Recipe recipe, @Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch branchMap, int index, int count) {
+    boolean recurseIngredientTreeAdd(@NotNull Recipe recipe, @NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch branchMap, int index, int count) {
         if (count >= ingredients.size()) return true;
         if (index >= ingredients.size()) {
             throw new RuntimeException("Index out of bounds for recurseItemTreeAdd, should not happen");
@@ -878,7 +878,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * @param ingredients    list of input ingredients.
      * @param branchMap      the current branch in the recursion.
      */
-    private Recipe recurseIngredientTreeRemove(@Nonnull Recipe recipeToRemove, @Nonnull List<List<AbstractMapIngredient>> ingredients, @Nonnull Branch branchMap, int depth) {
+    private Recipe recurseIngredientTreeRemove(@NotNull Recipe recipeToRemove, @NotNull List<List<AbstractMapIngredient>> ingredients, @NotNull Branch branchMap, int depth) {
         for (List<AbstractMapIngredient> current : ingredients) {
             for (AbstractMapIngredient obj : current) {
                 Map<AbstractMapIngredient, Either<Recipe, Branch>> targetMap;
@@ -907,7 +907,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return null;
     }
 
-    private Recipe removeDive(Recipe recipeToRemove, @Nonnull List<List<AbstractMapIngredient>> ingredients, Map<AbstractMapIngredient, Either<Recipe, Branch>> targetMap, AbstractMapIngredient obj, int depth) {
+    private Recipe removeDive(Recipe recipeToRemove, @NotNull List<List<AbstractMapIngredient>> ingredients, Map<AbstractMapIngredient, Either<Recipe, Branch>> targetMap, AbstractMapIngredient obj, int depth) {
         Either<Recipe, Branch> result = targetMap.get(obj);
         if (result != null) {
             // Either return recipe or continue branch.

--- a/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
@@ -9,7 +9,7 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.ValidationResult;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlastRecipeBuilder extends RecipeBuilder<BlastRecipeBuilder> {
 
@@ -30,7 +30,7 @@ public class BlastRecipeBuilder extends RecipeBuilder<BlastRecipeBuilder> {
     }
 
     @Override
-    public boolean applyProperty(@Nonnull String key, Object value) {
+    public boolean applyProperty(@NotNull String key, Object value) {
         if (key.equals(TemperatureProperty.KEY)) {
             this.blastFurnaceTemp(((Number) value).intValue());
             return true;

--- a/src/main/java/gregtech/api/recipes/builders/CircuitAssemblerRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/CircuitAssemblerRecipeBuilder.java
@@ -9,7 +9,7 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.ValidationResult;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CircuitAssemblerRecipeBuilder extends RecipeBuilder<CircuitAssemblerRecipeBuilder> {
 
@@ -27,7 +27,7 @@ public class CircuitAssemblerRecipeBuilder extends RecipeBuilder<CircuitAssemble
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public CircuitAssemblerRecipeBuilder copy() {
         return new CircuitAssemblerRecipeBuilder(this);
     }

--- a/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
@@ -8,7 +8,7 @@ import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
 
@@ -29,7 +29,7 @@ public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
     }
 
     @Override
-    public boolean applyProperty(@Nonnull String key, Object value) {
+    public boolean applyProperty(@NotNull String key, Object value) {
         if (key.equals(FusionEUToStartProperty.KEY)) {
             this.EUToStart(((Number) value).longValue());
             return true;

--- a/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/GasCollectorRecipeBuilder.java
@@ -10,7 +10,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntLists;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class GasCollectorRecipeBuilder extends RecipeBuilder<GasCollectorRecipeBuilder> {
@@ -32,7 +32,7 @@ public class GasCollectorRecipeBuilder extends RecipeBuilder<GasCollectorRecipeB
     }
 
     @Override
-    public boolean applyProperty(@Nonnull String key, Object value) {
+    public boolean applyProperty(@NotNull String key, Object value) {
         if (key.equals(GasCollectorDimensionProperty.KEY)) {
             if (value instanceof Integer) {
                 this.dimension((Integer) value);

--- a/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
@@ -14,7 +14,7 @@ import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder> {
 
@@ -36,7 +36,7 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
     }
 
     @Override
-    public boolean applyProperty(@Nonnull String key, Object value) {
+    public boolean applyProperty(@NotNull String key, Object value) {
         if (key.equals(ImplosionExplosiveProperty.KEY)) {
             if (value instanceof ItemStack) {
                 this.applyProperty(ImplosionExplosiveProperty.getInstance(), value);

--- a/src/main/java/gregtech/api/recipes/builders/IntCircuitRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/IntCircuitRecipeBuilder.java
@@ -9,7 +9,7 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class IntCircuitRecipeBuilder extends RecipeBuilder<IntCircuitRecipeBuilder> {
 
@@ -27,7 +27,7 @@ public class IntCircuitRecipeBuilder extends RecipeBuilder<IntCircuitRecipeBuild
     }
 
     @Override
-    public boolean applyProperty(@Nonnull String key, Object value) {
+    public boolean applyProperty(@NotNull String key, Object value) {
         if (key.equals("circuit") && value instanceof Number) {
             circuitMeta(((Number) value).intValue());
             return true;

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -13,7 +13,7 @@ import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 

--- a/src/main/java/gregtech/api/recipes/ingredients/GTRecipeFluidInput.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/GTRecipeFluidInput.java
@@ -3,7 +3,7 @@ package gregtech.api.recipes.ingredients;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class GTRecipeFluidInput extends GTRecipeInput {

--- a/src/main/java/gregtech/api/recipes/ingredients/GTRecipeInput.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/GTRecipeInput.java
@@ -9,7 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/gregtech/api/recipes/ingredients/GTRecipeOreInput.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/GTRecipeOreInput.java
@@ -6,7 +6,7 @@ import gregtech.api.unification.stack.UnificationEntry;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class GTRecipeOreInput extends GTRecipeInput {

--- a/src/main/java/gregtech/api/recipes/ingredients/IntCircuitIngredient.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/IntCircuitIngredient.java
@@ -6,7 +6,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.MathHelper;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class IntCircuitIngredient extends GTRecipeItemInput {
 

--- a/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/IParallelableRecipeLogic.java
@@ -9,7 +9,7 @@ import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public interface IParallelableRecipeLogic {
 
@@ -19,7 +19,7 @@ public interface IParallelableRecipeLogic {
      *
      * @param builder the recipe builder
      */
-    default void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
+    default void applyParallelBonus(@NotNull RecipeBuilder<?> builder) {
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -4,7 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A class for holding all the various Overclocking logics
@@ -63,7 +63,7 @@ public class OverclockingLogic {
         return new int[]{overclockedEUt, (int) Math.ceil(overclockedDuration)};
     }
 
-    @Nonnull
+    @NotNull
     public static int[] heatingCoilOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration, int maxOverclocks, int currentTemp, int recipeRequiredTemp) {
         int amountEUDiscount = Math.max(0, (currentTemp - recipeRequiredTemp) / 900);
         int amountPerfectOC = amountEUDiscount / 2;

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -9,7 +9,7 @@ import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
@@ -21,7 +21,7 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ModularUI.Builder createJeiUITemplate(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 176)
                 .widget(new ProgressWidget(200, 80, 1, 54, 72, GuiTextures.PROGRESS_BAR_ASSEMBLY_LINE, ProgressWidget.MoveType.HORIZONTAL))
@@ -32,7 +32,7 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
     }
 
     @Override
-    protected void addInventorySlotGroup(ModularUI.Builder builder, @Nonnull IItemHandlerModifiable itemHandler, @Nonnull FluidTankList fluidHandler, boolean isOutputs, int yOffset) {
+    protected void addInventorySlotGroup(ModularUI.Builder builder, @NotNull IItemHandlerModifiable itemHandler, @NotNull FluidTankList fluidHandler, boolean isOutputs, int yOffset) {
         int itemInputsCount = itemHandler.getSlots();
         int fluidInputsCount = fluidHandler.getTanks();
         boolean invertFluids = false;

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFluidCanner.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFluidCanner.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class RecipeMapFluidCanner extends RecipeMap<SimpleRecipeBuilder> {

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFormingPress.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFormingPress.java
@@ -15,7 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class RecipeMapFormingPress extends RecipeMap<SimpleRecipeBuilder> {

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
@@ -8,7 +8,7 @@ import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class RecipeMapFurnace extends RecipeMap<SimpleRecipeBuilder> {

--- a/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
@@ -5,7 +5,7 @@ import gregtech.api.recipes.ingredients.nbtmatch.NBTCondition;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class MapItemStackNBTIngredient extends MapItemStackIngredient {
     @Nullable

--- a/src/main/java/gregtech/api/recipes/map/MapOreDictNBTIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapOreDictNBTIngredient.java
@@ -4,7 +4,7 @@ import gregtech.api.recipes.ingredients.nbtmatch.NBTMatcher;
 import gregtech.api.recipes.ingredients.nbtmatch.NBTCondition;
 import net.minecraft.nbt.NBTTagCompound;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class MapOreDictNBTIngredient extends MapOreDictIngredient {
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/CleanroomProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/CleanroomProperty.java
@@ -4,7 +4,7 @@ import gregtech.api.metatileentity.multiblock.CleanroomType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CleanroomProperty extends RecipeProperty<CleanroomType> {
 
@@ -24,15 +24,15 @@ public class CleanroomProperty extends RecipeProperty<CleanroomType> {
     }
 
     @Override
-    public void drawInfo(@Nonnull Minecraft minecraft, int x, int y, int color, Object value) {
+    public void drawInfo(@NotNull Minecraft minecraft, int x, int y, int color, Object value) {
         CleanroomType type = castValue(value);
         if (type == null) return;
 
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.cleanroom", getName(type)), x, y, color);
     }
 
-    @Nonnull
-    private String getName(@Nonnull CleanroomType value) {
+    @NotNull
+    private String getName(@NotNull CleanroomType value) {
         String name = I18n.format(value.getTranslationKey());
         if (name.length() >= 20) return name.substring(0, 20) + "..";
         return name;

--- a/src/main/java/gregtech/api/recipes/recipes/DummyRecipe.java
+++ b/src/main/java/gregtech/api/recipes/recipes/DummyRecipe.java
@@ -6,18 +6,18 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class DummyRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe {
 
     @Override
-    public boolean matches(@Nonnull final InventoryCrafting inv, @Nonnull final World worldIn) {
+    public boolean matches(@NotNull final InventoryCrafting inv, @NotNull final World worldIn) {
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getCraftingResult(@Nonnull final InventoryCrafting inv) {
+    public ItemStack getCraftingResult(@NotNull final InventoryCrafting inv) {
         return ItemStack.EMPTY;
     }
 
@@ -26,7 +26,7 @@ public class DummyRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IR
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getRecipeOutput() {
         return ItemStack.EMPTY;

--- a/src/main/java/gregtech/api/terminal/TerminalRegistry.java
+++ b/src/main/java/gregtech/api/terminal/TerminalRegistry.java
@@ -39,7 +39,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -192,7 +192,7 @@ public class TerminalRegistry {
         HW_REGISTER.put(name, hardware);
     }
 
-    public static void registerHardwareDemand(String name, boolean isDefaultApp, @Nonnull List<Hardware>[] hardware, @Nonnull List<ItemStack>[] upgrade) {
+    public static void registerHardwareDemand(String name, boolean isDefaultApp, @NotNull List<Hardware>[] hardware, @NotNull List<ItemStack>[] upgrade) {
         if (name != null && APP_REGISTER.containsKey(name)) {
             if (isDefaultApp) {
                 DEFAULT_APPS.add(name);

--- a/src/main/java/gregtech/api/terminal/hardware/HardwareProvider.java
+++ b/src/main/java/gregtech/api/terminal/hardware/HardwareProvider.java
@@ -11,8 +11,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -109,7 +109,7 @@ public class HardwareProvider implements ICapabilityProvider, IItemCapabilityPro
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         if (providers != null) {
             for (Map.Entry<String, Hardware> entry : providers.entrySet()) {
                 Hardware provider = entry.getValue();
@@ -125,7 +125,7 @@ public class HardwareProvider implements ICapabilityProvider, IItemCapabilityPro
 
     @Nullable
     @Override
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+    public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
         if (providers != null) {
             for (Map.Entry<String, Hardware> entry : providers.entrySet()) {
                 Hardware provider = entry.getValue();

--- a/src/main/java/gregtech/api/terminal/hardware/IHardwareCapability.java
+++ b/src/main/java/gregtech/api/terminal/hardware/IHardwareCapability.java
@@ -2,12 +2,12 @@ package gregtech.api.terminal.hardware;
 
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public interface IHardwareCapability {
-    default boolean hasCapability(@Nonnull Capability<?> capability) {
+    default boolean hasCapability(@NotNull Capability<?> capability) {
         return getCapability(capability) != null;
     }
 
-    <T> T getCapability(@Nonnull Capability<T> capability);
+    <T> T getCapability(@NotNull Capability<T> capability);
 }

--- a/src/main/java/gregtech/api/terminal/util/SearchEngine.java
+++ b/src/main/java/gregtech/api/terminal/util/SearchEngine.java
@@ -1,6 +1,6 @@
 package gregtech.api.terminal.util;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 public  class SearchEngine<T> {
@@ -8,7 +8,7 @@ public  class SearchEngine<T> {
     private final Consumer<T> result;
     private Thread thread;
 
-    public SearchEngine(@Nonnull ISearch<T> search, @Nonnull Consumer<T> result){
+    public SearchEngine(@NotNull ISearch<T> search, @NotNull Consumer<T> result){
         this.search = search;
         this.result = result;
     }

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreDictionary.OreRegisterEvent;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.*;
 import java.util.Map.Entry;

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import stanhebben.zenscript.annotations.*;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 @ZenClass("mods.gregtech.material.Material")
@@ -34,7 +34,7 @@ public class Material implements Comparable<Material> {
      *
      * @see MaterialInfo
      */
-    @Nonnull
+    @NotNull
     private final MaterialInfo materialInfo;
 
     /**
@@ -42,7 +42,7 @@ public class Material implements Comparable<Material> {
      *
      * @see MaterialProperties
      */
-    @Nonnull
+    @NotNull
     private final MaterialProperties properties;
 
     /**
@@ -50,7 +50,7 @@ public class Material implements Comparable<Material> {
      *
      * @see MaterialFlags
      */
-    @Nonnull
+    @NotNull
     private final MaterialFlags flags;
 
     /**
@@ -98,7 +98,7 @@ public class Material implements Comparable<Material> {
         return getMaterialComponents().toArray(new MaterialStack[0]);
     }
 
-    private Material(@Nonnull MaterialInfo materialInfo, @Nonnull MaterialProperties properties, @Nonnull MaterialFlags flags) {
+    private Material(@NotNull MaterialInfo materialInfo, @NotNull MaterialProperties properties, @NotNull MaterialFlags flags) {
         this.materialInfo = materialInfo;
         this.properties = properties;
         this.flags = flags;
@@ -313,7 +313,7 @@ public class Material implements Comparable<Material> {
         return new MaterialStack(this, amount);
     }
 
-    @Nonnull
+    @NotNull
     public MaterialProperties getProperties() {
         return properties;
     }

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -6,7 +6,7 @@ import gregtech.api.fluids.fluidType.FluidTypes;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class FluidProperty implements IMaterialProperty<FluidProperty> {
 
@@ -23,7 +23,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
     private boolean isGas;
     private int fluidTemperature = BASE_TEMP;
 
-    public FluidProperty(@Nonnull FluidType fluidType, boolean hasBlock) {
+    public FluidProperty(@NotNull FluidType fluidType, boolean hasBlock) {
         this.fluidType = fluidType;
         this.isGas = fluidType == FluidTypes.GAS;
         this.hasBlock = hasBlock;
@@ -43,7 +43,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
     /**
      * internal usage only
      */
-    public void setFluid(@Nonnull Fluid materialFluid) {
+    public void setFluid(@NotNull Fluid materialFluid) {
         Preconditions.checkNotNull(materialFluid);
         this.fluid = materialFluid;
     }
@@ -64,7 +64,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
         this.isGas = isGas;
     }
 
-    @Nonnull
+    @NotNull
     public FluidStack getFluid(int amount) {
         return new FluidStack(fluid, amount);
     }
@@ -85,7 +85,7 @@ public class FluidProperty implements IMaterialProperty<FluidProperty> {
         return fluidTemperature;
     }
 
-    @Nonnull
+    @NotNull
     public FluidType getFluidType() {
         return this.fluidType;
     }

--- a/src/main/java/gregtech/api/unification/material/properties/IngotProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/IngotProperty.java
@@ -2,7 +2,7 @@ package gregtech.api.unification.material.properties;
 
 import gregtech.api.unification.material.Material;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class IngotProperty implements IMaterialProperty<IngotProperty> {
 

--- a/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
@@ -3,7 +3,7 @@ package gregtech.api.unification.material.properties;
 import gregtech.api.unification.material.Material;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/gregtech/api/unification/material/properties/PlasmaProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/PlasmaProperty.java
@@ -4,7 +4,7 @@ import com.google.common.base.Preconditions;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class PlasmaProperty implements IMaterialProperty<PlasmaProperty> {
 
@@ -20,7 +20,7 @@ public class PlasmaProperty implements IMaterialProperty<PlasmaProperty> {
     /**
      * internal usage only
      */
-    public void setPlasma(@Nonnull Fluid plasma) {
+    public void setPlasma(@NotNull Fluid plasma) {
         Preconditions.checkNotNull(plasma);
         this.plasma = plasma;
     }
@@ -29,7 +29,7 @@ public class PlasmaProperty implements IMaterialProperty<PlasmaProperty> {
         return plasma;
     }
 
-    @Nonnull
+    @NotNull
     public FluidStack getPlasma(int amount) {
         return new FluidStack(plasma, amount);
     }

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.Validate;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;

--- a/src/main/java/gregtech/api/unification/ore/StoneType.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneType.java
@@ -13,7 +13,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.Loader;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -54,7 +54,7 @@ public class StoneType implements Comparable<StoneType> {
     }
 
     @Override
-    public int compareTo(@Nonnull StoneType stoneType) {
+    public int compareTo(@NotNull StoneType stoneType) {
         return STONE_TYPE_REGISTRY.getIDForObject(this) - STONE_TYPE_REGISTRY.getIDForObject(stoneType);
     }
 

--- a/src/main/java/gregtech/api/unification/stack/UnificationEntry.java
+++ b/src/main/java/gregtech/api/unification/stack/UnificationEntry.java
@@ -3,7 +3,7 @@ package gregtech.api.unification.stack;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class UnificationEntry {

--- a/src/main/java/gregtech/api/util/BaseCreativeTab.java
+++ b/src/main/java/gregtech/api/util/BaseCreativeTab.java
@@ -4,7 +4,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Supplier;
 
 public class BaseCreativeTab extends CreativeTabs {
@@ -21,7 +21,7 @@ public class BaseCreativeTab extends CreativeTabs {
             setBackgroundImageName("item_search.png");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack createIcon() {
         if (iconSupplier == null) {

--- a/src/main/java/gregtech/api/util/BlockPosFace.java
+++ b/src/main/java/gregtech/api/util/BlockPosFace.java
@@ -3,7 +3,7 @@ package gregtech.api.util;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class BlockPosFace {
     public final EnumFacing facing;

--- a/src/main/java/gregtech/api/util/BlockUtility.java
+++ b/src/main/java/gregtech/api/util/BlockUtility.java
@@ -5,7 +5,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockUtility {
 
@@ -17,7 +17,7 @@ public class BlockUtility {
             super(Material.AIR);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public NonNullList<ItemStack> captureDrops(boolean start) {
             return super.captureDrops(start);

--- a/src/main/java/gregtech/api/util/CTRecipeHelper.java
+++ b/src/main/java/gregtech/api/util/CTRecipeHelper.java
@@ -15,7 +15,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class CTRecipeHelper {
 

--- a/src/main/java/gregtech/api/util/DummyContainer.java
+++ b/src/main/java/gregtech/api/util/DummyContainer.java
@@ -3,7 +3,7 @@ package gregtech.api.util;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class DummyContainer extends Container {
 
@@ -15,7 +15,7 @@ public class DummyContainer extends Container {
     }
 
     @Override
-    public boolean canInteractWith(@Nonnull EntityPlayer playerIn) {
+    public boolean canInteractWith(@NotNull EntityPlayer playerIn) {
         return true;
     }
 

--- a/src/main/java/gregtech/api/util/EntityDamageUtil.java
+++ b/src/main/java/gregtech/api/util/EntityDamageUtil.java
@@ -13,7 +13,7 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class EntityDamageUtil {
 
@@ -25,7 +25,7 @@ public class EntityDamageUtil {
      * @param multiplier  the multiplier on the damage taken
      * @param maximum     the maximum damage to apply to the entity, use -1 for no maximum
      */
-    public static void applyTemperatureDamage(@Nonnull EntityLivingBase entity, int temperature, float multiplier, int maximum) {
+    public static void applyTemperatureDamage(@NotNull EntityLivingBase entity, int temperature, float multiplier, int maximum) {
         if (temperature > 320) {
             int damage = (int) ((multiplier * (temperature - 300)) / 50.0F);
             if (maximum > 0) {
@@ -45,7 +45,7 @@ public class EntityDamageUtil {
      * @param entity the entity to damage
      * @param damage the damage to apply
      */
-    public static void applyHeatDamage(@Nonnull EntityLivingBase entity, int damage) {
+    public static void applyHeatDamage(@NotNull EntityLivingBase entity, int damage) {
         // do not attempt to damage by 0
         if (damage <= 0) return;
         if (!entity.isEntityAlive()) return;
@@ -64,7 +64,7 @@ public class EntityDamageUtil {
      * @param entity the entity to damage
      * @param damage the damage to apply
      */
-    public static void applyFrostDamage(@Nonnull EntityLivingBase entity, int damage) {
+    public static void applyFrostDamage(@NotNull EntityLivingBase entity, int damage) {
         // do not attempt to damage by 0
         if (damage <= 0) return;
         if (!entity.isEntityAlive()) return;
@@ -94,7 +94,7 @@ public class EntityDamageUtil {
      * @param entity the entity to damage
      * @param damage the damage to apply
      */
-    public static void applyChemicalDamage(@Nonnull EntityLivingBase entity, int damage) {
+    public static void applyChemicalDamage(@NotNull EntityLivingBase entity, int damage) {
         // do not attempt to damage by 0
         if (damage <= 0) return;
         if (!entity.isEntityAlive()) return;

--- a/src/main/java/gregtech/api/util/FluidTankSwitchShim.java
+++ b/src/main/java/gregtech/api/util/FluidTankSwitchShim.java
@@ -6,7 +6,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 // probably causes problems
 public class FluidTankSwitchShim implements IFluidTank, IFluidHandler {

--- a/src/main/java/gregtech/api/util/FluidTooltipUtil.java
+++ b/src/main/java/gregtech/api/util/FluidTooltipUtil.java
@@ -9,7 +9,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -91,7 +91,7 @@ public class FluidTooltipUtil {
     /**
      * A simple helper method to get the tooltip for Water, since it is an edge case of fluids.
      */
-    @Nonnull
+    @NotNull
     public static List<String> getWaterTooltip() {
         return getMaterialTooltip(Materials.Water, Materials.Water.getProperty(PropertyKey.FLUID).getFluidTemperature(), false);
     }
@@ -99,13 +99,13 @@ public class FluidTooltipUtil {
     /**
      * A simple helper method to get the tooltip for Lava, since it is an edge case of fluids.
      */
-    @Nonnull
+    @NotNull
     public static List<String> getLavaTooltip() {
         return getMaterialTooltip(Materials.Lava, Materials.Lava.getProperty(PropertyKey.FLUID).getFluidTemperature(), false);
     }
 
-    @Nonnull
-    public static List<String> getMaterialTooltip(@Nonnull Material material, int temperature, boolean isPlasma) {
+    @NotNull
+    public static List<String> getMaterialTooltip(@NotNull Material material, int temperature, boolean isPlasma) {
         List<String> tooltip = new ArrayList<>();
         if (!material.getChemicalFormula().isEmpty())
             tooltip.add(TextFormatting.YELLOW + material.getChemicalFormula());

--- a/src/main/java/gregtech/api/util/GTControlledRegistry.java
+++ b/src/main/java/gregtech/api/util/GTControlledRegistry.java
@@ -10,8 +10,8 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.registries.GameData;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -69,7 +69,7 @@ public class GTControlledRegistry<K, V> extends RegistrySimple<K, V> {
     }
 
     @Override
-    public void putObject(@Nonnull K key, @Nonnull V value) {
+    public void putObject(@NotNull K key, @NotNull V value) {
         throw new UnsupportedOperationException("Use #register(int, String, T)");
     }
 
@@ -83,7 +83,7 @@ public class GTControlledRegistry<K, V> extends RegistrySimple<K, V> {
     protected final IntIdentityHashBiMap<V> underlyingIntegerMap = new IntIdentityHashBiMap<>(256);
     protected final Map<V, K> inverseObjectRegistry;
 
-    @Nonnull
+    @NotNull
     @Override
     protected Map<K, V> createUnderlyingMap() {
         return HashBiMap.create();
@@ -103,7 +103,7 @@ public class GTControlledRegistry<K, V> extends RegistrySimple<K, V> {
         return this.underlyingIntegerMap.get(id);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<V> iterator() {
         return this.underlyingIntegerMap.iterator();

--- a/src/main/java/gregtech/api/util/GTTransferUtils.java
+++ b/src/main/java/gregtech/api/util/GTTransferUtils.java
@@ -12,7 +12,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,15 +20,15 @@ import java.util.function.Predicate;
 
 public class GTTransferUtils {
 
-    public static int transferFluids(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler) {
+    public static int transferFluids(@NotNull IFluidHandler sourceHandler, @NotNull IFluidHandler destHandler) {
         return transferFluids(sourceHandler, destHandler, Integer.MAX_VALUE, fluidStack -> true);
     }
 
-    public static int transferFluids(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler, int transferLimit) {
+    public static int transferFluids(@NotNull IFluidHandler sourceHandler, @NotNull IFluidHandler destHandler, int transferLimit) {
         return transferFluids(sourceHandler, destHandler, transferLimit, fluidStack -> true);
     }
 
-    public static int transferFluids(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler, int transferLimit, @Nonnull Predicate<FluidStack> fluidFilter) {
+    public static int transferFluids(@NotNull IFluidHandler sourceHandler, @NotNull IFluidHandler destHandler, int transferLimit, @NotNull Predicate<FluidStack> fluidFilter) {
         int fluidLeftToTransfer = transferLimit;
 
         for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {
@@ -60,7 +60,7 @@ public class GTTransferUtils {
         return transferLimit - fluidLeftToTransfer;
     }
 
-    public static boolean transferExactFluidStack(@Nonnull IFluidHandler sourceHandler, @Nonnull IFluidHandler destHandler, FluidStack fluidStack) {
+    public static boolean transferExactFluidStack(@NotNull IFluidHandler sourceHandler, @NotNull IFluidHandler destHandler, FluidStack fluidStack) {
         int amount = fluidStack.amount;
         FluidStack sourceFluid = sourceHandler.drain(fluidStack, false);
         if (sourceFluid == null || sourceFluid.amount != amount) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -63,8 +63,8 @@ import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -925,7 +925,7 @@ public class GTUtility {
      * @param values to find the mean of
      * @return the mean value
      */
-    public static long mean(@Nonnull long[] values) {
+    public static long mean(@NotNull long[] values) {
         if (values.length == 0L)
             return 0L;
 
@@ -939,7 +939,7 @@ public class GTUtility {
      * @param world the {@link World} to get the average tick time of
      * @return the mean tick time
      */
-    public static double getMeanTickTime(@Nonnull World world) {
+    public static double getMeanTickTime(@NotNull World world) {
         return mean(Objects.requireNonNull(world.getMinecraftServer()).tickTimeArray) * 1.0E-6D;
     }
 

--- a/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
+++ b/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
@@ -3,7 +3,7 @@ package gregtech.api.util;
 import it.unimi.dsi.fastutil.Hash;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**

--- a/src/main/java/gregtech/api/util/MCGuiUtil.java
+++ b/src/main/java/gregtech/api/util/MCGuiUtil.java
@@ -2,7 +2,7 @@ package gregtech.api.util;
 
 import net.minecraft.client.gui.GuiPageButtonList.GuiResponder;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 public class MCGuiUtil {
@@ -18,7 +18,7 @@ public class MCGuiUtil {
             }
 
             @Override
-            public void setEntryValue(int id, @Nonnull String value) {
+            public void setEntryValue(int id, @NotNull String value) {
                 onChanged.accept(value);
             }
         };

--- a/src/main/java/gregtech/api/util/OreDictExprFilter.java
+++ b/src/main/java/gregtech/api/util/OreDictExprFilter.java
@@ -3,7 +3,7 @@ package gregtech.api.util;
 import gregtech.api.unification.OreDictUnifier;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -6,7 +6,7 @@ import gregtech.api.recipes.FluidKey;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -65,7 +65,7 @@ public class OverlayedFluidHandler {
         }
     }
 
-    public int insertStackedFluidKey(@Nonnull FluidKey toInsert, int amountToInsert) {
+    public int insertStackedFluidKey(@NotNull FluidKey toInsert, int amountToInsert) {
         int insertedAmount = 0;
         for (int i = 0; i < this.overlayedTanks.length; i++) {
             initTank(i);

--- a/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
+++ b/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
@@ -10,7 +10,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -20,7 +20,7 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
     private final Predicate<ItemStack> chargePredicate;
     private final boolean transferMaxCharge;
 
-    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, Object... recipe) {
+    public ShapedOreEnergyTransferRecipe(ResourceLocation group, @NotNull ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, Object... recipe) {
         super(group, result, CraftingHelper.parseShaped(recipe));
         this.chargePredicate = chargePredicate;
         this.transferMaxCharge = transferMaxCharge;
@@ -43,9 +43,9 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getCraftingResult(@Nonnull InventoryCrafting inventoryCrafting) {
+    public ItemStack getCraftingResult(@NotNull InventoryCrafting inventoryCrafting) {
         ItemStack resultStack = super.getCraftingResult(inventoryCrafting);
         chargeStackFromComponents(resultStack, inventoryCrafting, chargePredicate, transferMaxCharge);
         return resultStack;

--- a/src/main/java/gregtech/api/util/SlotDelegate.java
+++ b/src/main/java/gregtech/api/util/SlotDelegate.java
@@ -6,8 +6,8 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SlotDelegate extends Slot {
 
@@ -19,22 +19,22 @@ public class SlotDelegate extends Slot {
     }
 
     @Override
-    public void onSlotChange(@Nonnull ItemStack p_75220_1_, @Nonnull ItemStack p_75220_2_) {
+    public void onSlotChange(@NotNull ItemStack p_75220_1_, @NotNull ItemStack p_75220_2_) {
         this.delegate.onSlotChange(p_75220_1_, p_75220_2_);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack onTake(@Nonnull EntityPlayer thePlayer, @Nonnull ItemStack stack) {
+    public ItemStack onTake(@NotNull EntityPlayer thePlayer, @NotNull ItemStack stack) {
         return this.delegate.onTake(thePlayer, stack);
     }
 
     @Override
-    public boolean isItemValid(@Nonnull ItemStack stack) {
+    public boolean isItemValid(@NotNull ItemStack stack) {
         return this.delegate.isItemValid(stack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getStack() {
         return this.delegate.getStack();
@@ -46,7 +46,7 @@ public class SlotDelegate extends Slot {
     }
 
     @Override
-    public void putStack(@Nonnull ItemStack stack) {
+    public void putStack(@NotNull ItemStack stack) {
         this.delegate.putStack(stack);
     }
 
@@ -61,18 +61,18 @@ public class SlotDelegate extends Slot {
     }
 
     @Override
-    public int getItemStackLimit(@Nonnull ItemStack stack) {
+    public int getItemStackLimit(@NotNull ItemStack stack) {
         return this.delegate.getItemStackLimit(stack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack decrStackSize(int amount) {
         return this.delegate.decrStackSize(amount);
     }
 
     @Override
-    public boolean canTakeStack(@Nonnull EntityPlayer playerIn) {
+    public boolean canTakeStack(@NotNull EntityPlayer playerIn) {
         return this.delegate.canTakeStack(playerIn);
     }
 
@@ -87,7 +87,7 @@ public class SlotDelegate extends Slot {
         return this.delegate.getBackgroundSprite();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ResourceLocation getBackgroundLocation() {
         return this.delegate.getBackgroundLocation();
@@ -100,7 +100,7 @@ public class SlotDelegate extends Slot {
     }
 
     @Override
-    public void setBackgroundLocation(@Nonnull ResourceLocation texture) {
+    public void setBackgroundLocation(@NotNull ResourceLocation texture) {
         this.delegate.setBackgroundLocation(texture);
     }
 

--- a/src/main/java/gregtech/api/util/TaskScheduler.java
+++ b/src/main/java/gregtech/api/util/TaskScheduler.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 @EventBusSubscriber(modid = GTValues.MODID)

--- a/src/main/java/gregtech/api/util/VirtualTankRegistry.java
+++ b/src/main/java/gregtech/api/util/VirtualTankRegistry.java
@@ -11,8 +11,8 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -154,7 +154,7 @@ public class VirtualTankRegistry extends WorldSavedData {
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound compound) {
         compound.setTag("Private", new NBTTagCompound());

--- a/src/main/java/gregtech/api/util/advancement/GTTrigger.java
+++ b/src/main/java/gregtech/api/util/advancement/GTTrigger.java
@@ -9,7 +9,7 @@ import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 
 public abstract class GTTrigger<T extends GTInstance> implements ICriterionTrigger<T> {
@@ -23,14 +23,14 @@ public abstract class GTTrigger<T extends GTInstance> implements ICriterionTrigg
 
     public abstract T create();
 
-    @Nonnull
+    @NotNull
     @Override
     public ResourceLocation getId() {
         return ID;
     }
 
     @Override
-    public void addListener(@Nonnull PlayerAdvancements playerAdvancementsIn, @Nonnull Listener<T> listener) {
+    public void addListener(@NotNull PlayerAdvancements playerAdvancementsIn, @NotNull Listener<T> listener) {
         GTListeners<T> gtListener = listeners.get(playerAdvancementsIn);
 
         if (gtListener == null) {
@@ -42,7 +42,7 @@ public abstract class GTTrigger<T extends GTInstance> implements ICriterionTrigg
     }
 
     @Override
-    public void removeListener(@Nonnull PlayerAdvancements playerAdvancementsIn, @Nonnull Listener<T> listener) {
+    public void removeListener(@NotNull PlayerAdvancements playerAdvancementsIn, @NotNull Listener<T> listener) {
         GTListeners<T> gtListener = listeners.get(playerAdvancementsIn);
 
         if (gtListener != null) {
@@ -55,13 +55,13 @@ public abstract class GTTrigger<T extends GTInstance> implements ICriterionTrigg
     }
 
     @Override
-    public void removeAllListeners(@Nonnull PlayerAdvancements playerAdvancementsIn) {
+    public void removeAllListeners(@NotNull PlayerAdvancements playerAdvancementsIn) {
         listeners.remove(playerAdvancementsIn);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public T deserializeInstance(@Nonnull JsonObject json, @Nonnull JsonDeserializationContext context) {
+    public T deserializeInstance(@NotNull JsonObject json, @NotNull JsonDeserializationContext context) {
         return create();
     }
 

--- a/src/main/java/gregtech/api/util/world/DummyChunkProvider.java
+++ b/src/main/java/gregtech/api/util/world/DummyChunkProvider.java
@@ -7,8 +7,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class DummyChunkProvider implements IChunkProvider {
 
@@ -25,7 +25,7 @@ public class DummyChunkProvider implements IChunkProvider {
         return loadedChunks.get(ChunkPos.asLong(x, z));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Chunk provideChunk(int x, int z) {
         long chunkKey = ChunkPos.asLong(x, z);
@@ -44,7 +44,7 @@ public class DummyChunkProvider implements IChunkProvider {
         return loadedChunks.size() > 0;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String makeString() {
         return "Dummy";

--- a/src/main/java/gregtech/api/util/world/DummySaveHandler.java
+++ b/src/main/java/gregtech/api/util/world/DummySaveHandler.java
@@ -12,8 +12,8 @@ import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.ISaveHandler;
 import net.minecraft.world.storage.WorldInfo;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.File;
 
 public class DummySaveHandler implements ISaveHandler, IPlayerFileData, IChunkLoader {
@@ -28,58 +28,58 @@ public class DummySaveHandler implements ISaveHandler, IPlayerFileData, IChunkLo
     public void checkSessionLock() {
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IChunkLoader getChunkLoader(@Nonnull WorldProvider provider) {
+    public IChunkLoader getChunkLoader(@NotNull WorldProvider provider) {
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IPlayerFileData getPlayerNBTManager() {
         return this;
     }
 
 
-    @Nonnull
+    @NotNull
     @Override
     public TemplateManager getStructureTemplateManager() {
         return new TemplateManager("", new DataFixer(0));
     }
 
     @Override
-    public void saveWorldInfoWithPlayer(@Nonnull WorldInfo worldInformation, @Nonnull NBTTagCompound tagCompound) {
+    public void saveWorldInfoWithPlayer(@NotNull WorldInfo worldInformation, @NotNull NBTTagCompound tagCompound) {
     }
 
     @Override
-    public void saveWorldInfo(@Nonnull WorldInfo worldInformation) {
+    public void saveWorldInfo(@NotNull WorldInfo worldInformation) {
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public File getWorldDirectory() {
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public File getMapFileFromName(@Nonnull String mapName) {
+    public File getMapFileFromName(@NotNull String mapName) {
         return null;
     }
 
 
     @Nullable
     @Override
-    public Chunk loadChunk(@Nonnull World worldIn, int x, int z) {
+    public Chunk loadChunk(@NotNull World worldIn, int x, int z) {
         return null;
     }
 
     @Override
-    public void saveChunk(@Nonnull World worldIn, @Nonnull Chunk chunkIn) {
+    public void saveChunk(@NotNull World worldIn, @NotNull Chunk chunkIn) {
     }
 
     @Override
-    public void saveExtraChunkData(@Nonnull World worldIn, @Nonnull Chunk chunkIn) {
+    public void saveExtraChunkData(@NotNull World worldIn, @NotNull Chunk chunkIn) {
     }
 
     @Override
@@ -96,16 +96,16 @@ public class DummySaveHandler implements ISaveHandler, IPlayerFileData, IChunkLo
     }
 
     @Override
-    public void writePlayerData(@Nonnull EntityPlayer player) {
+    public void writePlayerData(@NotNull EntityPlayer player) {
     }
 
     @Nullable
     @Override
-    public NBTTagCompound readPlayerData(@Nonnull EntityPlayer player) {
+    public NBTTagCompound readPlayerData(@NotNull EntityPlayer player) {
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String[] getAvailablePlayerDat() {
         return new String[0];

--- a/src/main/java/gregtech/api/util/world/DummyWorld.java
+++ b/src/main/java/gregtech/api/util/world/DummyWorld.java
@@ -12,8 +12,8 @@ import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class DummyWorld extends World {
 
@@ -39,31 +39,31 @@ public class DummyWorld extends World {
     }
 
     @Override
-    public void notifyNeighborsRespectDebug(@Nonnull BlockPos pos, @Nonnull Block blockType, boolean p_175722_3_) {
+    public void notifyNeighborsRespectDebug(@NotNull BlockPos pos, @NotNull Block blockType, boolean p_175722_3_) {
         //NOOP - do not trigger forge events
     }
 
     @Override
-    public void notifyNeighborsOfStateChange(@Nonnull BlockPos pos, @Nonnull Block blockType, boolean updateObservers) {
+    public void notifyNeighborsOfStateChange(@NotNull BlockPos pos, @NotNull Block blockType, boolean updateObservers) {
         //NOOP - do not trigger forge events
     }
 
     @Override
-    public void notifyNeighborsOfStateExcept(@Nonnull BlockPos pos, @Nonnull Block blockType, @Nonnull EnumFacing skipSide) {
+    public void notifyNeighborsOfStateExcept(@NotNull BlockPos pos, @NotNull Block blockType, @NotNull EnumFacing skipSide) {
         //NOOP - do not trigger forge events
     }
 
     @Override
-    public void markAndNotifyBlock(@Nonnull BlockPos pos, @Nullable Chunk chunk, @Nonnull IBlockState iblockstate, @Nonnull IBlockState newState, int flags) {
+    public void markAndNotifyBlock(@NotNull BlockPos pos, @Nullable Chunk chunk, @NotNull IBlockState iblockstate, @NotNull IBlockState newState, int flags) {
         //NOOP - do not trigger forge events
     }
 
     @Override
-    public void notifyBlockUpdate(@Nonnull BlockPos pos, @Nonnull IBlockState oldState, @Nonnull IBlockState newState, int flags) {
+    public void notifyBlockUpdate(@NotNull BlockPos pos, @NotNull IBlockState oldState, @NotNull IBlockState newState, int flags) {
     }
 
     @Override
-    public void markBlockRangeForRenderUpdate(@Nonnull BlockPos rangeMin, @Nonnull BlockPos rangeMax) {
+    public void markBlockRangeForRenderUpdate(@NotNull BlockPos rangeMin, @NotNull BlockPos rangeMax) {
     }
 
     @Override
@@ -71,10 +71,10 @@ public class DummyWorld extends World {
     }
 
     @Override
-    public void updateObservingBlocksAt(@Nonnull BlockPos pos, @Nonnull Block blockType) {
+    public void updateObservingBlocksAt(@NotNull BlockPos pos, @NotNull Block blockType) {
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected IChunkProvider createChunkProvider() {
         return new DummyChunkProvider(this);

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
@@ -15,8 +15,8 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -41,7 +41,7 @@ public class BedrockFluidVeinHandler {
      * @return The FluidVeinWorldInfo corresponding with the given chunk
      */
     @Nullable
-    public static FluidVeinWorldEntry getFluidVeinWorldEntry(@Nonnull World world, int chunkX, int chunkZ) {
+    public static FluidVeinWorldEntry getFluidVeinWorldEntry(@NotNull World world, int chunkX, int chunkZ) {
         if (world.isRemote)
             return null;
 
@@ -94,7 +94,7 @@ public class BedrockFluidVeinHandler {
      * @param biome    The biome type to check
      * @return The total weight associated with the dimension/biome pair
      */
-    public static int getTotalWeight(@Nonnull WorldProvider provider, Biome biome) {
+    public static int getTotalWeight(@NotNull WorldProvider provider, Biome biome) {
         int dim = provider.getDimension();
         if (!totalWeightMap.containsKey(dim)) {
             totalWeightMap.put(dim, new HashMap<>());
@@ -277,8 +277,8 @@ public class BedrockFluidVeinHandler {
             return tag;
         }
 
-        @Nonnull
-        public static FluidVeinWorldEntry readFromNBT(@Nonnull NBTTagCompound tag) {
+        @NotNull
+        public static FluidVeinWorldEntry readFromNBT(@NotNull NBTTagCompound tag) {
             FluidVeinWorldEntry info = new FluidVeinWorldEntry();
             info.fluidYield = tag.getInteger("fluidYield");
             info.operationsRemaining = tag.getInteger("operationsRemaining");

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
@@ -7,7 +7,7 @@ import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 
 public class BedrockFluidVeinSaveData extends WorldSavedData {
@@ -34,8 +34,8 @@ public class BedrockFluidVeinSaveData extends WorldSavedData {
     }
 
     @Override
-    public @Nonnull
-    NBTTagCompound writeToNBT(@Nonnull NBTTagCompound nbt) {
+    public @NotNull
+    NBTTagCompound writeToNBT(@NotNull NBTTagCompound nbt) {
         NBTTagList oilList = new NBTTagList();
         for (Map.Entry<ChunkPosDimension, BedrockFluidVeinHandler.FluidVeinWorldEntry> e : BedrockFluidVeinHandler.veinCache.entrySet()) {
             if (e.getKey() != null && e.getValue() != null) {

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/ChunkPosDimension.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/ChunkPosDimension.java
@@ -3,7 +3,7 @@ package gregtech.api.worldgen.bedrockFluids;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.ChunkPos;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ChunkPosDimension extends ChunkPos {
     public int dimension;
@@ -25,7 +25,7 @@ public class ChunkPosDimension extends ChunkPos {
         return this.dimension == coordinatePair.dimension && this.x == coordinatePair.x && this.z == coordinatePair.z;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String toString() {
         return "[dim:" + this.dimension + "; " + this.x + ", " + this.z + "]";

--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -8,7 +8,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,7 +34,7 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition {
     }
 
     @Override
-    public boolean initializeFromConfig(@Nonnull JsonObject configRoot) {
+    public boolean initializeFromConfig(@NotNull JsonObject configRoot) {
         // the weight value for determining which vein will appear
         this.weight = configRoot.get("weight").getAsInt();
         // the [minimum, maximum) yield of the vein

--- a/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
@@ -2,12 +2,12 @@ package gregtech.api.worldgen.config;
 
 import com.google.gson.JsonObject;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public interface IWorldgenDefinition {
 
     //This is the file name
     String getDepositName();
 
-    boolean initializeFromConfig(@Nonnull JsonObject configRoot);
+    boolean initializeFromConfig(@NotNull JsonObject configRoot);
 }

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -9,7 +9,7 @@ import gregtech.api.worldgen.shape.ShapeGenerator;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.biome.Biome;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -42,7 +42,7 @@ public class OreDepositDefinition implements IWorldgenDefinition {
     }
 
     @Override
-    public boolean initializeFromConfig(@Nonnull JsonObject configRoot) {
+    public boolean initializeFromConfig(@NotNull JsonObject configRoot) {
         this.weight = configRoot.get("weight").getAsInt();
         this.density = configRoot.get("density").getAsFloat();
         if (configRoot.has("name")) {

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -26,7 +26,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.io.IOUtils;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
@@ -393,7 +393,7 @@ public class WorldGenRegistry {
         }
     }
 
-    private void removeExistingFiles(Path root, @Nonnull List<? extends IWorldgenDefinition> definitions){
+    private void removeExistingFiles(Path root, @NotNull List<? extends IWorldgenDefinition> definitions){
         for(IWorldgenDefinition definition : definitions) {
             Path filePath = root.resolve(Paths.get(definition.getDepositName()));
 
@@ -409,7 +409,7 @@ public class WorldGenRegistry {
         }
     }
 
-    private <T extends IWorldgenDefinition> void addAddonFiles(Path root, @Nonnull List<T> definitions, @Nonnull List<T> registeredDefinitions){
+    private <T extends IWorldgenDefinition> void addAddonFiles(Path root, @NotNull List<T> definitions, @NotNull List<T> registeredDefinitions){
         for(IWorldgenDefinition definition : definitions) {
 
             JsonObject element = FileUtility.tryExtractFromFile(root.resolve(definition.getDepositName()));

--- a/src/main/java/gregtech/api/worldgen/generator/GTWorldGenCapability.java
+++ b/src/main/java/gregtech/api/worldgen/generator/GTWorldGenCapability.java
@@ -15,8 +15,8 @@ import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.Callable;
 
 @EventBusSubscriber
@@ -81,13 +81,13 @@ public class GTWorldGenCapability {
         private final GTWorldGenCapability capabilityInstance = new GTWorldGenCapability();
 
         @Override
-        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+        public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
             return capability == CAPABILITY;
         }
 
         @Nullable
         @Override
-        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+        public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
             if (capability == CAPABILITY) {
                 return CAPABILITY.cast(capabilityInstance);
             }

--- a/src/main/java/gregtech/client/ClientProxy.java
+++ b/src/main/java/gregtech/client/ClientProxy.java
@@ -57,7 +57,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import paulscode.sound.SoundSystemConfig;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -164,7 +164,7 @@ public class ClientProxy extends CommonProxy {
     }
 
     @SubscribeEvent
-    public static void addMaterialFormulaHandler(@Nonnull ItemTooltipEvent event) {
+    public static void addMaterialFormulaHandler(@NotNull ItemTooltipEvent event) {
         ItemStack itemStack = event.getItemStack();
 
         // Handles Item tooltips

--- a/src/main/java/gregtech/client/model/SimpleStateMapper.java
+++ b/src/main/java/gregtech/client/model/SimpleStateMapper.java
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.block.statemap.IStateMapper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 
 @SideOnly(Side.CLIENT)
@@ -21,7 +21,7 @@ public class SimpleStateMapper implements IStateMapper {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public Map<IBlockState, ModelResourceLocation> putStateModelLocations(Block block) {
         Map<IBlockState, ModelResourceLocation> map = new Object2ObjectOpenHashMap<>(block.getBlockState().getValidStates().size());
         for (IBlockState state : block.getBlockState().getValidStates()) {

--- a/src/main/java/gregtech/client/model/customtexture/CustomTexture.java
+++ b/src/main/java/gregtech/client/model/customtexture/CustomTexture.java
@@ -18,7 +18,7 @@ import org.lwjgl.util.vector.Vector;
 import org.lwjgl.util.vector.Vector2f;
 import org.lwjgl.util.vector.Vector3f;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/client/model/customtexture/CustomTextureBakedModel.java
+++ b/src/main/java/gregtech/client/model/customtexture/CustomTextureBakedModel.java
@@ -15,8 +15,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.vecmath.Matrix4f;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -119,7 +119,7 @@ public class CustomTextureBakedModel implements IBakedModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
         IBakedModel parent = getParent(rand);
 
@@ -171,20 +171,20 @@ public class CustomTextureBakedModel implements IBakedModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public TextureAtlasSprite getParticleTexture() {
         return parent.getParticleTexture();
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public ItemOverrideList getOverrides() {
         return parent.getOverrides();
     }
 
     @Override
-    @Nonnull
-    public Pair<? extends IBakedModel, Matrix4f> handlePerspective(@Nonnull ItemCameraTransforms.TransformType cameraTransformType) {
+    @NotNull
+    public Pair<? extends IBakedModel, Matrix4f> handlePerspective(@NotNull ItemCameraTransforms.TransformType cameraTransformType) {
         return parent.handlePerspective(cameraTransformType);
     }
 

--- a/src/main/java/gregtech/client/model/customtexture/CustomTextureModel.java
+++ b/src/main/java/gregtech/client/model/customtexture/CustomTextureModel.java
@@ -19,7 +19,7 @@ import net.minecraftforge.common.model.animation.IClip;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
@@ -56,7 +56,7 @@ public class CustomTextureModel implements IModel {
 
     @Override
     @ParametersAreNonnullByDefault
-    @Nonnull
+    @NotNull
     public IBakedModel bake(IModelState state, VertexFormat format, Function<ResourceLocation, TextureAtlasSprite> bakedTextureGetter) {
         IBakedModel parent = vanillaModel.bake(state, format, rl -> {
             TextureAtlasSprite sprite = bakedTextureGetter.apply(rl);
@@ -76,37 +76,37 @@ public class CustomTextureModel implements IModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public Collection<ResourceLocation> getDependencies() {
         return Collections.emptySet();
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public Collection<ResourceLocation> getTextures() {
         return textureDependencies;
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IModelState getDefaultState() {
         return getVanillaParent().getDefaultState();
     }
 
     @Override
-    @Nonnull
-    public Optional<? extends IClip> getClip(@Nonnull String name) {
+    @NotNull
+    public Optional<? extends IClip> getClip(@NotNull String name) {
         return getVanillaParent().getClip(name);
     }
 
     @Override
-    @Nonnull
-    public IModel process(@Nonnull ImmutableMap<String, String> customData) {
+    @NotNull
+    public IModel process(@NotNull ImmutableMap<String, String> customData) {
         return deepCopyOrMissing(getVanillaParent().process(customData), null, null);
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IModel smoothLighting(boolean value) {
         if (modelInfo.isAmbientOcclusion() != value) {
             return deepCopyOrMissing(getVanillaParent().smoothLighting(value), value, null);
@@ -119,7 +119,7 @@ public class CustomTextureModel implements IModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IModel gui3d(boolean value) {
         if (modelInfo.isGui3d() != value) {
             return deepCopyOrMissing(getVanillaParent().gui3d(value), null, value);
@@ -128,7 +128,7 @@ public class CustomTextureModel implements IModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IModel uvlock(boolean value) {
         if (uvLock == null || uvLock.booleanValue() != value) {
             IModel newParent = getVanillaParent().uvlock(value);
@@ -144,8 +144,8 @@ public class CustomTextureModel implements IModel {
     }
 
     @Override
-    @Nonnull
-    public IModel retexture(@Nonnull ImmutableMap<String, String> textures) {
+    @NotNull
+    public IModel retexture(@NotNull ImmutableMap<String, String> textures) {
         try {
             CustomTextureModel ret = deepCopy(getVanillaParent().retexture(textures), null, null);
             ret.modelInfo.textures.putAll(textures);
@@ -167,7 +167,7 @@ public class CustomTextureModel implements IModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public Optional<ModelBlock> asVanillaModel() {
         return Optional.ofNullable(_asVanillaModel)
                 .<Optional<ModelBlock>>map(mh -> {

--- a/src/main/java/gregtech/client/model/customtexture/CustomTextureModelHandler.java
+++ b/src/main/java/gregtech/client/model/customtexture/CustomTextureModelHandler.java
@@ -21,8 +21,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
@@ -62,7 +62,7 @@ public enum CustomTextureModelHandler implements IResourceManagerReloadListener 
         }
     }
 
-    private @Nonnull
+    private @NotNull
     IBakedModel wrap(IModel model, IBakedModel object) {
         CustomTextureModel ctm = new CustomTextureModel(null, model);
         ctm.bake(TRSRTransformation.identity(), DefaultVertexFormats.ITEM, rl -> Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(rl.toString()));

--- a/src/main/java/gregtech/client/model/customtexture/MetadataSectionCTM.java
+++ b/src/main/java/gregtech/client/model/customtexture/MetadataSectionCTM.java
@@ -7,8 +7,8 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Type;
 
 @SideOnly(Side.CLIENT)
@@ -74,7 +74,7 @@ public class MetadataSectionCTM implements IMetadataSection {
         }
 
         @Override
-        public @Nonnull
+        public @NotNull
         String getSectionName() {
             return SECTION_NAME;
         }

--- a/src/main/java/gregtech/client/model/modelfactories/BakedModelHandler.java
+++ b/src/main/java/gregtech/client/model/modelfactories/BakedModelHandler.java
@@ -28,8 +28,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.vecmath.Matrix4f;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -95,7 +95,7 @@ public class BakedModelHandler {
             this.particleTexture = particleTexture;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
             return Collections.emptyList();
@@ -116,21 +116,21 @@ public class BakedModelHandler {
             return true;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public TextureAtlasSprite getParticleTexture() {
             return TextureUtils.getBlockTexture(particleTexture);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemOverrideList getOverrides() {
             return ItemOverrideList.NONE;
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public Pair<? extends IBakedModel, Matrix4f> handlePerspective(@Nonnull TransformType cameraTransformType) {
+        public Pair<? extends IBakedModel, Matrix4f> handlePerspective(@NotNull TransformType cameraTransformType) {
             CCRenderItem.notifyTransform(cameraTransformType);
             return PerspectiveMapWrapper.handlePerspective(this, TransformUtils.DEFAULT_BLOCK, cameraTransformType);
         }

--- a/src/main/java/gregtech/client/model/modelfactories/CompressedBlockBakedModel.java
+++ b/src/main/java/gregtech/client/model/modelfactories/CompressedBlockBakedModel.java
@@ -22,8 +22,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.util.vector.Vector3f;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.vecmath.Matrix4f;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +41,7 @@ public class CompressedBlockBakedModel implements IBakedModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
         List<BakedQuad> quads = new ArrayList<>();
         if (side == null) return quads;

--- a/src/main/java/gregtech/client/model/modelfactories/FrameBakedModel.java
+++ b/src/main/java/gregtech/client/model/modelfactories/FrameBakedModel.java
@@ -22,8 +22,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.util.vector.Vector3f;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.vecmath.Matrix4f;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +41,7 @@ public class FrameBakedModel implements IBakedModel {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
         List<BakedQuad> quads = new ArrayList<>();
         if (side == null) return quads;

--- a/src/main/java/gregtech/client/model/modelfactories/OreBakedModel.java
+++ b/src/main/java/gregtech/client/model/modelfactories/OreBakedModel.java
@@ -29,8 +29,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.vecmath.Matrix4f;
 import java.util.*;
 
@@ -52,7 +52,7 @@ public class OreBakedModel implements IBakedModel {
    }
 
     @Override
-    @Nonnull
+    @NotNull
     public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
         if (state != null) {
             BlockOre ore = (BlockOre) state.getBlock();

--- a/src/main/java/gregtech/client/renderer/handler/DynamiteRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/DynamiteRenderer.java
@@ -9,7 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @SideOnly(Side.CLIENT)
 public class DynamiteRenderer extends RenderSnowball<DynamiteEntity> {
@@ -18,8 +18,8 @@ public class DynamiteRenderer extends RenderSnowball<DynamiteEntity> {
         super(renderManagerIn, MetaItems.DYNAMITE.getMetaItem(), itemRendererIn);
     }
 
-    @Nonnull
-    public ItemStack getStackToRender(@Nonnull DynamiteEntity entityIn) {
+    @NotNull
+    public ItemStack getStackToRender(@NotNull DynamiteEntity entityIn) {
         return MetaItems.DYNAMITE.getStackForm();
     }
 }

--- a/src/main/java/gregtech/client/renderer/handler/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/client/renderer/handler/MetaTileEntityTESR.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @SideOnly(Side.CLIENT)
 public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntityHolder> {
@@ -85,7 +85,7 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
     }
 
     @Override
-    public void renderTileEntityFast(MetaTileEntityHolder te, double x, double y, double z, float partialTicks, int destroyStage, float alpha, @Nonnull BufferBuilder buffer) {
+    public void renderTileEntityFast(MetaTileEntityHolder te, double x, double y, double z, float partialTicks, int destroyStage, float alpha, @NotNull BufferBuilder buffer) {
         MetaTileEntity metaTileEntity = te.getMetaTileEntity();
         if (metaTileEntity instanceof IFastRenderMetaTileEntity) {
             CCRenderState renderState = CCRenderState.instance();
@@ -111,7 +111,7 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
     }
 
     @Override
-    public boolean isGlobalRenderer(@Nonnull MetaTileEntityHolder te) {
+    public boolean isGlobalRenderer(@NotNull MetaTileEntityHolder te) {
         if (te.getMetaTileEntity() instanceof IFastRenderMetaTileEntity) {
             return ((IFastRenderMetaTileEntity) te.getMetaTileEntity()).isGlobalRenderer();
         }

--- a/src/main/java/gregtech/client/renderer/handler/PortalRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/PortalRenderer.java
@@ -10,7 +10,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @SideOnly(Side.CLIENT)
 public class PortalRenderer extends Render<PortalEntity> {

--- a/src/main/java/gregtech/client/renderer/pipe/CableRenderer.java
+++ b/src/main/java/gregtech/client/renderer/pipe/CableRenderer.java
@@ -17,7 +17,7 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.ResourceLocation;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class CableRenderer extends PipeRenderer {
 

--- a/src/main/java/gregtech/client/renderer/pipe/FluidPipeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/pipe/FluidPipeRenderer.java
@@ -13,7 +13,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.EnumMap;
 
 public class FluidPipeRenderer extends PipeRenderer {

--- a/src/main/java/gregtech/client/renderer/pipe/ItemPipeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/pipe/ItemPipeRenderer.java
@@ -12,7 +12,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.EnumMap;
 
 public class ItemPipeRenderer extends PipeRenderer {

--- a/src/main/java/gregtech/client/renderer/pipe/PipeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/pipe/PipeRenderer.java
@@ -57,7 +57,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/gregtech/client/renderer/texture/cube/SimpleOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/SimpleOverlayRenderer.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class SimpleOverlayRenderer implements ICubeRenderer {
 

--- a/src/main/java/gregtech/client/utils/AdvCCRSConsumer.java
+++ b/src/main/java/gregtech/client/utils/AdvCCRSConsumer.java
@@ -11,7 +11,7 @@ import net.minecraftforge.client.model.pipeline.IVertexConsumer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @SideOnly(Side.CLIENT)
 public class AdvCCRSConsumer implements IVertexConsumer {
@@ -23,19 +23,19 @@ public class AdvCCRSConsumer implements IVertexConsumer {
         this.ccrs = ccrs;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VertexFormat getVertexFormat() {
         return ccrs.getVertexFormat();
     }
 
     @Override
-    public void setTexture(@Nonnull TextureAtlasSprite texture) {
+    public void setTexture(@NotNull TextureAtlasSprite texture) {
         ccrs.sprite = texture;
     }
 
     @Override
-    public void put(int e, @Nonnull float... data) {
+    public void put(int e, @NotNull float... data) {
         VertexFormat format = getVertexFormat();
 
         VertexFormatElement fmte = format.getElement(e);
@@ -75,7 +75,7 @@ public class AdvCCRSConsumer implements IVertexConsumer {
     }
 
     @Override
-    public void setQuadOrientation(@Nonnull EnumFacing orientation) {
+    public void setQuadOrientation(@NotNull EnumFacing orientation) {
     }
 
     @Override

--- a/src/main/java/gregtech/client/utils/FacadeBlockAccess.java
+++ b/src/main/java/gregtech/client/utils/FacadeBlockAccess.java
@@ -13,7 +13,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import static net.minecraft.util.EnumFacing.*;
 
@@ -67,9 +67,9 @@ public class FacadeBlockAccess implements IBlockAccess {
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getBlockState(@Nonnull BlockPos pos) {
+    public IBlockState getBlockState(@NotNull BlockPos pos) {
         IBlockState ret;
         Result action = getAction(pos);
         if (action == Result.ORIGINAL) {
@@ -87,13 +87,13 @@ public class FacadeBlockAccess implements IBlockAccess {
     }
 
     @Override
-    public TileEntity getTileEntity(@Nonnull BlockPos pos) {
+    public TileEntity getTileEntity(@NotNull BlockPos pos) {
         return getAction(pos) == Result.ORIGINAL ? world.getTileEntity(pos) : null;
     }
 
     @Override
     @SideOnly(Side.CLIENT)
-    public int getCombinedLight(@Nonnull BlockPos pos, int t) {
+    public int getCombinedLight(@NotNull BlockPos pos, int t) {
         if (((side == DOWN && pos.getY() > this.pos.getY()) ||
                 (side == UP && pos.getY() < this.pos.getY()) ||
                 (side == NORTH && pos.getZ() > this.pos.getZ()) ||
@@ -106,33 +106,33 @@ public class FacadeBlockAccess implements IBlockAccess {
     }
 
     @Override
-    public int getStrongPower(@Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public int getStrongPower(@NotNull BlockPos pos, @NotNull EnumFacing side) {
         return world.getStrongPower(pos, side);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public WorldType getWorldType() {
         return world.getWorldType();
     }
 
     @Override
-    public boolean isAirBlock(@Nonnull BlockPos pos) {
+    public boolean isAirBlock(@NotNull BlockPos pos) {
         Result action = getAction(pos);
         return action == Result.AIR ||
                 (action == Result.ORIGINAL && world.isAirBlock(pos)) ||
                 (action == Result.COVER && getBlockState(pos).getBlock().isAir(getBlockState(pos), this, pos));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SideOnly(Side.CLIENT)
-    public Biome getBiome(@Nonnull BlockPos pos) {
+    public Biome getBiome(@NotNull BlockPos pos) {
         return world.getBiome(pos);
     }
 
     @Override
-    public boolean isSideSolid(BlockPos pos, @Nonnull EnumFacing side, boolean _default) {
+    public boolean isSideSolid(BlockPos pos, @NotNull EnumFacing side, boolean _default) {
         if (pos.getX() < -30000000 ||
                 pos.getZ() < -30000000 ||
                 pos.getX() >= 30000000 ||

--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -24,7 +24,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/gregtech/client/utils/TrackedDummyWorld.java
+++ b/src/main/java/gregtech/client/utils/TrackedDummyWorld.java
@@ -10,7 +10,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.vecmath.Vector3f;
 import java.util.HashSet;
 import java.util.Map;
@@ -57,22 +57,22 @@ public class TrackedDummyWorld extends DummyWorld {
     }
 
     @Override
-    public TileEntity getTileEntity(@Nonnull BlockPos pos) {
+    public TileEntity getTileEntity(@NotNull BlockPos pos) {
         if (renderFilter != null && !renderFilter.test(pos))
             return null;
         return proxyWorld != null ? proxyWorld.getTileEntity(pos) : super.getTileEntity(pos);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IBlockState getBlockState(@Nonnull BlockPos pos) {
+    public IBlockState getBlockState(@NotNull BlockPos pos) {
         if (renderFilter != null && !renderFilter.test(pos))
             return Blocks.AIR.getDefaultState(); //return air if not rendering this block
         return proxyWorld != null ? proxyWorld.getBlockState(pos) : super.getBlockState(pos);
     }
 
     @Override
-    public boolean setBlockState(@Nonnull BlockPos pos, IBlockState newState, int flags) {
+    public boolean setBlockState(@NotNull BlockPos pos, IBlockState newState, int flags) {
         minPos.setX(Math.min(minPos.getX(), pos.getX()));
         minPos.setY(Math.min(minPos.getY(), pos.getY()));
         minPos.setZ(Math.min(minPos.getZ(), pos.getZ()));

--- a/src/main/java/gregtech/common/blocks/BlockAsphalt.java
+++ b/src/main/java/gregtech/common/blocks/BlockAsphalt.java
@@ -11,7 +11,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockAsphalt extends VariantBlock<BlockAsphalt.BlockType> {
 
@@ -25,12 +25,12 @@ public class BlockAsphalt extends VariantBlock<BlockAsphalt.BlockType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public void onEntityWalk(@NotNull World worldIn, @NotNull BlockPos pos, Entity entityIn) {
         if ((entityIn.motionX != 0 || entityIn.motionZ != 0) && !entityIn.isInWater() && !entityIn.isSneaking()) {
             entityIn.motionX *= 1.3;
             entityIn.motionZ *= 1.3;
@@ -49,7 +49,7 @@ public class BlockAsphalt extends VariantBlock<BlockAsphalt.BlockType> {
             this.harvestLevel = harvestLevel;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockBoilerCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockBoilerCasing.java
@@ -10,7 +10,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockBoilerCasing extends VariantBlock<BlockBoilerCasing.BoilerCasingType> {
 
@@ -24,7 +24,7 @@ public class BlockBoilerCasing extends VariantBlock<BlockBoilerCasing.BoilerCasi
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
@@ -44,7 +44,7 @@ public class BlockBoilerCasing extends VariantBlock<BlockBoilerCasing.BoilerCasi
             this.harvestLevel = harvestLevel;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
@@ -14,8 +14,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
@@ -48,13 +48,13 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String toString() {
             return getName();
@@ -73,7 +73,7 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
     }
 
     @Override
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag advanced) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World player, @NotNull List<String> tooltip, @NotNull ITooltipFlag advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         if (stack.isItemEqual(getItemVariant(CasingType.FILTER_CASING))) tooltip.add(I18n.format("tile.cleanroom_casing.filter.tooltip"));
         if (stack.isItemEqual(getItemVariant(CasingType.FILTER_CASING_STERILE))) tooltip.add(I18n.format("tile.cleanroom_casing.filter_sterile.tooltip"));

--- a/src/main/java/gregtech/common/blocks/BlockCompressed.java
+++ b/src/main/java/gregtech/common/blocks/BlockCompressed.java
@@ -30,8 +30,8 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class BlockCompressed extends DelayedStateBlock implements IModelSupplier {
 
@@ -50,7 +50,7 @@ public final class BlockCompressed extends DelayedStateBlock implements IModelSu
     }
 
     @Override
-    public int damageDropped(@Nonnull IBlockState state) {
+    public int damageDropped(@NotNull IBlockState state) {
         return getMetaFromState(state);
     }
 
@@ -74,7 +74,7 @@ public final class BlockCompressed extends DelayedStateBlock implements IModelSu
         return 0;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
     public IBlockState getStateFromMeta(int meta) {
@@ -111,14 +111,14 @@ public final class BlockCompressed extends DelayedStateBlock implements IModelSu
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> list) {
+    public void getSubBlocks(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> list) {
         blockState.getValidStates().stream()
                 .filter(blockState -> blockState.getValue(variantProperty) != Materials.NULL)
                 .forEach(blockState -> list.add(getItem(blockState)));
     }
 
     @Override
-    @Nonnull
+    @NotNull
     @SuppressWarnings("deprecation")
     public net.minecraft.block.material.Material getMaterial(IBlockState state) {
         Material material = state.getValue(variantProperty);
@@ -132,16 +132,16 @@ public final class BlockCompressed extends DelayedStateBlock implements IModelSu
         return net.minecraft.block.material.Material.ROCK;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public MapColor getMapColor(@Nonnull IBlockState state, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {
+    public MapColor getMapColor(@NotNull IBlockState state, @NotNull IBlockAccess worldIn, @NotNull BlockPos pos) {
         return getMaterial(state).getMaterialMapColor();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public SoundType getSoundType(IBlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nullable Entity entity) {
+    public SoundType getSoundType(IBlockState state, @NotNull World world, @NotNull BlockPos pos, @Nullable Entity entity) {
         Material material = state.getValue(variantProperty);
         if (material.hasProperty(PropertyKey.GEM)) {
             return SoundType.STONE;

--- a/src/main/java/gregtech/common/blocks/BlockFireboxCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockFireboxCasing.java
@@ -11,7 +11,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockFireboxCasing extends VariantActiveBlock<FireboxCasingType> {
 
@@ -25,13 +25,13 @@ public class BlockFireboxCasing extends VariantActiveBlock<FireboxCasingType> {
     }
 
     @Override
-    public int getLightValue(IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos) {
+    public int getLightValue(IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos) {
         return state.getValue(ACTIVE) ? 15 : 0;
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public int getPackedLightmapCoords(IBlockState state, @Nonnull IBlockAccess source, @Nonnull BlockPos pos) {
+    public int getPackedLightmapCoords(IBlockState state, @NotNull IBlockAccess source, @NotNull BlockPos pos) {
         if (state.getValue(ACTIVE)) {
             return 0b10100000 << 16 | 0b10100000;
         }
@@ -39,7 +39,7 @@ public class BlockFireboxCasing extends VariantActiveBlock<FireboxCasingType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
@@ -58,7 +58,7 @@ public class BlockFireboxCasing extends VariantActiveBlock<FireboxCasingType> {
             this.harvestLevel = harvestLevel;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockFrame.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrame.java
@@ -42,8 +42,8 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class BlockFrame extends DelayedStateBlock implements IModelSupplier {
 
@@ -64,11 +64,11 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     @Override
-    public int damageDropped(@Nonnull IBlockState state) {
+    public int damageDropped(@NotNull IBlockState state) {
         return getMetaFromState(state);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
     public IBlockState getStateFromMeta(int meta) {
@@ -92,9 +92,9 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
         return "wrench";
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public SoundType getSoundType(IBlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nullable Entity entity) {
+    public SoundType getSoundType(IBlockState state, @NotNull World world, @NotNull BlockPos pos, @Nullable Entity entity) {
         Material material = state.getValue(variantProperty);
         if (ModHandler.isMaterialWood(material)) {
             return SoundType.WOOD;
@@ -103,7 +103,7 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     @Override
-    public int getHarvestLevel(@Nonnull IBlockState state) {
+    public int getHarvestLevel(@NotNull IBlockState state) {
         return 1;
     }
 
@@ -113,7 +113,7 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     @Override
-    @Nonnull
+    @NotNull
     @SuppressWarnings("deprecation")
     public net.minecraft.block.material.Material getMaterial(IBlockState state) {
         Material material = state.getValue(variantProperty);
@@ -124,7 +124,7 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> list) {
+    public void getSubBlocks(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> list) {
         blockState.getValidStates().stream()
                 .filter(blockState -> blockState.getValue(variantProperty) != Materials.NULL)
                 .forEach(blockState -> list.add(getItem(blockState)));
@@ -147,12 +147,12 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
     @Override
-    public boolean onBlockActivated(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, EntityPlayer playerIn, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
+    public boolean onBlockActivated(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, EntityPlayer playerIn, @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
         ItemStack stackInHand = playerIn.getHeldItem(hand);
         if (stackInHand.isEmpty()) {
             return false;
@@ -216,7 +216,7 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
     }
 
     @Override
-    public void onEntityCollision(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, Entity entityIn) {
+    public void onEntityCollision(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, Entity entityIn) {
         entityIn.motionX = MathHelper.clamp(entityIn.motionX, -0.15, 0.15);
         entityIn.motionZ = MathHelper.clamp(entityIn.motionZ, -0.15, 0.15);
         entityIn.fallDistance = 0.0F;
@@ -231,20 +231,20 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public EnumPushReaction getPushReaction(@Nonnull IBlockState state) {
+    public EnumPushReaction getPushReaction(@NotNull IBlockState state) {
         return EnumPushReaction.DESTROY;
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public AxisAlignedBB getCollisionBoundingBox(@Nonnull IBlockState blockState, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {
+    public AxisAlignedBB getCollisionBoundingBox(@NotNull IBlockState blockState, @NotNull IBlockAccess worldIn, @NotNull BlockPos pos) {
         return COLLISION_BOX;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
@@ -252,14 +252,14 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isOpaqueCube(@Nonnull IBlockState state) {
+    public boolean isOpaqueCube(@NotNull IBlockState state) {
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public BlockFaceShape getBlockFaceShape(@Nonnull IBlockAccess worldIn, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+    public BlockFaceShape getBlockFaceShape(@NotNull IBlockAccess worldIn, @NotNull IBlockState state, @NotNull BlockPos pos, @NotNull EnumFacing face) {
         return BlockFaceShape.UNDEFINED;
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockFusionCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockFusionCasing.java
@@ -9,7 +9,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockFusionCasing extends VariantActiveBlock<BlockFusionCasing.CasingType> {
 
@@ -23,7 +23,7 @@ public class BlockFusionCasing extends VariantActiveBlock<BlockFusionCasing.Casi
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -43,7 +43,7 @@ public class BlockFusionCasing extends VariantActiveBlock<BlockFusionCasing.Casi
             this.harvestLevel = harvestLevel;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
@@ -14,7 +14,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -36,7 +36,7 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT;
     }
@@ -77,7 +77,7 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public String getName() {
             return this.name;
         }

--- a/src/main/java/gregtech/common/blocks/BlockHermeticCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockHermeticCasing.java
@@ -10,7 +10,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -31,7 +31,7 @@ public class BlockHermeticCasing extends VariantBlock<BlockHermeticCasing.Hermet
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public BlockRenderLayer getRenderLayer() {
         // cutout is needed for the top (outer) layer/overlay to render properly in world
@@ -57,7 +57,7 @@ public class BlockHermeticCasing extends VariantBlock<BlockHermeticCasing.Hermet
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public String getName() {
             return this.name;
         }

--- a/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
@@ -13,7 +13,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -69,7 +69,7 @@ public class BlockMachineCasing extends VariantBlock<BlockMachineCasing.MachineC
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public String getName() {
             return this.name;
         }

--- a/src/main/java/gregtech/common/blocks/BlockMetalCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMetalCasing.java
@@ -10,7 +10,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockMetalCasing extends VariantBlock<BlockMetalCasing.MetalCasingType> {
 
@@ -24,7 +24,7 @@ public class BlockMetalCasing extends VariantBlock<BlockMetalCasing.MetalCasingT
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
@@ -50,7 +50,7 @@ public class BlockMetalCasing extends VariantBlock<BlockMetalCasing.MetalCasingT
             this.harvestLevel = harvestLevel;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockMultiblockCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMultiblockCasing.java
@@ -9,7 +9,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockMultiblockCasing extends VariantActiveBlock<BlockMultiblockCasing.MultiblockCasingType> {
 
@@ -24,7 +24,7 @@ public class BlockMultiblockCasing extends VariantActiveBlock<BlockMultiblockCas
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockMultiblockCasing extends VariantActiveBlock<BlockMultiblockCas
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -31,8 +31,8 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class BlockOre extends Block implements IBlockOre, IModelSupplier {
@@ -53,10 +53,10 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
         initBlockState();
     }
 
-    @Nonnull
+    @NotNull
     @SuppressWarnings("deprecation")
     @Override
-    public net.minecraft.block.material.Material getMaterial(@Nonnull IBlockState state) {
+    public net.minecraft.block.material.Material getMaterial(@NotNull IBlockState state) {
         String harvestTool = getHarvestTool(state);
         if (harvestTool != null && harvestTool.equals("shovel")) {
             return net.minecraft.block.material.Material.GROUND;
@@ -64,7 +64,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
         return net.minecraft.block.material.Material.ROCK;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected final BlockStateContainer createBlockState() {
         return new BlockStateContainer(this);
@@ -77,13 +77,13 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     @Override
-    public int damageDropped(@Nonnull IBlockState state) {
+    public int damageDropped(@NotNull IBlockState state) {
         return getMetaFromState(state);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public SoundType getSoundType(IBlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nullable Entity entity) {
+    public SoundType getSoundType(IBlockState state, @NotNull World world, @NotNull BlockPos pos, @Nullable Entity entity) {
         StoneType stoneType = state.getValue(STONE_TYPE);
         return stoneType.soundType;
     }
@@ -101,7 +101,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
         return Math.max(state.getValue(STONE_TYPE).stoneMaterial.getBlockHarvestLevel(), material.getBlockHarvestLevel());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
     public IBlockState getStateFromMeta(int meta) {
@@ -121,7 +121,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     @Override
-    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
+    public void getDrops(@NotNull NonNullList<ItemStack> drops, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull IBlockState state, int fortune) {
         StoneType stoneType = state.getValue(STONE_TYPE);
         if (stoneType.shouldBeDroppedAsItem) {
             super.getDrops(drops, world, pos, state, fortune);
@@ -131,9 +131,9 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     @SuppressWarnings("deprecation")
-    public ItemStack getItem(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public ItemStack getItem(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state) {
         StoneType stoneType = state.getValue(STONE_TYPE);
         if (stoneType.shouldBeDroppedAsItem) {
             return super.getItem(worldIn, pos, state);
@@ -142,7 +142,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     protected ItemStack getSilkTouchDrop(IBlockState state) {
         StoneType stoneType = state.getValue(STONE_TYPE);
         if (stoneType.shouldBeDroppedAsItem) {
@@ -152,7 +152,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> list) {
+    public void getSubBlocks(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> list) {
         if (tab == CreativeTabs.SEARCH || tab == GregTechAPI.TAB_GREGTECH_ORES) {
             blockState.getValidStates().stream()
                     .filter(state -> state.getValue(STONE_TYPE).shouldBeDroppedAsItem)
@@ -161,7 +161,7 @@ public class BlockOre extends Block implements IBlockOre, IModelSupplier {
     }
 
     @Override
-    public boolean canRenderInLayer(@Nonnull IBlockState state, @Nonnull BlockRenderLayer layer) {
+    public boolean canRenderInLayer(@NotNull IBlockState state, @NotNull BlockRenderLayer layer) {
         return layer == BlockRenderLayer.CUTOUT_MIPPED || (material.getProperty(PropertyKey.ORE).isEmissive() && layer == BloomEffectUtil.getRealBloomLayer());
     }
 

--- a/src/main/java/gregtech/common/blocks/BlockSteamCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockSteamCasing.java
@@ -14,8 +14,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
@@ -66,7 +66,7 @@ public class BlockSteamCasing extends VariantBlock<BlockSteamCasing.SteamCasingT
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public String getName() {
             return name;
         }

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricks.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricks.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneBricks extends VariantBlock<BlockStoneBricks.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneBricks extends VariantBlock<BlockStoneBricks.BlockType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneBricks extends VariantBlock<BlockStoneBricks.BlockType> {
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksCracked.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksCracked.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneBricksCracked extends VariantBlock<BlockStoneBricksCracked.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneBricksCracked extends VariantBlock<BlockStoneBricksCracke
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneBricksCracked extends VariantBlock<BlockStoneBricksCracke
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksMossy.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksMossy.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneBricksMossy extends VariantBlock<BlockStoneBricksMossy.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneBricksMossy extends VariantBlock<BlockStoneBricksMossy.Bl
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneBricksMossy extends VariantBlock<BlockStoneBricksMossy.Bl
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksSmall.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksSmall.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneBricksSmall extends VariantBlock<BlockStoneBricksSmall.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneBricksSmall extends VariantBlock<BlockStoneBricksSmall.Bl
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneBricksSmall extends VariantBlock<BlockStoneBricksSmall.Bl
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksSquare.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksSquare.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneBricksSquare extends VariantBlock<BlockStoneBricksSquare.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneBricksSquare extends VariantBlock<BlockStoneBricksSquare.
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneBricksSquare extends VariantBlock<BlockStoneBricksSquare.
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneChiseled.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneChiseled.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneChiseled extends VariantBlock<BlockStoneChiseled.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneChiseled extends VariantBlock<BlockStoneChiseled.BlockTyp
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneChiseled extends VariantBlock<BlockStoneChiseled.BlockTyp
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneCobble.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneCobble.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneCobble extends VariantBlock<BlockStoneCobble.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneCobble extends VariantBlock<BlockStoneCobble.BlockType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneCobble extends VariantBlock<BlockStoneCobble.BlockType> {
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneCobbleMossy.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneCobbleMossy.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneCobbleMossy extends VariantBlock<BlockStoneCobbleMossy.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneCobbleMossy extends VariantBlock<BlockStoneCobbleMossy.Bl
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneCobbleMossy extends VariantBlock<BlockStoneCobbleMossy.Bl
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStonePolished.java
+++ b/src/main/java/gregtech/common/blocks/BlockStonePolished.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStonePolished extends VariantBlock<BlockStonePolished.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStonePolished extends VariantBlock<BlockStonePolished.BlockTyp
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStonePolished extends VariantBlock<BlockStonePolished.BlockTyp
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneSmooth.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneSmooth.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneSmooth extends VariantBlock<BlockStoneSmooth.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneSmooth extends VariantBlock<BlockStoneSmooth.BlockType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -46,7 +46,7 @@ public class BlockStoneSmooth extends VariantBlock<BlockStoneSmooth.BlockType> {
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneTiled.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneTiled.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneTiled extends VariantBlock<BlockStoneTiled.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneTiled extends VariantBlock<BlockStoneTiled.BlockType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneTiled extends VariantBlock<BlockStoneTiled.BlockType> {
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneTiledSmall.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneTiledSmall.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneTiledSmall extends VariantBlock<BlockStoneTiledSmall.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneTiledSmall extends VariantBlock<BlockStoneTiledSmall.Bloc
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneTiledSmall extends VariantBlock<BlockStoneTiledSmall.Bloc
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneWindmillA.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneWindmillA.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneWindmillA extends VariantBlock<BlockStoneWindmillA.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneWindmillA extends VariantBlock<BlockStoneWindmillA.BlockT
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneWindmillA extends VariantBlock<BlockStoneWindmillA.BlockT
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockStoneWindmillB.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneWindmillB.java
@@ -8,7 +8,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockStoneWindmillB extends VariantBlock<BlockStoneWindmillB.BlockType> {
 
@@ -23,7 +23,7 @@ public class BlockStoneWindmillB extends VariantBlock<BlockStoneWindmillB.BlockT
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
@@ -42,7 +42,7 @@ public class BlockStoneWindmillB extends VariantBlock<BlockStoneWindmillB.BlockT
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockSurfaceRock.java
+++ b/src/main/java/gregtech/common/blocks/BlockSurfaceRock.java
@@ -25,8 +25,8 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("deprecation")
 public class BlockSurfaceRock extends DelayedStateBlock {
@@ -45,11 +45,11 @@ public class BlockSurfaceRock extends DelayedStateBlock {
 
     @Nullable
     @Override
-    public String getHarvestTool(@Nonnull IBlockState state) {
+    public String getHarvestTool(@NotNull IBlockState state) {
         return "shovel";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IBlockState getStateFromMeta(int meta) {
         Material material = variantProperty.getAllowedValues().get(meta);
@@ -57,7 +57,7 @@ public class BlockSurfaceRock extends DelayedStateBlock {
     }
 
     @Override
-    public int getMetaFromState(@Nonnull IBlockState state) {
+    public int getMetaFromState(@NotNull IBlockState state) {
         Material material = state.getValue(variantProperty);
         return variantProperty.getAllowedValues().indexOf(material);
     }
@@ -80,29 +80,29 @@ public class BlockSurfaceRock extends DelayedStateBlock {
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> list) {
+    public void getSubBlocks(@NotNull CreativeTabs tab, @NotNull NonNullList<ItemStack> list) {
         blockState.getValidStates().stream()
                 .filter(blockState -> blockState.getValue(variantProperty) != Materials.NULL)
                 .forEach(blockState -> list.add(getItem(blockState)));
     }
 
     @Override
-    public boolean onBlockActivated(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, EntityPlayer playerIn, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
+    public boolean onBlockActivated(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, EntityPlayer playerIn, @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
         dropBlockAsItem(worldIn, pos, state, 0);
         worldIn.setBlockToAir(pos);
         playerIn.swingArm(hand);
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public SoundType getSoundType(@Nonnull IBlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nullable Entity entity) {
+    public SoundType getSoundType(@NotNull IBlockState state, @NotNull World world, @NotNull BlockPos pos, @Nullable Entity entity) {
         return SoundType.GROUND;
     }
 
     @Override
-    @Nonnull
-    public AxisAlignedBB getBoundingBox(@Nonnull IBlockState state, @Nonnull IBlockAccess source, @Nonnull BlockPos pos) {
+    @NotNull
+    public AxisAlignedBB getBoundingBox(@NotNull IBlockState state, @NotNull IBlockAccess source, @NotNull BlockPos pos) {
         return STONE_AABB;
     }
 
@@ -112,29 +112,29 @@ public class BlockSurfaceRock extends DelayedStateBlock {
     }
 
     @Override
-    @Nonnull
-    public ItemStack getPickBlock(@Nonnull IBlockState state, @Nonnull RayTraceResult target, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EntityPlayer player) {
+    @NotNull
+    public ItemStack getPickBlock(@NotNull IBlockState state, @NotNull RayTraceResult target, @NotNull World world, @NotNull BlockPos pos, @NotNull EntityPlayer player) {
         return getDropStack(state, 1);
     }
 
     @Override
-    public void getDrops(NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
+    public void getDrops(NonNullList<ItemStack> drops, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull IBlockState state, int fortune) {
         int amount = 3 + GTValues.RNG.nextInt((int) (2 + fortune * 1.5));
         drops.add(getDropStack(state, amount));
     }
 
     @Override
-    public boolean isFullCube(@Nonnull IBlockState state) {
+    public boolean isFullCube(@NotNull IBlockState state) {
         return false;
     }
 
     @Override
-    public boolean isOpaqueCube(@Nonnull IBlockState state) {
+    public boolean isOpaqueCube(@NotNull IBlockState state) {
         return false;
     }
 
     @Override
-    public void neighborChanged(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Block blockIn, BlockPos fromPos) {
+    public void neighborChanged(@NotNull IBlockState state, @NotNull World worldIn, @NotNull BlockPos pos, @NotNull Block blockIn, BlockPos fromPos) {
         if (fromPos.up().equals(pos)) {
             if (worldIn.getBlockState(fromPos).getBlockFaceShape(worldIn, fromPos, EnumFacing.UP) != BlockFaceShape.SOLID) {
                 worldIn.destroyBlock(pos, true);
@@ -143,8 +143,8 @@ public class BlockSurfaceRock extends DelayedStateBlock {
     }
 
     @Override
-    @Nonnull
-    public BlockFaceShape getBlockFaceShape(@Nonnull IBlockAccess worldIn, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+    @NotNull
+    public BlockFaceShape getBlockFaceShape(@NotNull IBlockAccess worldIn, @NotNull IBlockState state, @NotNull BlockPos pos, @NotNull EnumFacing face) {
         return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockTurbineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockTurbineCasing.java
@@ -10,7 +10,7 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -52,7 +52,7 @@ public class BlockTurbineCasing extends VariantBlock<BlockTurbineCasing.TurbineC
         }
 
         @Override
-        @Nonnull
+        @NotNull
         public String getName() {
             return this.name;
         }

--- a/src/main/java/gregtech/common/blocks/BlockWarningSign.java
+++ b/src/main/java/gregtech/common/blocks/BlockWarningSign.java
@@ -5,7 +5,7 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockWarningSign extends VariantBlock<BlockWarningSign.SignType> {
 
@@ -44,7 +44,7 @@ public class BlockWarningSign extends VariantBlock<BlockWarningSign.SignType> {
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockWarningSign1.java
+++ b/src/main/java/gregtech/common/blocks/BlockWarningSign1.java
@@ -5,7 +5,7 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockWarningSign1 extends VariantBlock<BlockWarningSign1.SignType> {
 
@@ -37,7 +37,7 @@ public class BlockWarningSign1 extends VariantBlock<BlockWarningSign1.SignType> 
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -19,8 +19,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
@@ -37,7 +37,7 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack itemStack, @Nullable World worldIn, List<String> lines, @Nonnull ITooltipFlag tooltipFlag) {
+    public void addInformation(@NotNull ItemStack itemStack, @Nullable World worldIn, List<String> lines, @NotNull ITooltipFlag tooltipFlag) {
         super.addInformation(itemStack, worldIn, lines, tooltipFlag);
 
         // noinspection rawtypes, unchecked
@@ -62,7 +62,7 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 
@@ -93,7 +93,7 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
             this.material = material;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;
@@ -125,7 +125,7 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
             return material;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String toString() {
             return getName();

--- a/src/main/java/gregtech/common/blocks/CompressedItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/CompressedItemBlock.java
@@ -8,8 +8,8 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class CompressedItemBlock extends ItemBlock {
@@ -31,15 +31,15 @@ public class CompressedItemBlock extends ItemBlock {
         return compressedBlock.getStateFromMeta(getMetadata(stack.getItemDamage()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getItemStackDisplayName(@Nonnull ItemStack stack) {
+    public String getItemStackDisplayName(@NotNull ItemStack stack) {
         Material material = getBlockState(stack).getValue(compressedBlock.variantProperty);
         return OrePrefix.block.getLocalNameForItem(material);
     }
 
     @Override
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World worldIn, @NotNull List<String> tooltip, @NotNull ITooltipFlag flagIn) {
         super.addInformation(stack, worldIn, tooltip, flagIn);
         if(flagIn.isAdvanced()) {
             tooltip.add("MetaItem Id: block" + compressedBlock.getGtMaterial(stack.getMetadata()).toCamelCaseString());

--- a/src/main/java/gregtech/common/blocks/FrameItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/FrameItemBlock.java
@@ -8,8 +8,8 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class FrameItemBlock extends ItemBlock {
@@ -31,9 +31,9 @@ public class FrameItemBlock extends ItemBlock {
         return frameBlock.getStateFromMeta(getMetadata(stack.getItemDamage()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getItemStackDisplayName(@Nonnull ItemStack stack) {
+    public String getItemStackDisplayName(@NotNull ItemStack stack) {
         Material material = getBlockState(stack).getValue(frameBlock.variantProperty);
         return OrePrefix.frameGt.getLocalNameForItem(material);
     }

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -61,7 +61,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.BiConsumer;
@@ -405,9 +405,9 @@ public class MetaBlocks {
         }
 
         normalStateMapper = new StateMapperBase() {
-            @Nonnull
+            @NotNull
             @Override
-            protected ModelResourceLocation getModelResourceLocation(@Nonnull IBlockState state) {
+            protected ModelResourceLocation getModelResourceLocation(@NotNull IBlockState state) {
                 return new ModelResourceLocation(Block.REGISTRY.getNameForObject(state.getBlock()), "normal");
             }
         };

--- a/src/main/java/gregtech/common/blocks/OreItemBlock.java
+++ b/src/main/java/gregtech/common/blocks/OreItemBlock.java
@@ -7,7 +7,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class OreItemBlock extends ItemBlock {
 
@@ -24,7 +24,7 @@ public class OreItemBlock extends ItemBlock {
         return damage;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CreativeTabs[] getCreativeTabs() {
         return new CreativeTabs[]{CreativeTabs.SEARCH, GregTechAPI.TAB_GREGTECH_ORES};
@@ -34,9 +34,9 @@ public class OreItemBlock extends ItemBlock {
         return oreBlock.getStateFromMeta(getMetadata(stack.getItemDamage()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getItemStackDisplayName(@Nonnull ItemStack stack) {
+    public String getItemStackDisplayName(@NotNull ItemStack stack) {
         IBlockState blockState = getBlockState(stack);
         StoneType stoneType = blockState.getValue(oreBlock.STONE_TYPE);
         return stoneType.processingPrefix.getLocalNameForItem(oreBlock.material);

--- a/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
@@ -24,8 +24,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Random;
 
 public class BlockFoam extends BlockColored {
@@ -45,7 +45,7 @@ public class BlockFoam extends BlockColored {
     }
 
     @Override
-    public boolean onBlockActivated(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, EntityPlayer playerIn, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
+    public boolean onBlockActivated(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, EntityPlayer playerIn, @NotNull EnumHand hand, @NotNull EnumFacing facing, float hitX, float hitY, float hitZ) {
         ItemStack stackInHand = playerIn.getHeldItem(hand);
         if (!stackInHand.isEmpty() && OreDictUnifier.getOreDictionaryNames(stackInHand).contains("sand")) {
             worldIn.setBlockState(pos, getPetrifiedBlock(state));
@@ -58,7 +58,7 @@ public class BlockFoam extends BlockColored {
     }
 
     @Override
-    public void randomTick(World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, Random random) {
+    public void randomTick(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, Random random) {
         int lightLevel = (worldIn.canSeeSky(pos) && worldIn.isDaytime()) ? 16 : worldIn.getLight(pos);
         if (random.nextInt(20 - lightLevel) == 0) {
             worldIn.setBlockState(pos, getPetrifiedBlock(state));
@@ -70,27 +70,27 @@ public class BlockFoam extends BlockColored {
         return block.getDefaultState().withProperty(COLOR, state.getValue(COLOR));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public EnumPushReaction getPushReaction(@Nonnull IBlockState state) {
+    public EnumPushReaction getPushReaction(@NotNull IBlockState state) {
         return EnumPushReaction.DESTROY;
     }
 
     @Nullable
     @Override
     @SuppressWarnings("deprecation")
-    public AxisAlignedBB getCollisionBoundingBox(@Nonnull IBlockState blockState, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {
+    public AxisAlignedBB getCollisionBoundingBox(@NotNull IBlockState blockState, @NotNull IBlockAccess worldIn, @NotNull BlockPos pos) {
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Item getItemDropped(@Nonnull IBlockState state, @Nonnull Random rand, int fortune) {
+    public Item getItemDropped(@NotNull IBlockState state, @NotNull Random rand, int fortune) {
         return Items.AIR;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public BlockRenderLayer getRenderLayer() {
         return BlockRenderLayer.CUTOUT_MIPPED;
@@ -98,21 +98,21 @@ public class BlockFoam extends BlockColored {
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isOpaqueCube(@Nonnull IBlockState state) {
+    public boolean isOpaqueCube(@NotNull IBlockState state) {
         return false;
     }
 
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isFullCube(@Nonnull IBlockState state) {
+    public boolean isFullCube(@NotNull IBlockState state) {
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public BlockFaceShape getBlockFaceShape(@Nonnull IBlockAccess worldIn, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+    public BlockFaceShape getBlockFaceShape(@NotNull IBlockAccess worldIn, @NotNull IBlockState state, @NotNull BlockPos pos, @NotNull EnumFacing face) {
         return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/gregtech/common/blocks/foam/BlockPetrifiedFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockPetrifiedFoam.java
@@ -9,7 +9,7 @@ import net.minecraft.entity.EntityLiving.SpawnPlacementType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockPetrifiedFoam extends BlockColored {
 
@@ -24,7 +24,7 @@ public class BlockPetrifiedFoam extends BlockColored {
     }
 
     @Override
-    public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, @NotNull SpawnPlacementType type) {
         return false;
     }
 }

--- a/src/main/java/gregtech/common/blocks/properties/PropertyMaterial.java
+++ b/src/main/java/gregtech/common/blocks/properties/PropertyMaterial.java
@@ -7,7 +7,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import net.minecraft.block.properties.PropertyHelper;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -28,15 +28,15 @@ public class PropertyMaterial extends PropertyHelper<Material> {
         return new PropertyMaterial(name, Arrays.asList(allowedValues));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ImmutableList<Material> getAllowedValues() {
         return allowedValues;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Optional<Material> parseValue(@Nonnull String value) {
+    public Optional<Material> parseValue(@NotNull String value) {
         Material material = GregTechAPI.MATERIAL_REGISTRY.getObject(value);
         if (this.allowedValues.contains(material)) {
             return Optional.of(material);
@@ -44,7 +44,7 @@ public class PropertyMaterial extends PropertyHelper<Material> {
         return Optional.of(Materials.NULL);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName(Material material) {
         return material.toString();

--- a/src/main/java/gregtech/common/blocks/properties/PropertyStoneType.java
+++ b/src/main/java/gregtech/common/blocks/properties/PropertyStoneType.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableList;
 import gregtech.api.unification.ore.StoneType;
 import net.minecraft.block.properties.PropertyHelper;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -26,15 +26,15 @@ public class PropertyStoneType extends PropertyHelper<StoneType> {
         return new PropertyStoneType(name, Arrays.asList(allowedValues));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ImmutableList<StoneType> getAllowedValues() {
         return allowedValues;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Optional<StoneType> parseValue(@Nonnull String value) {
+    public Optional<StoneType> parseValue(@NotNull String value) {
         StoneType stoneType = StoneType.STONE_TYPE_REGISTRY.getObject(value);
         if (this.allowedValues.contains(stoneType)) {
             return Optional.of(stoneType);
@@ -42,7 +42,7 @@ public class PropertyStoneType extends PropertyHelper<StoneType> {
         return Optional.absent();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName(StoneType stoneType) {
         return stoneType.name;

--- a/src/main/java/gregtech/common/blocks/wood/BlockGregPlanks.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregPlanks.java
@@ -4,7 +4,7 @@ import gregtech.api.block.VariantBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class BlockGregPlanks extends VariantBlock<BlockGregPlanks.BlockType> {
 
@@ -29,7 +29,7 @@ public class BlockGregPlanks extends VariantBlock<BlockGregPlanks.BlockType> {
             this.name = name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return this.name;

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberLeaves.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberLeaves.java
@@ -16,7 +16,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Random;
 
@@ -36,13 +36,13 @@ public class BlockRubberLeaves extends BlockLeaves {
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
         return new BlockStateContainer(this, CHECK_DECAY, DECAYABLE);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
     public IBlockState getStateFromMeta(int meta) {
@@ -63,20 +63,20 @@ public class BlockRubberLeaves extends BlockLeaves {
         return meta;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Item getItemDropped(@Nonnull IBlockState state, @Nonnull Random rand, int fortune) {
+    public Item getItemDropped(@NotNull IBlockState state, @NotNull Random rand, int fortune) {
         return Item.getItemFromBlock(MetaBlocks.RUBBER_SAPLING);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<ItemStack> onSheared(@Nonnull ItemStack item, IBlockAccess world, BlockPos pos, int fortune) {
+    public List<ItemStack> onSheared(@NotNull ItemStack item, IBlockAccess world, BlockPos pos, int fortune) {
         return Lists.newArrayList(new ItemStack(this, 1, 0));
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public BlockRenderLayer getRenderLayer() {
         if (!fancyLeaves()) {
             return super.getRenderLayer();
@@ -86,7 +86,7 @@ public class BlockRubberLeaves extends BlockLeaves {
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean isOpaqueCube(@Nonnull IBlockState state) {
+    public boolean isOpaqueCube(@NotNull IBlockState state) {
         if (!fancyLeaves()) {
             return super.isOpaqueCube(state);
         }
@@ -95,7 +95,7 @@ public class BlockRubberLeaves extends BlockLeaves {
 
     @Override
     @SuppressWarnings("deprecation")
-    public boolean shouldSideBeRendered(@Nonnull IBlockState blockState, @Nonnull IBlockAccess blockAccess, @Nonnull BlockPos pos, @Nonnull EnumFacing side) {
+    public boolean shouldSideBeRendered(@NotNull IBlockState blockState, @NotNull IBlockAccess blockAccess, @NotNull BlockPos pos, @NotNull EnumFacing side) {
         if (!fancyLeaves()) {
             return super.shouldSideBeRendered(blockState, blockAccess, pos, side);
         }

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
@@ -12,7 +12,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 
 public class BlockRubberLog extends BlockLog {
@@ -27,13 +27,13 @@ public class BlockRubberLog extends BlockLog {
         this.setCreativeTab(GregTechAPI.TAB_GREGTECH);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
         return new BlockStateContainer(this, LOG_AXIS, NATURAL);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IBlockState getStateFromMeta(int meta) {
         return getDefaultState()
@@ -47,7 +47,7 @@ public class BlockRubberLog extends BlockLog {
     }
 
     @Override
-    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, IBlockState state, int fortune) {
+    public void getDrops(@NotNull NonNullList<ItemStack> drops, @NotNull IBlockAccess world, @NotNull BlockPos pos, IBlockState state, int fortune) {
         Random rand = world instanceof World ? ((World) world).rand : RANDOM;
         if (state.getValue(NATURAL)) {
             if(rand.nextDouble() <= .85D) {

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberSapling.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberSapling.java
@@ -13,7 +13,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.EnumPlantType;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 
 import static net.minecraft.block.BlockSapling.STAGE;
@@ -31,14 +31,14 @@ public class BlockRubberSapling extends BlockBush implements IGrowable {
         setSoundType(SoundType.PLANT);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
         return new BlockStateContainer(this, STAGE);
     }
 
     @Override
-    public void updateTick(World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Random rand) {
+    public void updateTick(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull Random rand) {
         if (!worldIn.isRemote) {
             super.updateTick(worldIn, pos, state, rand);
             if (!worldIn.isAreaLoaded(pos, 1))
@@ -50,7 +50,7 @@ public class BlockRubberSapling extends BlockBush implements IGrowable {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     @SuppressWarnings("deprecation")
     public IBlockState getStateFromMeta(int meta) {
         return this.getDefaultState().withProperty(STAGE, (meta & 8) >> 3);
@@ -63,36 +63,36 @@ public class BlockRubberSapling extends BlockBush implements IGrowable {
         return i;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("deprecation")
-    public AxisAlignedBB getBoundingBox(@Nonnull IBlockState state, @Nonnull IBlockAccess source, @Nonnull BlockPos pos) {
+    public AxisAlignedBB getBoundingBox(@NotNull IBlockState state, @NotNull IBlockAccess source, @NotNull BlockPos pos) {
         return SAPLING_AABB;
     }
 
     @Override
-    public boolean canGrow(@Nonnull World world, @Nonnull BlockPos blockPos, @Nonnull IBlockState iBlockState, boolean b) {
+    public boolean canGrow(@NotNull World world, @NotNull BlockPos blockPos, @NotNull IBlockState iBlockState, boolean b) {
         return true;
     }
 
     @Override
-    public boolean canUseBonemeal(@Nonnull World world, @Nonnull Random random, @Nonnull BlockPos blockPos, @Nonnull IBlockState iBlockState) {
+    public boolean canUseBonemeal(@NotNull World world, @NotNull Random random, @NotNull BlockPos blockPos, @NotNull IBlockState iBlockState) {
         return true;
     }
 
     @Override
-    public boolean canBeReplacedByLeaves(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos) {
+    public boolean canBeReplacedByLeaves(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos) {
         return true;
     }
 
     @Override
-    public void grow(@Nonnull World worldIn, @Nonnull Random rand, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public void grow(@NotNull World worldIn, @NotNull Random rand, @NotNull BlockPos pos, @NotNull IBlockState state) {
         WorldGenRubberTree.TREE_GROW_INSTANCE.grow(worldIn, pos, rand);
     }
 
     @Override
-    @Nonnull
-    public EnumPlantType getPlantType(@Nonnull IBlockAccess world, @Nonnull BlockPos pos) {
+    @NotNull
+    public EnumPlantType getPlantType(@NotNull IBlockAccess world, @NotNull BlockPos pos) {
         return EnumPlantType.Plains;
     }
 }

--- a/src/main/java/gregtech/common/command/CommandHand.java
+++ b/src/main/java/gregtech/common/command/CommandHand.java
@@ -27,25 +27,25 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 
 public class CommandHand extends CommandBase {
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return "hand";
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getUsage(@Nonnull ICommandSender sender) {
+    public String getUsage(@NotNull ICommandSender sender) {
         return "gregtech.command.hand.usage";
     }
 
     @Override
-    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) throws CommandException {
+    public void execute(@NotNull MinecraftServer server, @NotNull ICommandSender sender, @NotNull String[] args) throws CommandException {
         if (sender instanceof EntityPlayerMP) {
             EntityPlayerMP player = (EntityPlayerMP) sender;
             ItemStack stackInHand = player.getHeldItemMainhand();

--- a/src/main/java/gregtech/common/command/CommandRecipeCheck.java
+++ b/src/main/java/gregtech/common/command/CommandRecipeCheck.java
@@ -29,26 +29,26 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class CommandRecipeCheck extends CommandBase {
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return "recipecheck";
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getUsage(@Nonnull ICommandSender sender) {
+    public String getUsage(@NotNull ICommandSender sender) {
         return "gregtech.command.util.recipecheck.usage";
     }
 
     @Override
-    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) {
+    public void execute(@NotNull MinecraftServer server, @NotNull ICommandSender sender, @NotNull String[] args) {
         sender.sendMessage(new TextComponentTranslation("gregtech.command.recipecheck.begin"));
 
         Object2ObjectOpenHashMap<RecipeMap<?>, Object2ObjectOpenHashMap<Recipe, Set<Recipe>>> mismatchedRecipes = new Object2ObjectOpenHashMap<>();

--- a/src/main/java/gregtech/common/command/CommandShaders.java
+++ b/src/main/java/gregtech/common/command/CommandShaders.java
@@ -8,24 +8,24 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentString;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandShaders extends CommandBase {
 
     @Override
-    @Nonnull
+    @NotNull
     public String getName() {
         return "reloadshaders";
     }
 
     @Override
-    @Nonnull
-    public String getUsage(@Nonnull ICommandSender iCommandSender) {
+    @NotNull
+    public String getUsage(@NotNull ICommandSender iCommandSender) {
         return "Reload GTCEu Shaders";
     }
 
     @Override
-    public void execute(@Nonnull MinecraftServer minecraftServer, @Nonnull ICommandSender iCommandSender, @Nonnull String[] strings) {
+    public void execute(@NotNull MinecraftServer minecraftServer, @NotNull ICommandSender iCommandSender, @NotNull String[] strings) {
         if (iCommandSender instanceof EntityPlayerMP) {
             NetworkHandler.channel.sendTo(new SPacketReloadShaders().toFMLPacket(), (EntityPlayerMP) iCommandSender);
             iCommandSender.sendMessage(new TextComponentString("Reloaded Shaders"));

--- a/src/main/java/gregtech/common/command/GregTechCommand.java
+++ b/src/main/java/gregtech/common/command/GregTechCommand.java
@@ -13,7 +13,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.server.command.CommandTreeBase;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class GregTechCommand extends CommandTreeBase {
@@ -25,26 +25,26 @@ public class GregTechCommand extends CommandTreeBase {
         addSubcommand(new CommandShaders());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return "gregtech";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<String> getAliases() {
         return Lists.newArrayList("gt");
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getUsage(@Nonnull ICommandSender sender) {
+    public String getUsage(@NotNull ICommandSender sender) {
         return "gregtech.command.usage";
     }
 
     @Override
-    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, String[] args) throws CommandException {
+    public void execute(@NotNull MinecraftServer server, @NotNull ICommandSender sender, String[] args) throws CommandException {
         if (args.length > 0) {
             if (args[0].equals("copy")) {
                 StringBuilder message = new StringBuilder();

--- a/src/main/java/gregtech/common/command/worldgen/CommandWorldgen.java
+++ b/src/main/java/gregtech/common/command/worldgen/CommandWorldgen.java
@@ -3,7 +3,7 @@ package gregtech.common.command.worldgen;
 import net.minecraft.command.ICommandSender;
 import net.minecraftforge.server.command.CommandTreeBase;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandWorldgen extends CommandTreeBase {
 
@@ -11,7 +11,7 @@ public class CommandWorldgen extends CommandTreeBase {
         addSubcommand(new CommandWorldgenReload());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return "worldgen";
@@ -22,9 +22,9 @@ public class CommandWorldgen extends CommandTreeBase {
         return 3;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getUsage(@Nonnull ICommandSender sender) {
+    public String getUsage(@NotNull ICommandSender sender) {
         return "gregtech.command.worldgen.usage";
     }
 }

--- a/src/main/java/gregtech/common/command/worldgen/CommandWorldgenReload.java
+++ b/src/main/java/gregtech/common/command/worldgen/CommandWorldgenReload.java
@@ -9,25 +9,25 @@ import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 public class CommandWorldgenReload extends CommandBase {
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return "reload";
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getUsage(@Nonnull ICommandSender sender) {
+    public String getUsage(@NotNull ICommandSender sender) {
         return "gregtech.command.worldgen.reload.usage";
     }
 
     @Override
-    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) {
+    public void execute(@NotNull MinecraftServer server, @NotNull ICommandSender sender, @NotNull String[] args) {
         try {
             WorldGenRegistry.INSTANCE.reinitializeRegisteredVeins();
             sender.sendMessage(new TextComponentTranslation("gregtech.command.worldgen.reload.success")

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -40,7 +40,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
@@ -574,7 +574,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
             this.localeName = localeName;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return localeName;
@@ -592,9 +592,9 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
             super(delegate);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
             if (conveyorMode == ConveyorMode.EXPORT && manualImportExportMode == ManualImportExportMode.DISABLED) {
                 return stack;
             }
@@ -604,7 +604,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
             return super.insertItem(slot, stack, simulate);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             if (conveyorMode == ConveyorMode.IMPORT && manualImportExportMode == ManualImportExportMode.DISABLED) {

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -30,7 +30,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class CoverFluidFilter extends CoverBehavior implements CoverWithUI {
 

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -30,7 +30,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CoverItemFilter extends CoverBehavior implements CoverWithUI {
 
@@ -140,16 +140,16 @@ public class CoverItemFilter extends CoverBehavior implements CoverWithUI {
             super(delegate);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
             if (getFilterMode() == ItemFilterMode.FILTER_EXTRACT || !itemFilter.testItemStack(stack)) {
                 return stack;
             }
             return super.insertItem(slot, stack, simulate);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             if (getFilterMode() != ItemFilterMode.FILTER_INSERT) {

--- a/src/main/java/gregtech/common/covers/CoverItemVoiding.java
+++ b/src/main/java/gregtech/common/covers/CoverItemVoiding.java
@@ -19,7 +19,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CoverItemVoiding extends CoverConveyor {
 
@@ -99,22 +99,22 @@ public class CoverItemVoiding extends CoverConveyor {
             return 9;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack getStackInSlot(int slot) {
             return ItemStack.EMPTY;
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
             if (!itemFilterContainer.testItemStack(stack)) {
                 return stack;
             }
             return ItemStack.EMPTY;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             return ItemStack.EMPTY;

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -21,7 +21,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.*;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -248,7 +248,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
         }
 
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return localeName;

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -39,8 +39,8 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
 
@@ -364,7 +364,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
             this.localeName = localeName;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return localeName;
@@ -386,7 +386,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
             this.localeName = localeName;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return localeName;

--- a/src/main/java/gregtech/common/covers/DistributionMode.java
+++ b/src/main/java/gregtech/common/covers/DistributionMode.java
@@ -2,7 +2,7 @@ package gregtech.common.covers;
 
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum DistributionMode implements IStringSerializable {
     ROUND_ROBIN_GLOBAL("cover.conveyor.distribution.round_robin_enhanced"),
@@ -15,7 +15,7 @@ public enum DistributionMode implements IStringSerializable {
         this.localeName = localeName;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return localeName;

--- a/src/main/java/gregtech/common/covers/ManualImportExportMode.java
+++ b/src/main/java/gregtech/common/covers/ManualImportExportMode.java
@@ -2,7 +2,7 @@ package gregtech.common.covers;
 
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum ManualImportExportMode implements IStringSerializable {
 
@@ -16,7 +16,7 @@ public enum ManualImportExportMode implements IStringSerializable {
         this.localeName = localeName;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return localeName;

--- a/src/main/java/gregtech/common/covers/TransferMode.java
+++ b/src/main/java/gregtech/common/covers/TransferMode.java
@@ -2,7 +2,7 @@ package gregtech.common.covers;
 
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum TransferMode implements IStringSerializable {
     TRANSFER_ANY("cover.robotic_arm.transfer_mode.transfer_any", 1),
@@ -18,7 +18,7 @@ public enum TransferMode implements IStringSerializable {
     }
 
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return localeName;

--- a/src/main/java/gregtech/common/covers/VoidingMode.java
+++ b/src/main/java/gregtech/common/covers/VoidingMode.java
@@ -2,7 +2,7 @@ package gregtech.common.covers;
 
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum VoidingMode implements IStringSerializable {
     VOID_ANY("cover.voiding.voiding_mode.void_any", 1),
@@ -17,7 +17,7 @@ public enum VoidingMode implements IStringSerializable {
     }
 
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return localeName;

--- a/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
@@ -11,7 +11,7 @@ import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -24,7 +24,7 @@ public class FluidFilterContainer implements INBTSerializable<NBTTagCompound> {
         this.filterWrapper = new FluidFilterWrapper(dirtyNotifiable, capacity);
         this.filterInventory = new ItemStackHandler(1) {
             @Override
-            public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+            public boolean isItemValid(int slot, @NotNull ItemStack stack) {
                 return FilterTypeRegistry.getFluidFilterForStack(stack) != null;
             }
 

--- a/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
@@ -11,7 +11,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 public class ItemFilterContainer implements INBTSerializable<NBTTagCompound> {
@@ -26,7 +26,7 @@ public class ItemFilterContainer implements INBTSerializable<NBTTagCompound> {
         this.filterWrapper.setOnFilterInstanceChange(this::onFilterInstanceChange);
         this.filterInventory = new ItemStackHandler(1) {
             @Override
-            public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+            public boolean isItemValid(int slot, @NotNull ItemStack stack) {
                 return FilterTypeRegistry.getItemFilterForStack(stack) != null;
             }
 

--- a/src/main/java/gregtech/common/covers/filter/SimpleFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SimpleFluidFilter.java
@@ -9,7 +9,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 
 public class SimpleFluidFilter extends FluidFilter {

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -11,7 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IStringSerializable;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -126,7 +126,7 @@ public class SmartItemFilter extends ItemFilter {
             this.recipeMap = recipeMap;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName() {
             return localeName;

--- a/src/main/java/gregtech/common/crafting/FacadeRecipe.java
+++ b/src/main/java/gregtech/common/crafting/FacadeRecipe.java
@@ -12,8 +12,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FacadeRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe {
 
@@ -28,7 +28,7 @@ public class FacadeRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements I
     }
 
     @Override
-    public boolean matches(@Nonnull InventoryCrafting inv, @Nonnull World worldIn) {
+    public boolean matches(@NotNull InventoryCrafting inv, @NotNull World worldIn) {
         boolean[] matched = new boolean[ingredients.size()];
         mainLoop:
         for (int i = 0; i < inv.getSizeInventory(); i++) {
@@ -49,9 +49,9 @@ public class FacadeRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements I
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack getCraftingResult(@Nonnull InventoryCrafting inv) {
+    public ItemStack getCraftingResult(@NotNull InventoryCrafting inv) {
         ItemStack resultStack = getRecipeOutput();
         ItemStack facadeStack = ItemStack.EMPTY;
         for (int i = 0; i < inv.getSizeInventory(); i++) {
@@ -66,13 +66,13 @@ public class FacadeRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements I
         return resultStack;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getRecipeOutput() {
         return resultStack.copy();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public NonNullList<Ingredient> getIngredients() {
         return this.ingredients;
@@ -88,7 +88,7 @@ public class FacadeRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements I
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getGroup() {
         return group == null ? "" : group.toString();

--- a/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
+++ b/src/main/java/gregtech/common/crafting/GTFluidCraftingIngredient.java
@@ -6,7 +6,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class GTFluidCraftingIngredient extends Ingredient {
     private final FluidStack fluidStack;

--- a/src/main/java/gregtech/common/crafting/GTShapedNBTClearingOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapedNBTClearingOreRecipe.java
@@ -5,15 +5,15 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class GTShapedNBTClearingOreRecipe extends GTShapedOreRecipe {
-    public GTShapedNBTClearingOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+    public GTShapedNBTClearingOreRecipe(ResourceLocation group, @NotNull ItemStack result, Object... recipe) {
         super(group, result, recipe);
     }
 
     @Override
-    public @Nonnull NonNullList<ItemStack> getRemainingItems(@Nonnull InventoryCrafting inv) {
+    public @NotNull NonNullList<ItemStack> getRemainingItems(@NotNull InventoryCrafting inv) {
         return NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
     }
 }

--- a/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapedOreRecipe.java
@@ -19,14 +19,14 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreIngredient;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Set;
 
 public class GTShapedOreRecipe extends ShapedOreRecipe {
 
 
-    public GTShapedOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+    public GTShapedOreRecipe(ResourceLocation group, @NotNull ItemStack result, Object... recipe) {
         super(group, result, parseShaped(recipe));
     }
 

--- a/src/main/java/gregtech/common/crafting/GTShapelessNBTClearingOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapelessNBTClearingOreRecipe.java
@@ -5,15 +5,15 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class GTShapelessNBTClearingOreRecipe extends GTShapelessOreRecipe {
-    public GTShapelessNBTClearingOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+    public GTShapelessNBTClearingOreRecipe(ResourceLocation group, @NotNull ItemStack result, Object... recipe) {
         super(group, result, recipe);
     }
 
     @Override
-    public @Nonnull NonNullList<ItemStack> getRemainingItems(@Nonnull InventoryCrafting inv) {
+    public @NotNull NonNullList<ItemStack> getRemainingItems(@NotNull InventoryCrafting inv) {
         return NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
     }
 }

--- a/src/main/java/gregtech/common/crafting/GTShapelessOreRecipe.java
+++ b/src/main/java/gregtech/common/crafting/GTShapelessOreRecipe.java
@@ -13,10 +13,10 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreIngredient;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class GTShapelessOreRecipe extends ShapelessOreRecipe {
-    public GTShapelessOreRecipe(ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+    public GTShapelessOreRecipe(ResourceLocation group, @NotNull ItemStack result, Object... recipe) {
         super(group, result);
         for (Object in : recipe) {
             Ingredient ing = getIngredient(in);

--- a/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListGridWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListGridWidget.java
@@ -14,7 +14,7 @@ import gregtech.common.inventory.SimpleItemInfo;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.*;
 

--- a/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListSlotWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListSlotWidget.java
@@ -17,7 +17,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.text.TextFormatting;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 

--- a/src/main/java/gregtech/common/inventory/IItemList.java
+++ b/src/main/java/gregtech/common/inventory/IItemList.java
@@ -2,7 +2,7 @@ package gregtech.common.inventory;
 
 import gregtech.api.util.ItemStackKey;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Set;
 
 public interface IItemList {

--- a/src/main/java/gregtech/common/inventory/handlers/CycleItemStackHandler.java
+++ b/src/main/java/gregtech/common/inventory/handlers/CycleItemStackHandler.java
@@ -5,7 +5,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class CycleItemStackHandler extends ItemStackHandler {
 
@@ -13,7 +13,7 @@ public class CycleItemStackHandler extends ItemStackHandler {
         super(stacks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getStackInSlot(int slot) {
         return stacks.isEmpty() ? ItemStack.EMPTY : super.getStackInSlot(Math.abs((int)(System.currentTimeMillis() / 1000) % stacks.size()));

--- a/src/main/java/gregtech/common/inventory/handlers/TapeItemStackHandler.java
+++ b/src/main/java/gregtech/common/inventory/handlers/TapeItemStackHandler.java
@@ -4,7 +4,7 @@ import gregtech.common.items.MetaItems;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class TapeItemStackHandler extends ItemStackHandler {
 
@@ -13,8 +13,8 @@ public class TapeItemStackHandler extends ItemStackHandler {
     }
 
     @Override
-    @Nonnull
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         if (!stack.isEmpty() && stack.isItemEqual(MetaItems.DUCT_TAPE.getStackForm())) {
             return super.insertItem(slot, stack, simulate);
         }

--- a/src/main/java/gregtech/common/inventory/handlers/ToolItemStackHandler.java
+++ b/src/main/java/gregtech/common/inventory/handlers/ToolItemStackHandler.java
@@ -4,7 +4,7 @@ import gregtech.api.items.toolitem.ToolMetaItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTool;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ToolItemStackHandler extends SingleItemStackHandler {
 
@@ -13,8 +13,8 @@ public class ToolItemStackHandler extends SingleItemStackHandler {
     }
 
     @Override
-    @Nonnull
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    @NotNull
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         if (!(stack.getItem() instanceof ToolMetaItem)
                 && !(stack.getItem() instanceof ItemTool)
                 && !(stack.isItemStackDamageable())) {

--- a/src/main/java/gregtech/common/inventory/itemsource/ItemSources.java
+++ b/src/main/java/gregtech/common/inventory/itemsource/ItemSources.java
@@ -7,7 +7,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class ItemSources implements IItemList {

--- a/src/main/java/gregtech/common/items/EnchantmentTableTweaks.java
+++ b/src/main/java/gregtech/common/items/EnchantmentTableTweaks.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @EventBusSubscriber(modid = GTValues.MODID)
 public class EnchantmentTableTweaks {
@@ -87,7 +87,7 @@ public class EnchantmentTableTweaks {
         }
 
         @Override
-        public boolean isItemValid(@Nonnull ItemStack stack) {
+        public boolean isItemValid(@NotNull ItemStack stack) {
             return super.isItemValid(stack) || isValidForEnchantment(stack);
         }
     }

--- a/src/main/java/gregtech/common/items/armor/AdvancedJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedJetpack.java
@@ -18,7 +18,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class AdvancedJetpack extends Jetpack {
 
@@ -27,7 +27,7 @@ public class AdvancedJetpack extends Jetpack {
     }
 
     @Override
-    public void onArmorTick(World world, EntityPlayer player, @Nonnull ItemStack item) {
+    public void onArmorTick(World world, EntityPlayer player, @NotNull ItemStack item) {
         IElectricItem cont = item.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if(cont == null) {
             return;

--- a/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Iterator;
 import java.util.List;
 
@@ -33,7 +33,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
     }
 
     @Override
-    public void onArmorTick(World world, EntityPlayer player, @Nonnull ItemStack item) {
+    public void onArmorTick(World world, EntityPlayer player, @NotNull ItemStack item) {
         IElectricItem cont = item.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (cont == null) {
             return;
@@ -151,7 +151,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
     }
 
     @Override
-    public ActionResult<ItemStack> onRightClick(World world, @Nonnull EntityPlayer player, EnumHand hand) {
+    public ActionResult<ItemStack> onRightClick(World world, @NotNull EntityPlayer player, EnumHand hand) {
         ItemStack armor = player.getHeldItem(hand);
 
         if (armor.getItem() instanceof ArmorMetaItem && player.isSneaking()) {
@@ -214,7 +214,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
     }
 
     @Override
-    public boolean canUseEnergy(@Nonnull ItemStack stack, int amount) {
+    public boolean canUseEnergy(@NotNull ItemStack stack, int amount) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return false;
@@ -222,7 +222,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
     }
 
     @Override
-    public void drainEnergy(@Nonnull ItemStack stack, int amount) {
+    public void drainEnergy(@NotNull ItemStack stack, int amount) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return;
@@ -230,14 +230,14 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
     }
 
     @Override
-    public boolean hasEnergy(@Nonnull ItemStack stack) {
+    public boolean hasEnergy(@NotNull ItemStack stack) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return false;
         return container.getCharge() > 0;
     }
 
-    private IElectricItem getIElectricItem(@Nonnull ItemStack stack) {
+    private IElectricItem getIElectricItem(@NotNull ItemStack stack) {
         return stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
     }
 

--- a/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Iterator;
 import java.util.List;
 
@@ -211,7 +211,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
     }
 
     @Override
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         int damageLimit = Integer.MAX_VALUE;
         IElectricItem item = armor.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (item == null) {
@@ -224,7 +224,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
     }
 
     @Override
-    public boolean handleUnblockableDamage(EntityLivingBase entity, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public boolean handleUnblockableDamage(EntityLivingBase entity, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         return source != DamageSource.FALL && source != DamageSource.DROWN && source != DamageSource.STARVE;
     }
 
@@ -239,7 +239,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
     }
 
     @Override
-    public boolean canUseEnergy(@Nonnull ItemStack stack, int amount) {
+    public boolean canUseEnergy(@NotNull ItemStack stack, int amount) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return false;
@@ -247,7 +247,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
     }
 
     @Override
-    public void drainEnergy(@Nonnull ItemStack stack, int amount) {
+    public void drainEnergy(@NotNull ItemStack stack, int amount) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return;
@@ -255,14 +255,14 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
     }
 
     @Override
-    public boolean hasEnergy(@Nonnull ItemStack stack) {
+    public boolean hasEnergy(@NotNull ItemStack stack) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return false;
         return container.getCharge() > 0;
     }
 
-    private IElectricItem getIElectricItem(@Nonnull ItemStack stack) {
+    private IElectricItem getIElectricItem(@NotNull ItemStack stack) {
         return stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
     }
 

--- a/src/main/java/gregtech/common/items/armor/IJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/IJetpack.java
@@ -7,7 +7,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumParticleTypes;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 
 /**
@@ -59,7 +59,7 @@ public interface IJetpack {
 
     boolean hasEnergy(ItemStack stack);
 
-    default void performFlying(@Nonnull EntityPlayer player, boolean hover, ItemStack stack) {
+    default void performFlying(@NotNull EntityPlayer player, boolean hover, ItemStack stack) {
         double currentAccel = getVerticalAcceleration() * (player.motionY < 0.3D ? 2.5D : 1.0D);
         double currentSpeedVertical = getVerticalSpeed() * (player.isInWater() ? 0.4D : 1.0D);
         boolean flyKeyDown = KeyBind.VANILLA_JUMP.isKeyDown(player);

--- a/src/main/java/gregtech/common/items/armor/IStepAssist.java
+++ b/src/main/java/gregtech/common/items/armor/IStepAssist.java
@@ -2,7 +2,7 @@ package gregtech.common.items.armor;
 
 import net.minecraft.entity.player.EntityPlayer;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Logic from EnderIO: https://github.com/SleepyTrousers/EnderIO/blob/d6dfb9d3964946ceb9fd72a66a3cff197a51a1fe/enderio-base/src/main/java/crazypants/enderio/base/handler/darksteel/DarkSteelController.java
@@ -11,7 +11,7 @@ public interface IStepAssist {
 
     float MAGIC_STEP_HEIGHT = 1.0023f;
 
-    default void updateStepHeight(@Nonnull EntityPlayer player) {
+    default void updateStepHeight(@NotNull EntityPlayer player) {
         if (!player.isSneaking()) {
             if (player.stepHeight < MAGIC_STEP_HEIGHT) {
                 player.stepHeight = MAGIC_STEP_HEIGHT;

--- a/src/main/java/gregtech/common/items/armor/Jetpack.java
+++ b/src/main/java/gregtech/common/items/armor/Jetpack.java
@@ -21,7 +21,7 @@ import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class Jetpack extends ArmorLogicSuite implements IJetpack {
@@ -31,7 +31,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     }
 
     @Override
-    public void onArmorTick(World world, EntityPlayer player, @Nonnull ItemStack stack) {
+    public void onArmorTick(World world, EntityPlayer player, @NotNull ItemStack stack) {
         NBTTagCompound data = GTUtility.getOrCreateNbtCompound(stack);
         byte toggleTimer = 0;
         boolean hover = false;
@@ -60,7 +60,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     }
 
     @Override
-    public boolean canUseEnergy(@Nonnull ItemStack stack, int amount) {
+    public boolean canUseEnergy(@NotNull ItemStack stack, int amount) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return false;
@@ -68,7 +68,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     }
 
     @Override
-    public void drainEnergy(@Nonnull ItemStack stack, int amount) {
+    public void drainEnergy(@NotNull ItemStack stack, int amount) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return;
@@ -76,14 +76,14 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     }
 
     @Override
-    public boolean hasEnergy(@Nonnull ItemStack stack) {
+    public boolean hasEnergy(@NotNull ItemStack stack) {
         IElectricItem container = getIElectricItem(stack);
         if (container == null)
             return false;
         return container.getCharge() > 0;
     }
 
-    private IElectricItem getIElectricItem(@Nonnull ItemStack stack) {
+    private IElectricItem getIElectricItem(@NotNull ItemStack stack) {
         return stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
     }
 
@@ -93,7 +93,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     }
 
     @Override
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         return new ArmorProperties(0, 0, 0);
     }
 

--- a/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
@@ -23,7 +23,7 @@ import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
@@ -33,7 +33,7 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
     }
 
     @Override
-    public void onArmorTick(World world, EntityPlayer player, @Nonnull ItemStack itemStack) {
+    public void onArmorTick(World world, EntityPlayer player, @NotNull ItemStack itemStack) {
         IElectricItem item = itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (item == null) {
             return;
@@ -78,19 +78,19 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
         player.inventoryContainer.detectAndSendChanges();
     }
 
-    public void disableNightVision(@Nonnull World world, EntityPlayer player, boolean sendMsg) {
+    public void disableNightVision(@NotNull World world, EntityPlayer player, boolean sendMsg) {
         if (!world.isRemote) {
             player.removePotionEffect(MobEffects.NIGHT_VISION);
             if (sendMsg) player.sendStatusMessage(new TextComponentTranslation("metaarmor.nms.nightvision.disabled"), true);
         }
     }
 
-    public boolean handleUnblockableDamage(EntityLivingBase entity, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public boolean handleUnblockableDamage(EntityLivingBase entity, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         return source == DamageSource.FALL;
     }
 
     @Override
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         IElectricItem container = armor.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         int damageLimit = Integer.MAX_VALUE;
         if (source == DamageSource.FALL && this.getEquipmentSlot(armor) == EntityEquipmentSlot.FEET) {

--- a/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
+++ b/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
@@ -16,7 +16,7 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class NightvisionGoggles extends ArmorLogicSuite {
@@ -26,7 +26,7 @@ public class NightvisionGoggles extends ArmorLogicSuite {
     }
 
     @Override
-    public void onArmorTick(World world, @Nonnull EntityPlayer player, @Nonnull ItemStack itemStack) {
+    public void onArmorTick(World world, @NotNull EntityPlayer player, @NotNull ItemStack itemStack) {
         IElectricItem item = itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (item == null) {
             return;
@@ -71,7 +71,7 @@ public class NightvisionGoggles extends ArmorLogicSuite {
         player.inventoryContainer.detectAndSendChanges();
     }
 
-    public void disableNightVision(@Nonnull World world, EntityPlayer player, boolean sendMsg) {
+    public void disableNightVision(@NotNull World world, EntityPlayer player, boolean sendMsg) {
         if (!world.isRemote) {
             player.removePotionEffect(MobEffects.NIGHT_VISION);
             if (sendMsg) player.sendStatusMessage(new TextComponentTranslation("metaarmor.message.nightvision.disabled"), true);

--- a/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
@@ -34,7 +34,7 @@ import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -57,7 +57,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
     }
 
     @Override
-    public void onArmorTick(World world, EntityPlayer player, @Nonnull ItemStack stack) {
+    public void onArmorTick(World world, EntityPlayer player, @NotNull ItemStack stack) {
         IFluidHandlerItem internalTank = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
         if (internalTank == null)
             return;
@@ -103,7 +103,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
     }
 
     @Override
-    public void addToolComponents(@Nonnull ArmorMetaValueItem mvi) {
+    public void addToolComponents(@NotNull ArmorMetaValueItem mvi) {
         mvi.addComponents(new Behaviour(tankCapacity));
     }
 
@@ -113,7 +113,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
     }
 
     @SideOnly(Side.CLIENT)
-    public void drawHUD(@Nonnull ItemStack item) {
+    public void drawHUD(@NotNull ItemStack item) {
         IFluidHandlerItem tank = item.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
         if (tank != null) {
             IFluidTankProperties[] prop = tank.getTankProperties();
@@ -181,11 +181,11 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
         return burnTimer > 0 || currentRecipe != null;
     }
 
-    private IFluidHandlerItem getIFluidHandlerItem(@Nonnull ItemStack stack) {
+    private IFluidHandlerItem getIFluidHandlerItem(@NotNull ItemStack stack) {
         return stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
     }
 
-    public void findNewRecipe(@Nonnull ItemStack stack) {
+    public void findNewRecipe(@NotNull ItemStack stack) {
         IFluidHandlerItem internalTank = getIFluidHandlerItem(stack);
         if (internalTank != null) {
             FluidStack fluidStack = internalTank.drain(1, false);
@@ -226,14 +226,14 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
     }
 
     @Override
-    public ISpecialArmor.ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, @Nonnull DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public ISpecialArmor.ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, @NotNull DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         int damageLimit = (int) Math.min(Integer.MAX_VALUE, burnTimer * 1.0 / 32 * 25.0);
         if (source.isUnblockable()) return new ISpecialArmor.ArmorProperties(0, 0.0, 0);
         return new ISpecialArmor.ArmorProperties(0, 0, damageLimit);
     }
 
     @Override
-    public int getArmorDisplay(EntityPlayer player, @Nonnull ItemStack armor, int slot) {
+    public int getArmorDisplay(EntityPlayer player, @NotNull ItemStack armor, int slot) {
         return 0;
     }
 
@@ -251,7 +251,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
         }
 
         @Override
-        public double getDurabilityForDisplay(@Nonnull ItemStack itemStack) {
+        public double getDurabilityForDisplay(@NotNull ItemStack itemStack) {
             IFluidHandlerItem fluidHandlerItem = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (fluidHandlerItem == null)
                 return 1.0;

--- a/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -211,7 +211,7 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         }
     }
 
-    public void disableNightVision(@Nonnull World world, EntityPlayer player, boolean sendMsg) {
+    public void disableNightVision(@NotNull World world, EntityPlayer player, boolean sendMsg) {
         if (!world.isRemote) {
             player.removePotionEffect(MobEffects.NIGHT_VISION);
             if (sendMsg) player.sendStatusMessage(new TextComponentTranslation("metaarmor.qts.nightvision.disabled"), true);
@@ -219,7 +219,7 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
     }
 
     @Override
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public ArmorProperties getProperties(EntityLivingBase player, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         int damageLimit = Integer.MAX_VALUE;
         IElectricItem item = armor.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (item == null) {
@@ -242,12 +242,12 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
     }
 
     @Override
-    public boolean handleUnblockableDamage(EntityLivingBase entity, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
+    public boolean handleUnblockableDamage(EntityLivingBase entity, @NotNull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot equipmentSlot) {
         return source != DamageSource.FALL && source != DamageSource.DROWN && source != DamageSource.STARVE && source != DamageSource.OUT_OF_WORLD;
     }
 
     @Override
-    public void damageArmor(EntityLivingBase entity, @Nonnull ItemStack itemStack, DamageSource source, int damage, EntityEquipmentSlot equipmentSlot) {
+    public void damageArmor(EntityLivingBase entity, @NotNull ItemStack itemStack, DamageSource source, int damage, EntityEquipmentSlot equipmentSlot) {
         IElectricItem item = itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (item == null) {
             return;

--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -23,7 +23,7 @@ import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class ItemMagnetBehavior implements IItemBehaviour {
@@ -38,7 +38,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     }
 
     @Override
-    public ActionResult<ItemStack> onItemRightClick(World world, @Nonnull EntityPlayer player, EnumHand hand) {
+    public ActionResult<ItemStack> onItemRightClick(World world, @NotNull EntityPlayer player, EnumHand hand) {
         if (!player.world.isRemote && player.isSneaking()) {
             player.sendStatusMessage(new TextComponentTranslation(toggleActive(player.getHeldItem(hand)) ? "behavior.item_magnet.enabled" : "behavior.item_magnet.disabled"), true);
         }
@@ -118,7 +118,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     }
 
     @SubscribeEvent
-    public void onItemToss(@Nonnull ItemTossEvent event) {
+    public void onItemToss(@NotNull ItemTossEvent event) {
         if (event.getPlayer() == null)
             return;
 
@@ -138,16 +138,16 @@ public class ItemMagnetBehavior implements IItemBehaviour {
         }
     }
 
-    private boolean isMagnet(@Nonnull ItemStack stack) {
+    private boolean isMagnet(@NotNull ItemStack stack) {
         return stack.getItem() instanceof MetaItem && ((MetaItem<?>) stack.getItem()).getBehaviours(stack).contains(this);
     }
 
-    @Nonnull
-    private AxisAlignedBB getAreaBoundingBox(@Nonnull EntityPlayer player) {
+    @NotNull
+    private AxisAlignedBB getAreaBoundingBox(@NotNull EntityPlayer player) {
         return new AxisAlignedBB(player.getPosition()).grow(range, range, range);
     }
 
-    private boolean drainEnergy(boolean simulate, @Nonnull ItemStack stack, long amount) {
+    private boolean drainEnergy(boolean simulate, @NotNull ItemStack stack, long amount) {
         IElectricItem electricItem = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (electricItem == null)
             return false;

--- a/src/main/java/gregtech/common/items/behaviors/LighterBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/LighterBehaviour.java
@@ -26,8 +26,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class LighterBehaviour implements IItemBehaviour {
@@ -75,7 +75,7 @@ public class LighterBehaviour implements IItemBehaviour {
     }
 
     @Override
-    public EnumActionResult onItemUseFirst(@Nonnull EntityPlayer player, @Nonnull World world, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ, EnumHand hand) {
+    public EnumActionResult onItemUseFirst(@NotNull EntityPlayer player, @NotNull World world, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
 
         if (canOpen) {
@@ -110,7 +110,7 @@ public class LighterBehaviour implements IItemBehaviour {
     }
 
     @Override
-    public void addInformation(ItemStack itemStack, @Nonnull List<String> lines) {
+    public void addInformation(ItemStack itemStack, @NotNull List<String> lines) {
         lines.add(I18n.format(usesFluid ? "behaviour.lighter.fluid.tooltip" : "behaviour.lighter.tooltip"));
         if (hasMultipleUses && !usesFluid) {
             lines.add(I18n.format("behaviour.lighter.uses", getUsesLeft(itemStack)));
@@ -142,7 +142,7 @@ public class LighterBehaviour implements IItemBehaviour {
         return false;
     }
 
-    private int getUsesLeft(@Nonnull ItemStack stack) {
+    private int getUsesLeft(@NotNull ItemStack stack) {
         if (usesFluid) {
             IFluidHandlerItem fluidHandlerItem = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (fluidHandlerItem == null)
@@ -163,7 +163,7 @@ public class LighterBehaviour implements IItemBehaviour {
         return stack.getCount();
     }
 
-    private void setUsesLeft(EntityPlayer entity, @Nonnull ItemStack stack, int usesLeft) {
+    private void setUsesLeft(EntityPlayer entity, @NotNull ItemStack stack, int usesLeft) {
         if (usesFluid) {
             IFluidHandlerItem fluidHandlerItem = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (fluidHandlerItem != null) {
@@ -185,7 +185,7 @@ public class LighterBehaviour implements IItemBehaviour {
     }
 
     @Override
-    public void onAddedToItem(@Nonnull MetaItem.MetaValueItem metaValueItem) {
+    public void onAddedToItem(@NotNull MetaItem.MetaValueItem metaValueItem) {
         if (overrideLocation != null) {
             metaValueItem.getMetaItem().addPropertyOverride(overrideLocation,
                     (stack, worldIn, entityIn) -> GTUtility.getOrCreateNbtCompound(stack).getBoolean(LIGHTER_OPEN) ? 1.0F : 0.0F);

--- a/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ProspectorScannerBehavior.java
@@ -24,7 +24,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
     }
 
     @Override
-    public ActionResult<ItemStack> onItemRightClick(@Nonnull World world, @Nonnull EntityPlayer player, EnumHand hand) {
+    public ActionResult<ItemStack> onItemRightClick(@NotNull World world, @NotNull EntityPlayer player, EnumHand hand) {
         ItemStack heldItem = player.getHeldItem(hand);
         if (!world.isRemote) {
             if (player.isSneaking()) {
@@ -97,11 +97,11 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
         stack.getTagCompound().setInteger("Mode", mode);
     }
 
-    private boolean checkCanUseScanner(ItemStack stack, @Nonnull EntityPlayer player, boolean simulate) {
+    private boolean checkCanUseScanner(ItemStack stack, @NotNull EntityPlayer player, boolean simulate) {
         return player.isCreative() || drainEnergy(stack, GTValues.V[tier] / VOLTAGE_FACTOR, simulate);
     }
 
-    private boolean drainEnergy(@Nonnull ItemStack stack, long amount, boolean simulate) {
+    private boolean drainEnergy(@NotNull ItemStack stack, long amount, boolean simulate) {
         IElectricItem electricItem = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (electricItem == null)
             return false;
@@ -110,7 +110,7 @@ public class ProspectorScannerBehavior implements IItemBehaviour, ItemUIFactory,
     }
 
     @Override
-    public ModularUI createUI(PlayerInventoryHolder holder, @Nonnull EntityPlayer entityPlayer) {
+    public ModularUI createUI(PlayerInventoryHolder holder, @NotNull EntityPlayer entityPlayer) {
         int mode = getMode(entityPlayer.getHeldItem(EnumHand.MAIN_HAND));
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 332, 200);
         this.widgetOreList = new WidgetOreList(32 * radius - 6, 18, 332 - 32 * radius, 176);

--- a/src/main/java/gregtech/common/items/behaviors/TricorderBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/TricorderBehavior.java
@@ -37,7 +37,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -298,7 +298,7 @@ public class TricorderBehavior implements IItemBehaviour {
         return list;
     }
 
-    private boolean drainEnergy(@Nonnull ItemStack stack, long amount, boolean simulate) {
+    private boolean drainEnergy(@NotNull ItemStack stack, long amount, boolean simulate) {
         if (debugLevel > 2)
             return true;
 

--- a/src/main/java/gregtech/common/items/behaviors/TurbineRotorBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/TurbineRotorBehavior.java
@@ -9,8 +9,8 @@ import gregtech.api.unification.material.properties.ToolProperty;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class TurbineRotorBehavior extends AbstractMaterialPartBehavior implements IItemMaxStackSizeProvider {
@@ -62,7 +62,7 @@ public class TurbineRotorBehavior extends AbstractMaterialPartBehavior implement
     }
 
     @Nullable
-    public static TurbineRotorBehavior getInstanceFor(@Nonnull ItemStack itemStack) {
+    public static TurbineRotorBehavior getInstanceFor(@NotNull ItemStack itemStack) {
         if (!(itemStack.getItem() instanceof MetaItem))
             return null;
 

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -47,7 +47,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
@@ -35,7 +35,7 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.SYNC_TILE_MODE;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAdjustableTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAdjustableTransformer.java
@@ -25,7 +25,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBatteryBuffer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBatteryBuffer.java
@@ -36,8 +36,8 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -106,9 +106,9 @@ public class MetaTileEntityBatteryBuffer extends TieredMetaTileEntity implements
                 ((EnergyContainerBatteryBuffer) energyContainer).notifyEnergyListener(false);
             }
 
-            @Nonnull
+            @NotNull
             @Override
-            public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+            public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
                 IElectricItem electricItem = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
                 if ((electricItem != null && getTier() >= electricItem.getTier()) ||
                         (ConfigHolder.compat.energy.nativeEUToFE && stack.hasCapability(CapabilityEnergy.ENERGY, null))) {
@@ -185,7 +185,7 @@ public class MetaTileEntityBatteryBuffer extends TieredMetaTileEntity implements
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = new ArrayList<>();

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
@@ -37,7 +37,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityCharger.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityCharger.java
@@ -21,8 +21,8 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityCharger extends TieredMetaTileEntity {
@@ -49,9 +49,9 @@ public class MetaTileEntityCharger extends TieredMetaTileEntity {
     @Override
     protected IItemHandlerModifiable createImportItemHandler() {
         return new ItemStackHandler(inventorySize) {
-            @Nonnull
+            @NotNull
             @Override
-            public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+            public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
                 IElectricItem electricItem = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
                 if ((electricItem != null && getTier() >= electricItem.getTier()) ||
                         (ConfigHolder.compat.energy.nativeEUToFE && stack.hasCapability(CapabilityEnergy.ENERGY, null))) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -31,8 +31,8 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -129,7 +129,7 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
     }
 
     @Override
-    public boolean onRightClick(@Nonnull EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
+    public boolean onRightClick(@NotNull EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
         ItemStack itemStack = playerIn.getHeldItem(hand);
         if (!itemStack.isEmpty() && itemStack.hasCapability(GregtechCapabilities.CAPABILITY_MALLET, null)) {
             ISoftHammerItem softHammerItem = itemStack.getCapability(GregtechCapabilities.CAPABILITY_MALLET, null);
@@ -160,7 +160,7 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @NotNull List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.machine.diode.tooltip_general"));
         tooltip.add(I18n.format("gregtech.machine.diode.tooltip_tool_usage"));
         tooltip.add(I18n.format("gregtech.universal.tooltip.voltage_in",
@@ -173,11 +173,11 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
     }
 
     @Override
-    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+    public void registerAbilities(@NotNull List<IPassthroughHatch> abilityList) {
         abilityList.add(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<?> getPassthroughType() {
         return IEnergyContainer.class;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
@@ -31,8 +31,8 @@ import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityFisher extends TieredMetaTileEntity {
@@ -114,9 +114,9 @@ public class MetaTileEntityFisher extends TieredMetaTileEntity {
     @Override
     protected IItemHandlerModifiable createImportItemHandler() {
         return new ItemStackHandler(1) {
-            @Nonnull
+            @NotNull
             @Override
-            public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+            public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
                 if (OreDictUnifier.getOreDictionaryNames(stack).contains("string")) {
                     return super.insertItem(slot, stack, simulate);
                 }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
@@ -14,7 +14,7 @@ import gregtech.client.renderer.texture.Textures;
 import it.unimi.dsi.fastutil.ints.IntLists;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -38,7 +38,7 @@ public class MetaTileEntityGasCollector extends SimpleMachineMetaTileEntity {
         return new GasCollectorRecipeLogic(this, recipeMap, () -> energyContainer);
     }
 
-    protected boolean checkRecipe(@Nonnull Recipe recipe) {
+    protected boolean checkRecipe(@NotNull Recipe recipe) {
         for (int dimension : recipe.getProperty(GasCollectorDimensionProperty.getInstance(), IntLists.EMPTY_LIST)) {
             if (dimension == this.getWorld().provider.getDimension()) {
                 return true;
@@ -54,7 +54,7 @@ public class MetaTileEntityGasCollector extends SimpleMachineMetaTileEntity {
         }
 
         @Override
-        protected boolean checkRecipe(@Nonnull Recipe recipe) {
+        protected boolean checkRecipe(@NotNull Recipe recipe) {
             return ((MetaTileEntityGasCollector) metaTileEntity).checkRecipe(recipe) && super.checkRecipe(recipe);
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
@@ -30,8 +30,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Optional;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
@@ -101,10 +101,10 @@ public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements 
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @Optional.Method(modid = GTValues.MODID_APPENG)
-    public AECableType getCableConnectionType(@Nonnull AEPartLocation part) {
+    public AECableType getCableConnectionType(@NotNull AEPartLocation part) {
         return AECableType.SMART;
     }
 
@@ -124,11 +124,11 @@ public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements 
     }
 
     @Override
-    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+    public void registerAbilities(@NotNull List<IPassthroughHatch> abilityList) {
         abilityList.add(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<?> getPassthroughType() {
         return IEnergyContainer.class;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -37,7 +37,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMiner.java
@@ -35,8 +35,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -94,7 +94,7 @@ public class MetaTileEntityMiner extends TieredMetaTileEntity implements IMiner,
     }
 
     @Override
-    protected ModularUI createUI(@Nonnull EntityPlayer entityPlayer) {
+    protected ModularUI createUI(@NotNull EntityPlayer entityPlayer) {
         int rowSize = (int) Math.sqrt(inventorySize);
         ModularUI.Builder builder = new ModularUI.Builder(GuiTextures.BACKGROUND, 195, 176);
         builder.bindPlayerInventory(entityPlayer.inventory, 94);
@@ -129,7 +129,7 @@ public class MetaTileEntityMiner extends TieredMetaTileEntity implements IMiner,
         return builder.build(getHolder(), entityPlayer);
     }
 
-    private void addDisplayText(@Nonnull List<ITextComponent> textList) {
+    private void addDisplayText(@NotNull List<ITextComponent> textList) {
         textList.add(new TextComponentTranslation("gregtech.machine.miner.startx", this.minerLogic.getX().get()));
         textList.add(new TextComponentTranslation("gregtech.machine.miner.starty", this.minerLogic.getY().get()));
         textList.add(new TextComponentTranslation("gregtech.machine.miner.startz", this.minerLogic.getZ().get()));
@@ -146,14 +146,14 @@ public class MetaTileEntityMiner extends TieredMetaTileEntity implements IMiner,
             textList.add(new TextComponentTranslation("gregtech.multiblock.large_miner.needspower").setStyle(new Style().setColor(TextFormatting.RED)));
     }
 
-    private void addDisplayText2(@Nonnull List<ITextComponent> textList) {
+    private void addDisplayText2(@NotNull List<ITextComponent> textList) {
         textList.add(new TextComponentTranslation("gregtech.machine.miner.minex", this.minerLogic.getMineX().get()));
         textList.add(new TextComponentTranslation("gregtech.machine.miner.miney", this.minerLogic.getMineY().get()));
         textList.add(new TextComponentTranslation("gregtech.machine.miner.minez", this.minerLogic.getMineZ().get()));
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @NotNull List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.universal.tooltip.voltage_in", energyContainer.getInputVoltage(), GTValues.VNF[getTier()]));
         tooltip.add(I18n.format("gregtech.universal.tooltip.energy_storage_capacity", energyContainer.getEnergyCapacity()));
         tooltip.add(I18n.format("gregtech.machine.miner.tooltip"));
@@ -287,7 +287,7 @@ public class MetaTileEntityMiner extends TieredMetaTileEntity implements IMiner,
         return minerLogic.isActive() && isWorkingEnabled();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation(I18n.format("gregtech.multiblock.large_miner.radius", this.minerLogic.getCurrentRadius())));

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -44,7 +44,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTransformer.java
@@ -27,7 +27,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
@@ -31,7 +31,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.function.Supplier;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
@@ -29,7 +29,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockController {
 
@@ -74,7 +74,7 @@ public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockControll
         getFrontOverlay().renderOrientedState(renderState, translation, pipeline, getFrontFacing(), recipeMapWorkable.isActive(), recipeMapWorkable.isWorkingEnabled());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.COKE_OVEN_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -34,8 +34,8 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 import static gregtech.api.gui.widgets.AdvancedTextWidget.withButton;
@@ -190,7 +190,7 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase {
         this.getFrontOverlay().renderOrientedState(renderState, translation, pipeline, getFrontFacing(), isActive(), recipeLogic.isWorkingEnabled());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return boilerType.frontOverlay;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
@@ -33,8 +33,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidTank;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,7 +56,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
         this.fluidInventory = new FluidHandlerProxy(this.importFluids, this.exportFluids);
     }
 
-    @Nonnull
+    @NotNull
     private List<FluidTank> makeFluidTanks() {
         List<FluidTank> fluidTankList = new ArrayList<>(1);
         fluidTankList.add(new FilteredFluidHandler(capacity).setFillPredicate(
@@ -120,7 +120,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
     }
 
     @Override
-    protected ModularUI.Builder createUITemplate(@Nonnull EntityPlayer entityPlayer) {
+    protected ModularUI.Builder createUITemplate(@NotNull EntityPlayer entityPlayer) {
         return ModularUI.defaultBuilder()
                 .widget(new LabelWidget(6, 6, getMetaFullName()))
                 .widget(new TankWidget(importFluids.getTankAt(0), 52, 18, 72, 61)
@@ -135,7 +135,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
         getFrontOverlay().renderSided(getFrontFacing(), renderState, translation, pipeline);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.MULTIBLOCK_TANK_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -36,7 +36,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import org.apache.commons.lang3.ArrayUtils;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMultiblockController {
 
@@ -108,7 +108,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.PRIMITIVE_BLAST_FURNACE_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveWaterPump.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveWaterPump.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -150,7 +150,7 @@ public class MetaTileEntityPrimitiveWaterPump extends MultiblockControllerBase i
         return Textures.PRIMITIVE_PUMP;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.PRIMITIVE_PUMP_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
@@ -31,7 +31,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidTank> {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
@@ -27,8 +27,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidHandler> {
@@ -139,7 +139,7 @@ public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public void registerAbilities(@Nonnull List<IFluidHandler> abilityList) {
+    public void registerAbilities(@NotNull List<IFluidHandler> abilityList) {
         abilityList.add(this.getImportFluids());
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -56,8 +56,8 @@ import net.minecraftforge.fml.common.Loader;
 import org.apache.commons.lang3.ArrayUtils;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_FRONT_FACING;
@@ -208,7 +208,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
      * @param direction the direction to move
      * @return if a block is a valid wall block at pos moved in direction
      */
-    public boolean isBlockEdge(@Nonnull World world, @Nonnull BlockPos.MutableBlockPos pos, @Nonnull EnumFacing direction) {
+    public boolean isBlockEdge(@NotNull World world, @NotNull BlockPos.MutableBlockPos pos, @NotNull EnumFacing direction) {
         return world.getBlockState(pos.move(direction)) == MetaBlocks.CLEANROOM_CASING.getState(BlockCleanroomCasing.CasingType.PLASCRETE);
     }
 
@@ -218,7 +218,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
      * @param direction the direction to move
      * @return if a block is a valid floor block at pos moved in direction
      */
-    public boolean isBlockFloor(@Nonnull World world, @Nonnull BlockPos.MutableBlockPos pos, @Nonnull EnumFacing direction) {
+    public boolean isBlockFloor(@NotNull World world, @NotNull BlockPos.MutableBlockPos pos, @NotNull EnumFacing direction) {
         return isBlockEdge(world, pos, direction) || world.getBlockState(pos) == MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.CLEANROOM_GLASS);
     }
 
@@ -322,7 +322,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
                 .build();
     }
 
-    @Nonnull
+    @NotNull
     protected TraceabilityPredicate filterPredicate() {
         return new TraceabilityPredicate(blockWorldState -> {
             IBlockState blockState = blockWorldState.getBlockState();
@@ -354,22 +354,22 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
     }
 
     // protected to allow easy addition of addon "cleanrooms"
-    @Nonnull
+    @NotNull
     protected IBlockState getCasingState() {
         return MetaBlocks.CLEANROOM_CASING.getState(BlockCleanroomCasing.CasingType.PLASCRETE);
     }
 
-    @Nonnull
+    @NotNull
     protected IBlockState getGlassState() {
         return MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.CLEANROOM_GLASS);
     }
 
-    @Nonnull
+    @NotNull
     protected static TraceabilityPredicate doorPredicate() {
         return new TraceabilityPredicate(blockWorldState -> blockWorldState.getBlockState().getBlock() instanceof BlockDoor);
     }
 
-    @Nonnull
+    @NotNull
     protected TraceabilityPredicate innerPredicate() {
         return new TraceabilityPredicate(blockWorldState -> {
             // all non-MetaTileEntities are allowed inside by default
@@ -468,7 +468,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
         this.getFrontOverlay().renderOrientedState(renderState, translation, pipeline, getFrontFacing(), isActive(), isWorkingEnabled());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.CLEANROOM_OVERLAY;
@@ -495,7 +495,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
         return this.cleanAmount >= CLEAN_AMOUNT_THRESHOLD;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation(isClean() ? "gregtech.multiblock.cleanroom.clean_state" : "gregtech.multiblock.cleanroom.dirty_state"));
@@ -608,7 +608,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
     }
 
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound data) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound data) {
         super.writeToNBT(data);
         data.setInteger("lDist", this.lDist);
         data.setInteger("rDist", this.rDist);

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -22,8 +22,8 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
@@ -75,7 +75,7 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
         tooltip.add(I18n.format("gregtech.machine.cracker.tooltip.1"));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.CRACKING_UNIT_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -20,7 +20,7 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.function.Function;
 
@@ -89,7 +89,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.STAINLESS_CLEAN);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.DISTILLATION_TOWER_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -38,8 +38,8 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -87,7 +87,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
     }
 
     @Override
-    public boolean checkRecipe(@Nonnull Recipe recipe, boolean consumeIfSuccess) {
+    public boolean checkRecipe(@NotNull Recipe recipe, boolean consumeIfSuccess) {
         return this.blastFurnaceTemperature >= recipe.getProperty(TemperatureProperty.getInstance(), 0);
     }
 
@@ -128,7 +128,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
         return this.blastFurnaceTemperature;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.BLAST_FURNACE_OVERLAY;
@@ -173,7 +173,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
         return shapeInfo;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = super.getDataInfo();

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
@@ -40,8 +40,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -124,7 +124,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
         return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.STEEL_SOLID);
     }
 
-    @Nonnull
+    @NotNull
     private IBlockState getFrameState() {
         if (tier == GTValues.MV)
             return MetaBlocks.FRAMES.get(Materials.Steel).getBlock(Materials.Steel);
@@ -212,7 +212,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
         return 1;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.FLUID_RIG_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -53,8 +53,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -282,7 +282,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         tooltip.add(I18n.format("gregtech.machine.fusion_reactor.overclocking"));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.FUSION_REACTOR_OVERLAY;
@@ -327,7 +327,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         }
 
         @Override
-        protected boolean checkRecipe(@Nonnull Recipe recipe) {
+        protected boolean checkRecipe(@NotNull Recipe recipe) {
             if (!super.checkRecipe(recipe))
                 return false;
 
@@ -359,7 +359,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         }
 
         @Override
-        public void deserializeNBT(@Nonnull NBTTagCompound compound) {
+        public void deserializeNBT(@NotNull NBTTagCompound compound) {
             super.deserializeNBT(compound);
             heat = compound.getLong("Heat");
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
@@ -14,7 +14,7 @@ import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockController {
 
@@ -48,7 +48,7 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.STEEL_SOLID);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.IMPLOSION_COMPRESSOR_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
@@ -25,8 +25,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -126,7 +126,7 @@ public class MetaTileEntityLargeChemicalReactor extends RecipeMapMultiblockContr
         tooltip.add(I18n.format("gregtech.machine.perfect_oc"));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.LARGE_CHEMICAL_REACTOR_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -54,8 +54,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -188,7 +188,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @NotNull List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.machine.miner.multi.modes"));
         tooltip.add(I18n.format("gregtech.machine.miner.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.miner.multi.tooltip", this.minerLogic.getCurrentRadius() / CHUNK_LENGTH, this.minerLogic.getCurrentRadius() / CHUNK_LENGTH));
@@ -249,7 +249,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
         return MetaBlocks.METAL_CASING.getState(BlockMetalCasing.MetalCasingType.STEEL_SOLID);
     }
 
-    @Nonnull
+    @NotNull
     private IBlockState getFrameState() {
         if (this.material.equals(Materials.Titanium))
             return MetaBlocks.FRAMES.get(Materials.Titanium).getBlock(Materials.Titanium);
@@ -302,7 +302,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
         this.minerLogic.receiveCustomData(dataId, buf);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         if (this.tier == 5)
@@ -438,7 +438,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
         return minerLogic.isActive() && isWorkingEnabled();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation(I18n.format("gregtech.multiblock.large_miner.radius", this.minerLogic.getCurrentRadius())));

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
@@ -23,7 +23,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
@@ -93,7 +93,7 @@ public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
         return Textures.HEAT_PROOF_CASING;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.MULTI_FURNACE_OVERLAY;
@@ -116,7 +116,7 @@ public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
         }
 
         @Override
-        public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
+        public void applyParallelBonus(@NotNull RecipeBuilder<?> builder) {
             builder.EUt(Math.max(1, 16 / heatingCoilDiscount))
                     .duration((int) Math.max(1.0, 256 * builder.getParallel() / (getParallelLimit() * 1.0)));
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -36,8 +36,8 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 import static gregtech.api.recipes.logic.OverclockingLogic.unlockedVoltageOverclockingLogic;
@@ -104,7 +104,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected OrientedOverlayRenderer getFrontOverlay() {
         return tier == 0
@@ -261,7 +261,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
-        protected int[] calculateOverclock(@Nonnull Recipe recipe) {
+        protected int[] calculateOverclock(@NotNull Recipe recipe) {
             int recipeEUt = recipe.getEUt();
             int recipeDuration = recipe.getDuration();
             if (!isAllowOverclocking()) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -22,8 +22,8 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
@@ -63,7 +63,7 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
         return MetaBlocks.MACHINE_CASING.getState(MachineCasingType.ULV);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.PYROLYSE_OVEN_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityVacuumFreezer.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityVacuumFreezer.java
@@ -14,7 +14,7 @@ import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MetaTileEntityVacuumFreezer extends RecipeMapMultiblockController {
     public MetaTileEntityVacuumFreezer(ResourceLocation metaTileEntityId) {
@@ -47,7 +47,7 @@ public class MetaTileEntityVacuumFreezer extends RecipeMapMultiblockController {
         return MetaBlocks.METAL_CASING.getState(MetalCasingType.ALUMINIUM_FROSTPROOF);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.VACUUM_FREEZER_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityCentralMonitor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityCentralMonitor.java
@@ -59,7 +59,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.*;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
@@ -49,8 +49,8 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.*;
 
@@ -407,12 +407,12 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
             }
 
             @Override
-            public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+            public boolean isItemValid(int slot, @NotNull ItemStack stack) {
                 MonitorPluginBaseBehavior behavior = MonitorPluginBaseBehavior.getBehavior(stack);
                 return behavior != null;
             }
 
-            @Nonnull
+            @NotNull
             @Override
             public ItemStack extractItem(int slot, int amount, boolean simulate) {
                 if (!getWorld().isRemote && !getStackInSlot(slot).isEmpty() && !simulate) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -35,8 +35,8 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockController {
@@ -152,7 +152,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         return isExtreme ? Textures.ROBUST_TUNGSTENSTEEL_CASING : Textures.STABLE_TITANIUM_CASING;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return isExtreme ? Textures.EXTREME_COMBUSTION_ENGINE_OVERLAY : Textures.LARGE_COMBUSTION_ENGINE_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -26,8 +26,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityLargeTurbine extends FuelMultiblockController implements ITieredMetaTileEntity {
@@ -175,7 +175,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController impleme
         return casingRenderer;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return frontOverlay;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -25,8 +25,8 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import org.apache.commons.lang3.ArrayUtils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Set;
 
@@ -106,7 +106,7 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
      * @param type the type to add
      */
     @SuppressWarnings("unused")
-    public static void addCleanroomType(@Nonnull CleanroomType type) {
+    public static void addCleanroomType(@NotNull CleanroomType type) {
         CLEANED_TYPES.add(type);
     }
 
@@ -142,7 +142,7 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
             return 0;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Set<CleanroomType> getTypes() {
             return getCleanroomTypes();

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -24,8 +24,8 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IEnergyContainer> {
@@ -65,7 +65,7 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
         checkWeatherOrTerrainExplosion(getTier(), getTier() * 10, energyContainer);
     }
 
-    @Nonnull
+    @NotNull
     private SimpleOverlayRenderer getOverlay() {
         if (isExportHatch) {
             if (amperage <= 2) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -38,7 +38,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank>, IControllable {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -30,7 +30,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IItemHandlerModifiable>, IControllable {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -24,8 +24,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IItemHandlerModifiable> {
@@ -102,10 +102,10 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
             super(1, null, false);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         // Insert item returns the remainder stack that was not inserted
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
 
             // If the item was not valid, nothing from the stack can be inserted
             if (!isItemValid(slot, stack)) {
@@ -159,7 +159,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
         }
 
         @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+        public boolean isItemValid(int slot, @NotNull ItemStack stack) {
 
             boolean slotMatches = this.getStackInSlot(slot).isEmpty() || ItemStackHashStrategy.comparingAllButCount().equals(this.getStackInSlot(slot), stack);
 
@@ -171,7 +171,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
             return slotMatches;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -43,7 +43,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
@@ -30,7 +30,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -32,7 +32,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.function.Supplier;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -24,8 +24,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
@@ -142,11 +142,11 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     }
 
     @Override
-    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+    public void registerAbilities(@NotNull List<IPassthroughHatch> abilityList) {
         abilityList.add(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<IFluidHandler> getPassthroughType() {
         return IFluidHandler.class;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -23,8 +23,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
@@ -143,11 +143,11 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     }
 
     @Override
-    public void registerAbilities(@Nonnull List<IPassthroughHatch> abilityList) {
+    public void registerAbilities(@NotNull List<IPassthroughHatch> abilityList) {
         abilityList.add(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<IItemHandlerModifiable> getPassthroughType() {
         return IItemHandlerModifiable.class;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -33,8 +33,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IRotorHolder>, IRotorHolder {
@@ -62,7 +62,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     }
 
     @Override
-    protected ModularUI createUI(@Nonnull EntityPlayer entityPlayer) {
+    protected ModularUI createUI(@NotNull EntityPlayer entityPlayer) {
         return ModularUI.defaultBuilder()
                 .label(6, 6, getMetaFullName())
                 .slot(inventory, 0, 79, 36, GuiTextures.SLOT, GuiTextures.TURBINE_OVERLAY)
@@ -129,7 +129,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     }
 
     @Override
-    public void registerAbilities(@Nonnull List<IRotorHolder> abilityList) {
+    public void registerAbilities(@NotNull List<IRotorHolder> abilityList) {
         abilityList.add(this);
     }
 
@@ -161,7 +161,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         return true;
     }
 
-    private boolean onRotorHolderInteract(@Nonnull EntityPlayer player) {
+    private boolean onRotorHolderInteract(@NotNull EntityPlayer player) {
         if (player.isCreative())
             return false;
 
@@ -415,11 +415,11 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         }
 
         @Override
-        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+        public boolean isItemValid(int slot, @NotNull ItemStack stack) {
             return TurbineRotorBehavior.getInstanceFor(stack) != null && super.isItemValid(slot, stack);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             ItemStack itemStack = super.extractItem(slot, amount, simulate);

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
@@ -16,7 +16,7 @@ import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import static gregtech.client.renderer.texture.Textures.BRONZE_PLATED_BRICKS;
 import static gregtech.client.renderer.texture.Textures.SOLID_STEEL_CASING;
@@ -57,7 +57,7 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
         return ConfigHolder.machines.steelSteamMultiblocks ? SOLID_STEEL_CASING : BRONZE_PLATED_BRICKS;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.ROCK_BREAKER_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
@@ -20,7 +20,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
 
@@ -159,7 +159,7 @@ public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController 
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected ICubeRenderer getFrontOverlay() {
         return Textures.ELECTRIC_FURNACE_OVERLAY;

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMiner.java
@@ -46,8 +46,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -318,7 +318,7 @@ public class SteamMiner extends MetaTileEntity implements IMiner, IControllable,
         return ventingStuck;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation(I18n.format("gregtech.multiblock.large_miner.radius", this.minerLogic.getCurrentRadius())));

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -44,8 +44,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -341,7 +341,7 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
         clearInventory(itemBuffer, containerInventory);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation("gregtech.machine.steam_boiler.heat_amount", GTUtility.formatNumbers((int) (this.getTemperaturePercent() * 100))));

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -77,9 +77,9 @@ public class SteamCoalBoiler extends SteamBoiler implements IFuelable {
     @Override
     public IItemHandlerModifiable createImportItemHandler() {
         return new ItemStackHandler(1) {
-            @Nonnull
+            @NotNull
             @Override
-            public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+            public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
                 if (TileEntityFurnace.getItemBurnTime(stack) <= 0)
                     return stack;
                 return super.insertItem(slot, stack, simulate);

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
@@ -35,7 +35,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidTank> {

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamItemBus.java
@@ -22,7 +22,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntitySteamItemBus extends MetaTileEntityItemBus implements IMultiblockAbilityPart<IItemHandlerModifiable> {

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeMemory.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeMemory.java
@@ -9,7 +9,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityBuffer.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityBuffer.java
@@ -27,7 +27,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityBuffer extends MetaTileEntity implements ITieredMetaTileEntity {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
@@ -27,7 +27,7 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class MetaTileEntityCrate extends MetaTileEntity {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
@@ -44,7 +44,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Random;
 import java.util.function.DoubleSupplier;
@@ -65,9 +65,9 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
     private long unlockComponentsSeed = 0L;
     private final ItemStackHandler unlockComponents = new ItemStackHandler(2);
     private final ItemStackHandler unlockInventory = new ItemStackHandler(2) {
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
             int maxStackSize = canPutUnlockItemInSlot(slot, stack);
             if (maxStackSize == 0) return stack;
             int maxAmount = Math.min(maxStackSize, stack.getCount());

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -45,8 +45,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -207,7 +207,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     protected IItemHandlerModifiable createImportItemHandler() {
         return new ItemStackHandler(1) {
             @Override
-            public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+            public boolean isItemValid(int slot, @NotNull ItemStack stack) {
                 NBTTagCompound compound = stack.getTagCompound();
                 if (compound == null) return true;
                 return !(compound.hasKey(NBT_ITEMSTACK, NBT.TAG_COMPOUND) || compound.hasKey("Fluid", NBT.TAG_COMPOUND)); //prevents inserting items with NBT to the Quantum Chest
@@ -441,7 +441,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             return 1;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack getStackInSlot(int slot) {
             ItemStack itemStack = MetaTileEntityQuantumChest.this.itemStack;
@@ -459,7 +459,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             return (int) MetaTileEntityQuantumChest.this.maxStoredItems;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             int extractedAmount = (int) Math.min(amount, itemsStoredInside);
@@ -477,9 +477,9 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             return extractedStack;
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
 
             if (stack.isEmpty()) {
                 return ItemStack.EMPTY;

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -42,7 +42,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_AUTO_OUTPUT_FLUIDS;

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -39,7 +39,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -88,7 +88,7 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs itemIn, @Nonnull NonNullList<ItemStack> items) {
+    public void getSubBlocks(@NotNull CreativeTabs itemIn, @NotNull NonNullList<ItemStack> items) {
         for (Material material : enabledMaterials.keySet()) {
             items.add(getItem(material));
         }
@@ -131,7 +131,7 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     @Override
-    public void breakBlock(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public void breakBlock(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state) {
         if (worldIn.isRemote) {
             TileEntityCable cable = (TileEntityCable) getPipeTileEntity(worldIn, pos);
             cable.killParticle();
@@ -159,7 +159,7 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     }
 
     @Override
-    public void onEntityCollision(World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Entity entityIn) {
+    public void onEntityCollision(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull Entity entityIn) {
         if (worldIn.isRemote) return;
         Insulation insulation = getPipeTileEntity(worldIn, pos).getPipeType();
         if (insulation.insulationLevel == -1 && entityIn instanceof EntityLivingBase) {
@@ -184,11 +184,11 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
         return stack.hasCapability(GregtechCapabilities.CAPABILITY_CUTTER, null);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("deprecation")
-    public EnumBlockRenderType getRenderType(@Nonnull IBlockState state) {
+    public EnumBlockRenderType getRenderType(@NotNull IBlockState state) {
         return CableRenderer.INSTANCE.getBlockRenderType();
     }
 

--- a/src/main/java/gregtech/common/pipelike/cable/Insulation.java
+++ b/src/main/java/gregtech/common/pipelike/cable/Insulation.java
@@ -4,7 +4,7 @@ import gregtech.api.pipenet.block.material.IMaterialPipeType;
 import gregtech.api.unification.material.properties.WireProperties;
 import gregtech.api.unification.ore.OrePrefix;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum Insulation implements IMaterialPipeType<WireProperties> {
 
@@ -36,7 +36,7 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
         this.lossMultiplier = lossMultiplier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return name;

--- a/src/main/java/gregtech/common/pipelike/cable/ItemBlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/ItemBlockCable.java
@@ -12,8 +12,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class ItemBlockCable extends ItemBlockMaterialPipe<Insulation, WireProperties> {
@@ -24,7 +24,7 @@ public class ItemBlockCable extends ItemBlockMaterialPipe<Insulation, WireProper
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World worldIn, @NotNull List<String> tooltip, @NotNull ITooltipFlag flagIn) {
         WireProperties wireProperties = blockPipe.createItemProperties(stack);
         int tier = GTUtility.getTierByVoltage(wireProperties.getVoltage());
         if (wireProperties.isSuperconductor()) tooltip.add(I18n.format("gregtech.cable.superconductor", GTValues.VN[tier]));

--- a/src/main/java/gregtech/common/pipelike/cable/net/EnergyNetWalker.java
+++ b/src/main/java/gregtech/common/pipelike/cable/net/EnergyNetWalker.java
@@ -11,7 +11,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.apache.commons.lang3.ArrayUtils;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/gregtech/common/pipelike/cable/tile/TileEntityCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/tile/TileEntityCable.java
@@ -32,8 +32,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -319,21 +319,21 @@ public class TileEntityCable extends TileEntityMaterialPipeBase<Insulation, Wire
         return pipeBoxes;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound compound) {
         super.writeToNBT(compound);
         compound.setInteger("Temp", temperature);
         return compound;
     }
 
     @Override
-    public void readFromNBT(@Nonnull NBTTagCompound compound) {
+    public void readFromNBT(@NotNull NBTTagCompound compound) {
         super.readFromNBT(compound);
         temperature = compound.getInteger("Temp");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = new ArrayList<>();

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -31,7 +31,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.SortedMap;
@@ -78,14 +78,14 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs itemIn, @Nonnull NonNullList<ItemStack> items) {
+    public void getSubBlocks(@NotNull CreativeTabs itemIn, @NotNull NonNullList<ItemStack> items) {
         for (Material material : enabledMaterials.keySet()) {
             items.add(getItem(material));
         }
     }
 
     @Override
-    public void breakBlock(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
+    public void breakBlock(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state) {
         super.breakBlock(worldIn, pos, state);
         //TODO insert to neighbours
     }
@@ -110,7 +110,7 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
     }
 
     @Override
-    public void onEntityCollision(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Entity entityIn) {
+    public void onEntityCollision(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state, @NotNull Entity entityIn) {
         if (worldIn.isRemote) return;
         TileEntityFluidPipe pipe = (TileEntityFluidPipe) getPipeTileEntity(worldIn, pos);
         if (pipe instanceof TileEntityFluidPipeTickable && pipe.getFrameMaterial() == null && ((TileEntityFluidPipeTickable) pipe).getOffsetTimer() % 10 == 0) {
@@ -148,10 +148,10 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
     }
 
     @Override
-    @Nonnull
+    @NotNull
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("deprecation")
-    public EnumBlockRenderType getRenderType(@Nonnull IBlockState state) {
+    public EnumBlockRenderType getRenderType(@NotNull IBlockState state) {
         return FluidPipeRenderer.INSTANCE.getBlockRenderType();
     }
 

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/FluidPipeType.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/FluidPipeType.java
@@ -4,7 +4,7 @@ import gregtech.api.pipenet.block.material.IMaterialPipeType;
 import gregtech.api.unification.material.properties.FluidPipeProperties;
 import gregtech.api.unification.ore.OrePrefix;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum FluidPipeType implements IMaterialPipeType<FluidPipeProperties> {
 
@@ -37,7 +37,7 @@ public enum FluidPipeType implements IMaterialPipeType<FluidPipeProperties> {
         this.channels = channels;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return name;

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/ItemBlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/ItemBlockFluidPipe.java
@@ -12,8 +12,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.input.Keyboard;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class ItemBlockFluidPipe extends ItemBlockMaterialPipe<FluidPipeType, FluidPipeProperties> {
@@ -24,7 +24,7 @@ public class ItemBlockFluidPipe extends ItemBlockMaterialPipe<FluidPipeType, Flu
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World worldIn, @NotNull List<String> tooltip, @NotNull ITooltipFlag flagIn) {
         super.addInformation(stack, worldIn, tooltip, flagIn);
         FluidPipeProperties pipeProperties = blockPipe.createItemProperties(stack);
         tooltip.add(I18n.format("gregtech.fluid_pipe.throughput", pipeProperties.getThroughput()));

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/net/PipeTankList.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/net/PipeTankList.java
@@ -9,8 +9,8 @@ import net.minecraftforge.fluids.capability.FluidTankPropertiesWrapper;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -119,7 +119,7 @@ public class PipeTankList implements IFluidHandler, Iterable<FluidTank> {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public Iterator<FluidTank> iterator() {
         return Arrays.stream(tanks).iterator();
     }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -31,8 +31,8 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import org.apache.commons.lang3.tuple.MutableTriple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -167,7 +167,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
         }
     }
 
-    public void checkAndDestroy(@Nonnull FluidStack stack) {
+    public void checkAndDestroy(@NotNull FluidStack stack) {
         Fluid fluid = stack.getFluid();
         boolean burning = getNodeData().getMaxFluidTemperature() < fluid.getTemperature(stack);
         boolean leaking = !getNodeData().isGasProof() && fluid.isGaseous(stack);
@@ -343,9 +343,9 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
         return fluids;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound nbt) {
+    public NBTTagCompound writeToNBT(@NotNull NBTTagCompound nbt) {
         super.writeToNBT(nbt);
         NBTTagList list = new NBTTagList();
         for (int i = 0; i < getFluidTanks().length; i++) {
@@ -362,7 +362,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
     }
 
     @Override
-    public void readFromNBT(@Nonnull NBTTagCompound nbt) {
+    public void readFromNBT(@NotNull NBTTagCompound nbt) {
         super.readFromNBT(nbt);
         NBTTagList list = (NBTTagList) nbt.getTag("Fluids");
         createTanksList();
@@ -374,7 +374,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<ITextComponent> getDataInfo() {
         List<ITextComponent> list = new ArrayList<>();

--- a/src/main/java/gregtech/common/pipelike/itempipe/BlockItemPipe.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/BlockItemPipe.java
@@ -27,7 +27,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,7 +84,7 @@ public class BlockItemPipe extends BlockMaterialPipe<ItemPipeType, ItemPipePrope
     }
 
     @Override
-    public void getSubBlocks(@Nonnull CreativeTabs itemIn, @Nonnull NonNullList<ItemStack> items) {
+    public void getSubBlocks(@NotNull CreativeTabs itemIn, @NotNull NonNullList<ItemStack> items) {
         for (Material material : enabledMaterials.keySet()) {
             items.add(getItem(material));
         }
@@ -115,10 +115,10 @@ public class BlockItemPipe extends BlockMaterialPipe<ItemPipeType, ItemPipePrope
     }
 
     @Override
-    @Nonnull
+    @NotNull
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("deprecation")
-    public EnumBlockRenderType getRenderType(@Nonnull IBlockState state) {
+    public EnumBlockRenderType getRenderType(@NotNull IBlockState state) {
         return ItemPipeRenderer.INSTANCE.getBlockRenderType();
     }
 

--- a/src/main/java/gregtech/common/pipelike/itempipe/ItemBlockItemPipe.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/ItemBlockItemPipe.java
@@ -10,8 +10,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class ItemBlockItemPipe extends ItemBlockMaterialPipe<ItemPipeType, ItemPipeProperties> {
@@ -22,7 +22,7 @@ public class ItemBlockItemPipe extends ItemBlockMaterialPipe<ItemPipeType, ItemP
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn) {
+    public void addInformation(@NotNull ItemStack stack, @Nullable World worldIn, @NotNull List<String> tooltip, @NotNull ITooltipFlag flagIn) {
         ItemPipeProperties pipeProperties = blockPipe.createItemProperties(stack);
         if (pipeProperties.getTransferRate() % 1 != 0)
             tooltip.add(I18n.format("gregtech.item_pipe.rate_items", (int) ((pipeProperties.getTransferRate() * 64) + 0.5)));

--- a/src/main/java/gregtech/common/pipelike/itempipe/ItemPipeType.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/ItemPipeType.java
@@ -4,7 +4,7 @@ import gregtech.api.pipenet.block.material.IMaterialPipeType;
 import gregtech.api.unification.material.properties.ItemPipeProperties;
 import gregtech.api.unification.ore.OrePrefix;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum ItemPipeType implements IMaterialPipeType<ItemPipeProperties> {
     //TINY_OPAQUE("tiny", 0.25f, OrePrefix.pipeTinyItem, 0.25f, 2f),
@@ -62,7 +62,7 @@ public enum ItemPipeType implements IMaterialPipeType<ItemPipeProperties> {
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName() {
         return name;

--- a/src/main/java/gregtech/common/pipelike/itempipe/net/ItemNetHandler.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/net/ItemNetHandler.java
@@ -18,7 +18,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public class ItemNetHandler implements IItemHandler {
@@ -53,9 +53,9 @@ public class ItemNetHandler implements IItemHandler {
         simulatedTransfersGlobalRoundRobin.putAll(pipe.getTransferred());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
         if (stack.isEmpty()) return stack;
         // only set pipe to ticking when something is inserted
         if (tickingPipe == null) {
@@ -423,13 +423,13 @@ public class ItemNetHandler implements IItemHandler {
         return 1;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack getStackInSlot(int i) {
         return ItemStack.EMPTY;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         return ItemStack.EMPTY;

--- a/src/main/java/gregtech/common/pipelike/itempipe/net/ItemNetWalker.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/net/ItemNetWalker.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;

--- a/src/main/java/gregtech/common/pipelike/itempipe/tile/TileEntityItemPipe.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/tile/TileEntityItemPipe.java
@@ -14,7 +14,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.EnumMap;
 import java.util.HashMap;

--- a/src/main/java/gregtech/common/terminal/app/prospector/ProspectingTexture.java
+++ b/src/main/java/gregtech/common/terminal/app/prospector/ProspectingTexture.java
@@ -13,7 +13,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;

--- a/src/main/java/gregtech/common/terminal/hardware/BatteryHardware.java
+++ b/src/main/java/gregtech/common/terminal/hardware/BatteryHardware.java
@@ -13,8 +13,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -151,13 +151,13 @@ public class BatteryHardware extends Hardware implements IElectricItem, IHardwar
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability) {
+    public boolean hasCapability(@NotNull Capability<?> capability) {
         return capability == GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM;
     }
 
     @Nullable
     @Override
-    public <T> T getCapability(@Nonnull Capability<T> capability) {
+    public <T> T getCapability(@NotNull Capability<T> capability) {
         return capability == GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM ? GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM.cast(this) : null;
     }
 

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -17,7 +17,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorldEventListener;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/gregtech/common/worldgen/AbstractItemLootEntry.java
+++ b/src/main/java/gregtech/common/worldgen/AbstractItemLootEntry.java
@@ -9,7 +9,7 @@ import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraft.world.storage.loot.conditions.LootConditionManager;
 import net.minecraft.world.storage.loot.functions.LootFunction;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.Random;
 
@@ -25,7 +25,7 @@ public abstract class AbstractItemLootEntry extends LootEntry {
     protected abstract ItemStack createItemStack();
 
     @Override
-    public void addLoot(@Nonnull Collection<ItemStack> stacks, @Nonnull Random rand, @Nonnull LootContext context) {
+    public void addLoot(@NotNull Collection<ItemStack> stacks, @NotNull Random rand, @NotNull LootContext context) {
         ItemStack itemStack = createItemStack();
         for (LootFunction lootfunction : this.functions) {
             if (LootConditionManager.testAllConditions(lootfunction.getConditions(), rand, context)) {
@@ -49,7 +49,7 @@ public abstract class AbstractItemLootEntry extends LootEntry {
     }
 
     @Override
-    protected final void serialize(@Nonnull JsonObject json, @Nonnull JsonSerializationContext context) {
+    protected final void serialize(@NotNull JsonObject json, @NotNull JsonSerializationContext context) {
         throw new UnsupportedOperationException("Unsupported by custom loot entries");
     }
 }

--- a/src/main/java/gregtech/common/worldgen/WorldGenRubberTree.java
+++ b/src/main/java/gregtech/common/worldgen/WorldGenRubberTree.java
@@ -11,7 +11,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.SaplingGrowTreeEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Random;
 
 import static gregtech.common.blocks.wood.BlockRubberLog.NATURAL;
@@ -26,11 +26,11 @@ public class WorldGenRubberTree extends WorldGenerator {
     }
 
     @Override
-    public boolean generate(@Nonnull World world, @Nonnull Random random, @Nonnull BlockPos pos) {
+    public boolean generate(@NotNull World world, @NotNull Random random, @NotNull BlockPos pos) {
         return generateImpl(world, random, new BlockPos.MutableBlockPos(pos));
     }
 
-    public boolean generateImpl(@Nonnull World world, @Nonnull Random random, BlockPos.MutableBlockPos pos) {
+    public boolean generateImpl(@NotNull World world, @NotNull Random random, BlockPos.MutableBlockPos pos) {
         pos.setPos(pos.getX() + 8, world.getHeight() - 1, pos.getZ() + 8);
         while (pos.getY() > 0 && world.isAirBlock(pos)) {
             pos.setY(pos.getY() - 1);

--- a/src/main/java/gregtech/core/GregTechLoadingPlugin.java
+++ b/src/main/java/gregtech/core/GregTechLoadingPlugin.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.Name;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 
 @Name("GregTechLoadingPlugin")

--- a/src/main/java/gregtech/core/hooks/BlockHooks.java
+++ b/src/main/java/gregtech/core/hooks/BlockHooks.java
@@ -7,14 +7,14 @@ import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.WeightedBakedModel;
 import net.minecraft.util.BlockRenderLayer;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unused")
 public class BlockHooks {
 
     public static boolean ENABLE = true;
 
-    public static Boolean canRenderInLayer(@Nonnull IBlockState state, @Nonnull BlockRenderLayer layer) {
+    public static Boolean canRenderInLayer(@NotNull IBlockState state, @NotNull BlockRenderLayer layer) {
         if (ENABLE) {
             IBakedModel model = Minecraft.getMinecraft().getBlockRendererDispatcher().getModelForState(state);
             if (model instanceof WeightedBakedModel) {

--- a/src/main/java/gregtech/core/hooks/RenderChunkHooks.java
+++ b/src/main/java/gregtech/core/hooks/RenderChunkHooks.java
@@ -5,7 +5,7 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused")
 public class RenderChunkHooks {

--- a/src/main/java/gregtech/core/util/ObfMapping.java
+++ b/src/main/java/gregtech/core/util/ObfMapping.java
@@ -13,7 +13,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.tree.*;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -344,7 +344,7 @@ public class ObfMapping extends Remapper {
         }
 
         @Override
-        public boolean processLine(@Nonnull String line) {
+        public boolean processLine(@NotNull String line) {
             int i = line.indexOf(',');
             String srg = line.substring(0, i);
             int i2 = i + 1;

--- a/src/main/java/gregtech/integration/ctm/IFacadeWrapper.java
+++ b/src/main/java/gregtech/integration/ctm/IFacadeWrapper.java
@@ -8,16 +8,16 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.Optional;
 import team.chisel.ctm.api.IFacade;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @Optional.Interface(modid = GTValues.MODID_CTM, iface = "team.chisel.ctm.api.IFacade")
 public interface IFacadeWrapper extends IFacade {
 
-    @Nonnull
+    @NotNull
     @Override
-    IBlockState getFacade(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, EnumFacing side);
+    IBlockState getFacade(@NotNull IBlockAccess world, @NotNull BlockPos pos, EnumFacing side);
 
-    @Nonnull
+    @NotNull
     @Override
-    IBlockState getFacade(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, EnumFacing side, @Nonnull BlockPos connection);
+    IBlockState getFacade(@NotNull IBlockAccess world, @NotNull BlockPos pos, EnumFacing side, @NotNull BlockPos connection);
 }

--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -43,7 +43,7 @@ import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
@@ -59,12 +59,12 @@ public class GTJeiPlugin implements IModPlugin {
     public static IGuiHelper guiHelper;
 
     @Override
-    public void onRuntimeAvailable(@Nonnull IJeiRuntime jeiRuntime) {
+    public void onRuntimeAvailable(@NotNull IJeiRuntime jeiRuntime) {
         GTJeiPlugin.jeiRuntime = jeiRuntime;
     }
 
     @Override
-    public void registerItemSubtypes(@Nonnull ISubtypeRegistry subtypeRegistry) {
+    public void registerItemSubtypes(@NotNull ISubtypeRegistry subtypeRegistry) {
         MetaItemSubtypeHandler subtype = new MetaItemSubtypeHandler();
         for (MetaItem<?> metaItem : MetaItems.ITEMS) {
             subtypeRegistry.registerSubtypeInterpreter(metaItem, subtype);

--- a/src/main/java/gregtech/integration/jei/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/GTOreCategory.java
@@ -19,7 +19,7 @@ import net.minecraft.world.DimensionType;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.common.Loader;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -53,7 +53,7 @@ public class GTOreCategory extends BasicRecipeCategory<GTOreInfo, GTOreInfo> {
 
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, GTOreInfo recipeWrapper, @Nonnull IIngredients ingredients) {
+    public void setRecipe(IRecipeLayout recipeLayout, GTOreInfo recipeWrapper, @NotNull IIngredients ingredients) {
 
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         int baseYPos = 19;
@@ -83,14 +83,14 @@ public class GTOreCategory extends BasicRecipeCategory<GTOreInfo, GTOreInfo> {
         definition = recipeWrapper.getDefinition();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IRecipeWrapper getRecipeWrapper(@Nonnull GTOreInfo recipe) {
+    public IRecipeWrapper getRecipeWrapper(@NotNull GTOreInfo recipe) {
         return recipe;
     }
 
     @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
+    public void drawExtras(@NotNull Minecraft minecraft) {
 
         int baseXPos = 70;
         int baseYPos = 19;

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
@@ -13,7 +13,7 @@ import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.gui.recipes.RecipeLayout;
 import net.minecraft.client.resources.I18n;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,25 +40,25 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
         registry.addRecipes(REGISTER.stream().map(MultiblockInfoRecipeWrapper::new).collect(Collectors.toList()), "gregtech:multiblock_info");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getUid() {
         return "gregtech:multiblock_info";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getTitle() {
         return I18n.format("gregtech.multiblock.title");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getModName() {
         return GTValues.MODID;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IDrawable getBackground() {
         return background;
@@ -70,7 +70,7 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
     }
 
     @Override
-    public void setRecipe(@Nonnull IRecipeLayout recipeLayout, MultiblockInfoRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+    public void setRecipe(@NotNull IRecipeLayout recipeLayout, MultiblockInfoRecipeWrapper recipeWrapper, @NotNull IIngredients ingredients) {
         recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout, this.guiHelper);
     }
 }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -57,7 +57,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import javax.vecmath.Vector3f;
 import java.util.*;
 import java.util.Map.Entry;
@@ -114,7 +114,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     private TraceabilityPredicate father;
 
     @SuppressWarnings("NewExpressionSideOnly")
-    public MultiblockInfoRecipeWrapper(@Nonnull MultiblockControllerBase controller) {
+    public MultiblockInfoRecipeWrapper(@NotNull MultiblockControllerBase controller) {
         this.controller = controller;
         Set<ItemStackKey> drops = new ObjectOpenHashSet<>();
         this.patterns = controller.getMatchingShapes().stream()
@@ -265,7 +265,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     }
 
     @Override
-    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+    public void drawInfo(@NotNull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         WorldSceneRenderer renderer = getCurrentRenderer();
         int sceneHeight = recipeHeight - PARTS_HEIGHT;
 
@@ -372,7 +372,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     }
 
     @Override
-    public boolean handleClick(@Nonnull Minecraft minecraft, int mouseX, int mouseY, int mouseButton) {
+    public boolean handleClick(@NotNull Minecraft minecraft, int mouseX, int mouseY, int mouseButton) {
         for (Entry<GuiButton, Runnable> button : buttons.entrySet()) {
             if (button.getKey().mousePressed(minecraft, mouseX, mouseY)) {
                 button.getValue().run();
@@ -430,7 +430,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<String> getTooltipStrings(int mouseX, int mouseY) {
         if (drawInfoIcon) {
@@ -481,8 +481,8 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         }
     }
 
-    @Nonnull
-    private Collection<PartInfo> gatherStructureBlocks(World world, @Nonnull Map<BlockPos, BlockInfo> blocks, Set<ItemStackKey> parts) {
+    @NotNull
+    private Collection<PartInfo> gatherStructureBlocks(World world, @NotNull Map<BlockPos, BlockInfo> blocks, Set<ItemStackKey> parts) {
         Map<ItemStackKey, PartInfo> partsMap = new HashMap<>();
         for (Entry<BlockPos, BlockInfo> entry : blocks.entrySet()) {
             BlockPos pos = entry.getKey();
@@ -533,8 +533,8 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     }
 
     @SuppressWarnings("NewExpressionSideOnly")
-    @Nonnull
-    private MBPattern initializePattern(@Nonnull MultiblockShapeInfo shapeInfo, @Nonnull Set<ItemStackKey> parts) {
+    @NotNull
+    private MBPattern initializePattern(@NotNull MultiblockShapeInfo shapeInfo, @NotNull Set<ItemStackKey> parts) {
         Map<BlockPos, BlockInfo> blockMap = new HashMap<>();
         MultiblockControllerBase controllerBase = null;
         BlockInfo[][][] blocks = shapeInfo.getBlocks();

--- a/src/main/java/gregtech/integration/jei/recipe/FacadeRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/FacadeRecipeWrapper.java
@@ -8,7 +8,7 @@ import mezz.jei.api.recipe.wrapper.ICraftingRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class FacadeRecipeWrapper implements ICraftingRecipeWrapper {
 

--- a/src/main/java/gregtech/integration/jei/recipe/FacadeRegistryPlugin.java
+++ b/src/main/java/gregtech/integration/jei/recipe/FacadeRegistryPlugin.java
@@ -14,13 +14,13 @@ import mezz.jei.api.recipe.IFocus.Mode;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 
 public class FacadeRegistryPlugin implements IRecipeRegistryPlugin {
 
-    @Nonnull
+    @NotNull
     @Override
     public <V> List<String> getRecipeCategoryUids(IFocus<V> focus) {
         if (focus.getValue() instanceof ItemStack) {
@@ -40,9 +40,9 @@ public class FacadeRegistryPlugin implements IRecipeRegistryPlugin {
         return Collections.emptyList();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public <T extends IRecipeWrapper, V> List<T> getRecipeWrappers(IRecipeCategory<T> recipeCategory, @Nonnull IFocus<V> focus) {
+    public <T extends IRecipeWrapper, V> List<T> getRecipeWrappers(IRecipeCategory<T> recipeCategory, @NotNull IFocus<V> focus) {
         if (!VanillaRecipeCategoryUid.CRAFTING.equals(recipeCategory.getUid())) {
             return Collections.emptyList();
         }
@@ -76,9 +76,9 @@ public class FacadeRegistryPlugin implements IRecipeRegistryPlugin {
                 OreDictUnifier.get(OrePrefix.plate, material), itemStackCopy);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public <T extends IRecipeWrapper> List<T> getRecipeWrappers(@Nonnull IRecipeCategory<T> recipeCategory) {
+    public <T extends IRecipeWrapper> List<T> getRecipeWrappers(@NotNull IRecipeCategory<T> recipeCategory) {
         return Collections.emptyList();
     }
 }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -25,7 +25,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.oredict.OreDictionary;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
@@ -47,7 +47,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     }
 
     @Override
-    public void getIngredients(@Nonnull IIngredients ingredients) {
+    public void getIngredients(@NotNull IIngredients ingredients) {
 
         // Inputs
         if (!recipe.getInputs().isEmpty()) {
@@ -119,7 +119,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     }
 
     @Override
-    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+    public void drawInfo(@NotNull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         super.drawInfo(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
         int yPosition = recipeHeight - getPropertyListHeight();
         if (!recipe.hasProperty(PrimitiveProperty.getInstance())) {

--- a/src/main/java/gregtech/integration/jei/recipe/IntCircuitCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/IntCircuitCategory.java
@@ -29,7 +29,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Iterator;
 import java.util.function.Supplier;

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -28,8 +28,8 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 
@@ -66,13 +66,13 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getUid() {
         return GTValues.MODID + ":" + recipeMap.unlocalizedName;
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getTitle() {
         return recipeMap.getLocalizedName();
     }
@@ -97,19 +97,19 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public String getModName() {
         return GTValues.MODID;
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public IDrawable getBackground() {
         return backgroundDrawable;
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, @Nonnull GTRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+    public void setRecipe(IRecipeLayout recipeLayout, @NotNull GTRecipeWrapper recipeWrapper, @NotNull IIngredients ingredients) {
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStackGroup = recipeLayout.getFluidStacks();
         for (Widget uiWidget : modularUI.guiWidgets.values()) {
@@ -182,7 +182,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     }
 
     @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
+    public void drawExtras(@NotNull Minecraft minecraft) {
         for (Widget widget : modularUI.guiWidgets.values()) {
             if (widget instanceof ProgressWidget) widget.detectAndSendChanges();
             widget.drawInBackground(0, 0, minecraft.getRenderPartialTicks(), new IRenderContext() {
@@ -195,12 +195,12 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
         return categoryMap;
     }
 
-    private static boolean shouldShiftWidgets(@Nonnull RecipeMap<?> recipeMap) {
+    private static boolean shouldShiftWidgets(@NotNull RecipeMap<?> recipeMap) {
         return recipeMap.getMaxInputs() + recipeMap.getMaxOutputs() >= 6 ||
                 recipeMap.getMaxFluidInputs() + recipeMap.getMaxFluidOutputs() >= 6;
     }
 
-    private static int getPropertyShiftAmount(@Nonnull RecipeMap<?> recipeMap) {
+    private static int getPropertyShiftAmount(@NotNull RecipeMap<?> recipeMap) {
         int maxPropertyCount = 0;
         if (shouldShiftWidgets(recipeMap)) {
             for (Recipe recipe : recipeMap.getRecipeList()) {

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/BasicRecipeCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/BasicRecipeCategory.java
@@ -9,8 +9,8 @@ import mezz.jei.api.recipe.IRecipeWrapperFactory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,35 +32,35 @@ public abstract class BasicRecipeCategory<T, W extends IRecipeWrapper> implement
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getUid() {
         return getModName() + ":" + uniqueName;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getTitle() {
         return localizedName;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IDrawable getBackground() {
         return background;
     }
 
     @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
+    public void drawExtras(@NotNull Minecraft minecraft) {
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<String> getTooltipStrings(int mouseX, int mouseY) {
         return Collections.emptyList();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getModName() {
         return GTValues.MODID;

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTreeCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTreeCategory.java
@@ -21,8 +21,8 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -124,7 +124,7 @@ public class MaterialTreeCategory extends BasicRecipeCategory<MaterialTree, Mate
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, @Nonnull MaterialTree recipeWrapper, IIngredients ingredients) {
+    public void setRecipe(IRecipeLayout recipeLayout, @NotNull MaterialTree recipeWrapper, IIngredients ingredients) {
         // place and check existence of items
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         List<List<ItemStack>> itemInputs = ingredients.getInputs(VanillaTypes.ITEM);
@@ -155,9 +155,9 @@ public class MaterialTreeCategory extends BasicRecipeCategory<MaterialTree, Mate
         materialAvgN = I18n.format("gregtech.jei.materials.average_neutrons", recipeWrapper.getAvgN());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IRecipeWrapper getRecipeWrapper(@Nonnull MaterialTree recipe) {
+    public IRecipeWrapper getRecipeWrapper(@NotNull MaterialTree recipe) {
         return recipe;
     }
 
@@ -168,7 +168,7 @@ public class MaterialTreeCategory extends BasicRecipeCategory<MaterialTree, Mate
     }
 
     @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
+    public void drawExtras(@NotNull Minecraft minecraft) {
         // item slot rendering
         for (int i = 0; i < ITEM_LOCATIONS.size(); i += 2) {
             if (itemExists.get(i / 2))

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProductCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProductCategory.java
@@ -21,8 +21,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -130,7 +130,7 @@ public class OreByProductCategory extends BasicRecipeCategory<OreByProduct, OreB
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, @Nonnull OreByProduct recipeWrapper, @Nonnull IIngredients ingredients) {
+    public void setRecipe(IRecipeLayout recipeLayout, @NotNull OreByProduct recipeWrapper, @NotNull IIngredients ingredients) {
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStackGroup = recipeLayout.getFluidStacks();
 
@@ -165,9 +165,9 @@ public class OreByProductCategory extends BasicRecipeCategory<OreByProduct, OreB
         hasSifter = recipeWrapper.hasSifter();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public IRecipeWrapper getRecipeWrapper(@Nonnull OreByProduct recipe) {
+    public IRecipeWrapper getRecipeWrapper(@NotNull OreByProduct recipe) {
         return recipe;
     }
 
@@ -178,7 +178,7 @@ public class OreByProductCategory extends BasicRecipeCategory<OreByProduct, OreB
     }
 
     @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
+    public void drawExtras(@NotNull Minecraft minecraft) {
         arrowsBase.draw(minecraft, 0, 0);
         if (hasDirectSmelt) {
             arrowsDirectSmelt.draw(minecraft, 0, 0);

--- a/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
@@ -8,7 +8,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.client.config.GuiUtils;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +23,7 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
     public abstract void initExtras();
 
     @Override
-    public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+    public void drawInfo(@NotNull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         for (JeiButton button : buttons) {
             button.render(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
             if (button.isHovering(mouseX, mouseY)) {
@@ -43,7 +43,7 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
     }
 
     @Override
-    public boolean handleClick(@Nonnull Minecraft minecraft, int mouseX, int mouseY, int mouseButton) {
+    public boolean handleClick(@NotNull Minecraft minecraft, int mouseX, int mouseY, int mouseButton) {
         for (JeiButton button : buttons) {
             if (button.isHovering(mouseX, mouseY) && button.getClickAction().click(minecraft, mouseX, mouseY, mouseButton)) {
                 Minecraft.getMinecraft().getSoundHandler().playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));

--- a/src/main/java/gregtech/integration/jei/utils/MachineSubtypeHandler.java
+++ b/src/main/java/gregtech/integration/jei/utils/MachineSubtypeHandler.java
@@ -5,12 +5,12 @@ import gregtech.api.util.GTUtility;
 import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MachineSubtypeHandler implements ISubtypeInterpreter {
-    @Nonnull
+    @NotNull
     @Override
-    public String apply(@Nonnull ItemStack itemStack) {
+    public String apply(@NotNull ItemStack itemStack) {
         String additionalData = "";
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(itemStack);
         if (metaTileEntity != null) {

--- a/src/main/java/gregtech/integration/jei/utils/MetaItemSubtypeHandler.java
+++ b/src/main/java/gregtech/integration/jei/utils/MetaItemSubtypeHandler.java
@@ -5,10 +5,10 @@ import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MetaItemSubtypeHandler implements ISubtypeInterpreter {
-    @Nonnull
+    @NotNull
     @Override
     public String apply(ItemStack itemStack) {
         MetaItem<?> metaItem = (MetaItem<?>) itemStack.getItem();

--- a/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
+++ b/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
@@ -14,8 +14,8 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import net.minecraft.entity.player.EntityPlayer;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.awt.*;
 import java.util.List;
 import java.util.*;
@@ -34,13 +34,13 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
         this.validHandlers = validHandlers;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<ModularUIGui> getGuiContainerClass() {
         return ModularUIGui.class;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Class<ModularUIContainer> getContainerClass() {
         return ModularUIContainer.class;
@@ -48,7 +48,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
 
     @Nullable
     @Override
-    public IRecipeTransferError transferRecipe(ModularUIContainer container, @Nonnull IRecipeLayout recipeLayout, @Nonnull EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
+    public IRecipeTransferError transferRecipe(ModularUIContainer container, @NotNull IRecipeLayout recipeLayout, @NotNull EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
         Optional<IRecipeTransferHandlerWidget> transferHandler = container.getModularUI()
                 .getFlatVisibleWidgetCollection().stream()
                 .filter(it -> it instanceof IRecipeTransferHandlerWidget)
@@ -80,9 +80,9 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public <I> List<Target<I>> getTargets(ModularUIGui gui, @Nonnull I ingredient, boolean doStart) {
+    public <I> List<Target<I>> getTargets(ModularUIGui gui, @NotNull I ingredient, boolean doStart) {
         Collection<Widget> widgets = gui.getModularUI().guiWidgets.values();
         List<Target<I>> targets = new ArrayList<>();
         for (Widget widget : widgets) {
@@ -98,7 +98,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
 
     @Nullable
     @Override
-    public List<Rectangle> getGuiExtraAreas(@Nonnull ModularUIGui guiContainer) {
+    public List<Rectangle> getGuiExtraAreas(@NotNull ModularUIGui guiContainer) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/gregtech/integration/jei/utils/render/CompositeDrawable.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/CompositeDrawable.java
@@ -3,7 +3,7 @@ package gregtech.integration.jei.utils.render;
 import mezz.jei.api.gui.IDrawable;
 import net.minecraft.client.Minecraft;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class CompositeDrawable implements IDrawable {
     }
 
     @Override
-    public void draw(@Nonnull Minecraft minecraft, int xOffset, int yOffset) {
+    public void draw(@NotNull Minecraft minecraft, int xOffset, int yOffset) {
         for (RenderNode step : steps) {
             step.draw(minecraft, xOffset, yOffset);
         }
@@ -65,6 +65,6 @@ public class CompositeDrawable implements IDrawable {
 
     @FunctionalInterface
     public interface RenderNode {
-        void draw(@Nonnull Minecraft minecraft, int xOffset, int yOffset);
+        void draw(@NotNull Minecraft minecraft, int xOffset, int yOffset);
     }
 }

--- a/src/main/java/gregtech/integration/jei/utils/render/CompositeRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/CompositeRenderer.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.util.ITooltipFlag;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
@@ -9,8 +9,8 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraftforge.fluids.FluidStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FluidStackTextRenderer extends FluidStackRenderer {
     private boolean notConsumed;
@@ -26,7 +26,7 @@ public class FluidStackTextRenderer extends FluidStackRenderer {
     }
 
     @Override
-    public void render(@Nonnull Minecraft minecraft, final int xPosition, final int yPosition, @Nullable FluidStack fluidStack) {
+    public void render(@NotNull Minecraft minecraft, final int xPosition, final int yPosition, @Nullable FluidStack fluidStack) {
         if (fluidStack == null)
             return;
 

--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
@@ -7,8 +7,8 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemStackTextRenderer extends ItemStackRenderer {
     private final int chanceBase;
@@ -39,7 +39,7 @@ public class ItemStackTextRenderer extends ItemStackRenderer {
     }
 
     @Override
-    public void render(@Nonnull Minecraft minecraft, int xPosition, int yPosition, @Nullable ItemStack ingredient) {
+    public void render(@NotNull Minecraft minecraft, int xPosition, int yPosition, @Nullable ItemStack ingredient) {
         super.render(minecraft, xPosition, yPosition, ingredient);
 
         if (this.chanceBase >= 0) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CapabilityInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CapabilityInfoProvider.java
@@ -10,11 +10,11 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class CapabilityInfoProvider<T> implements IProbeInfoProvider {
 
-    @Nonnull
+    @NotNull
     protected abstract Capability<T> getCapability();
 
     protected abstract void addProbeInfo(T capability, IProbeInfo probeInfo, EntityPlayer player, TileEntity tileEntity, IProbeHitData data);
@@ -24,7 +24,7 @@ public abstract class CapabilityInfoProvider<T> implements IProbeInfoProvider {
     }
 
     @Override
-    public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
+    public void addProbeInfo(@NotNull ProbeMode mode, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull World world, @NotNull IBlockState blockState, @NotNull IProbeHitData data) {
         if (blockState.getBlock().hasTileEntity(blockState)) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (tileEntity == null) return;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ControllableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ControllableInfoProvider.java
@@ -10,11 +10,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ControllableInfoProvider extends CapabilityInfoProvider<IControllable> {
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IControllable> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE;
@@ -26,7 +26,7 @@ public class ControllableInfoProvider extends CapabilityInfoProvider<IControllab
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IControllable capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IControllable capability, @NotNull IProbeInfo probeInfo, EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         if (!capability.isWorkingEnabled()) probeInfo.text(TextStyleClass.WARNING + "{*gregtech.top.working_disabled*}");
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
@@ -15,7 +15,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait> {
 
@@ -24,14 +24,14 @@ public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait
         return GTValues.MODID + ":converter_info_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<ConverterTrait> getCapability() {
         return GregtechCapabilities.CAPABILITY_CONVERTER;
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull ConverterTrait capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull ConverterTrait capability, @NotNull IProbeInfo probeInfo, EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         // Info on current converter mode
         probeInfo.text(TextStyleClass.INFO + ((capability.isFeToEu()) ? "{*gregtech.top.convert_fe*}" : "{*gregtech.top.convert_eu*}"));
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverProvider.java
@@ -15,12 +15,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<ICoverable> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_COVERABLE;
@@ -32,7 +32,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull ICoverable capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull ICoverable capability, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         CoverBehavior coverBehavior = capability.getCoverAtSide(data.getSideHit());
         if (coverBehavior instanceof CoverConveyor) {
             conveyorInfo(probeInfo, (CoverConveyor) coverBehavior);
@@ -53,7 +53,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param conveyor  the conveyor to get data from
      */
-    private static void conveyorInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverConveyor conveyor) {
+    private static void conveyorInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverConveyor conveyor) {
         String rateUnit = " {*cover.conveyor.transfer_rate*}";
 
         if (conveyor instanceof CoverItemVoiding) {
@@ -77,7 +77,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param voiding   the voiding cover to get data from
      */
-    private static void itemVoidingInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverItemVoiding voiding) {
+    private static void itemVoidingInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverItemVoiding voiding) {
         String unit = " {*gregtech.top.unit.items*}";
 
         ItemFilterContainer container = voiding.getItemFilterContainer();
@@ -94,7 +94,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param pump      the pump to get data from
      */
-    private static void pumpInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverPump pump) {
+    private static void pumpInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverPump pump) {
         String rateUnit = IProbeInfo.STARTLOC + pump.getBucketMode().getName() + IProbeInfo.ENDLOC;
 
         if (pump instanceof CoverFluidVoiding) {
@@ -118,7 +118,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param voiding   the voiding cover to get data from
      */
-    private static void fluidVoidingInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverFluidVoiding voiding) {
+    private static void fluidVoidingInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverFluidVoiding voiding) {
         String unit = voiding.getBucketMode() == CoverPump.BucketMode.BUCKET ? " {*gregtech.top.unit.fluid_buckets*}" : " {*gregtech.top.unit.fluid_milibuckets*}";
 
         if (voiding instanceof CoverFluidVoidingAdvanced) {
@@ -135,7 +135,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo  the info to add the text to
      * @param itemFilter the filter to get data from
      */
-    private static void itemFilterInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverItemFilter itemFilter) {
+    private static void itemFilterInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverItemFilter itemFilter) {
         filterModeText(probeInfo, itemFilter.getFilterMode());
         itemFilterText(probeInfo, itemFilter.getItemFilter().getItemFilter());
     }
@@ -146,7 +146,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo   the info to add the text to
      * @param fluidFilter the filter to get data from
      */
-    private static void fluidFilterInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverFluidFilter fluidFilter) {
+    private static void fluidFilterInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverFluidFilter fluidFilter) {
         filterModeText(probeInfo, fluidFilter.getFilterMode());
         fluidFilterText(probeInfo, fluidFilter.getFluidFilter().getFluidFilter());
     }
@@ -157,7 +157,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo      the info to add the text to
      * @param enderFluidLink the ender fluid link cover to get data from
      */
-    private static void enderFluidLinkInfo(@Nonnull IProbeInfo probeInfo, @Nonnull CoverEnderFluidLink enderFluidLink) {
+    private static void enderFluidLinkInfo(@NotNull IProbeInfo probeInfo, @NotNull CoverEnderFluidLink enderFluidLink) {
         transferRateText(probeInfo, enderFluidLink.getPumpMode(), " {*cover.bucket.mode.milli_bucket*}", enderFluidLink.isIOEnabled() ? CoverEnderFluidLink.TRANSFER_RATE : 0);
         fluidFilterText(probeInfo, enderFluidLink.getFluidFilterContainer().getFilterWrapper().getFluidFilter());
 
@@ -175,7 +175,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param rateUnit  the unit of what is transferred
      * @param rate      the transfer rate of the mode
      */
-    private static void transferRateText(@Nonnull IProbeInfo probeInfo, @Nonnull IIOMode mode, @Nonnull String rateUnit, int rate) {
+    private static void transferRateText(@NotNull IProbeInfo probeInfo, @NotNull IIOMode mode, @NotNull String rateUnit, int rate) {
         String modeText = mode.isImport() ? "{*gregtech.top.mode.import*} " : "{*gregtech.top.mode.export*} ";
         probeInfo.text(TextStyleClass.OK + modeText + TextStyleClass.LABEL + GTUtility.formatNumbers(rate) + rateUnit);
     }
@@ -189,7 +189,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param rate      the transfer rate of the mode
      * @param hasFilter whether the cover has a filter installed
      */
-    private static void transferModeText(@Nonnull IProbeInfo probeInfo, @Nonnull TransferMode mode, @Nonnull String rateUnit, int rate, boolean hasFilter) {
+    private static void transferModeText(@NotNull IProbeInfo probeInfo, @NotNull TransferMode mode, @NotNull String rateUnit, int rate, boolean hasFilter) {
         String text = TextStyleClass.OK + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
         if (!hasFilter && mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + rate + rateUnit;
         probeInfo.text(text);
@@ -204,7 +204,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param amount    the transfer rate of the mode
      * @param hasFilter whether the cover has a filter in it or not
      */
-    private static void voidingText(@Nonnull IProbeInfo probeInfo, @Nonnull VoidingMode mode, @Nonnull String unit, int amount, boolean hasFilter) {
+    private static void voidingText(@NotNull IProbeInfo probeInfo, @NotNull VoidingMode mode, @NotNull String unit, int amount, boolean hasFilter) {
         String text = TextFormatting.RED + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
         if (mode != VoidingMode.VOID_ANY && !hasFilter) text += " " + amount + unit;
         probeInfo.text(text);
@@ -216,7 +216,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param mode      the filter mode of the cover
      */
-    private static void filterModeText(@Nonnull IProbeInfo probeInfo, @Nonnull IFilterMode mode) {
+    private static void filterModeText(@NotNull IProbeInfo probeInfo, @NotNull IFilterMode mode) {
         probeInfo.text(TextStyleClass.WARNING + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC);
     }
 
@@ -226,7 +226,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param filter    the filter to display info from
      */
-    private static void itemFilterText(@Nonnull IProbeInfo probeInfo, @Nullable ItemFilter filter) {
+    private static void itemFilterText(@NotNull IProbeInfo probeInfo, @Nullable ItemFilter filter) {
         String label = TextStyleClass.INFO + "{*gregtech.top.filter.label*} ";
         if (filter instanceof OreDictionaryItemFilter) {
             String expression = ((OreDictionaryItemFilter) filter).getOreDictFilterExpression();
@@ -242,7 +242,7 @@ public class CoverProvider extends CapabilityInfoProvider<ICoverable> {
      * @param probeInfo the info to add the text to
      * @param filter    the filter to display info from
      */
-    private static void fluidFilterText(@Nonnull IProbeInfo probeInfo, @Nullable FluidFilter filter) {
+    private static void fluidFilterText(@NotNull IProbeInfo probeInfo, @Nullable FluidFilter filter) {
         // TODO If more unique fluid filtration is added, providers for it go here
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/DebugPipeNetInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/DebugPipeNetInfoProvider.java
@@ -17,7 +17,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +28,7 @@ public class DebugPipeNetInfoProvider implements IProbeInfoProvider {
     }
 
     @Override
-    public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
+    public void addProbeInfo(@NotNull ProbeMode mode, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull World world, @NotNull IBlockState blockState, @NotNull IProbeHitData data) {
         if (mode == ProbeMode.DEBUG && ConfigHolder.misc.debug) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (tileEntity instanceof IGregTechTileEntity) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/DiodeInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/DiodeInfoProvider.java
@@ -10,7 +10,7 @@ import mcjty.theoneprobe.api.TextStyleClass;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class DiodeInfoProvider extends ElectricContainerInfoProvider {
 
@@ -20,7 +20,7 @@ public class DiodeInfoProvider extends ElectricContainerInfoProvider {
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IEnergyContainer capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IEnergyContainer capability, @NotNull IProbeInfo probeInfo, EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         if (tileEntity instanceof IGregTechTileEntity) {
             MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity instanceof MetaTileEntityDiode) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -9,7 +9,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnergyContainer> {
 
@@ -18,19 +18,19 @@ public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnerg
         return GTValues.MODID + ":energy_container_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IEnergyContainer> getCapability() {
         return GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER;
     }
 
     @Override
-    protected boolean allowDisplaying(@Nonnull IEnergyContainer capability) {
+    protected boolean allowDisplaying(@NotNull IEnergyContainer capability) {
         return !capability.isOneProbeHidden();
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IEnergyContainer capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IEnergyContainer capability, @NotNull IProbeInfo probeInfo, EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         long maxStorage = capability.getEnergyCapacity();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
         probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()

--- a/src/main/java/gregtech/integration/theoneprobe/provider/FuelableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/FuelableInfoProvider.java
@@ -14,7 +14,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.StringUtils;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 public class FuelableInfoProvider extends CapabilityInfoProvider<IFuelable> {
@@ -24,19 +24,19 @@ public class FuelableInfoProvider extends CapabilityInfoProvider<IFuelable> {
         return GTValues.MODID + ":fuelable_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IFuelable> getCapability() {
         return GregtechCapabilities.CAPABILITY_FUELABLE;
     }
 
     @Override
-    protected boolean allowDisplaying(@Nonnull IFuelable capability) {
+    protected boolean allowDisplaying(@NotNull IFuelable capability) {
         return !capability.isOneProbeHidden();
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IFuelable capability, IProbeInfo probeInfo, EntityPlayer player, TileEntity tileEntity, IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IFuelable capability, IProbeInfo probeInfo, EntityPlayer player, TileEntity tileEntity, IProbeHitData data) {
         Collection<IFuelInfo> fuels = capability.getFuels();
         if (fuels == null || fuels.isEmpty()) {
             probeInfo.text(TextStyleClass.WARNING + "{*gregtech.top.fuel_none*}");

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MaintenanceInfoProvider.java
@@ -16,7 +16,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MaintenanceInfoProvider extends CapabilityInfoProvider<IMaintenance> {
 
@@ -32,7 +32,7 @@ public class MaintenanceInfoProvider extends CapabilityInfoProvider<IMaintenance
         return GTValues.MODID + ":multiblock_maintenance_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IMaintenance> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_MAINTENANCE;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -11,7 +11,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MultiRecipeMapInfoProvider extends CapabilityInfoProvider<IMultipleRecipeMaps> {
 
@@ -20,14 +20,14 @@ public class MultiRecipeMapInfoProvider extends CapabilityInfoProvider<IMultiple
         return GTValues.MODID + ":multi_recipemap_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IMultipleRecipeMaps> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_MULTIPLE_RECIPEMAPS;
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IMultipleRecipeMaps iMultipleRecipeMaps, @Nonnull IProbeInfo iProbeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IMultipleRecipeMaps iMultipleRecipeMaps, @NotNull IProbeInfo iProbeInfo, @NotNull EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         if (iMultipleRecipeMaps.getAvailableRecipeMaps().length == 1) return;
 
         iProbeInfo.text(TextStyleClass.INFO + IProbeInfo.STARTLOC + "gregtech.multiblock.multiple_recipemaps.header" + IProbeInfo.ENDLOC);

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiblockInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiblockInfoProvider.java
@@ -11,7 +11,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class MultiblockInfoProvider extends CapabilityInfoProvider<IMultiblockController> {
 
@@ -20,14 +20,14 @@ public class MultiblockInfoProvider extends CapabilityInfoProvider<IMultiblockCo
         return GTValues.MODID + ":multiblock_controller_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IMultiblockController> getCapability() {
         return GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER;
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IMultiblockController capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IMultiblockController capability, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         if (capability.isStructureFormed()) {
             probeInfo.text(TextStyleClass.OK + "{*gregtech.top.valid_structure*}");
             if (capability.isStructureObstructed()) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
@@ -11,7 +11,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class PrimitivePumpInfoProvider implements IProbeInfoProvider {
 
@@ -21,7 +21,7 @@ public class PrimitivePumpInfoProvider implements IProbeInfoProvider {
     }
 
     @Override
-    public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
+    public void addProbeInfo(@NotNull ProbeMode mode, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull World world, @NotNull IBlockState blockState, @NotNull IProbeHitData data) {
         if (blockState.getBlock().hasTileEntity(blockState)) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (!(tileEntity instanceof IGregTechTileEntity)) return;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -13,7 +13,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractRecipeLogic> {
 
@@ -22,14 +22,14 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
         return GTValues.MODID + ":recipe_logic_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<AbstractRecipeLogic> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_RECIPE_LOGIC;
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull AbstractRecipeLogic capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull AbstractRecipeLogic capability, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         // do not show energy usage on machines that do not use energy
         if (capability.isWorking()) {
             if (!(capability instanceof PrimitiveRecipeLogic)) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
@@ -13,7 +13,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.TextFormatting;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class TransformerInfoProvider extends ElectricContainerInfoProvider {
 
@@ -23,7 +23,7 @@ public class TransformerInfoProvider extends ElectricContainerInfoProvider {
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IEnergyContainer capability, @Nonnull IProbeInfo probeInfo, EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IEnergyContainer capability, @NotNull IProbeInfo probeInfo, EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         if (tileEntity instanceof IGregTechTileEntity) {
             MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
             if (metaTileEntity instanceof MetaTileEntityTransformer) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
@@ -9,7 +9,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {
 
@@ -18,14 +18,14 @@ public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {
         return GTValues.MODID + ":workable_provider";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     protected Capability<IWorkable> getCapability() {
         return GregtechTileCapabilities.CAPABILITY_WORKABLE;
     }
 
     @Override
-    protected void addProbeInfo(@Nonnull IWorkable capability, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull TileEntity tileEntity, @Nonnull IProbeHitData data) {
+    protected void addProbeInfo(@NotNull IWorkable capability, @NotNull IProbeInfo probeInfo, @NotNull EntityPlayer player, @NotNull TileEntity tileEntity, @NotNull IProbeHitData data) {
         if (!capability.isActive()) return;
 
         int currentProgress = capability.getProgress();

--- a/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
+++ b/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
@@ -15,7 +15,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Random;
@@ -63,9 +63,9 @@ public class ChestGenHooks {
     public static void addItem(ResourceLocation lootTable, ItemStack item, int minAmount, int maxAmount, int weight) {
         LootEntryItem itemEntry = new LootEntryItem(item.getItem(), weight, 1, new LootFunction[]{
                 new LootFunction(NO_CONDITIONS) {
-                    @Nonnull
+                    @NotNull
                     @Override
-                    public ItemStack apply(@Nonnull ItemStack stack, @Nonnull Random rand, @Nonnull LootContext context) {
+                    public ItemStack apply(@NotNull ItemStack stack, @NotNull Random rand, @NotNull LootContext context) {
                         stack.setItemDamage(item.getItemDamage());
                         stack.setTagCompound(item.getTagCompound());
 

--- a/src/main/java/gregtech/loaders/recipe/CustomItemReturnShapedOreRecipeRecipe.java
+++ b/src/main/java/gregtech/loaders/recipe/CustomItemReturnShapedOreRecipeRecipe.java
@@ -9,19 +9,19 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.crafting.CraftingHelper.ShapedPrimer;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.function.Predicate;
 
 public class CustomItemReturnShapedOreRecipeRecipe extends ShapedOreRecipe implements IRecipe {
 
     private final Predicate<ItemStack> itemsToReturn;
 
-    public CustomItemReturnShapedOreRecipeRecipe(ResourceLocation group, @Nonnull ItemStack result, Predicate<ItemStack> itemsToReturn, Object... recipe) {
+    public CustomItemReturnShapedOreRecipeRecipe(ResourceLocation group, @NotNull ItemStack result, Predicate<ItemStack> itemsToReturn, Object... recipe) {
         super(group, result, recipe);
         this.itemsToReturn = itemsToReturn;
     }
 
-    public CustomItemReturnShapedOreRecipeRecipe(ResourceLocation group, @Nonnull ItemStack result, ShapedPrimer primer, Predicate<ItemStack> itemsToReturn) {
+    public CustomItemReturnShapedOreRecipeRecipe(ResourceLocation group, @NotNull ItemStack result, ShapedPrimer primer, Predicate<ItemStack> itemsToReturn) {
         super(group, result, primer);
         this.itemsToReturn = itemsToReturn;
     }
@@ -30,9 +30,9 @@ public class CustomItemReturnShapedOreRecipeRecipe extends ShapedOreRecipe imple
         return itemsToReturn.test(itemStack);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public NonNullList<ItemStack> getRemainingItems(@Nonnull InventoryCrafting inv) {
+    public NonNullList<ItemStack> getRemainingItems(@NotNull InventoryCrafting inv) {
         NonNullList<ItemStack> remainingItems = super.getRemainingItems(inv);
         for (int i = 0; i < remainingItems.size(); i++) {
             if (!remainingItems.get(i).isEmpty()) continue;

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -17,8 +17,8 @@ import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -251,7 +251,7 @@ public class RecyclingRecipes {
         return materialStack;
     }
 
-    private static ItemStack getArcIngotOrDust(@Nonnull MaterialStack stack) {
+    private static ItemStack getArcIngotOrDust(@NotNull MaterialStack stack) {
         if (stack.material == Materials.Carbon) {
             return OreDictUnifier.getDust(stack);
         }


### PR DESCRIPTION
Converts all `@Nonnul` and `@Nullable` javax annotations to their jetbrains variants.
Jetbrains also provides some other usefull annotations for api status.
The annotations where converted by a script i didnt to it by hand.
