### PR TITLE
Speed Up CI and Jar Builds

### DIFF
--- a/.github/workflows/curseforge_release.yml
+++ b/.github/workflows/curseforge_release.yml
@@ -50,5 +50,5 @@ jobs:
           changelog_type: "markdown"
           relations: "codechicken-lib-1-8:requiredDependency,gregtechce:incompatible,gregtech-chill-edition:incompatible"
           file_path: "gregtech-${{ steps.get_current_version.outputs.version }}.jar"
-          project_id: "{{ secrets.CURSEFORGE_PROJECT_ID }}"
+          project_id: "${{ secrets.CURSEFORGE_PROJECT_ID }}"
           token: "${{ secrets.CURSEFORGE_API_KEY }}"

--- a/.github/workflows/curseforge_release.yml
+++ b/.github/workflows/curseforge_release.yml
@@ -1,4 +1,5 @@
-# Requires a Release on GitHub of the current version
+# Requires a release on GitHub of the current version
+# Creates a release on Curseforge
 name: Release to CurseForge
 
 # manually run, or automatically after the GitHub release is done
@@ -16,21 +17,28 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Get Mod Version
-        id: get_version
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-executable: ".gradlew"
+          generate-job-summary: false
+
+      - name: Get Current Mod Version
+        id: get_current_version
         run: echo ::set-output name=version::$(./gradlew getVersionFromJava --q)
 
       - name: Get Mod Version without Extra
         id: get_version_no_extra
-        run: echo ::set-output name=version::$(./gradlew getVersionFromJavaNoExtra --q)
+        run: echo ::set-output name=version::$(echo "$(./gradlew getVersionFromJava --q | sed -E 's/1.12.2-|-.+//g')")
 
       - name: Retrieve Jar from Latest Release
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: "${{ github.repository }}"
-          version: "tags/v${{ steps.get_version.outputs.version }}"
-          file: "gregtech-1.12.2-${{ steps.get_version.outputs.version }}.jar"
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: wget "https://github.com/${{ github.repository }}/releases/download/v${{ steps.get_version_no_extra.outputs.version }}/gregtech-${{ steps.get_current_version.outputs.version }}.jar"
 
       - name: Create CurseForge Release
         uses: itsmeow/curseforge-upload@v3
@@ -41,6 +49,6 @@ jobs:
           changelog: "Changelog is available [here](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.get_version_no_extra.outputs.version }})."
           changelog_type: "markdown"
           relations: "codechicken-lib-1-8:requiredDependency,gregtechce:incompatible,gregtech-chill-edition:incompatible"
-          file_path: "$gregtech-1.12.2-${{ steps.get_version.outputs.version }}.jar"
-          project_id: "${{ secrets.CURSEFORGE_PROJECT_ID }}"
+          file_path: "gregtech-${{ steps.get_current_version.outputs.version }}.jar"
+          project_id: "{{ secrets.CURSEFORGE_PROJECT_ID }}"
           token: "${{ secrets.CURSEFORGE_API_KEY }}"

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -20,47 +20,44 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Get Mod Version
-        id: get_version_no_extra
-        run: echo ::set-output name=version::$(./gradlew getVersionFromJavaNoExtra --q)
-
-      - name: Get Previous tag
-        id: previous_tag
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: ${{ github.repository }}
-
-      # exit CI early as a failure if creating this release clashes with the previous version
-      - name: Check if Version Bump is Needed
-        if: ${{ format('v{0}', steps.get_version_no_extra.outputs.version) == (steps.previous_tag.outputs.release) }}
-        uses: actions/github-script@v6
-        with:
-          script: core.setFailed("A version bump from ${{ steps.previous_tag.outputs.release }} is required!")
+      - name: Fetch Git Tags
+        run: git fetch --prune --unshallow --tags
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
 
-      - name: Use Cached Gradle Packages
-        uses: actions/cache@v2
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle.properties*') }}
-          restore-keys: ${{ runner.os }}-gradle-
+          gradle-executable: ".gradlew"
+          generate-job-summary: false
 
-      - name: Build with Gradle
-        run: |
-          chmod +x gradlew
-          ./gradlew build
+      - name: Get Current Mod Version
+        id: get_current_version
+        run: echo ::set-output name=version::$(echo "$(./gradlew getVersionFromJava --q | sed -E 's/1.12.2-|-.+//g')")
+
+      - name: Get Latest Tag
+        id: get_latest_tag
+        run: echo ::set-output name=version::$(git describe --tags --abbrev=0)
+
+      # exit CI early as a failure if creating this release clashes with the previous version
+      - name: Check Build Versions
+        if: ${{ (steps.get_latest_tag.outputs.version) == format('v{0}', steps.get_current_version.outputs.version) }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('A version bump from ${{ steps.get_latest_tag.outputs.latest }} is required!')
+
+      - name: Execute Gradle build
+        run: ./gradlew build
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@master
         with:
-          tag_name: v${{ steps.get_version_no_extra.outputs.version }}
+          tag_name: v${{ steps.get_current_version.outputs.version }}
           files: build/libs/*.jar
           body: "**${{ github.event.inputs.label }}${{ inputs.hotfix && ' (HOTFIX)' || '' }}**\n"
           generate_release_notes: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,4 @@
 # This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
 name: CI
 
 on:
@@ -16,15 +14,21 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v2
+
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
-      - name: Build with Gradle
-        run: |
-          chmod +x gradlew
-          ./gradlew test
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-executable: ".gradlew"
+          generate-job-summary: false
+
+      - name: Execute Gradle build
+        run: ./gradlew build
 
   formatting:
     name: check-fmt
@@ -41,7 +45,7 @@ jobs:
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short $GITHUB_SHA)"
       - name: Install npm
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
       - name: Run Formatter
         run: |
           cd scripts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,8 +27,8 @@ jobs:
           gradle-executable: ".gradlew"
           generate-job-summary: false
 
-      - name: Execute Gradle build
-        run: ./gradlew build
+      - name: Execute Gradle test
+        run: ./gradlew test --no-daemon # remove the --no-daemon if more than 1 gradlew command is run
 
   formatting:
     name: check-fmt

--- a/.github/workflows/pr_enforce_labels.yml
+++ b/.github/workflows/pr_enforce_labels.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: yogevbd/enforce-label-action@2.1.0
         with:
-          REQUIRED_LABELS_ANY: "type: bug,type: feature,type: translation,ignore changelog"
+          REQUIRED_LABELS_ANY: "type: bug,type: feature,type: translation,type: refactor,ignore changelog"
           REQUIRED_LABELS_ANY_DESCRIPTION: "Pull Requests need at least one of the following labels: ['type: bug', 'type: feature', 'type: translation', 'ignore changelog']"
           BANNED_LABELS: "status: do not merge"
           BANNED_LABELS_DESCRIPTION: "Pull Requests cannot be merged with the '${bannedLabel.name}' label."

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,19 +3,12 @@ import net.minecraftforge.gradle.user.UserBaseExtension
 buildscript {
     repositories {
         mavenCentral()
-        /*
-        maven {
-            name = "jitpack"
-            setUrl("https://jitpack.io")
-        }
-         */
         maven {
             name = "forge"
             setUrl("https://maven.minecraftforge.net/")
         }
     }
     dependencies {
-        // classpath("com.github.GregTechCE:ForgeGradle:FG_2.3-SNAPSHOT")
         classpath("net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT")
         classpath("org.eclipse.jgit:org.eclipse.jgit:5.8.0.202006091008-r")
         classpath("org.apache.commons:commons-lang3:3.12.0")
@@ -150,42 +143,15 @@ idea {
 }
 
 // used for GitHub Actions CI releases
-task<Exec>("getVersionFromJavaNoExtra") {
-    commandLine("echo", getVersionFromJavaNoExtra(file("src/main/java/gregtech/GregTechVersion.java")))
-}
-
-
-// used for GitHub Actions CI releases
 task<Exec>("getVersionFromJava") {
     commandLine("echo", getVersionFromJava(file("src/main/java/gregtech/GregTechVersion.java")))
 }
 
 fun getVersionFromJava(file: File): String  {
-    var version = getVersionFromJavaNoExtra(file)
-    var extra = ""
-
-    val extraPrefix = "public static final String"
-    file.forEachLine { line ->
-        var s = line.trim()
-        if (s.startsWith(extraPrefix)) {
-            s = s.substring(extraPrefix.length, s.length - 2)
-            s = s.replace("=", " ").replace(" +", " ").replace("\"", " ").trim()
-            val pts = s.split(" ")
-            when {
-                pts[0] == "EXTRA" -> extra = pts[pts.size - 1]
-            }
-        }
-    }
-    if (extra != "") {
-        return "$version-$extra"
-    }
-    return version
-}
-
-fun getVersionFromJavaNoExtra(file: File): String  {
     var major = "0"
     var minor = "0"
     var revision = "0"
+    var extra = ""
 
     val prefix = "public static final int"
     val extraPrefix = "public static final String"
@@ -201,7 +167,17 @@ fun getVersionFromJavaNoExtra(file: File): String  {
                 pts[0] == "MINOR" -> minor = pts[pts.size - 1]
                 pts[0] == "REVISION" -> revision = pts[pts.size - 1]
             }
+        } else if (s.startsWith(extraPrefix)) {
+            s = s.substring(extraPrefix.length, s.length - 2)
+            s = s.replace("=", " ").replace(" +", " ").replace("\"", " ").trim()
+            val pts = s.split(" ")
+            when {
+                pts[0] == "EXTRA" -> extra = pts[pts.size - 1]
+            }
         }
+    }
+    if (extra != "") {
+        return "$major.$minor.$revision-$extra"
     }
     return "$major.$minor.$revision"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,12 +141,6 @@ val energyApiTask: Jar = tasks.create("energyApi", Jar::class.java) {
     classifier = "energy-api"
 }
 
-artifacts {
-    add("archives", jar)
-    add("archives", sourceTask)
-    add("archives", energyApiTask)
-}
-
 fun Project.idea(configure: org.gradle.plugins.ide.idea.model.IdeaModel.() -> Unit): Unit =
     (this as ExtensionAware).extensions.configure("idea", configure)
 idea {


### PR DESCRIPTION
## What
This PR leverages the use of the gradle-build-action Github Action to setup gradle much faster for tests and automated releases. Additionally, it should fix the CurseForge deployment buildscript, and also adds the Refactor PR label to the list of available labels required for PR merge.
## Outcome
Improves and Fixes CI