### PR TITLE
Fix Default Enchantments for non-vanilla tools

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -554,13 +554,13 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
     }
 
     default boolean definition$canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment) {
-        if(stack.isEmpty()) {
+        if (stack.isEmpty()) {
             return false;
         }
 
         ToolProperty property = getToolProperty(stack);
 
-        if(property == null)  {
+        if (property == null) {
             return false;
         }
 

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -127,7 +127,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
 
         // Set material enchantments
         toolProperty.getEnchantments().forEach((enchantment, level) -> {
-            if ((getToolStats().isEnchantable(stack) && getToolStats().canApplyEnchantment(stack, enchantment)) || stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
+            if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
                 stack.addEnchantment(enchantment, level);
             }
         });

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -564,7 +564,9 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             return false;
         }
 
-        return !property.getEnchantments().isEmpty() && property.getEnchantments().containsKey(enchantment);
+        // Check for any special enchantments specified by the material of this Tool, or any additional Enchantment Types added in the builder
+        return (!property.getEnchantments().isEmpty() && property.getEnchantments().containsKey(enchantment)) ||
+                (getToolStats().isEnchantable(stack) && getToolStats().canApplyEnchantment(stack, enchantment));
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -564,14 +564,6 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             return false;
         }
 
-        Material material = getToolMaterial(stack);
-
-        // This is the default fallback material, so if the tool material is null, this will be returned
-        // Exclude this material in case of incorrect tool materials, although this means neutronium cannot have default enchants
-        if(material == Materials.Neutronium) {
-            return false;
-        }
-
         return !property.getEnchantments().isEmpty() && property.getEnchantments().containsKey(enchantment);
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -126,7 +126,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
 
         // Set material enchantments
         toolProperty.getEnchantments().forEach((enchantment, level) -> {
-            if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
+            if ((getToolStats().isEnchantable(stack) && getToolStats().canApplyEnchantment(stack, enchantment)) || stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
                 stack.addEnchantment(enchantment, level);
             }
         });

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -35,6 +35,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -550,6 +551,28 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             tooltip.add(I18n.format("item.gt.tool.behavior.behaviors"));
             tooltip.addAll(behaviors);
         }
+    }
+
+    default boolean definition$canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment) {
+        if(stack.isEmpty()) {
+            return false;
+        }
+
+        ToolProperty property = getToolProperty(stack);
+
+        if(property == null)  {
+            return false;
+        }
+
+        Material material = getToolMaterial(stack);
+
+        // This is the default fallback material, so if the tool material is null, this will be returned
+        // Exclude this material in case of incorrect tool materials, although this means neutronium cannot have default enchants
+        if(material == Materials.Neutronium) {
+            return false;
+        }
+
+        return !property.getEnchantments().isEmpty() && property.getEnchantments().containsKey(enchantment);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTSword.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTSword.java
@@ -5,6 +5,7 @@ import gregtech.api.util.LocalizationUtils;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.player.EntityPlayer;
@@ -122,6 +123,11 @@ public class ItemGTSword extends ItemSword implements IGTTool {
     @Override
     public boolean onBlockDestroyed(@Nonnull ItemStack stack, @Nonnull World worldIn, @Nonnull IBlockState state, @Nonnull BlockPos pos, @Nonnull EntityLivingBase entityLiving) {
         return definition$onBlockDestroyed(stack, worldIn, state, pos, entityLiving);
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
+        return definition$canApplyAtEnchantingTable(stack, enchantment) || super.canApplyAtEnchantingTable(stack, enchantment);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTTool.java
@@ -6,6 +6,7 @@ import gregtech.api.util.LocalizationUtils;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.player.EntityPlayer;
@@ -264,6 +265,11 @@ public class ItemGTTool extends ItemTool implements IGTTool {
     @SideOnly(Side.CLIENT)
     public void addInformation(@Nonnull ItemStack stack, @Nullable World world, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flag) {
         definition$addInformation(stack, world, tooltip, flag);
+    }
+
+    @Override
+    public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
+        return definition$canApplyAtEnchantingTable(stack, enchantment) || super.canApplyAtEnchantingTable(stack, enchantment);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -101,11 +101,13 @@ public class ToolDefinitionBuilder {
     }
 
     public ToolDefinitionBuilder canApplyEnchantment(BiPredicate<ItemStack, Enchantment> canApplyEnchantment) {
+        this.isEnchantable = true;
         this.canApplyEnchantment = canApplyEnchantment;
         return this;
     }
 
     public ToolDefinitionBuilder canApplyEnchantment(EnumEnchantmentType... enchantmentTypes) {
+        this.isEnchantable = true;
         this.canApplyEnchantment = (stack, enchantment) -> {
             for (EnumEnchantmentType type : enchantmentTypes) {
                 if (type == enchantment.type) {

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -31,7 +31,7 @@ public class ToolDefinitionBuilder {
     private float attackDamage = 0F;
     private float baseEfficiency = 4F;
     private float efficiencyMultiplier = 1.0F;
-    private boolean isEnchantable = true;
+    private boolean isEnchantable;
     private BiPredicate<ItemStack, Enchantment> canApplyEnchantment;
     private float attackSpeed = 0F;
     private boolean sneakBypassUse = false;
@@ -100,19 +100,12 @@ public class ToolDefinitionBuilder {
         return this;
     }
 
-    public ToolDefinitionBuilder enchantable() {
-        this.isEnchantable = true;
-        return this;
-    }
-
     public ToolDefinitionBuilder canApplyEnchantment(BiPredicate<ItemStack, Enchantment> canApplyEnchantment) {
-        this.isEnchantable = true;
         this.canApplyEnchantment = canApplyEnchantment;
         return this;
     }
 
     public ToolDefinitionBuilder canApplyEnchantment(EnumEnchantmentType... enchantmentTypes) {
-        this.isEnchantable = true;
         this.canApplyEnchantment = (stack, enchantment) -> {
             for (EnumEnchantmentType type : enchantmentTypes) {
                 if (type == enchantment.type) {
@@ -265,7 +258,7 @@ public class ToolDefinitionBuilder {
 
             @Override
             public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
-                return canApplyEnchantment != null && canApplyEnchantment.test(stack, enchantment);
+                return canApplyEnchantment.test(stack, enchantment);
             }
 
             @Override

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -31,7 +31,7 @@ public class ToolDefinitionBuilder {
     private float attackDamage = 0F;
     private float baseEfficiency = 4F;
     private float efficiencyMultiplier = 1.0F;
-    private boolean isEnchantable;
+    private boolean isEnchantable = true;
     private BiPredicate<ItemStack, Enchantment> canApplyEnchantment;
     private float attackSpeed = 0F;
     private boolean sneakBypassUse = false;
@@ -100,12 +100,19 @@ public class ToolDefinitionBuilder {
         return this;
     }
 
+    public ToolDefinitionBuilder enchantable() {
+        this.isEnchantable = true;
+        return this;
+    }
+
     public ToolDefinitionBuilder canApplyEnchantment(BiPredicate<ItemStack, Enchantment> canApplyEnchantment) {
+        this.isEnchantable = true;
         this.canApplyEnchantment = canApplyEnchantment;
         return this;
     }
 
     public ToolDefinitionBuilder canApplyEnchantment(EnumEnchantmentType... enchantmentTypes) {
+        this.isEnchantable = true;
         this.canApplyEnchantment = (stack, enchantment) -> {
             for (EnumEnchantmentType type : enchantmentTypes) {
                 if (type == enchantment.type) {
@@ -258,7 +265,7 @@ public class ToolDefinitionBuilder {
 
             @Override
             public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
-                return canApplyEnchantment.test(stack, enchantment);
+                return canApplyEnchantment != null && canApplyEnchantment.test(stack, enchantment);
             }
 
             @Override

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -7,6 +7,7 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.items.tool.*;
 import gregtech.core.sound.GTSoundEvents;
 import net.minecraft.client.Minecraft;
+import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
@@ -141,7 +142,7 @@ public class ToolItems {
                         .behaviors(new HoeGroundBehavior(), new HarvestCropsBehavior()))
                 .toolClasses(ToolClasses.SCYTHE, ToolClasses.HOE));
         KNIFE = register(ItemGTTool.Builder.of(GTValues.MODID, "knife")
-                .toolStats(b -> b.crafting().attacking())
+                .toolStats(b -> b.attacking().crafting().canApplyEnchantment(EnumEnchantmentType.WEAPON))
                 .oreDict(ToolOreDicts.craftingToolKnife)
                 .symbol('k')
                 .toolClasses(ToolClasses.KNIFE, ToolClasses.SWORD));

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -7,6 +7,7 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.items.tool.*;
 import gregtech.core.sound.GTSoundEvents;
 import net.minecraft.client.Minecraft;
+import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
@@ -138,7 +139,7 @@ public class ToolItems {
         SCYTHE = register(ItemGTSword.Builder.of(GTValues.MODID, "scythe")
                 .toolStats(b -> b.blockBreaking().attacking()
                         .aoe(2, 2, 2)
-                        .behaviors(new HoeGroundBehavior(), new HarvestCropsBehavior()))
+                        .behaviors(new HoeGroundBehavior(), new HarvestCropsBehavior()).canApplyEnchantment(EnumEnchantmentType.DIGGER))
                 .toolClasses(ToolClasses.SCYTHE, ToolClasses.HOE));
         KNIFE = register(ItemGTTool.Builder.of(GTValues.MODID, "knife")
                 .toolStats(b -> b.crafting().attacking())

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -7,7 +7,6 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.items.tool.*;
 import gregtech.core.sound.GTSoundEvents;
 import net.minecraft.client.Minecraft;
-import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
@@ -142,7 +141,7 @@ public class ToolItems {
                         .behaviors(new HoeGroundBehavior(), new HarvestCropsBehavior()))
                 .toolClasses(ToolClasses.SCYTHE, ToolClasses.HOE));
         KNIFE = register(ItemGTTool.Builder.of(GTValues.MODID, "knife")
-                .toolStats(b -> b.attacking().crafting().canApplyEnchantment(EnumEnchantmentType.WEAPON))
+                .toolStats(b -> b.crafting().attacking())
                 .oreDict(ToolOreDicts.craftingToolKnife)
                 .symbol('k')
                 .toolClasses(ToolClasses.KNIFE, ToolClasses.SWORD));


### PR DESCRIPTION
## What

Fixes Materials with Default Enchantments not applying those enchantments to non-vanilla GT tools when the tools were crafted.
