### PR TITLE
Fix miners mining cobblestone when overlapping working areas

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -136,7 +136,7 @@ public class MinerLogic {
             IBlockState blockState = metaTileEntity.getWorld().getBlockState(blocksToMine.getFirst());
 
             // if the block is not air or cobblestone., harvest it
-            if (blockState != Blocks.AIR.getDefaultState() && blockState != Blocks.COBBLESTONE.getDefaultState()) {
+            if (GTUtility.isOre(GTUtility.toItem(blockState))) {
                 // get the small ore drops, if a small ore
                 getSmallOreBlockDrops(blockDrops, world, blocksToMine.getFirst(), blockState);
                 // get the block's drops.

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -135,8 +135,8 @@ public class MinerLogic {
             NonNullList<ItemStack> blockDrops = NonNullList.create();
             IBlockState blockState = metaTileEntity.getWorld().getBlockState(blocksToMine.getFirst());
 
-            // if the block is not air, harvest it
-            if (blockState != Blocks.AIR.getDefaultState()) {
+            // if the block is not air or cobblestone., harvest it
+            if (blockState != Blocks.AIR.getDefaultState() && blockState != Blocks.COBBLESTONE.getDefaultState()) {
                 // get the small ore drops, if a small ore
                 getSmallOreBlockDrops(blockDrops, world, blocksToMine.getFirst(), blockState);
                 // get the block's drops.
@@ -144,8 +144,9 @@ public class MinerLogic {
                 // try to insert them
                 mineAndInsertItems(blockDrops, world);
             } else {
-                // the block attempted to mine was air, so remove it from the queue and move on
-                // This can occur because of block destruction when lowering the pipe
+                // the block attempted to mine was air or cobblestone, so remove it from the queue and move on
+                // This can occur because of block destruction when lowering the pipe or when two miners are attempting
+                // to mine the same area
                 blocksToMine.removeFirst();
             }
 


### PR DESCRIPTION
## What
#1202 

## Implementation Details
Adds an extra condition in the miner logic that causes miners to ignore cobblestone exactly how they ignore air.

## Outcome
Fixes: #1202 

## Additional Information
This fix does remove cobblestone being gathered as an unintended byproduct, however it does not fix any other issues that comes from two miners attempting to mine the same area. One miner will still always be the dominant one and get priority in mining as the other one desperately attempts to catch up and fails to do so. No attempt was made to change this behavior