### PR TITLE
Fix hydrogen duplication exploit

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/LCRCombined.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/LCRCombined.java
@@ -25,7 +25,7 @@ public class LCRCombined {
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
                 .notConsumable(new IntCircuitIngredient(24))
                 .fluidInputs(Hydrogen.getFluid(6000))
-                .fluidInputs(CarbonDioxide.getFluid(1000))
+                .fluidInputs(CarbonMonoxide.getFluid(1000))
                 .fluidOutputs(Methane.getFluid(1000))
                 .fluidOutputs(Water.getFluid(1000))
                 .EUt(VA[LV])


### PR DESCRIPTION
## What
This PR fixes a hydrogen duplication exploit.

You could previously use the imbalanced recipe: `CO2 + 3H2 -> CH4 + H2O` in combination with the recipe `CH4 + 2H2O -> CO2 + 4H2`. This meant you could use 6 Hydrogen to make 8, infinitely. The balanced recipe, `CO + 3H2 -> CH4 + H2O`, prevents this.

## Outcome
Fixes hydrogen duplication exploit.
