### PR TITLE
Scale hot ingot damage by blast temperature

### DIFF
--- a/src/main/java/gregtech/api/items/armor/IArmorLogic.java
+++ b/src/main/java/gregtech/api/items/armor/IArmorLogic.java
@@ -67,4 +67,12 @@ public interface IArmorLogic {
     default ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, EntityEquipmentSlot armorSlot, ModelBiped defaultModel) {
         return null;
     }
+
+    /**
+     *
+     * @return the value to multiply heat damage by
+     */
+    default float getHeatResistance() {
+        return 1.0f;
+    }
 }

--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -174,7 +174,7 @@ public class MetaPrefixItem extends StandardMetaItem {
                     heatDamage *= ((ArmorMetaItem<?>) armor.getItem()).getItem(armor).getArmorLogic().getHeatResistance();
                 }
 
-                if (heatDamage != 0.0 && heatDamage > 0.0) {
+                if (heatDamage > 0.0) {
                     entity.attackEntityFrom(DamageSources.getHeatDamage().setDamageBypassesArmor(), heatDamage);
                 } else if (heatDamage < 0.0) {
                     entity.attackEntityFrom(DamageSources.getFrostDamage().setDamageBypassesArmor(), -heatDamage);

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -244,7 +244,7 @@ public class OrePrefix {
     }
 
     static {
-        ingotHot.heatDamageFunction = (temp) -> ((temp - 1750) / 1000.0F) + 3;
+        ingotHot.heatDamageFunction = (temp) -> ((temp - 1750) / 1000.0F) + 2;
         gemFlawless.maxStackSize = 32;
         gemExquisite.maxStackSize = 16;
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -244,7 +244,7 @@ public class OrePrefix {
     }
 
     static {
-        ingotHot.heatDamageFunction = (temp) -> ((temp - 1750) / 500.0F) + 3;
+        ingotHot.heatDamageFunction = (temp) -> ((temp - 1750) / 1000.0F) + 3;
         gemFlawless.maxStackSize = 32;
         gemExquisite.maxStackSize = 16;
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -244,7 +244,7 @@ public class OrePrefix {
     }
 
     static {
-        ingotHot.heatDamage = 3.0F;
+        ingotHot.heatDamageFunction = (temp) -> ((temp - 1750) / 500.0F) + 3;
         gemFlawless.maxStackSize = 32;
         gemExquisite.maxStackSize = 16;
 
@@ -433,7 +433,7 @@ public class OrePrefix {
 
     public byte maxStackSize = 64;
     public final List<MaterialStack> secondaryMaterials = new ArrayList<>();
-    public float heatDamage = 0.0F; // Negative for Frost Damage
+    public Function<Integer, Float> heatDamageFunction = null; // Negative for Frost Damage
     public Function<Material, List<String>> tooltipFunc;
 
     private String alternativeOreName = null;

--- a/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
@@ -131,6 +131,11 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
         return 1.0D;
     }
 
+    @Override
+    public float getHeatResistance() {
+        return 0.75f;
+    }
+
     @SideOnly(Side.CLIENT)
     public boolean isNeedDrawHUD() {
         return true;

--- a/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
@@ -271,6 +271,11 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         return SLOT == EntityEquipmentSlot.CHEST ? 1.2D : 1.0D;
     }
 
+    @Override
+    public float getHeatResistance() {
+        return 0.5f;
+    }
+
     @SideOnly(Side.CLIENT)
     public boolean isNeedDrawHUD() {
         return true;


### PR DESCRIPTION
## What
This PR changes hot ingots to scale their damage based on the blast temperature. The damage floor is 3, just as before, but hotter materials will do more damage. The hottest ingots, at over 10kK, will kill the player in one hit without wearing protection. Wearing a Nano Chestplate reduces the damage by 25%, and a Quantum Chestplate by 50%.

## Outcome
Scales hot ingot damage by blast temperature.
