### PR TITLE
Implement new chanced output recipe logic

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -4,7 +4,10 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.*;
 import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.multiblock.*;
+import gregtech.api.metatileentity.multiblock.CleanroomType;
+import gregtech.api.metatileentity.multiblock.ICleanroomProvider;
+import gregtech.api.metatileentity.multiblock.ICleanroomReceiver;
+import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.logic.IParallelableRecipeLogic;
@@ -643,7 +646,11 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         setMaxProgress(overclockResults[1]);
         this.recipeEUt = overclockResults[0];
         this.fluidOutputs = GTUtility.copyFluidList(recipe.getAllFluidOutputs(metaTileEntity.getFluidOutputLimit()));
-        this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(GTUtility.getTierByVoltage(recipeEUt), getRecipeMap()));
+        this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(
+                GTUtility.getTierByVoltage(recipe.getEUt()),
+                getOverclockTier(),
+                getRecipeMap())
+        );
 
         if (this.wasActiveAndNeedsUpdate) {
             this.wasActiveAndNeedsUpdate = false;

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -8,13 +8,12 @@ import gregtech.api.capability.IMiner;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.util.GTTransferUtils;
-import gregtech.client.renderer.ICubeRenderer;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
-import net.minecraft.block.Block;
+import gregtech.client.renderer.ICubeRenderer;
+import gregtech.client.renderer.texture.Textures;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -364,7 +363,7 @@ public class MinerLogic {
         Recipe recipe = map.findRecipe(Long.MAX_VALUE, Collections.singletonList(itemStack), Collections.emptyList(), 0);
         if (recipe != null && !recipe.getOutputs().isEmpty()) {
             drops.clear();
-            for (ItemStack outputStack : recipe.getResultItemOutputs(tier, map)) {
+            for (ItemStack outputStack : recipe.getResultItemOutputs(GTUtility.getTierByVoltage(recipe.getEUt()), tier, map)) {
                 outputStack = outputStack.copy();
                 if (OreDictUnifier.getPrefix(outputStack) == OrePrefix.crushed) {
                     if (fortuneLevel > 0) {

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -7,7 +7,6 @@ import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.recipeproperties.EmptyRecipePropertyStorage;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
-import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.ItemStackHashStrategy;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -363,17 +362,19 @@ public class Recipe {
      * The Recipe should be trimmed by calling {@link Recipe#getItemAndChanceOutputs(int)} before calling this method,
      * if trimming is required.
      *
-     * @param tier The Voltage Tier of the Recipe, used for chanced output calculation
-     * @param recipeMap The RecipeMap that the recipe is being performed upon, used for chanced output calculation
-     *
+     * @param recipeTier  The Voltage Tier of the Recipe, used for chanced output calculation
+     * @param machineTier The Voltage Tier of the Machine, used for chanced output calculation
+     * @param recipeMap   The RecipeMap that the recipe is being performed upon, used for chanced output calculation
      * @return A list of all resulting ItemStacks from the recipe, after chance has been applied to any chanced outputs
      */
-    public List<ItemStack> getResultItemOutputs(int tier, RecipeMap<?> recipeMap) {
+    public List<ItemStack> getResultItemOutputs(int recipeTier, int machineTier, RecipeMap<?> recipeMap) {
         ArrayList<ItemStack> outputs = new ArrayList<>(GTUtility.copyStackList(getOutputs()));
         List<ChanceEntry> chancedOutputsList = getChancedOutputs();
         List<ItemStack> resultChanced = new ArrayList<>();
         for (ChanceEntry chancedOutput : chancedOutputsList) {
-            int outputChance = recipeMap.getChanceFunction().chanceFor(chancedOutput.getChance(), chancedOutput.getBoostPerTier(), tier);
+            int outputChance = recipeMap.getChanceFunction().chanceFor(
+                    chancedOutput.getChance(), chancedOutput.getBoostPerTier(),
+                    recipeTier, machineTier);
             if (GTValues.RNG.nextInt(Recipe.getMaxChancedValue()) <= outputChance) {
                 ItemStack stackToAdd = chancedOutput.getItemStack();
                 GTUtility.addStackToItemStackList(stackToAdd, resultChanced);

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -54,8 +54,17 @@ import java.util.stream.Collectors;
 public class RecipeMap<R extends RecipeBuilder<R>> {
 
     private static final Map<String, RecipeMap<?>> RECIPE_MAP_REGISTRY = new Object2ReferenceOpenHashMap<>();
-    private static final Comparator<Recipe> RECIPE_DURATION_THEN_EU = Comparator.comparingInt(Recipe::getDuration).thenComparingInt(Recipe::getEUt).thenComparing(Recipe::hashCode);
-    private static final IChanceFunction DEFAULT_CHANCE_FUNCTION = (chance, boostPerTier, tier) -> chance + (boostPerTier * tier);
+
+    private static final Comparator<Recipe> RECIPE_DURATION_THEN_EU = Comparator.comparingInt(Recipe::getDuration)
+            .thenComparingInt(Recipe::getEUt)
+            .thenComparing(Recipe::hashCode);
+
+    public static final IChanceFunction DEFAULT_CHANCE_FUNCTION = (baseChance, boostPerTier, baseTier, machineTier) -> {
+        int tierDiff = machineTier - baseTier;
+        if (tierDiff <= 0) return baseChance; // equal or invalid tiers do not boost at all
+        if (baseTier == GTValues.ULV) tierDiff--; // LV does not boost over ULV
+        return baseChance + (boostPerTier * tierDiff);
+    };
 
     public IChanceFunction chanceFunction = DEFAULT_CHANCE_FUNCTION;
 
@@ -975,7 +984,16 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     @ZenClass("mods.gregtech.recipe.IChanceFunction")
     @ZenRegister
     public interface IChanceFunction {
-        int chanceFor(int chance, int boostPerTier, int boostTier);
+
+        /**
+         *
+         * @param baseChance the base chance of the recipe
+         * @param boostPerTier the amount the chance is changed per tier over the base
+         * @param baseTier the lowest tier used to obtain un-boosted chances
+         * @param boostTier the tier the chance should be calculated at
+         * @return the chance
+         */
+        int chanceFor(int baseChance, int boostPerTier, int baseTier, int boostTier);
     }
 
 }

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
@@ -8,6 +8,7 @@ import crafttweaker.mc1120.item.MCItemStack;
 import crafttweaker.mc1120.liquid.MCLiquidStack;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.util.GTUtility;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
@@ -46,7 +47,8 @@ public class CTRecipe {
 
     @ZenMethod
     public List<IItemStack> getResultItemOutputs(@Optional(valueLong = 1) int tier) {
-        return this.backingRecipe.getResultItemOutputs(tier, recipeMap).stream()
+        return this.backingRecipe.getResultItemOutputs(GTUtility.getTierByVoltage(getEUt()), tier, recipeMap)
+                .stream()
                 .map(MCItemStack::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -25,7 +25,6 @@ import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.ConfigHolder;
 import gregtech.common.items.behaviors.CoverPlaceBehavior;
 import gregtech.common.items.behaviors.CrowbarBehaviour;
-import gregtech.common.metatileentities.electric.MetaTileEntityRockBreaker;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRedstoneWire;
 import net.minecraft.block.properties.IProperty;
@@ -86,6 +85,14 @@ public class GTUtility {
     private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
 
     private static TreeMap<Integer, String> romanNumeralConversions = new TreeMap<>();
+
+    private static final NavigableMap<Long, Byte> tierByVoltage = new TreeMap<>();
+
+    static {
+        for (int i = 0; i < V.length; i++) {
+            tierByVoltage.put(V[i], (byte) i);
+        }
+    }
 
     public static Runnable combine(Runnable... runnables) {
         return () -> {
@@ -439,15 +446,8 @@ public class GTUtility {
      * @return lowest tier that can handle passed voltage
      */
     public static byte getTierByVoltage(long voltage) {
-        byte tier = 0;
-        while (++tier < V.length) {
-            if (voltage == V[tier]) {
-                return tier;
-            } else if (voltage < V[tier]) {
-                return (byte) Math.max(0, tier - 1);
-            }
-        }
-        return (byte) Math.min(V.length - 1, tier);
+        if (voltage > V[GTValues.MAX]) return GTValues.MAX;
+        return tierByVoltage.ceilingEntry(voltage).getValue();
     }
 
     public static BiomeDictionary.Type getBiomeTypeTagByName(String name) {

--- a/src/test/java/gregtech/api/recipes/logic/ChancedOutputTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/ChancedOutputTest.java
@@ -1,0 +1,75 @@
+package gregtech.api.recipes.logic;
+
+import gregtech.api.GTValues;
+import gregtech.api.recipes.RecipeMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ChancedOutputTest {
+
+    private static final int BASE_AMOUNT = 1400;
+    private static final int BOOST_AMOUNT = 850;
+
+    private static final int RESULT_NO_BOOST = BASE_AMOUNT;
+    private static final int RESULT_ONE_BOOST = BASE_AMOUNT + BOOST_AMOUNT;
+    private static final int RESULT_TWO_BOOST = BASE_AMOUNT + (BOOST_AMOUNT * 2);
+
+    private static final RecipeMap.IChanceFunction defaultChanceFunction = RecipeMap.DEFAULT_CHANCE_FUNCTION;
+
+    @Test
+    public void test_ulv_no_boost() {
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.ULV, GTValues.LV);
+        assertEquals(RESULT_NO_BOOST, chance); // no chance boost should occur
+    }
+
+    @Test
+    public void test_ulv_single_boost() {
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.ULV, GTValues.MV);
+        assertEquals(RESULT_ONE_BOOST, chance); // chance boost by BOOST_AMOUNT should occur
+    }
+
+    @Test
+    public void test_ulv_double_boost() {
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.ULV, GTValues.HV);
+        assertEquals(RESULT_TWO_BOOST, chance); // chance boost by 2 * BOOST_AMOUNT should occur
+    }
+
+    @Test
+    public void test_lv_single_boost() {
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.LV, GTValues.MV);
+        assertEquals(RESULT_ONE_BOOST, chance); // chance boost by BOOST_AMOUNT should occur
+    }
+
+    @Test
+    public void test_lv_double_boost() {
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.LV, GTValues.HV);
+        assertEquals(RESULT_TWO_BOOST, chance); // chance boost by 2 * BOOST_AMOUNT should occur
+    }
+
+    @Test
+    public void test_same_tier() {
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.ULV, GTValues.ULV);
+        assertEquals(RESULT_NO_BOOST, chance); // no chance boost should occur
+
+        chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.LV, GTValues.LV);
+        assertEquals(RESULT_NO_BOOST, chance); // no chance boost should occur
+    }
+
+    @Test
+    public void test_invalid_boost() {
+        /*
+         * Check > RESULT_NO_BOOST here instead of exact values because invalid tier combinations should be considered
+         * mostly undefined behavior for GTCEu's default function.
+         *
+         * Anything is fine as long as the chance did not go up.
+         */
+
+        int chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.LV, GTValues.ULV);
+        assertFalse(chance > RESULT_NO_BOOST); // no chance boost should occur
+
+        chance = defaultChanceFunction.chanceFor(BASE_AMOUNT, BOOST_AMOUNT, GTValues.MV, GTValues.LV);
+        assertFalse(chance > RESULT_NO_BOOST); // no chance boost should occur
+    }
+}

--- a/src/test/java/gregtech/api/util/TierByVoltageTest.java
+++ b/src/test/java/gregtech/api/util/TierByVoltageTest.java
@@ -1,0 +1,130 @@
+package gregtech.api.util;
+
+import org.junit.Test;
+
+import static gregtech.api.GTValues.*;
+import static junit.framework.TestCase.assertEquals;
+
+public class TierByVoltageTest {
+
+    @Test
+    public void testV() {
+        assertEquals(ULV, GTUtility.getTierByVoltage(V[ULV]));
+        assertEquals(LV, GTUtility.getTierByVoltage(V[LV]));
+        assertEquals(MV, GTUtility.getTierByVoltage(V[MV]));
+        assertEquals(HV, GTUtility.getTierByVoltage(V[HV]));
+        assertEquals(EV, GTUtility.getTierByVoltage(V[EV]));
+        assertEquals(IV, GTUtility.getTierByVoltage(V[IV]));
+        assertEquals(LuV, GTUtility.getTierByVoltage(V[LuV]));
+        assertEquals(ZPM, GTUtility.getTierByVoltage(V[ZPM]));
+        assertEquals(UV, GTUtility.getTierByVoltage(V[UV]));
+        assertEquals(UHV, GTUtility.getTierByVoltage(V[UHV]));
+        assertEquals(UEV, GTUtility.getTierByVoltage(V[UEV]));
+        assertEquals(UIV, GTUtility.getTierByVoltage(V[UIV]));
+        assertEquals(UXV, GTUtility.getTierByVoltage(V[UXV]));
+        assertEquals(OpV, GTUtility.getTierByVoltage(V[OpV]));
+        assertEquals(MAX, GTUtility.getTierByVoltage(V[MAX]));
+    }
+
+    @Test
+    public void testV_div_2() {
+        assertEquals(ULV, GTUtility.getTierByVoltage(V[ULV] / 2L));
+        assertEquals(LV, GTUtility.getTierByVoltage(V[LV] / 2L));
+        assertEquals(MV, GTUtility.getTierByVoltage(V[MV] / 2L));
+        assertEquals(HV, GTUtility.getTierByVoltage(V[HV] / 2L));
+        assertEquals(EV, GTUtility.getTierByVoltage(V[EV] / 2L));
+        assertEquals(IV, GTUtility.getTierByVoltage(V[IV] / 2L));
+        assertEquals(LuV, GTUtility.getTierByVoltage(V[LuV] / 2L));
+        assertEquals(ZPM, GTUtility.getTierByVoltage(V[ZPM] / 2L));
+        assertEquals(UV, GTUtility.getTierByVoltage(V[UV] / 2L));
+        assertEquals(UHV, GTUtility.getTierByVoltage(V[UHV] / 2L));
+        assertEquals(UEV, GTUtility.getTierByVoltage(V[UEV] / 2L));
+        assertEquals(UIV, GTUtility.getTierByVoltage(V[UIV] / 2L));
+        assertEquals(UXV, GTUtility.getTierByVoltage(V[UXV] / 2L));
+        assertEquals(OpV, GTUtility.getTierByVoltage(V[OpV] / 2L));
+        assertEquals(MAX, GTUtility.getTierByVoltage(V[MAX] / 2L));
+    }
+
+    @Test
+    public void testV_mult_2() {
+        assertEquals(LV, GTUtility.getTierByVoltage(V[ULV] * 2L));
+        assertEquals(MV, GTUtility.getTierByVoltage(V[LV] * 2L));
+        assertEquals(HV, GTUtility.getTierByVoltage(V[MV] * 2L));
+        assertEquals(EV, GTUtility.getTierByVoltage(V[HV] * 2L));
+        assertEquals(IV, GTUtility.getTierByVoltage(V[EV] * 2L));
+        assertEquals(LuV, GTUtility.getTierByVoltage(V[IV] * 2L));
+        assertEquals(ZPM, GTUtility.getTierByVoltage(V[LuV] * 2L));
+        assertEquals(UV, GTUtility.getTierByVoltage(V[ZPM] * 2L));
+        assertEquals(UHV, GTUtility.getTierByVoltage(V[UV] * 2L));
+        assertEquals(UEV, GTUtility.getTierByVoltage(V[UHV] * 2L));
+        assertEquals(UIV, GTUtility.getTierByVoltage(V[UEV] * 2L));
+        assertEquals(UXV, GTUtility.getTierByVoltage(V[UIV] * 2L));
+        assertEquals(OpV, GTUtility.getTierByVoltage(V[UXV] * 2L));
+        assertEquals(MAX, GTUtility.getTierByVoltage(V[OpV] * 2L));
+        assertEquals(MAX, GTUtility.getTierByVoltage(V[MAX] * 2L));
+    }
+
+    @Test
+    public void testVA() {
+        assertEquals(ULV, GTUtility.getTierByVoltage(VA[ULV]));
+        assertEquals(LV, GTUtility.getTierByVoltage(VA[LV]));
+        assertEquals(MV, GTUtility.getTierByVoltage(VA[MV]));
+        assertEquals(HV, GTUtility.getTierByVoltage(VA[HV]));
+        assertEquals(EV, GTUtility.getTierByVoltage(VA[EV]));
+        assertEquals(IV, GTUtility.getTierByVoltage(VA[IV]));
+        assertEquals(LuV, GTUtility.getTierByVoltage(VA[LuV]));
+        assertEquals(ZPM, GTUtility.getTierByVoltage(VA[ZPM]));
+        assertEquals(UV, GTUtility.getTierByVoltage(VA[UV]));
+        assertEquals(UHV, GTUtility.getTierByVoltage(VA[UHV]));
+        assertEquals(UEV, GTUtility.getTierByVoltage(VA[UEV]));
+        assertEquals(UIV, GTUtility.getTierByVoltage(VA[UIV]));
+        assertEquals(UXV, GTUtility.getTierByVoltage(VA[UXV]));
+        assertEquals(OpV, GTUtility.getTierByVoltage(VA[OpV]));
+        assertEquals(MAX, GTUtility.getTierByVoltage(VA[MAX]));
+    }
+
+    @Test
+    public void testVA_div_2() {
+        assertEquals(ULV, GTUtility.getTierByVoltage(VA[ULV] / 2L));
+        assertEquals(LV, GTUtility.getTierByVoltage(VA[LV] / 2L));
+        assertEquals(MV, GTUtility.getTierByVoltage(VA[MV] / 2L));
+        assertEquals(HV, GTUtility.getTierByVoltage(VA[HV] / 2L));
+        assertEquals(EV, GTUtility.getTierByVoltage(VA[EV] / 2L));
+        assertEquals(IV, GTUtility.getTierByVoltage(VA[IV] / 2L));
+        assertEquals(LuV, GTUtility.getTierByVoltage(VA[LuV] / 2L));
+        assertEquals(ZPM, GTUtility.getTierByVoltage(VA[ZPM] / 2L));
+        assertEquals(UV, GTUtility.getTierByVoltage(VA[UV] / 2L));
+        assertEquals(UHV, GTUtility.getTierByVoltage(VA[UHV] / 2L));
+        assertEquals(UEV, GTUtility.getTierByVoltage(VA[UEV] / 2L));
+        assertEquals(UIV, GTUtility.getTierByVoltage(VA[UIV] / 2L));
+        assertEquals(UXV, GTUtility.getTierByVoltage(VA[UXV] / 2L));
+        assertEquals(OpV, GTUtility.getTierByVoltage(VA[OpV] / 2L));
+        assertEquals(MAX, GTUtility.getTierByVoltage(VA[MAX] / 2L));
+    }
+
+    @Test
+    public void testVA_mult_2() {
+        assertEquals(LV, GTUtility.getTierByVoltage(VA[ULV] * 2L));
+        assertEquals(MV, GTUtility.getTierByVoltage(VA[LV] * 2L));
+        assertEquals(HV, GTUtility.getTierByVoltage(VA[MV] * 2L));
+        assertEquals(EV, GTUtility.getTierByVoltage(VA[HV] * 2L));
+        assertEquals(IV, GTUtility.getTierByVoltage(VA[EV] * 2L));
+        assertEquals(LuV, GTUtility.getTierByVoltage(VA[IV] * 2L));
+        assertEquals(ZPM, GTUtility.getTierByVoltage(VA[LuV] * 2L));
+        assertEquals(UV, GTUtility.getTierByVoltage(VA[ZPM] * 2L));
+        assertEquals(UHV, GTUtility.getTierByVoltage(VA[UV] * 2L));
+        assertEquals(UEV, GTUtility.getTierByVoltage(VA[UHV] * 2L));
+        assertEquals(UIV, GTUtility.getTierByVoltage(VA[UEV] * 2L));
+        assertEquals(UXV, GTUtility.getTierByVoltage(VA[UIV] * 2L));
+        assertEquals(OpV, GTUtility.getTierByVoltage(VA[UXV] * 2L));
+        assertEquals(MAX, GTUtility.getTierByVoltage(VA[OpV] * 2L));
+        assertEquals(MAX, GTUtility.getTierByVoltage(VA[MAX] * 2L));
+    }
+
+
+    @Test
+    public void testSpecialCases() {
+        assertEquals(ULV, GTUtility.getTierByVoltage(0L));
+        assertEquals(ULV, GTUtility.getTierByVoltage(2L));
+    }
+}


### PR DESCRIPTION
## What
This PR implements new recipe logic for chanced outputs. They should behave a lot saner, and also make much more intuitive sense. 

Chanced outputs are now based on the amount of tiers a recipe is run at above the base tier, instead of previously being tied to the current tier regardless of the recipe. This should make a lot more sense to players. 

For example, a chanced HV recipe run at IV should boost twice, as `IV - HV = 5 - 3 = 2`. Whereas previously the recipe would boost 5 times due to IV being the 5th voltage tier.

## Implementation Details
A new implementation for GTUtility's `getTierByVoltage` was also implemented, in order to fix unexpected or incorrect behavior observed during the creation PR. There are tests added to confirm this.

Tests have also been added for the default chance functions in order to ensure this behavior is consistent and continues to work properly in the future.

## Outcome
Improves chanced output logic.

## Potential Compatibility Issues
As this PR changes the number of chanced output parameters, existing CraftTweaker scripts modifying a RecipeMap's chance function will now break, and will need to adjust accordingly.
