### PR TITLE
Fix multiblocks automatically voiding with no output bus or hatch

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -440,13 +440,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
 
         // We have already trimmed outputs and chanced outputs at this time
         // Attempt to merge all outputs + chanced outputs into the output bus, to prevent voiding chanced outputs
-        if (!metaTileEntity.canVoidRecipeItemOutputs() && exportInventory.getSlots() > 0 && !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
+        if (!metaTileEntity.canVoidRecipeItemOutputs() && !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
             this.isOutputsFull = true;
             return false;
         }
 
         // We have already trimmed fluid outputs at this time
-        if (!metaTileEntity.canVoidRecipeFluidOutputs() && exportFluids.getTanks() > 0 && !GTTransferUtils.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs())) {
+        if (!metaTileEntity.canVoidRecipeFluidOutputs() && !GTTransferUtils.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs())) {
             this.isOutputsFull = true;
             return false;
         }


### PR DESCRIPTION
## What
Fixes #1236 

## Implementation Details
Remove an additional check that was done in #666, on [this commit](https://github.com/GregTechCEu/GregTech/commit/bb842f0414186548934e4f861a251750ce102010).

## Outcome
Multiblocks will longer accidentally void when missing output bus or hatch. This voiding is intended to be switched with the voiding button.

## Additional Information
I believe the change was done to avoid recipe lookups in cases where a multiblock has neither output bus or hatch, but at that point it's on the player if they want to build useless multiblocks that still cause lag.