### PR TITLE
Split harder iron recipes into 2 configs

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -163,9 +163,13 @@ public class ConfigHolder {
         @Config.Comment({"Whether to make Redstone related recipes harder.", "Default: false"})
         public boolean hardRedstoneRecipes = false;
 
-        @Config.Comment({"Recipes for items like Iron Doors, Trapdoors, Buckets, Cauldrons, Hoppers, " +
-                "and Iron Bars require Iron Plates, Rods, and more.", "Default: true"})
+        @Config.Comment({"Recipes for Buckets, Cauldrons, Hoppers, and Iron Bars" +
+                " require Iron Plates, Rods, and more.", "Default: true"})
         public boolean hardIronRecipes = true;
+
+        @Config.Comment({"Recipes for items like Iron Doors, Trapdoors, Anvil" +
+                " require Iron Plates, Rods, and more.", "Default: false"})
+        public boolean hardAdvancedIronRecipes = false;
 
         @Config.Comment({"Whether to make miscellaneous recipes harder.", "Default: false"})
         public boolean hardMiscRecipes = false;

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -600,7 +600,6 @@ public class VanillaOverrideRecipes {
 
     }
 
-
     /**
      * Replaces Vanilla Beacon Recipe
      * Replaces Vanilla Jack-o-lantern Recipe

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -33,6 +33,8 @@ public class VanillaOverrideRecipes {
             redstoneRecipes();
         if (ConfigHolder.recipes.hardIronRecipes)
             metalRecipes();
+        if (ConfigHolder.recipes.hardAdvancedIronRecipes)
+            metalAdvancedRecipes();
         if (ConfigHolder.recipes.hardMiscRecipes)
             miscRecipes();
         if (ConfigHolder.recipes.hardDyeRecipes)
@@ -539,40 +541,19 @@ public class VanillaOverrideRecipes {
     }
 
     /**
-     * Changes vanilla recipes using metals to plates and other components
+     * Changes bucket, cauldron, hopper and iron bars to use plates, rods and gears
      */
     private static void metalRecipes() {
-        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:iron_door"));
-        ModHandler.addShapedRecipe("iron_door", new ItemStack(Items.IRON_DOOR), "PTh", "PRS", "PPd",
-                'P', new UnificationEntry(OrePrefix.plate, Materials.Iron),
-                'T', new ItemStack(Blocks.IRON_BARS),
-                'R', new UnificationEntry(OrePrefix.ring, Materials.Steel),
-                'S', new UnificationEntry(OrePrefix.screw, Materials.Steel)
-        );
-
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                .inputs(new ItemStack(Blocks.IRON_BARS))
-                .input(OrePrefix.plate, Materials.Iron, 4)
-                .fluidInputs(Materials.Steel.getFluid(GTValues.L / 9))
-                .outputs(new ItemStack(Items.IRON_DOOR))
-                .duration(400).EUt(VA[ULV]).buildAndRegister();
-
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:cauldron"));
         ModHandler.addShapedRecipe("cauldron", new ItemStack(Items.CAULDRON), "X X", "XhX", "XXX",
                 'X', new UnificationEntry(OrePrefix.plate, Materials.Iron)
         );
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                .input(OrePrefix.plate, Materials.Iron, 7)
-                .outputs(new ItemStack(Items.CAULDRON, 1))
-                .circuitMeta(7)
-                .duration(700).EUt(4).buildAndRegister();
-
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:hopper"));
         ModHandler.addShapedRecipe("hopper", new ItemStack(Blocks.HOPPER), "XCX", "XGX", "wXh",
                 'X', new UnificationEntry(OrePrefix.plate, Materials.Iron),
                 'C', "chestWood",
-                'G', new UnificationEntry(OrePrefix.gear, Materials.Iron)
+                'G', new UnificationEntry(OrePrefix.gearSmall, Materials.Iron)
         );
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:iron_bars"));
@@ -580,11 +561,22 @@ public class VanillaOverrideRecipes {
                 'X', new UnificationEntry(OrePrefix.stick, Materials.Iron)
         );
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                .input(OrePrefix.stick, Materials.Iron, 3)
-                .outputs(new ItemStack(Blocks.IRON_BARS, 4))
-                .circuitMeta(3)
-                .duration(300).EUt(4).buildAndRegister();
+        ModHandler.addShapedRecipe("iron_bucket", new ItemStack(Items.BUCKET), "XhX", " X ", 'X', new UnificationEntry(OrePrefix.plate, Materials.Iron));
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:bucket"));
+
+    }
+
+    /**
+     * Changes other vanilla recipes using metals to plates and other components
+     */
+    private static void metalAdvancedRecipes() {
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:iron_door"));
+        ModHandler.addShapedRecipe("iron_door", new ItemStack(Items.IRON_DOOR), "PTh", "PRS", "PPd",
+                'P', new UnificationEntry(OrePrefix.plate, Materials.Iron),
+                'T', new ItemStack(Blocks.IRON_BARS),
+                'R', new UnificationEntry(OrePrefix.ring, Materials.Steel),
+                'S', new UnificationEntry(OrePrefix.screw, Materials.Steel)
+        );
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:anvil"));
         ModHandler.addShapedRecipe("anvil", new ItemStack(Blocks.ANVIL), "BBB", "SBS", "PBP",
@@ -600,22 +592,14 @@ public class VanillaOverrideRecipes {
                 'T', new ItemStack(Blocks.TRAPDOOR)
         );
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                .input(OrePrefix.plate, Materials.Iron, 4)
-                .inputs(new ItemStack(Blocks.TRAPDOOR))
-                .outputs(new ItemStack(Blocks.IRON_TRAPDOOR))
-                .duration(100).EUt(16).buildAndRegister();
-
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:minecart"));
         ModHandler.addShapedRecipe("minecart", new ItemStack(Items.MINECART), "RhR", "PwP", "RPR",
                 'R', new UnificationEntry(OrePrefix.ring, Materials.Iron),
                 'P', new UnificationEntry(OrePrefix.plate, Materials.Iron)
         );
 
-        ModHandler.addShapedRecipe("iron_bucket", new ItemStack(Items.BUCKET), "XhX", " X ", 'X', new UnificationEntry(OrePrefix.plate, Materials.Iron));
-        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:bucket"));
-
     }
+
 
     /**
      * Replaces Vanilla Beacon Recipe

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -906,12 +906,29 @@ public class VanillaStandardRecipes {
                 'P', new UnificationEntry(OrePrefix.ring, Materials.Iron)
         );
 
-        if (!ConfigHolder.recipes.hardIronRecipes)
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                    .input(OrePrefix.plate, Materials.Iron, 4)
-                    .circuitMeta(4)
-                    .outputs(new ItemStack(Blocks.IRON_TRAPDOOR))
-                    .duration(100).EUt(16).buildAndRegister();
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.plate, Materials.Iron, 7)
+                .outputs(new ItemStack(Items.CAULDRON, 1))
+                .circuitMeta(7)
+                .duration(700).EUt(4).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.stick, Materials.Iron, 3)
+                .outputs(new ItemStack(Blocks.IRON_BARS, 4))
+                .circuitMeta(3)
+                .duration(300).EUt(4).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.plate, Materials.Iron, 4)
+                .circuitMeta(4)
+                .outputs(new ItemStack(Blocks.IRON_TRAPDOOR))
+                .duration(100).EUt(16).buildAndRegister();
+
+        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.plate, Materials.Iron, 6)
+                .circuitMeta(6)
+                .outputs(new ItemStack(Blocks.IRON_TRAPDOOR))
+                .duration(100).EUt(16).buildAndRegister();
     }
 
     /**

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -927,7 +927,7 @@ public class VanillaStandardRecipes {
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, Materials.Iron, 6)
                 .circuitMeta(6)
-                .outputs(new ItemStack(Blocks.IRON_TRAPDOOR))
+                .outputs(new ItemStack(Blocks.IRON_DOOR))
                 .duration(100).EUt(16).buildAndRegister();
     }
 


### PR DESCRIPTION
## What
This splits harder iron recipes into 2 configs. There are joke/meme recipes such as the door, trapdoor enabled by default. These are plain evil.
Splitting into 2 configs allows us to keep the gregified buckets, cauldron, iron bars, which are acceptable recipes.
The hopper is also kept gregified by default, but the large gear has been changed to a small gear to make it more affordable.

## Implementation Details
Added a new config and moved some recipes to it.
Made the assembler recipes generate regardless of config, as these should always exist.

## Outcome
Less frustration for new players.