### PR TITLE
Fixes #1186

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -258,6 +258,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
 
         if (requiredType == null) return true;
 
+        if (getMetaTileEntity() instanceof MultiblockWithDisplayBase && ConfigHolder.machines.cleanMultiblocks) return true;
+
         ICleanroomProvider cleanroomProvider = ((ICleanroomReceiver) getMetaTileEntity()).getCleanroom();
         if (cleanroomProvider == null) return false;
 


### PR DESCRIPTION
## What
#1186 

## Implementation Details
In AbstractRecipeLogic, the class will check for if a recipe can be run once before starting the run. Every time after that, progress is determined by a check from canProgressRecipe, which did not have the same check present in checkRecipe that sees whether or not the config enables cleanroom recipes in multiblocks without being inside of one. This change copies the line that checks that and puts it in canProgressRecipe to allow it to continue running rather than starting and never progressing.

## Outcome
Fixes: #1186 

## Additional Information
The original issue pointed out that the machine constantly stated that it did not have enough energy, despite being supplied enough to run the recipe. This happens because the updateRecipeProgress method got a False return from canRecipeProgress and therefore fell back into the second if clause, which saw that there was EU being supplied but since it failed the earlier check, assumed it was not enough. This is why that showed up that way.

## Potential Compatibility Issues
There shouldn't be any compat issues no.

Just in time for some cream soda before class.
