### PR TITLE
fix small issues with maintenance tool slot

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -236,11 +236,11 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     }
 
     /**
+     * Attempts to fix a provided maintenance problem with a tool in the player's
+     * inventory, if the tool exists.
      *
-     * Fixes all maintenance problems that a player's inventory has tools for
-     *
-     * @param problemIndex is the index of the maintenance problem
-     * @param entityPlayer is the target player whose inventory is used to scan for tools
+     * @param problemIndex The index of the maintenance problem.
+     * @param entityPlayer The player whose inventory the tool may be in.
      */
     private void fixProblemWithTool(int problemIndex, EntityPlayer entityPlayer) {
         List<ToolMetaItem<?>.MetaToolValueItem> tools = null;
@@ -260,13 +260,24 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
         for (ToolMetaItem<?>.MetaToolValueItem tool : tools) {
             for (ItemStack itemStack : entityPlayer.inventory.mainInventory) {
                 if (itemStack.isItemEqualIgnoreDurability(tool.getStackForm())) {
-                    ((IMaintenance) this.getController()).setMaintenanceFixed(problemIndex);
-                    IToolStats.onOtherUse(itemStack, getWorld(), getPos());
-                    damageTool(itemStack);
-                    this.setTaped(false);
+                    fixProblemWithTool(problemIndex, itemStack);
+                    return;
                 }
             }
+            // Try to use the item in the player's "hand" (under the cursor)
+            ItemStack heldItem = entityPlayer.inventory.getItemStack();
+            if (heldItem.isItemEqualIgnoreDurability(tool.getStackForm())) {
+                fixProblemWithTool(problemIndex, heldItem);
+                return;
+            }
         }
+    }
+
+    private void fixProblemWithTool(int problemIndex, ItemStack toolStack) {
+        ((IMaintenance) getController()).setMaintenanceFixed(problemIndex);
+        IToolStats.onOtherUse(toolStack, getWorld(), getPos());
+        damageTool(toolStack);
+        setTaped(false);
     }
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -258,17 +258,19 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
             return;
 
         for (ToolMetaItem<?>.MetaToolValueItem tool : tools) {
-            for (ItemStack itemStack : entityPlayer.inventory.mainInventory) {
-                if (itemStack.isItemEqualIgnoreDurability(tool.getStackForm())) {
-                    fixProblemWithTool(problemIndex, itemStack);
-                    return;
-                }
-            }
             // Try to use the item in the player's "hand" (under the cursor)
             ItemStack heldItem = entityPlayer.inventory.getItemStack();
             if (heldItem.isItemEqualIgnoreDurability(tool.getStackForm())) {
                 fixProblemWithTool(problemIndex, heldItem);
                 return;
+            }
+
+            // Then try all the remaining inventory slots
+            for (ItemStack itemStack : entityPlayer.inventory.mainInventory) {
+                if (itemStack.isItemEqualIgnoreDurability(tool.getStackForm())) {
+                    fixProblemWithTool(problemIndex, itemStack);
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes 2 issues:
- All tools in the inventory will be damaged when clicking on the maintenance tool button
    - For example, all wrenches in the inventory will be damaged when clicking on the slot, but ONLY if the wrench maintenance problem is not already fixed
- Clicking the tool slot in the maintenance hatch now also checks the "held item" (the item under the player's cursor). There is a slight graphical issue where if an undamaged tool is in the held item slot and used to fix a problem, it will not show the durability bar until the UI is refreshed (exited and reopened) but I believe this is just an MC issue, the tool is still properly damaged.
    - This "held item" will be prioritized if it exists
