### PR TITLE
Fix a few issues with placing Pipes into Frames

### DIFF
--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -292,10 +292,10 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         if (rayTraceResult == null || pipeTile == null) {
             return false;
         }
-        return onPipeActivated(worldIn, state, pos, playerIn, hand, rayTraceResult, pipeTile);
+        return onPipeActivated(worldIn, state, pos, playerIn, hand, facing, rayTraceResult, pipeTile);
     }
 
-    public boolean onPipeActivated(World world, IBlockState state, BlockPos pos, EntityPlayer entityPlayer, EnumHand hand, CuboidRayTraceResult hit, IPipeTile<PipeType, NodeDataType> pipeTile) {
+    public boolean onPipeActivated(World world, IBlockState state, BlockPos pos, EntityPlayer entityPlayer, EnumHand hand, EnumFacing side, CuboidRayTraceResult hit, IPipeTile<PipeType, NodeDataType> pipeTile) {
         ItemStack itemStack = entityPlayer.getHeldItem(hand);
 
         if (pipeTile.getFrameMaterial() == null && pipeTile instanceof TileEntityPipeBase && itemStack.getItem() instanceof FrameItemBlock && pipeTile.getPipeType().getThickness() < 1) {
@@ -308,6 +308,21 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                 itemStack.shrink(1);
             }
             return true;
+        }
+
+        if (itemStack.getItem() instanceof ItemBlockPipe) {
+            IBlockState blockStateAtSide = world.getBlockState(pos.offset(side));
+            if (blockStateAtSide.getBlock() instanceof BlockFrame) {
+                ItemBlockPipe<?, ?> itemBlockPipe = (ItemBlockPipe<?, ?>) itemStack.getItem();
+                if (itemBlockPipe.blockPipe.getItemPipeType(itemStack) == getItemPipeType(itemStack)) {
+                    BlockFrame frameBlock = (BlockFrame) blockStateAtSide.getBlock();
+                    boolean wasPlaced = frameBlock.replaceWithFramedPipe(world, pos.offset(side), blockStateAtSide, entityPlayer, itemStack, side);
+                    if (wasPlaced) {
+                        pipeTile.setConnection(side, true, false);
+                    }
+                    return wasPlaced;
+                }
+            }
         }
 
         EnumFacing coverSide = ICoverable.traceCoverSide(hit);


### PR DESCRIPTION
This PR primarily does 2 things:
- Allows pipe placement behavior like this (previously it was not allowed):
https://user-images.githubusercontent.com/10861407/204130916-8010ad4c-0064-467b-8f67-b469eb56a931.mp4

- Fixes the action of placing a pipe into a frame
    - This mostly worked before, but skipped a few steps. For example, it would not automatically connect to adjacent pipes with the GT6-style pipes config off, and would also not force-disconnect adjacent, incompatible pipe types (both different from our typical behavior)
    - Additionally this does some minor things like firing forge CriteriaHooks for advancements, stat tracking, etc

