### PR TITLE
Fix GTFO incompatibilities with GroovyScript compatibility

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -74,10 +74,10 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public final String unlocalizedName;
 
     private final R recipeBuilderSample;
-    private final int minInputs, maxInputs;
-    private final int minOutputs, maxOutputs;
-    private final int minFluidInputs, maxFluidInputs;
-    private final int minFluidOutputs, maxFluidOutputs;
+    private int minInputs, maxInputs;
+    private int minOutputs, maxOutputs;
+    private int minFluidInputs, maxFluidInputs;
+    private int minFluidOutputs, maxFluidOutputs;
     protected final TByteObjectMap<TextureArea> slotOverlays;
     protected TextureArea specialTexture;
     protected int[] specialTexturePosition;
@@ -1009,6 +1009,38 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return maxFluidOutputs;
     }
 
+    public void setMinInputs(int minInputs) {
+        this.minInputs = minInputs;
+    }
+
+    public void setMinOutputs(int minOutputs) {
+        this.minOutputs = minOutputs;
+    }
+
+    public void setMinFluidInputs(int minFluidInputs) {
+        this.minFluidInputs = minFluidInputs;
+    }
+
+    public void setMinFluidOutputs(int minFluidOutputs) {
+        this.minFluidOutputs = minFluidOutputs;
+    }
+
+    public void setMaxInputs(int maxInputs) {
+        this.maxInputs = maxInputs;
+    }
+
+    public void setMaxOutputs(int maxOutputs) {
+        this.maxOutputs = maxOutputs;
+    }
+
+    public void setMaxFluidInputs(int maxFluidInputs) {
+        this.maxFluidInputs = maxFluidInputs;
+    }
+
+    public void setMaxFluidOutputs(int maxFluidOutputs) {
+        this.maxFluidOutputs = maxFluidOutputs;
+    }
+    
     @Override
     @ZenMethod
     public String toString() {


### PR DESCRIPTION
## What
This fixes a fatal crash with GTFO and GTCEu 2.4.3+ on instances without GroovyScript installed, as outlined in this crash log: [Error Log](https://mclo.gs/S1ZysTC)

## Implementation Details
The main error results from GTFO reflection that is used in order to modify the minimum and maximum inputs and outputs of a RecipeMap. Most of these modifications are used in widely used recipes, and cannot be easily removed. Without reflection, there would be no other way to properly access these fields (access transformers do not work on modded classes), at least, as far as I am aware of.

To fix this, setters have been added to these fields, and these fields are no longer final, which should allow any mod to interact with them without adding a hard dependency on GroovyScript. This does somewhat break encapsulation, although no GTCEu class uses these fields.

## Outcome
This removes the final modifier from the minimum and maximum inputs and outputs for RecipeMaps, and adds setters to access these values. This allows them to be accessed without reflection, a method which currently adds hard GroovyScript dependencies to all mods that use it.