### PR TITLE
Fix multiple miners in the same chunk conflicting

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -164,7 +164,13 @@ public class MinerLogic {
             NonNullList<ItemStack> blockDrops = NonNullList.create();
             IBlockState blockState = metaTileEntity.getWorld().getBlockState(blocksToMine.getFirst());
 
-            // if the block is not air or cobblestone., harvest it
+            // check to make sure the ore is still there,
+            while(!GTUtility.isOre(GTUtility.toItem(blockState))) {
+                blocksToMine.removeFirst();
+                if (blocksToMine.isEmpty()) break;
+                blockState = metaTileEntity.getWorld().getBlockState(blocksToMine.getFirst());
+            }
+            // When we are here we have an ore to mine! I'm glad we aren't threaded
             if (GTUtility.isOre(GTUtility.toItem(blockState))) {
                 // get the small ore drops, if a small ore
                 getSmallOreBlockDrops(blockDrops, world, blocksToMine.getFirst(), blockState);
@@ -172,14 +178,10 @@ public class MinerLogic {
                 getRegularBlockDrops(blockDrops, world, blocksToMine.getFirst(), blockState);
                 // try to insert them
                 mineAndInsertItems(blockDrops, world);
-            } else {
-                // the block attempted to mine was air or cobblestone, so remove it from the queue and move on
-                // This can occur because of block destruction when lowering the pipe or when two miners are attempting
-                // to mine the same area
-                blocksToMine.removeFirst();
             }
 
-        } else if (blocksToMine.isEmpty()) {
+        }
+        if (blocksToMine.isEmpty()) {
             // there were no blocks to mine, so the current position is the previous position
             x.set(mineX.get());
             y.set(mineY.get());

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -146,6 +146,9 @@ public class MinerLogic {
                 setActive(false);
         }
 
+        // always drain storages when working, even if blocksToMine ends up being empty
+        drainStorages(false);
+
         // drill a hole beneath the miner and extend the pipe downwards by one
         WorldServer world = (WorldServer) metaTileEntity.getWorld();
         if (mineY.get() < pipeY.get()) {
@@ -193,9 +196,6 @@ public class MinerLogic {
                 this.wasActiveAndNeedsUpdate = true;
                 this.setActive(false);
             }
-        } else {
-            // we drain the energy at the end here to ensure that we only drain if a block was found
-            drainStorages(false);
         }
     }
 

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -136,8 +136,6 @@ public class MinerLogic {
         // if the inventory is not full, drain energy etc. from the miner
         // the storages have already been checked earlier
         if (!miner.isInventoryFull()) {
-            // actually drain the energy
-            drainStorages(false);
 
             // since energy is being consumed the miner is now active
             if (!this.isActive)
@@ -181,6 +179,7 @@ public class MinerLogic {
             }
 
         }
+
         if (blocksToMine.isEmpty()) {
             // there were no blocks to mine, so the current position is the previous position
             x.set(mineX.get());
@@ -194,6 +193,9 @@ public class MinerLogic {
                 this.wasActiveAndNeedsUpdate = true;
                 this.setActive(false);
             }
+        } else {
+            // we drain the energy at the end here to ensure that we only drain if a block was found
+            drainStorages(false);
         }
     }
 

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -136,6 +136,8 @@ public class MinerLogic {
         // if the inventory is not full, drain energy etc. from the miner
         // the storages have already been checked earlier
         if (!miner.isInventoryFull()) {
+            // always drain storages when working, even if blocksToMine ends up being empty
+            drainStorages(false);
 
             // since energy is being consumed the miner is now active
             if (!this.isActive)
@@ -145,9 +147,6 @@ public class MinerLogic {
             if (this.isActive)
                 setActive(false);
         }
-
-        // always drain storages when working, even if blocksToMine ends up being empty
-        drainStorages(false);
 
         // drill a hole beneath the miner and extend the pipe downwards by one
         WorldServer world = (WorldServer) metaTileEntity.getWorld();

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -171,7 +171,7 @@ public class MinerLogic {
                 blockState = metaTileEntity.getWorld().getBlockState(blocksToMine.getFirst());
             }
             // When we are here we have an ore to mine! I'm glad we aren't threaded
-            if (GTUtility.isOre(GTUtility.toItem(blockState))) {
+            if (!blocksToMine.isEmpty() & GTUtility.isOre(GTUtility.toItem(blockState))) {
                 // get the small ore drops, if a small ore
                 getSmallOreBlockDrops(blockDrops, world, blocksToMine.getFirst(), blockState);
                 // get the block's drops.


### PR DESCRIPTION
## What
This PR attempts to make multiple miners able to work on the same area without conflicts.


## Implementation Details
This PR causes the miners to retry their list of ores until they have either ran out of ores to try or have found a new ore to mine.

## Outcome
This allows multiple miners to mine in the same area.

