### PR TITLE
Don't transfer charge from electric tools

### DIFF
--- a/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
+++ b/src/main/java/gregtech/api/util/ShapedOreEnergyTransferRecipe.java
@@ -3,6 +3,7 @@ package gregtech.api.util;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.capability.impl.ElectricItem;
+import gregtech.api.items.toolitem.ToolMetaItem;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
@@ -33,6 +34,7 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
     private void fixOutputItemMaxCharge() {
         long totalMaxCharge = getIngredients().stream()
                 .mapToLong(it -> Arrays.stream(it.getMatchingStacks())
+                        .filter(itemStack -> !(itemStack.getItem() instanceof ToolMetaItem))
                         .map(stack -> stack.copy().getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null))
                         .filter(Objects::nonNull)
                         .mapToLong(IElectricItem::getMaxCharge)


### PR DESCRIPTION
## What
Don't transfer charge to crafted Electric Items from Electric Tools use in the craft, as this should only happen from batteries.

Closes #1193 

## Outcome
Don't transfer total Electric charge to crafted Electric Items from Electric tools used in the craft.
