### PR TITLE
Give frames a sound when placed vertically

### DIFF
--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -287,8 +287,11 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         ItemStack itemStack = entityPlayer.getHeldItem(hand);
 
         if (pipeTile.getFrameMaterial() == null && pipeTile instanceof TileEntityPipeBase && itemStack.getItem() instanceof FrameItemBlock && pipeTile.getPipeType().getThickness() < 1) {
-            Material material = ((BlockFrame) ((FrameItemBlock) itemStack.getItem()).getBlock()).getGtMaterial(itemStack.getMetadata());
+            BlockFrame frameBlock = (BlockFrame) ((FrameItemBlock) itemStack.getItem()).getBlock();
+            Material material = frameBlock.getGtMaterial(itemStack.getMetadata());
             ((TileEntityPipeBase<PipeType, NodeDataType>) pipeTile).setFrameMaterial(material);
+            SoundType type = frameBlock.getSoundType(itemStack);
+            world.playSound(entityPlayer, pos, type.getPlaceSound(), SoundCategory.BLOCKS, (type.getVolume() + 1.0F) / 2.0F, type.getPitch() * 0.8F);
             if (!entityPlayer.capabilities.isCreativeMode) {
                 itemStack.shrink(1);
             }

--- a/src/main/java/gregtech/common/blocks/BlockFrame.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrame.java
@@ -102,6 +102,14 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
         return SoundType.METAL;
     }
 
+    public SoundType getSoundType(ItemStack stack) {
+        Material material = getGtMaterial(stack.getMetadata());
+        if (ModHandler.isMaterialWood(material)) {
+            return SoundType.WOOD;
+        }
+        return SoundType.METAL;
+    }
+
     @Override
     public int getHarvestLevel(@Nonnull IBlockState state) {
         return 1;
@@ -171,6 +179,8 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
                     GTLog.logger.error("Pipe was not placed!");
                     return false;
                 }
+                SoundType type = blockPipe.getSoundType(state, worldIn, pos, playerIn);
+                worldIn.playSound(playerIn, pos, type.getPlaceSound(), SoundCategory.BLOCKS, (type.getVolume() + 1.0F) / 2.0F, type.getPitch() * 0.8F);
                 if (!playerIn.capabilities.isCreativeMode) {
                     stackInHand.shrink(1);
                 }
@@ -196,6 +206,8 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
             }
             if (canPlaceBlockAt(worldIn, blockPos)) {
                 worldIn.setBlockState(blockPos, ((FrameItemBlock) stackInHand.getItem()).getBlockState(stackInHand));
+                SoundType type = getSoundType(stackInHand);
+                worldIn.playSound(null, pos, type.getPlaceSound(), SoundCategory.BLOCKS, (type.getVolume() + 1.0F) / 2.0F, type.getPitch() * 0.8F);
                 if (!playerIn.capabilities.isCreativeMode) {
                     stackInHand.shrink(1);
                 }
@@ -204,6 +216,11 @@ public final class BlockFrame extends DelayedStateBlock implements IModelSupplie
             } else if (te instanceof TileEntityPipeBase && ((TileEntityPipeBase<?, ?>) te).getFrameMaterial() == null) {
                 Material material = ((BlockFrame) ((FrameItemBlock) stackInHand.getItem()).getBlock()).getGtMaterial(stackInHand.getMetadata());
                 ((TileEntityPipeBase<?, ?>) te).setFrameMaterial(material);
+                SoundType type = getSoundType(stackInHand);
+                worldIn.playSound(null, pos, type.getPlaceSound(), SoundCategory.BLOCKS, (type.getVolume() + 1.0F) / 2.0F, type.getPitch() * 0.8F);
+                if (!playerIn.capabilities.isCreativeMode) {
+                    stackInHand.shrink(1);
+                }
                 blockPos.release();
                 return true;
             } else {


### PR DESCRIPTION
Closes #1247

Follows exact MC logic for sound. Taken from `net.minecraft.item.ItemBlock.class`:
```
if (placeBlockAt(itemstack, player, worldIn, pos, facing, hitX, hitY, hitZ, iblockstate1))
{
    iblockstate1 = worldIn.getBlockState(pos);
    SoundType soundtype = iblockstate1.getBlock().getSoundType(iblockstate1, worldIn, pos, player);
    worldIn.playSound(player, pos, soundtype.getPlaceSound(), SoundCategory.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
    itemstack.shrink(1);
}
```
