### PR TITLE
Fix failing tests for polymer names

### DIFF
--- a/src/main/java/gregtech/api/util/GTControlledRegistry.java
+++ b/src/main/java/gregtech/api/util/GTControlledRegistry.java
@@ -2,13 +2,11 @@ package gregtech.api.util;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import gregtech.GregTechMod;
+import gregtech.api.GTValues;
 import net.minecraft.util.IntIdentityHashBiMap;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.RegistrySimple;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
-import net.minecraftforge.registries.GameData;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,10 +33,11 @@ public class GTControlledRegistry<K, V> extends RegistrySimple<K, V> {
         if (frozen) {
             throw new IllegalStateException("Registry is already frozen!");
         }
-        ModContainer container = Loader.instance().activeModContainer();
-        if (container == null || container.getMod() != GregTechMod.instance) {
+
+        if (!checkActiveModContainerIsGregtech()) {
             return;
         }
+
         this.frozen = true;
     }
 
@@ -46,11 +45,21 @@ public class GTControlledRegistry<K, V> extends RegistrySimple<K, V> {
         if (!frozen) {
             throw new IllegalStateException("Registry is already unfrozen!");
         }
-        ModContainer container = Loader.instance().activeModContainer();
-        if (container == null || container.getMod() != GregTechMod.instance) {
+
+        if (!checkActiveModContainerIsGregtech()) {
             return;
         }
+
         this.frozen = false;
+    }
+
+    private boolean checkActiveModContainerIsGregtech() {
+        ModContainer container = Loader.instance().activeModContainer();
+        if (container != null && container.getModId().equals(GTValues.MODID)) {
+            return true;
+        }
+
+        return false;
     }
 
     public void register(int id, K key, V value) {

--- a/src/test/java/gregtech/Bootstrap.java
+++ b/src/test/java/gregtech/Bootstrap.java
@@ -1,5 +1,7 @@
 package gregtech;
 
+import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.fluids.MetaFluids;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
@@ -34,9 +36,13 @@ public class Bootstrap {
         }
         net.minecraft.init.Bootstrap.register();
         ModMetadata meta = new ModMetadata();
-        meta.modId = "gregtech";
+        meta.modId = GTValues.MODID;
         Loader.instance().setupTestHarness(new DummyModContainer(meta));
+
+        GregTechAPI.MATERIAL_REGISTRY.unfreeze();
         Materials.register();
+        GregTechAPI.MATERIAL_REGISTRY.freeze();
+
         OrePrefix.runMaterialHandlers();
         MetaFluids.init();
         MetaItems.init();


### PR DESCRIPTION
## What
Fixes failing tests on polymer-names branch

## Implementation Details
Unfreeze MATERIAL_REGISTRY before writing to them in tests then freeze them back (simplified but same way as normal game run would use)

## Outcome
No more failing tests on polymer-names

## Additional Information
GTControlled registry now on freeze and unfreeze checks only modid instead of whole container. Which is easier to fake, but normal game run shouldn't allow 2 mods with same modid anyway so no problems are expected. 