### PR TITLE
Fix energy draw on special multiblocks

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -53,7 +53,7 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
             IEnergyContainer energyContainer = recipeMapWorkable.getEnergyContainer();
             if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
                 long maxVoltage = Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
-                String voltageName = GTValues.VN[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
+                String voltageName = GTValues.VN[GTUtility.getFloorTierByVoltage(maxVoltage)];
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 

--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -53,7 +53,7 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
             IEnergyContainer energyContainer = recipeMapWorkable.getEnergyContainer();
             if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
                 long maxVoltage = Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
-                String voltageName = GTValues.VN[GTUtility.getTierForVoltageDisplay(maxVoltage)];
+                String voltageName = GTValues.VN[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -141,7 +141,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
             IEnergyContainer energyContainer = recipeMapWorkable.getEnergyContainer();
             if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
                 long maxVoltage = Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
-                String voltageName = GTValues.VNF[GTUtility.getTierForVoltageDisplay(maxVoltage)];
+                String voltageName = GTValues.VNF[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -141,7 +141,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
             IEnergyContainer energyContainer = recipeMapWorkable.getEnergyContainer();
             if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
                 long maxVoltage = Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
-                String voltageName = GTValues.VNF[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
+                String voltageName = GTValues.VNF[GTUtility.getFloorTierByVoltage(maxVoltage)];
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -453,13 +453,11 @@ public class GTUtility {
     }
 
     /**
-     * Returns the last tier voltage that the voltage will overvolt.
-     * <p>
-     * Ex: This method turns both 960EU/t and 480EU/t into HV.
+     * Ex: This method turns both 1024 and 512 into HV.
      *
-     * @return highest tier that cannot handle the passed voltage
+     * @return the highest tier below or equal to the voltage value given
      */
-    public static byte getOvervoltTierByVoltage(long voltage) {
+    public static byte getFloorTierByVoltage(long voltage) {
         if (voltage < V[GTValues.ULV]) return GTValues.ULV;
         return tierByVoltage.floorEntry(voltage).getValue();
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -453,13 +453,13 @@ public class GTUtility {
     }
 
     /**
-     * <strong>Do not</strong> use for calculation. Intended for displays in multiblock machines and similar.
+     * Returns the last tier voltage that the voltage will overvolt.
      * <p>
-     * Ex: This method turns 960EU/t and 480EU/t into HV.
+     * Ex: This method turns both 960EU/t and 480EU/t into HV.
      *
-     * @return lowest tier that can handle passed voltage for display
+     * @return highest tier that cannot handle the passed voltage
      */
-    public static byte getTierForVoltageDisplay(long voltage) {
+    public static byte getOvervoltTierByVoltage(long voltage) {
         if (voltage < V[GTValues.ULV]) return GTValues.ULV;
         return tierByVoltage.floorEntry(voltage).getValue();
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -555,7 +555,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
     @Override
     public int getEnergyTier() {
         if (energyContainer == null) return GTValues.LV;
-        return Math.max(GTValues.LV, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage()));
+        return Math.max(GTValues.LV, GTUtility.getFloorTierByVoltage(energyContainer.getInputVoltage()));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -555,12 +555,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
     @Override
     public int getEnergyTier() {
         if (energyContainer == null) return GTValues.LV;
-        int tier = GTUtility.getTierByVoltage(energyContainer.getInputVoltage());
-
-        // account for cases with 2A = tier+1
-        if (GTValues.V[tier] != energyContainer.getInputVoltage()) tier--;
-
-        return Math.max(GTValues.LV, tier);
+        return Math.max(GTValues.LV, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage()));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
@@ -157,7 +157,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
 
         if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
             long maxVoltage = Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
-            String voltageName = GTValues.VNF[GTUtility.getTierForVoltageDisplay(maxVoltage)];
+            String voltageName = GTValues.VNF[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
             textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
         }
 
@@ -242,8 +242,8 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
     }
 
     public int getEnergyTier() {
-        int minVoltage = Math.max(this.tier, GTUtility.getTierByVoltage(energyContainer.getInputVoltage()));
-        return Math.min(minVoltage, this.tier + 1);
+        if (energyContainer == null) return this.tier;
+        return Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage()));
     }
 
     public long getEnergyInputPerSecond() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
@@ -244,7 +244,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
 
     public int getEnergyTier() {
         if (energyContainer == null) return this.tier;
-        return Math.min(this.tier + 1 , Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage())));
+        return Math.min(this.tier + 1 , Math.max(this.tier, GTUtility.getFloorTierByVoltage(energyContainer.getInputVoltage())));
     }
 
     public long getEnergyInputPerSecond() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
@@ -156,8 +156,9 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
             return;
 
         if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
-            long maxVoltage = Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
-            String voltageName = GTValues.VNF[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
+            int energyContainer = getEnergyTier();
+            long maxVoltage = GTValues.V[energyContainer];
+            String voltageName = GTValues.VNF[energyContainer];
             textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
         }
 
@@ -243,7 +244,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase implemen
 
     public int getEnergyTier() {
         if (energyContainer == null) return this.tier;
-        return Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage()));
+        return Math.min(this.tier + 1 , Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage())));
     }
 
     public long getEnergyInputPerSecond() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -125,9 +125,14 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
         this.energyContainer = new EnergyContainerList(Lists.newArrayList());
     }
 
+    public int getEnergyTier() {
+        if (energyContainer == null) return this.tier;
+        return Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage()));
+    }
+
     @Override
     public boolean drainEnergy(boolean simulate) {
-        long energyToDrain = GTValues.VA[GTUtility.getTierByVoltage(energyContainer.getInputVoltage())];
+        long energyToDrain = GTValues.VA[GTUtility.getTierByVoltage(getEnergyTier())];
         long resultEnergy = energyContainer.getEnergyStored() - energyToDrain;
         if (resultEnergy >= 0L && resultEnergy <= energyContainer.getEnergyCapacity()) {
             if (!simulate)
@@ -206,7 +211,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
         if (this.isStructureFormed()) {
             if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
                 long maxVoltage = energyContainer.getInputVoltage();
-                String voltageName = GTValues.VNF[GTUtility.getTierForVoltageDisplay(maxVoltage)];
+                String voltageName = GTValues.VNF[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -127,7 +127,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
 
     public int getEnergyTier() {
         if (energyContainer == null) return this.tier;
-        return Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage()));
+        return Math.min(this.tier + 1 , Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage())));
     }
 
     @Override
@@ -210,8 +210,9 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
 
         if (this.isStructureFormed()) {
             if (energyContainer != null && energyContainer.getEnergyCapacity() > 0) {
-                long maxVoltage = energyContainer.getInputVoltage();
-                String voltageName = GTValues.VNF[GTUtility.getOvervoltTierByVoltage(maxVoltage)];
+                int energyContainer = getEnergyTier();
+                long maxVoltage = GTValues.V[energyContainer];
+                String voltageName = GTValues.VNF[energyContainer];
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -127,7 +127,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
 
     public int getEnergyTier() {
         if (energyContainer == null) return this.tier;
-        return Math.min(this.tier + 1 , Math.max(this.tier, GTUtility.getOvervoltTierByVoltage(energyContainer.getInputVoltage())));
+        return Math.min(this.tier + 1 , Math.max(this.tier, GTUtility.getFloorTierByVoltage(energyContainer.getInputVoltage())));
     }
 
     @Override


### PR DESCRIPTION
## What
This PR fixes energy draw on special multiblocks: the fluid and mining drills, and also standarizes this behavior for the previously fixed cleanroom.

## Outcome
Fixes energy draw on special multiblocks.

