### PR TITLE
fix and improve overclocking logic

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -1,11 +1,8 @@
 package gregtech.api.capability.impl;
 
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.metatileentity.IVoidable;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
@@ -20,7 +17,7 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
     }
 
     @Override
-    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
+    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
         // no overclocking happens other than parallelization,
         // so return the recipe's values, with EUt made positive for it to be made negative later
         return new int[]{recipeEUt * -1, recipeDuration};

--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -21,14 +21,15 @@ public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int maxOverclocks) {
+    protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int amountOC) {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
-        return heatingCoilOverclockingLogic(Math.abs(recipeEUt),
+        return heatingCoilOverclockingLogic(
+                Math.abs(recipeEUt),
                 maxVoltage,
                 (int) Math.round(duration * maintenanceValues.getSecond()),
-                maxOverclocks,
+                amountOC,
                 ((IHeatingCoil) metaTileEntity).getCurrentTemperature(),
                 propertyStorage.getRecipePropertyValue(TemperatureProperty.getInstance(), 0)
         );

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -20,7 +20,7 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
+    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
         // apply maintenance penalties
         MultiblockWithDisplayBase displayBase = this.metaTileEntity instanceof MultiblockWithDisplayBase ? (MultiblockWithDisplayBase) metaTileEntity : null;
         int numMaintenanceProblems = displayBase == null ? 0 : displayBase.getNumMaintenanceProblems();

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -250,28 +250,31 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
+    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         int[] overclock = null;
         if (maintenanceValues.getSecond() != 1.0)
 
-            overclock = standardOverclockingLogic(Math.abs(recipeEUt),
+            overclock = standardOverclockingLogic(
+                    Math.abs(recipeEUt),
                     maxVoltage,
                     (int) Math.round(recipeDuration * maintenanceValues.getSecond()),
+                    amountOC,
                     getOverclockingDurationDivisor(),
-                    getOverclockingVoltageMultiplier(),
-                    maxOverclocks
+                    getOverclockingVoltageMultiplier()
             );
 
         if (overclock == null)
-            overclock = standardOverclockingLogic(Math.abs(recipeEUt),
+            overclock = standardOverclockingLogic(
+                    Math.abs(recipeEUt),
                     maxVoltage,
                     recipeDuration,
+                    amountOC,
                     getOverclockingDurationDivisor(),
-                    getOverclockingVoltageMultiplier(),
-                    maxOverclocks);
+                    getOverclockingVoltageMultiplier()
+            );
 
         if (maintenanceValues.getFirst() > 0)
             overclock[1] = (int) (overclock[1] * (1 + 0.1 * maintenanceValues.getFirst()));

--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -42,13 +42,15 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int maxOverclocks) {
-        return standardOverclockingLogic(1,
+    protected int[] runOverclockingLogic(IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
+        return standardOverclockingLogic(
+                1,
                 getMaxVoltage(),
                 recipeDuration,
+                amountOC,
                 getOverclockingDurationDivisor(),
-                getOverclockingVoltageMultiplier(),
-                maxOverclocks
+                getOverclockingVoltageMultiplier()
+
         );
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -41,7 +41,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
-import static gregtech.api.recipes.logic.OverclockingLogic.unlockedVoltageOverclockingLogic;
+import static gregtech.api.GTValues.ULV;
+import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
 
 public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController implements IMachineHatchMultiblock {
 
@@ -272,14 +273,21 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
             // apply maintenance penalties
             Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
-            int originalTier = Math.max(1, GTUtility.getTierByVoltage(recipeEUt / Math.max(1, this.parallelRecipesPerformed)));
+            int originalTier = Math.max(0, GTUtility.getTierByVoltage(recipeEUt / Math.max(1, this.parallelRecipesPerformed)));
             int numOverclocks = Math.min(this.machineTier, GTUtility.getTierByVoltage(getMaxVoltage())) - originalTier;
-            return unlockedVoltageOverclockingLogic(
-                    recipeEUt, getMaxVoltage(),
+
+            if (originalTier == ULV) numOverclocks--; // no ULV overclocking
+
+            // cannot overclock, so return the starting values
+            if (numOverclocks <= 0) return new int[]{recipe.getEUt(), recipe.getDuration()};
+
+            return standardOverclockingLogic(
+                    recipeEUt,
+                    getMaximumOverclockVoltage(),
                     (int) Math.round(recipeDuration * maintenanceValues.getSecond()),
+                    numOverclocks,
                     getOverclockingDurationDivisor(),
-                    getOverclockingVoltageMultiplier(),
-                    numOverclocks
+                    getOverclockingVoltageMultiplier()
             );
         }
 

--- a/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
@@ -27,7 +27,7 @@ public class OverclockingTest {
 
         oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
 
-        // 0 overclocks
+        // 1 overclock
         assertEquals(recipeVoltage * 4, oc[0]);
         assertEquals(recipeDuration / 2, oc[1]);
 
@@ -36,7 +36,7 @@ public class OverclockingTest {
 
         oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
 
-        // 0 overclocks
+        // 2 overclocks
         assertEquals(recipeVoltage * ((int) Math.pow(4, 2)), oc[0]);
         assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
     }
@@ -137,6 +137,37 @@ public class OverclockingTest {
         assertEquals(recipeDuration / 2 / 4, oc[1]);
     }
 
+    @Test
+    public void testFusionReactor() {
+        final int recipeDuration = 32768;
+        final int recipeTier = LuV;
+        final int recipeVoltage = (int) V[recipeTier];
+
+        // LuV recipe, LuV machine
+        int machineTier = LuV;
+
+        int[] oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        assertEquals(recipeVoltage, oc[0]);
+        assertEquals(recipeDuration, oc[1]);
+
+        // LuV recipe, ZPM machine
+        machineTier = ZPM;
+
+        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        assertEquals(recipeVoltage * 2, oc[0]);
+        assertEquals(recipeDuration / 2, oc[1]);
+
+        // LuV recipe, UV machine
+        machineTier = UV;
+
+        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        assertEquals(recipeVoltage * ((int) Math.pow(2, 2)), oc[0]);
+        assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
+    }
+
     private int[] testOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier, int maxVoltage) {
         int numberOfOCs = machineTier - recipeTier;
         if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
@@ -168,5 +199,21 @@ public class OverclockingTest {
                 numberOfOCs,
                 machineTemperature,
                 recipeTemperature);
+    }
+
+    private int[] testFusionOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier, int maxVoltage) {
+        int numberOfOCs = machineTier - recipeTier;
+        if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
+
+        // cannot overclock, so return the starting values
+        if (numberOfOCs <= 0) return new int[]{recipeVoltage, recipeDuration};
+
+        return OverclockingLogic.standardOverclockingLogic(
+                recipeVoltage,
+                maxVoltage,
+                recipeDuration,
+                numberOfOCs,
+                OverclockingLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR,
+                2.0);
     }
 }

--- a/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
@@ -1,0 +1,172 @@
+package gregtech.api.recipes.logic;
+
+import org.junit.Test;
+
+import static gregtech.api.GTValues.*;
+import static org.junit.Assert.assertEquals;
+
+public class OverclockingTest {
+
+    @Test
+    public void testULV() {
+        final int recipeDuration = 32768;
+        final int recipeTier = ULV;
+        final int recipeVoltage = (int) V[recipeTier];
+
+        // ULV recipe, LV machine
+        int machineTier = LV;
+
+        int[] oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        // 0 overclocks
+        assertEquals(recipeVoltage, oc[0]);
+        assertEquals(recipeDuration, oc[1]);
+
+        // ULV recipe, MV machine
+        machineTier = MV;
+
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        // 0 overclocks
+        assertEquals(recipeVoltage * 4, oc[0]);
+        assertEquals(recipeDuration / 2, oc[1]);
+
+        // ULV recipe, HV machine
+        machineTier = HV;
+
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        // 0 overclocks
+        assertEquals(recipeVoltage * ((int) Math.pow(4, 2)), oc[0]);
+        assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
+    }
+
+    @Test
+    public void testULV2() {
+        final int recipeDuration = 32768;
+        final int recipeTier = ULV;
+        final int recipeVoltage = (int) V[recipeTier] * 2;
+
+        // ULV recipe, LV machine
+        int machineTier = LV;
+
+        int[] oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        // 0 overclocks
+        assertEquals(recipeVoltage, oc[0]);
+        assertEquals(recipeDuration, oc[1]);
+
+        // ULV recipe, MV machine
+        machineTier = MV;
+
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        // 1 overclock
+        assertEquals(recipeVoltage * 4, oc[0]);
+        assertEquals(recipeDuration / 2, oc[1]);
+
+        // ULV recipe, HV machine
+        machineTier = HV;
+
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        // 2 overclocks
+        assertEquals(recipeVoltage * ((int) Math.pow(4, 2)), oc[0]);
+        assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
+    }
+
+    @Test
+    public void testLV() {
+        final int recipeDuration = 32768;
+        final int recipeTier = LV;
+        final int recipeVoltage = (int) V[recipeTier];
+
+        // LV recipe, LV machine
+        int machineTier = LV;
+
+        int[] oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        assertEquals(recipeVoltage, oc[0]);
+        assertEquals(recipeDuration, oc[1]);
+
+        // LV recipe, MV machine
+        machineTier = MV;
+
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        assertEquals(recipeVoltage * 4, oc[0]);
+        assertEquals(recipeDuration / 2, oc[1]);
+
+        // LV recipe, HV machine
+        machineTier = HV;
+
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+
+        assertEquals(recipeVoltage * ((int) Math.pow(4, 2)), oc[0]);
+        assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
+    }
+
+    @Test
+    public void testHeatingCoilsDiffTemp() {
+        final int recipeDuration = 32768;
+        final int recipeTier = LV;
+        final int recipeVoltage = (int) V[recipeTier];
+
+        // LV recipe, HV machine
+        final int machineTier = HV;
+
+        // 1800K recipe, 1800K machine
+        int[] oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier], 1800, 1800);
+
+        // 0 EU discounts, 2 overclocks
+        assertEquals(recipeVoltage * ((int) Math.pow(4, 2)), oc[0]);
+        assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
+
+        // 1800K recipe, 2700K machine
+        oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier], 1800, 2700);
+
+        // 1 EU discount, 2 overclocks
+        assertEquals(((int) (recipeVoltage * 0.95)) * ((int) Math.pow(4, 2)), oc[0]);
+        assertEquals(recipeDuration / ((int) Math.pow(2, 2)), oc[1]);
+
+        // 1800K recipe, 3600K machine
+        oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier], 1800, 3600);
+
+        // 2 EU discounts, 1 perfect overclock, 1 regular overclock
+        assertEquals(((int) (recipeVoltage * Math.pow(0.95, 2))) * ((int) Math.pow(4, 2)), oc[0]);
+        assertEquals(recipeDuration / 2 / 4, oc[1]);
+    }
+
+    private int[] testOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier, int maxVoltage) {
+        int numberOfOCs = machineTier - recipeTier;
+        if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
+
+        // cannot overclock, so return the starting values
+        if (numberOfOCs <= 0) return new int[]{recipeVoltage, recipeDuration};
+
+        return OverclockingLogic.standardOverclockingLogic(
+                recipeVoltage,
+                maxVoltage,
+                recipeDuration,
+                numberOfOCs,
+                OverclockingLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR,
+                OverclockingLogic.STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER);
+    }
+
+    private int[] testHeatingOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier, int maxVoltage,
+                                int recipeTemperature, int machineTemperature) {
+        int numberOfOCs = machineTier - recipeTier;
+        if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
+
+        // cannot overclock, so return the starting values
+        if (numberOfOCs <= 0) return new int[]{recipeVoltage, recipeDuration};
+
+        return OverclockingLogic.heatingCoilOverclockingLogic(
+                recipeVoltage,
+                maxVoltage,
+                recipeDuration,
+                numberOfOCs,
+                machineTemperature,
+                recipeTemperature);
+    }
+}


### PR DESCRIPTION
## What
This PR fixes issues with overclocking logic, causing recipes to often overclock one time fewer than they were supposed to.

## Implementation Details
In making this PR, the PA's custom overclocking logic was found to be largely redundant and was now removed.

## Outcome
Fixes problems with overclocking logic.
