### PR TITLE
Fix crash with Item Filter

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -127,6 +127,9 @@ public class CoverItemFilter extends CoverBehavior implements CoverWithUI {
     @Override
     public <T> T getCapability(Capability<T> capability, T defaultValue) {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            if (defaultValue == null) {
+                return null;
+            }
             IItemHandler delegate = (IItemHandler) defaultValue;
             if (itemHandler == null || itemHandler.delegate != delegate) {
                 this.itemHandler = new ItemHandlerFiltered(delegate);


### PR DESCRIPTION
## What
Fixes this crash: https://pastes.dev/vujjQBeCbr

## Implementation Details
Added a null check in the Item Filter Cover, to mirror the Conveyor Cover, as seen [here](https://github.com/GregTechCEu/GregTech/blob/master/src/main/java/gregtech/common/covers/CoverConveyor.java#L438).

## Outcome
Fixes a rare (yet world corrupting) crash, most likely related to the Item Filter.