### PR TITLE
Only show ores whose stone types should be dropped on Prospector map

### DIFF
--- a/src/main/java/gregtech/common/terminal/app/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/terminal/app/prospector/widget/WidgetProspectingMap.java
@@ -118,17 +118,19 @@ public class WidgetProspectingMap extends Widget {
                                 if (GTUtility.isOre(itemBlock)) {
                                     boolean added = false;
                                     String oreDictString = OreDictUnifier.getOreDictionaryNames(itemBlock).stream().findFirst().get();
+                                    OrePrefix prefix = OreDictUnifier.getPrefix(itemBlock);
                                     for(StoneType type : StoneType.STONE_TYPE_REGISTRY) {
-                                        OrePrefix prefix = OreDictUnifier.getPrefix(itemBlock);
                                         if(type.processingPrefix == prefix && type.shouldBeDroppedAsItem) {
                                             packet.addBlock(x, y, z, oreDictString);
                                             added = true;
+                                            break;
                                         }
                                         else if(type.processingPrefix == prefix) {
                                             MaterialStack materialStack = OreDictUnifier.getMaterial(itemBlock);
                                             if(materialStack != null) {
                                                 packet.addBlock(x, y, z, "ore" + materialStack.material.getLocalizedName());
                                                 added = true;
+                                                break;
                                             }
                                         }
                                     }


### PR DESCRIPTION
## What
Since Brachy's change that correctly fetched the meta for blocks from a blockstate, the ore prospector maps show all stone types of ore in the ore list on the right.

It is sort of spammy and drastically lengthens the list to show all stone types for all the ores found in the scanning range of the prospector, therefore this PR makes it so that only stone types that can be dropped are shown in the list, and anything that cannot be dropped is converted into the default (Stone) StoneType of the ore block.

An image of the prospector on current `master`:
![2022-09-21_20 28 26](https://user-images.githubusercontent.com/31759736/191653196-6beaf61b-9512-4de7-9d3a-5f4d477aa40c.png)


An image of the prospector in this PR:
![2022-09-21_20 25 19](https://user-images.githubusercontent.com/31759736/191653243-e1bb56a2-a907-4fb4-ad70-3b46d00aaf6e.png)



## Outcome
Only show ores that can be dropped on the ore list in prospectors, and convert everything else into the default stone type.
