### PR TITLE
FIx ActiveVariantBlockBakedModel and VariantActiveBlock NPE crashes

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -517,6 +517,8 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
 
             int id = buf.readInt();
             boolean isActive = buf.readBoolean();
+            //the server can send a packet to the client before the map is initialized by the world loading client-side
+            VariantActiveBlock.ACTIVE_BLOCKS.putIfAbsent(getWorld().provider.getDimension(), new ObjectOpenHashSet<>());
             int size = buf.readInt();
             for (int i = 0; i < size; i++) {
                 BlockPos blockPos = buf.readBlockPos();

--- a/src/main/java/gregtech/client/model/modelfactories/ActiveVariantBlockBakedModel.java
+++ b/src/main/java/gregtech/client/model/modelfactories/ActiveVariantBlockBakedModel.java
@@ -35,18 +35,17 @@ public class ActiveVariantBlockBakedModel implements IBakedModel {
         List<BakedQuad> quads;
         if (side == null || state == null) return Collections.emptyList();
         ModelResourceLocation mrl;
-        /*
-        if (((IExtendedBlockState) state).getValue(VariantActiveBlock.ACTIVE)) {
-            mrl = new ModelResourceLocation(state.getBlock().getRegistryName(),
-                    "active=true," + statePropertiesToString(state.getProperties()));
+        boolean activeState;
+        //Some mods like to call this without getting the extendedBlockState leading to a NPE crash since the
+        //unlisted ACTIVE property is null.
+        if (((IExtendedBlockState) state).getValue(VariantActiveBlock.ACTIVE) == null) {
+            activeState = false;
         } else {
-            mrl = new ModelResourceLocation(state.getBlock().getRegistryName(),
-                    "active=false," + statePropertiesToString(state.getProperties()));
+            activeState = ((IExtendedBlockState) state).getValue(VariantActiveBlock.ACTIVE);
         }
-        */
-        if (((IExtendedBlockState) state).getValue(VariantActiveBlock.ACTIVE)) {
+        if (activeState) {
             mrl = new ModelResourceLocation(state.getBlock().getRegistryName(),
-                    "active=true,variant="+ state.getProperties().entrySet().stream().filter(p -> p.getKey().getName().equals("variant")).map(e -> {
+                    "active=true,variant=" + state.getProperties().entrySet().stream().filter(p -> p.getKey().getName().equals("variant")).map(e -> {
                         IProperty<?> p = e.getKey();
                         return getPropertyName(p, e.getValue());
                     }).collect(Collectors.joining()));


### PR DESCRIPTION
## What
FIx 2 ActiveVariantBlockBakedModel and VariantActiveBlock NPE crashes

## Implementation Details
Initialize the map if a packet is received before its initialized by loading the world, client-side.
Return an "inactive" model if the models quad are queried without using the extended blockstate

## Outcome
Can join MP world again while an active block changes state
Can use effortless building again to place coils.