### PR TITLE
Fix Z-Fighting with Covers

### DIFF
--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -91,8 +91,9 @@ public interface ICoverable {
                 renderState.preRenderWorld(getWorld(), getPos());
                 coverBehavior.renderCoverPlate(renderState, translation, platePipeline, plateBox, layer);
             }
+
             if (coverBehavior.canRenderInLayer(layer)) {
-                coverBehavior.renderCover(renderState, RenderUtil.adjustTrans(translation, sideFacing, 1), coverPipeline, plateBox, layer);
+                coverBehavior.renderCover(renderState, RenderUtil.adjustTrans(translation, sideFacing, 2), coverPipeline, plateBox, layer);
                 if (coverPlateThickness == 0.0 && shouldRenderBackSide() && coverBehavior.canRenderBackside()) {
                     //machine is full block, but still not opaque - render cover on the back side too
                     Matrix4 backTranslation = translation.copy();

--- a/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
+++ b/src/main/java/gregtech/api/pipenet/tile/PipeCoverableImplementation.java
@@ -167,7 +167,14 @@ public class PipeCoverableImplementation implements ICoverable {
 
     @Override
     public double getCoverPlateThickness() {
-        return holder.getPipeType().getThickness() >= 1 ? 0 : 1.0 / 16.0;
+        float thickness = holder.getPipeType().getThickness();
+        // no cover plate for pipes >= 1 block thick
+        if (thickness >= 1) return 0;
+
+        // If the available space for the cover is less than the regular cover plate thickness, use that
+
+        // need to divide by 2 because thickness is centered on the block, so the space is half on each side of the pipe
+        return Math.min(1.0 / 16.0, (1.0 - thickness) / 2);
     }
 
     @Override

--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -251,24 +251,24 @@ public class RenderUtil {
      */
     public static Matrix4 adjustTrans(Matrix4 translation, EnumFacing side, int layer) {
         Matrix4 trans = translation.copy();
-        switch (side){
+        switch (side) {
             case DOWN:
-                trans.translate(0 , -0.001D * layer,0);
+                trans.translate(0 , -0.0005D * layer,0);
                 break;
             case UP:
-                trans.translate(0 , 0.001D * layer,0);
+                trans.translate(0 , 0.0005D * layer,0);
                 break;
             case NORTH:
-                trans.translate(0 , 0,-0.001D * layer);
+                trans.translate(0 , 0,-0.0005D * layer);
                 break;
             case SOUTH:
-                trans.translate(0 , 0,0.001D * layer);
+                trans.translate(0 , 0,0.0005D * layer);
                 break;
             case EAST:
-                trans.translate(0.001D * layer, 0,0);
+                trans.translate(0.0005D * layer, 0,0);
                 break;
             case WEST:
-                trans.translate(-0.001D * layer, 0,0);
+                trans.translate(-0.0005D * layer, 0,0);
                 break;
         }
         return trans;


### PR DESCRIPTION
## What
This PR fixes two cases of Z-Fighting with covers. 

The first is a cover placed onto a machine, particularly on the top face. Machines with a top overlay would z-fight with the cover. This PR fixes it by having the cover rendered above the machine overlay.

The second is z-fighting which occurred with covers on pipes. This was solved by shrinking the cover plate on pipes too thick to allow the default cover plate size to fit without overlap.

## Outcome
Fixes Z-Fighting with covers.
