### PR TITLE
Fix some log warnings after polymer PR

### DIFF
--- a/src/main/java/gregtech/api/unification/material/properties/PolymerProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/PolymerProperty.java
@@ -8,6 +8,7 @@ public class PolymerProperty implements IMaterialProperty<PolymerProperty>{
     @Override
     public void verifyProperty(MaterialProperties properties) {
 
+        properties.ensureSet(PropertyKey.DUST, true);
         properties.ensureSet(PropertyKey.INGOT, true);
         properties.ensureSet(PropertyKey.FLUID, true);
 


### PR DESCRIPTION
## What
Fixes some log warnings after the Polymer PR was merged. The no-arg `polymer` call did not verify that the material had the dust property, so there were some warnings in the logs about materials not having the correct properties for flag generation.


## Outcome
Fixes some log warns after the Polymer PR
