### PR TITLE
Fix Diodes only outputting 8A on 16A mode

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -110,7 +110,7 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
 
     protected void reinitializeEnergyContainer() {
         long tierVoltage = GTValues.V[getTier()];
-        this.energyContainer = new EnergyContainerHandler(this, tierVoltage * 8, tierVoltage, amps, tierVoltage, amps);
+        this.energyContainer = new EnergyContainerHandler(this, tierVoltage * 16, tierVoltage, amps, tierVoltage, amps);
         ((EnergyContainerHandler) this.energyContainer).setSideInputCondition(s -> s != getFrontFacing());
         ((EnergyContainerHandler) this.energyContainer).setSideOutputCondition(s -> s == getFrontFacing());
     }


### PR DESCRIPTION
## What
Fixes Diodes only outputting 8 Amps when on 16 Amp mode. This is because the diodes only had the storage capacity for 8 Amps.

Closes #1212 


## Outcome
Fix Diodes outputting 8 Amps on 16 Amp mode.
