### PR TITLE
Yet another Crafting station fix PR

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -20,7 +20,7 @@ public class CachedRecipeData {
     private final ItemSources itemSources;
     private IRecipe recipe;
     private final Map<ItemStackKey, Integer> requiredItems = new HashMap<>();
-    private final Map<Integer,Map<ItemStackKey,Boolean>> replaceAttemptMap= new Int2ObjectArrayMap<>();
+    private final Map<Integer, Map<ItemStackKey, Boolean>> replaceAttemptMap = new Int2ObjectArrayMap<>();
     private final InventoryCrafting inventory;
 
     public CachedRecipeData(ItemSources sourceList, IRecipe recipe, InventoryCrafting inventoryCrafting) {
@@ -80,12 +80,12 @@ public class CachedRecipeData {
 
         ItemStack previousStack = recipe.getCraftingResult(inventory);
 
-        Map<ItemStackKey,Boolean> map = replaceAttemptMap.computeIfAbsent(slot,(m) -> new Object2BooleanOpenHashMap<>());
+        Map<ItemStackKey, Boolean> map = replaceAttemptMap.computeIfAbsent(slot, (m) -> new Object2BooleanOpenHashMap<>());
 
         //iterate stored items to find equivalent
         for (ItemStackKey itemStackKey : itemSources.getStoredItems()) {
             if (map.containsKey(itemStackKey)) {
-                if(!map.get(itemStackKey)){
+                if (!map.get(itemStackKey)) {
                     continue;
                 } else {
                     return true;
@@ -98,14 +98,14 @@ public class CachedRecipeData {
             //Matching shapeless recipes actually is very bad for performance, as it checks the entire
             //recipe ingredients recursively, so we fail early here if none of the recipes ingredients can
             //take the stack
-            for(Ingredient in : recipe.getIngredients()) {
-                if (in.apply(itemStack)){
-                    matched =true;
+            for (Ingredient in : recipe.getIngredients()) {
+                if (in.apply(itemStack)) {
+                    matched = true;
                     break;
                 }
             }
             if (!matched) {
-                map.put(itemStackKey,false);
+                map.put(itemStackKey, false);
                 continue;
             }
 
@@ -118,7 +118,7 @@ public class CachedRecipeData {
                     return true;
                 }
             }
-            map.put(itemStackKey,false);
+            map.put(itemStackKey, false);
             inventory.setInventorySlotContents(slot, currentStack);
         }
         //nothing matched, so return null

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -2,6 +2,7 @@ package gregtech.common.metatileentities.storage;
 
 import gregtech.api.recipes.KeySharedStack;
 import gregtech.api.util.ItemStackKey;
+import gregtech.api.util.ShapedOreEnergyTransferRecipe;
 import gregtech.common.inventory.IItemList;
 import gregtech.common.inventory.itemsource.ItemSources;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
@@ -111,7 +112,8 @@ public class CachedRecipeData {
 
             //update item in slot, and check that recipe matches and output item is equal to the expected one
             inventory.setInventorySlotContents(slot, itemStack);
-            if (recipe.matches(inventory, itemSources.getWorld()) && ItemStack.areItemStacksEqual(recipe.getCraftingResult(inventory), previousStack)) {
+            if (recipe.matches(inventory, itemSources.getWorld()) &&
+                    (ItemStack.areItemStacksEqual(recipe.getCraftingResult(inventory), previousStack) || recipe instanceof ShapedOreEnergyTransferRecipe)) {
                 map.put(itemStackKey, true);
                 //ingredient matched, attempt to extract it and return if successful
                 if (simulateExtractItem(itemStackKey)) {

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -9,6 +9,7 @@ import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.world.World;
 
 import java.util.HashMap;
@@ -90,7 +91,24 @@ public class CachedRecipeData {
                     return true;
                 }
             }
+
             ItemStack itemStack = itemStackKey.getItemStack();
+
+            boolean matched = false;
+            //Matching shapeless recipes actually is very bad for performance, as it checks the entire
+            //recipe ingredients recursively, so we fail early here if none of the recipes ingredients can
+            //take the stack
+            for(Ingredient in : recipe.getIngredients()) {
+                if (in.apply(itemStack)){
+                    matched =true;
+                    break;
+                }
+            }
+            if (!matched) {
+                map.put(itemStackKey,false);
+                continue;
+            }
+
             //update item in slot, and check that recipe matches and output item is equal to the expected one
             inventory.setInventorySlotContents(slot, itemStack);
             if (recipe.matches(inventory, itemSources.getWorld()) && ItemStack.areItemStacksEqual(recipe.getCraftingResult(inventory), previousStack)) {


### PR DESCRIPTION
## What
Yet another Crafting Station Issue F I X.
This time fix the issue with Shapeless Recipes Murdering the server performance, when the Crafting Station is surrounded by inventories with many slots
Also made recipe re-matching stricter to avoid issue with recipes with NBT-dependent inputs not correctly updating the output.
(Like potion arrows)

## Implementation Details
Implement a cache for the tested stacks for the current recipe while also testing them individually against the ingredients before calling the recipe matches() method to avoid the recursion of Shapeless recipes

## Outcome
Game is playable while a shapeless recipe is on the crafting station's crafting grid

## Additional Information
Fixes #1235, and hopefully #935

## Potential Compatibility Issues
_This section is for defining possible compatibility issues. It must be used when there are API changes, item/block/material/machine changes, or recipe changes._

**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**
