### PR TITLE
Energy Converter fixes

### DIFF
--- a/src/main/java/gregtech/api/capability/FeCompat.java
+++ b/src/main/java/gregtech/api/capability/FeCompat.java
@@ -30,6 +30,15 @@ public class FeCompat {
     }
 
     /**
+     * Converts eu to fe, using a specified ratio, and with a specified upper bound.
+     * This can be useful for dealing with int-overflows when converting from a long to an int.
+     * @return fe
+     */
+    public static int toFeBounded(long eu, int ratio, int max) {
+        return (int) Math.min(max, toFeLong(eu, ratio));
+    }
+
+    /**
      * Converts fe to eu, using specified ratio
      * @return eu
      */

--- a/src/main/java/gregtech/api/capability/FeCompat.java
+++ b/src/main/java/gregtech/api/capability/FeCompat.java
@@ -16,8 +16,17 @@ public class FeCompat {
      * Converts eu to fe, using specified ratio
      * @return fe
      */
-    public static int toFe(long eu, int ratio){
-        return (int) (eu * ratio);
+    public static int toFe(long eu, int ratio) {
+        return (int) toFeLong(eu, ratio);
+    }
+
+    /**
+     * Converts eu to fe, using specified ratio, and returns as a long.
+     * Can be used for overflow protection.
+     * @return fe
+     */
+    public static long toFeLong(long eu, int ratio) {
+        return eu * ratio;
     }
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
@@ -251,12 +251,12 @@ public class ConverterTrait extends MTETrait {
 
         @Override
         public int getEnergyStored() {
-            return (int) Math.min(Integer.MAX_VALUE, FeCompat.toFeLong(storedEU, FeCompat.ratio(feToEu)));
+            return FeCompat.toFeBounded(storedEU, FeCompat.ratio(feToEu), Integer.MAX_VALUE);
         }
 
         @Override
         public int getMaxEnergyStored() {
-            return (int) Math.min(Integer.MAX_VALUE, FeCompat.toFeLong(baseCapacity, FeCompat.ratio(feToEu)));
+            return FeCompat.toFeBounded(baseCapacity, FeCompat.ratio(feToEu), Integer.MAX_VALUE);
         }
 
         @Override

--- a/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
@@ -251,12 +251,12 @@ public class ConverterTrait extends MTETrait {
 
         @Override
         public int getEnergyStored() {
-            return FeCompat.toFe(storedEU, FeCompat.ratio(feToEu));
+            return (int) Math.min(Integer.MAX_VALUE, FeCompat.toFeLong(storedEU, FeCompat.ratio(feToEu)));
         }
 
         @Override
         public int getMaxEnergyStored() {
-            return FeCompat.toFe(baseCapacity, FeCompat.ratio(feToEu));
+            return (int) Math.min(Integer.MAX_VALUE, FeCompat.toFeLong(baseCapacity, FeCompat.ratio(feToEu)));
         }
 
         @Override

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
@@ -43,11 +43,11 @@ public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait
             if (data.getSideHit() == facing) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + voltageN + TextFormatting.GREEN + " (" + amperage + "A)");
             } else {
-                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage(), FeCompat.ratio(true)) + " FE");
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(true)) + " FE");
             }
         } else {
             if (data.getSideHit() == facing) {
-                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage(), FeCompat.ratio(false)) + " FE");
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + TextFormatting.RED + FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(false)) + " FE");
             } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + voltageN + TextFormatting.GREEN + " (" + amperage + "A)");
             }


### PR DESCRIPTION
- Fixes TOP not showing the right FE input, as it was not multiplying voltage by amperage
- Fixes high-tier converters (16A UHV primarily) not working due to the FE-storage wrapper overflowing in `getEnergyStored()` and `getMaxEnergyStored()`
    - At a glance, this seems like it could be a problem, but at UHV 16A, the actual input/output FE/t is within an int, but the total storage amount is not. This should not cause any noticeable issues (and is an unavoidable problem). Though this does mean that Energy Converters for UEV+ are unfeasible due to the limitations of ints and the Forge Energy API