### PR TITLE
Fix Miners forming the list of blocks to mine incorrectly

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -354,12 +354,12 @@ public class MinerLogic {
                         x.incrementAndGet();
                     } else {
                         // reset x and move to the next z layer
-                        x.set(x.get() - currentRadius * 2);
+                        x.set(startX.get());
                         z.incrementAndGet();
                     }
                 } else {
                     // reset z and move to the next y layer
-                    z.set(z.get() - currentRadius * 2);
+                    z.set(startZ.get());
                     y.decrementAndGet();
                 }
             } else

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -326,6 +326,15 @@ public class MinerLogic {
     }
 
     /**
+     * Recalculates the mining area and refills the block list
+     */
+    public void resetArea() {
+        initPos(metaTileEntity.getPos(), currentRadius);
+        blocksToMine.clear();
+        checkBlocksToMine();
+    }
+
+    /**
      * Gets the blocks to mine
      * @return a {@link LinkedList} of {@link BlockPos} for each ore to mine
      */

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMiner.java
@@ -202,7 +202,7 @@ public class MetaTileEntityMiner extends TieredMetaTileEntity implements IMiner,
             else
                 this.minerLogic.setCurrentRadius(Math.max(1, currentRadius - 1));
 
-            this.minerLogic.checkBlocksToMine();
+            this.minerLogic.resetArea();
 
             playerIn.sendMessage(new TextComponentTranslation(I18n.format("gregtech.multiblock.large_miner.radius", this.minerLogic.getCurrentRadius())));
         } else {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -366,7 +366,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
             else
                 this.minerLogic.setCurrentRadius(currentRadius - CHUNK_LENGTH);
 
-            this.minerLogic.checkBlocksToMine();
+            this.minerLogic.resetArea();
 
             playerIn.sendMessage(new TextComponentTranslation("gregtech.multiblock.large_miner.radius", this.minerLogic.getCurrentRadius()));
         } else {


### PR DESCRIPTION
Miners skip the first x and z layer when going to the next z and y layer respectively. This PR should fix that
![image](https://user-images.githubusercontent.com/25221392/204377667-28d89fe8-b3e9-4754-98bb-ad2ac4876cf1.png)
Cobble was replaced with glass to show the pattern
