### PR TITLE
Render the solid active blocks on the solid layer

### DIFF
--- a/src/main/java/gregtech/api/block/VariantActiveBlock.java
+++ b/src/main/java/gregtech/api/block/VariantActiveBlock.java
@@ -61,13 +61,8 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
     }
 
     @Override
-    public BlockRenderLayer getRenderLayer() {
-        return BlockRenderLayer.CUTOUT;
-    }
-
-    @Override
     public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer) {
-        return layer == getRenderLayer() || layer == BloomEffectUtil.BLOOM;
+        return layer == getRenderLayer() || layer == BloomEffectUtil.getRealBloomLayer();
     }
 
     @Nonnull

--- a/src/main/java/gregtech/client/model/modelfactories/ActiveVariantBlockBakedModel.java
+++ b/src/main/java/gregtech/client/model/modelfactories/ActiveVariantBlockBakedModel.java
@@ -60,7 +60,7 @@ public class ActiveVariantBlockBakedModel implements IBakedModel {
         IBakedModel m = Minecraft.getMinecraft().blockRenderDispatcher.getBlockModelShapes().getModelManager().getModel(mrl);
         TextureAtlasSprite textureAtlasSprite = m.getParticleTexture();
         particle.set(textureAtlasSprite);
-        if (MinecraftForgeClient.getRenderLayer() == BloomEffectUtil.BLOOM) {
+        if (MinecraftForgeClient.getRenderLayer() == BloomEffectUtil.getRealBloomLayer()) {
             if (ConfigHolder.client.casingsActiveEmissiveTextures) {
                 quads = new ArrayList<>();
                 for (BakedQuad b : m.getQuads(state, side, rand)) {

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_cupronickel.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_cupronickel.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_cupronickel_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_hssg.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_hssg.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_hssg_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_kanthal.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_kanthal.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_kanthal_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_naquadah.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_naquadah.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_naquadah_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_nichrome.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_nichrome.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_nichrome_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_trinium.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_trinium.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_trinium_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_tritanium.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_tritanium.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_tritanium_ctm"
         ],

--- a/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_tungstensteel.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/casings/coils/machine_coil_tungstensteel.png.mcmeta
@@ -2,7 +2,7 @@
     "ctm": {
         "ctm_version": 1,
         "type": "CTM",
-        "layer": "CUTOUT",
+        "layer": "SOLID",
         "textures": [
             "gregtech:blocks/casings/coils/machine_coil_tungstensteel_ctm"
         ],


### PR DESCRIPTION
updated CTM meta accordingly.
I do not know why this worked before as it was.