### PR TITLE
Deprecate MetaTileEntity#onAttached

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -224,8 +224,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     @Override
     public boolean recolorBlock(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, @Nonnull EnumDyeColor color) {
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
-        if (metaTileEntity == null ||
-                metaTileEntity.getPaintingColor() == color.colorValue)
+        if (metaTileEntity == null || metaTileEntity.getPaintingColor() == color.colorValue)
             return false;
         metaTileEntity.setPaintingColor(color.colorValue);
         return true;
@@ -255,6 +254,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                     metaTileEntity.getProxy().setOwner((EntityPlayer) placer);
                 }
             }
+            metaTileEntity.onPlacement();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1174,7 +1174,15 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         }
     }
 
+    /**
+     * Deprecated, use {@link MetaTileEntity#onPlacement()} instead
+     */
+    @Deprecated
     public void onAttached(Object... data) {
+    }
+
+    public void onPlacement() {
+
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -277,6 +277,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         if (buf.readBoolean()) {
             int metaTileEntityId = buf.readVarInt();
             setMetaTileEntity(GregTechAPI.MTE_REGISTRY.getObjectById(metaTileEntityId));
+            this.metaTileEntity.onPlacement();
             this.metaTileEntity.receiveInitialSyncData(buf);
             scheduleRenderUpdate();
             this.needToUpdateLightning = true;
@@ -288,6 +289,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         if (discriminator == INITIALIZE_MTE) {
             int metaTileEntityId = buffer.readVarInt();
             setMetaTileEntity(GregTechAPI.MTE_REGISTRY.getObjectById(metaTileEntityId));
+            this.metaTileEntity.onPlacement();
             this.metaTileEntity.receiveInitialSyncData(buffer);
             scheduleRenderUpdate();
             this.needToUpdateLightning = true;

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -26,6 +26,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -61,8 +62,8 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     }
 
     @Override
-    public void onAttached(Object... data) {
-        super.onAttached(data);
+    public void onPlacement() {
+        super.onPlacement();
         reinitializeStructurePattern();
     }
 
@@ -152,6 +153,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
             // TODO
             MetaTileEntityHolder holder = new MetaTileEntityHolder();
             holder.setMetaTileEntity(tile);
+            holder.getMetaTileEntity().onPlacement();
             holder.getMetaTileEntity().setFrontFacing(EnumFacing.SOUTH);
             return new BlockInfo(MetaBlocks.MACHINE.getDefaultState(), holder);
         }).toArray(BlockInfo[]::new);
@@ -283,6 +285,12 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
 
     public List<IMultiblockPart> getMultiblockParts() {
         return Collections.unmodifiableList(multiblockParts);
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound data) {
+        super.readFromNBT(data);
+        this.reinitializeStructurePattern();
     }
 
     @Override

--- a/src/main/java/gregtech/api/pattern/BlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/BlockPattern.java
@@ -336,6 +336,7 @@ public class BlockPattern {
                                 MetaTileEntity sampleMetaTileEntity = GregTechAPI.MTE_REGISTRY.getObjectById(found.getItemDamage());
                                 if (sampleMetaTileEntity != null) {
                                     MetaTileEntity metaTileEntity = ((IGregTechTileEntity) holder).setMetaTileEntity(sampleMetaTileEntity);
+                                    metaTileEntity.onPlacement();
                                     blocks.put(pos, metaTileEntity);
                                     if (found.hasTagCompound()) {
                                         metaTileEntity.initFromItemStackData(found.getTagCompound());
@@ -519,6 +520,7 @@ public class BlockPattern {
                         if (info.getTileEntity() instanceof MetaTileEntityHolder) {
                             MetaTileEntityHolder holder = new MetaTileEntityHolder();
                             holder.setMetaTileEntity(((MetaTileEntityHolder) info.getTileEntity()).getMetaTileEntity());
+                            holder.getMetaTileEntity().onPlacement();
                             info = new BlockInfo(MetaBlocks.MACHINE.getDefaultState(), holder);
                         }
                         blocks.put(pos, info);

--- a/src/main/java/gregtech/api/pattern/MultiblockShapeInfo.java
+++ b/src/main/java/gregtech/api/pattern/MultiblockShapeInfo.java
@@ -53,6 +53,7 @@ public class MultiblockShapeInfo {
         public Builder where(char symbol, MetaTileEntity tileEntity, EnumFacing frontSide) {
             MetaTileEntityHolder holder = new MetaTileEntityHolder();
             holder.setMetaTileEntity(tileEntity);
+            holder.getMetaTileEntity().onPlacement();
             holder.getMetaTileEntity().setFrontFacing(frontSide);
             return where(symbol, new BlockInfo(MetaBlocks.MACHINE.getDefaultState(), holder));
         }
@@ -83,6 +84,7 @@ public class MultiblockShapeInfo {
                             final MetaTileEntity mte = holder.getMetaTileEntity();
                             holder = new MetaTileEntityHolder();
                             holder.setMetaTileEntity(mte);
+                            holder.getMetaTileEntity().onPlacement();
                             holder.getMetaTileEntity().setFrontFacing(mte.getFrontFacing());
                             info = new BlockInfo(info.getBlockState(), holder);
                         }

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -417,13 +417,6 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     }
 
     @Override
-    public void onAttached(Object... data) {
-        super.onAttached(data);
-        if (data.length != 0 && data[0] instanceof ItemStack)
-            this.setClipboard((ItemStack) data[0]);
-    }
-
-    @Override
     public void getSubItems(CreativeTabs creativeTab, NonNullList<ItemStack> subItems) { // JEI shouldn't show this
     }
 

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -577,6 +577,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
 
         Map<BlockPos, TraceabilityPredicate> predicateMap = new HashMap<>();
         if (controllerBase != null) {
+            controllerBase.reinitializeStructurePattern();
             controllerBase.structurePattern.cache.forEach((pos, blockInfo) -> predicateMap.put(BlockPos.fromLong(pos), (TraceabilityPredicate) blockInfo.getInfo()));
         }
 


### PR DESCRIPTION
## What
Deprecates `MetaTileEntity#onAttached` in favor of `MetaTileEntity#onPlacement`. The semantics of this has changed such that `onPlacement()` is called from the `BlockMachine` class directly, instead of in `setMetaTileEntity()` in `MetaTileEntityHolder`.

This method was overall quite strange, and `onPlacement()` should have saner behavior.

## Implementation Details
Everywhere `MetaTileEntityHolder#setMetaTileEntity` is called needs to subsequently call `onPlacement()` as a result.

## Outcome
Deprecates `MetaTileEntity#onAttached` in favor of `MetaTileEntity#onPlacement`
