### PR TITLE
Fix Parallel Recipe / by Zero Crashes

### DIFF
--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -437,18 +437,18 @@ public class ParallelLogic {
 
         // Simulate the merging of the maximum amount of recipes
         // and limit by the amount we can successfully merge
+        // Note that limitByOutput will be less than or equal to multiplierByInputs after this, so Math.min does not need using
         int limitByOutput;
         limitByOutput = ParallelLogic.limitByOutputMerging(currentRecipe, exportInventory, exportFluids, multiplierByInputs, voidItems, voidFluids);
 
-        int parallelizable = Math.min(multiplierByInputs, limitByOutput);
-
         if (currentRecipe.getEUt() != 0) {
             int limitByVoltage = Math.abs((int) (maxVoltage / currentRecipe.getEUt()));
-            parallelizable = Math.min(limitByVoltage, parallelizable);
-        }
-        if (parallelizable > 0) {
+            int parallelizable = Math.min(limitByVoltage, limitByOutput);
             recipeBuilder.append(currentRecipe, parallelizable, false);
+        } else if (limitByOutput > 0) {
+            recipeBuilder.append(currentRecipe, limitByOutput, false);
         }
+
 
         return recipeBuilder;
     }

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -435,20 +435,20 @@ public class ParallelLogic {
         boolean voidFluids = mte.canVoidRecipeFluidOutputs();
 
 
-        // Simulate the merging of the maximum amount of recipes
+        // Simulate the merging of the maximum amount of recipes that can be run with these items
         // and limit by the amount we can successfully merge
-        // Note that limitByOutput will be less than or equal to multiplierByInputs after this, so Math.min does not need using
         int limitByOutput;
         limitByOutput = ParallelLogic.limitByOutputMerging(currentRecipe, exportInventory, exportFluids, multiplierByInputs, voidItems, voidFluids);
 
-        if (currentRecipe.getEUt() != 0) {
-            int limitByVoltage = Math.abs((int) (maxVoltage / currentRecipe.getEUt()));
+        int recipeEUt = currentRecipe.getEUt();
+        if (recipeEUt != 0) {
+            int limitByVoltage = Math.abs((int) (maxVoltage / recipeEUt));
             int parallelizable = Math.min(limitByVoltage, limitByOutput);
-            recipeBuilder.append(currentRecipe, parallelizable, false);
+            if (parallelizable != 0)
+                recipeBuilder.append(currentRecipe, parallelizable, false);
         } else if (limitByOutput > 0) {
             recipeBuilder.append(currentRecipe, limitByOutput, false);
         }
-
 
         return recipeBuilder;
     }

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -440,9 +440,12 @@ public class ParallelLogic {
         int limitByOutput;
         limitByOutput = ParallelLogic.limitByOutputMerging(currentRecipe, exportInventory, exportFluids, multiplierByInputs, voidItems, voidFluids);
 
-        int limitByVoltage = Math.abs((int) (maxVoltage / currentRecipe.getEUt()));
-        int parallelizable = Math.min(limitByVoltage, Math.min(multiplierByInputs, limitByOutput));
+        int parallelizable = Math.min(multiplierByInputs, limitByOutput);
 
+        if (currentRecipe.getEUt() != 0) {
+            int limitByVoltage = Math.abs((int) (maxVoltage / currentRecipe.getEUt()));
+            parallelizable = Math.min(limitByVoltage, parallelizable);
+        }
         if (parallelizable > 0) {
             recipeBuilder.append(currentRecipe, parallelizable, false);
         }


### PR DESCRIPTION
Simply fixes crashes that occur when an addon's recipe with 0 EU/t is parallelized using `ParallelLogicType.MULTIPLY`, such as [https://pastes.dev/rT9skEjrvR](https://pastes.dev/rT9skEjrvR).