### PR TITLE
Fix cover input from output side on placement

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -137,7 +137,8 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
             if (cover != null && cover.shouldCoverInteractWithOutputside()) {
                 if (getOutputFacingItems() == side) {
                     setAllowInputFromOutputSideItems(true);
-                } else if (getOutputFacingFluids() == side) {
+                }
+                if (getOutputFacingFluids() == side) {
                     setAllowInputFromOutputSideFluids(true);
                 }
             }


### PR DESCRIPTION
## What
This PR fixes a bug where placing a cover on the output side of a machine would not update both auto item and fluid outputs. This fixes this behavior to allow both of them. Previously, the player would have to manually toggle off and then back on the auto-output in order to fix issues this caused.

## Outcome
Fixes covers not allowing input from output side on placement.
