### PR TITLE
Fix chanced output boost not being applied to multiblocks

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -646,7 +646,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.fluidOutputs = GTUtility.copyFluidList(recipe.getAllFluidOutputs(metaTileEntity.getFluidOutputLimit()));
         this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(
                 GTUtility.getTierByVoltage(recipe.getEUt()),
-                getOverclockTier(),
+                getOverclockForTier(getEnergyCapacity()),
                 getRecipeMap())
         );
 

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -646,7 +646,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.fluidOutputs = GTUtility.copyFluidList(recipe.getAllFluidOutputs(metaTileEntity.getFluidOutputLimit()));
         this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(
                 GTUtility.getTierByVoltage(recipe.getEUt()),
-                getOverclockForTier(getEnergyCapacity()),
+                getOverclockForTier(getMaximumOverclockVoltage()),
                 getRecipeMap())
         );
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -254,7 +254,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
         @Override
         protected int getOverclockForTier(long voltage) {
-            return super.getOverclockForTier(machineVoltage);
+            return super.getOverclockForTier(Math.min(machineVoltage, getEnergyCapacity()));
         }
 
         @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -254,7 +254,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
         @Override
         protected int getOverclockForTier(long voltage) {
-            return super.getOverclockForTier(Math.min(machineVoltage, getEnergyCapacity()));
+            return super.getOverclockForTier(Math.min(machineVoltage, getMaximumOverclockVoltage()));
         }
 
         @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -253,6 +253,11 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
+        protected int getOverclockForTier(long voltage) {
+            return super.getOverclockForTier(machineVoltage);
+        }
+
+        @Override
         public int getParallelLimit() {
             return (currentMachineStack == null || currentMachineStack.isEmpty()) ? getMachineLimit() : Math.min(currentMachineStack.getCount(), getMachineLimit());
         }


### PR DESCRIPTION
## What
This PR fixes chanced output boost not being applied to multiblocks

## Implementation Details
Pass the absolute tier for chanced boost instead of the maximum set on the GUI. (Since this is never set for multiblocks, the absolute tier passed was 0).

Special case for the PA as the absolute voltage passed should be the voltage of the machines in the hatch

## Outcome
Boosts applied