### PR TITLE
Fix #1089, Spray Can maceration material transmutation

### DIFF
--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -108,8 +108,7 @@ public class MetaItem1 extends StandardMetaItem {
         SHAPE_EXTRUDERS[26] = SHAPE_EXTRUDER_ROTOR = addItem(57, "shape.extruder.rotor").setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
 
         // Spray Cans: ID 60-77
-        SPRAY_EMPTY = addItem(61, "spray.empty")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Tin, M * 2), new MaterialStack(Materials.Redstone, M)));
+        SPRAY_EMPTY = addItem(61, "spray.empty");
 
         // out of registry order so it can reference the Empty Spray Can
         SPRAY_SOLVENT = addItem(60, "spray.solvent").setMaxStackSize(1)


### PR DESCRIPTION
## What
Fixes #1089 

## Implementation Details
Removed material info from empty spray cans.

## Outcome
Resolved #1089 