### PR TITLE
Decouple parallel voltage from overclock and recipe search voltage

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -109,9 +109,17 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     protected abstract boolean drawEnergy(int recipeEUt, boolean simulate);
 
     /**
-     * @return the maximum voltage tier the machine can use/handle
+     * @return the maximum voltage the machine can use/handle for recipe searching
      */
     protected abstract long getMaxVoltage();
+
+    /**
+     *
+     * @return the maximum voltage the machine can use/handle for parallel recipe creation
+     */
+    protected long getMaxParallelVoltage() {
+        return getMaxVoltage();
+    }
 
     /**
      * @return the inventory to input items from
@@ -431,7 +439,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
                 getInputTank(),
                 getOutputInventory(),
                 getOutputTank(),
-                getMaxVoltage(),
+                getMaxParallelVoltage(),
                 getParallelLimit());
 
         if (recipe != null && setupAndConsumeRecipeInputs(recipe, getInputInventory())) {

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -239,7 +239,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                 getInputTank(),
                 getOutputInventory(),
                 getOutputTank(),
-                getMaxVoltage(),
+                getMaxParallelVoltage(),
                 getParallelLimit());
 
         if (recipe != null && setupAndConsumeRecipeInputs(recipe, currentDistinctInputBus)) {


### PR DESCRIPTION
## What
This PR decouples the voltage used for parallel recipes from the voltage used in overclocking and recipe searching, allowing the two to be handled separately from each other through a method override.

## Outcome
Allows decoupling of parallel voltage from overclock and recipe search voltage.

## Potential Compatibility Issues
This PR maintains previous behavior and by default uses the same voltage for everything, unless overridden.
