### PR TITLE
Add Workability field to materials

### DIFF
--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
@@ -252,6 +252,12 @@ public class CTMaterialBuilder {
     }
 
     @ZenMethod
+    public CTMaterialBuilder workability(long workability) {
+        backingBuilder.workability(workability);
+        return this;
+    }
+
+    @ZenMethod
     public Material build() {
         return backingBuilder.build();
     }

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialExpansion.java
@@ -50,6 +50,11 @@ public class MaterialExpansion {
         return m.getMaterialIconSet().getName();
     }
 
+    @ZenMethod
+    public static void setWorkability(Material m, long workability) {
+        m.setWorkability(workability);
+    }
+
     ////////////////////////////////////
     //         Fluid Property         //
     ////////////////////////////////////

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -266,6 +266,19 @@ public class Material implements Comparable<Material> {
         return totalMass / totalAmount;
     }
 
+    @ZenGetter("workability")
+    public long getWorkability() {
+        if (materialInfo.workability == -1) {
+            return this.getMass();
+        }
+        return materialInfo.workability;
+    }
+
+    @ZenMethod
+    public void setWorkability(long workability) {
+        materialInfo.workability = workability;
+    }
+
     @ZenGetter("blastTemperature")
     public int getBlastTemperature() {
         BlastProperty prop = properties.getProperty(PropertyKey.BLAST);
@@ -928,6 +941,13 @@ public class Material implements Comparable<Material> {
          * Default: none.
          */
         private Element element;
+
+        /**
+         * The workability of this Material. Determines recipe length in auto-gen recipes, if specified.
+         * <p>
+         * Default: -1 (Same as mass).
+         */
+        private long workability = -1;
 
         private MaterialInfo(int metaItemSubId, String name) {
             this.metaItemSubId = metaItemSubId;

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -731,6 +731,11 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        public Builder workability(long workability) {
+            this.materialInfo.workability = workability;
+            return this;
+        }
+
         public Builder toolStats(float speed, float damage, int durability, int enchantability) {
             return toolStats(speed, damage, durability, enchantability, false);
         }

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -281,6 +281,7 @@ public class ElementMaterials {
                 .cableProperties(GTValues.V[3], 3, 2)
                 .fluidPipeProperties(1671, 25, true, true, false, false)
                 .fluidTemp(1337)
+                .workability(25)
                 .build();
 
         Hafnium = new Material.Builder(42, "hafnium")
@@ -744,6 +745,7 @@ public class ElementMaterials {
                 .cableProperties(GTValues.V[1], 1, 1)
                 .itemPipeProperties(4096, 0.5f)
                 .fluidTemp(505)
+                .workability(55)
                 .build();
 
         Titanium = new Material.Builder(113, "titanium") // todo Ore? Look at EBF recipe here if we do Ti ores
@@ -754,6 +756,7 @@ public class ElementMaterials {
                 .toolStats(7.0f, 3.0f, 1600, 21)
                 .fluidPipeProperties(2426, 150, true)
                 .blastTemp(1941, GasTier.MID, VA[HV], 1500)
+                .workability(90)
                 .build();
 
         Tritium = new Material.Builder(114, "tritium")

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -881,6 +881,7 @@ public class ElementMaterials {
                 .cableProperties(GTValues.V[8], 1, 8)
                 .toolStats(20.0f, 6.0f, 10240, 21)
                 .fluidTemp(25000)
+                .workability(700)
                 .build();
 
         Duranium = new Material.Builder(129, "duranium")
@@ -900,6 +901,7 @@ public class ElementMaterials {
                 .element(Elements.Ke)
                 .cableProperties(GTValues.V[7], 6, 4)
                 .blastTemp(7200, GasTier.HIGH, VA[LuV], 1500)
+                .workability(400)
                 .build();
 
     }

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -159,6 +159,7 @@ public class ElementMaterials {
                 .fluidPipeProperties(2180, 35, true, true, false, false)
                 .blastTemp(1700, GasTier.LOW)
                 .fluidTemp(2180)
+                .workability(105)
                 .build();
 
         Cobalt = new Material.Builder(23, "cobalt")
@@ -374,6 +375,7 @@ public class ElementMaterials {
                 .cableProperties(GTValues.V[0], 2, 2)
                 .fluidPipeProperties(1200, 8, true)
                 .fluidTemp(600)
+                .workability(50)
                 .build();
 
         Lithium = new Material.Builder(56, "lithium")

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -701,6 +701,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[8], 4, 4)
                 .blastTemp(4500, GasTier.HIGH) // todo redo this EBF process
                 .fluidTemp(1799)
+                .workability(390)
                 .build();
 
         NetherQuartz = new Material.Builder(339, "nether_quartz")
@@ -1256,6 +1257,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.LV], 2, 0, true, 78)
                 .blastTemp(1200, GasTier.LOW)
                 .fluidTemp(1368)
+                .workability(120)
                 .build();
 
         MagnesiumDiboride = new Material.Builder(425, "magnesium_diboride")
@@ -1266,6 +1268,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.MV], 4, 0, true, 78)
                 .blastTemp(2500, GasTier.LOW, VA[HV], 1000)
                 .fluidTemp(1103)
+                .workability(180)
                 .build();
 
         MercuryBariumCalciumCuprate = new Material.Builder(426, "mercury_barium_calcium_cuprate")
@@ -1276,6 +1279,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.HV], 4, 0, true, 78)
                 .blastTemp(3300, GasTier.LOW, VA[HV], 1500)
                 .fluidTemp(1075)
+                .workability(240)
                 .build();
 
         UraniumTriplatinum = new Material.Builder(427, "uranium_triplatinum")
@@ -1286,6 +1290,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.EV], 6, 0, true, 30)
                 .blastTemp(4400, GasTier.MID, VA[EV], 1000)
                 .fluidTemp(1882)
+                .workability(320)
                 .build()
                 .setFormula("UPt3", true);
 
@@ -1297,6 +1302,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.IV], 6, 0, true, 30)
                 .blastTemp(5200, GasTier.MID, VA[EV], 1500)
                 .fluidTemp(1347)
+                .workability(400)
                 .build();
 
         IndiumTinBariumTitaniumCuprate = new Material.Builder(429, "indium_tin_barium_titanium_cuprate")
@@ -1307,6 +1313,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.LuV], 8, 0, true, 5)
                 .blastTemp(6000, GasTier.HIGH, VA[IV], 1000)
                 .fluidTemp(1012)
+                .workability(500)
                 .build();
 
         UraniumRhodiumDinaquadide = new Material.Builder(430, "uranium_rhodium_dinaquadide")
@@ -1317,6 +1324,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.ZPM], 8, 0, true, 5)
                 .blastTemp(9000, GasTier.HIGH, VA[IV], 1500)
                 .fluidTemp(3410)
+                .workability(600)
                 .build()
                 .setFormula("URhNq2", true);
 
@@ -1328,6 +1336,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.UV], 16, 0, true, 3)
                 .blastTemp(9900, GasTier.HIGH, VA[LuV], 1000)
                 .fluidTemp(5930)
+                .workability(800)
                 .build();
 
         RutheniumTriniumAmericiumNeutronate = new Material.Builder(432, "ruthenium_trinium_americium_neutronate")
@@ -1338,6 +1347,7 @@ public class FirstDegreeMaterials {
                 .cableProperties(GTValues.V[GTValues.UHV], 24, 0, true, 3)
                 .blastTemp(10800, GasTier.HIGHER)
                 .fluidTemp(23691)
+                .workability(1000)
                 .build();
 
         InertMetalMixture = new Material.Builder(433, "inert_metal_mixture")

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -62,6 +62,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL)
                 .components(Lead, 4, Antimony, 1)
                 .fluidTemp(660)
+                .workability(45)
                 .build();
 
         BlueTopaz = new Material.Builder(257, "blue_topaz")
@@ -220,6 +221,7 @@ public class FirstDegreeMaterials {
                 .itemPipeProperties(1024, 2)
                 .cableProperties(GTValues.V[3], 2, 2)
                 .fluidTemp(1285)
+                .workability(27)
                 .build();
 
         Emerald = new Material.Builder(278, "emerald")

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -209,6 +209,7 @@ public class FirstDegreeMaterials {
                         HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .components(Carbon, 1)
                 .toolStats(8.0f, 3.0f, 1280, 15)
+                .workability(120)
                 .build();
 
         Electrum = new Material.Builder(277, "electrum")
@@ -1061,6 +1062,7 @@ public class FirstDegreeMaterials {
                 .toolStats(12.0f, 4.0f, 1280, 21)
                 .fluidPipeProperties(3837, 200, true)
                 .blastTemp(3058, GasTier.MID, VA[HV], 1500)
+                .workability(140)
                 .build();
 
         CarbonDioxide = new Material.Builder(397, "carbon_dioxide")

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -86,6 +86,7 @@ public class HigherDegreeMaterials {
                 .toolStats(10.0f, 5.5f, 4000, 21)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .blastTemp(4200, GasTier.MID, VA[EV], 1300)
+                .workability(240)
                 .build();
 
         RedAlloy = new Material.Builder(2517, "red_alloy")
@@ -111,6 +112,7 @@ public class HigherDegreeMaterials {
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
                 .toolStats(10.0f, 8.0f, 5120, 21)
                 .blastTemp(5000, GasTier.HIGH, VA[EV], 1400)
+                .workability(250)
                 .build();
 
         HSSS = new Material.Builder(2520, "hsss")
@@ -120,6 +122,7 @@ public class HigherDegreeMaterials {
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
                 .toolStats(15.0f, 7.0f, 3000, 21)
                 .blastTemp(5000, GasTier.HIGH, VA[EV], 1500)
+                .workability(270)
                 .build();
 
         // FREE ID: 2521

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -319,6 +319,7 @@ public class SecondDegreeMaterials {
                 .toolStats(8.0f, 5.0f, 5120, 21)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, VA[LuV], 1000)
+                .workability(615)
                 .build();
 
         SulfuricNickelSolution = new Material.Builder(2043, "sulfuric_nickel_solution")

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -310,6 +310,7 @@ public class UnknownCompositionMaterials {
                 .gem(4)
                 .iconSet(NETHERSTAR)
                 .flags(NO_SMASHING, NO_SMELTING, GENERATE_LENS)
+                .workability(666)
                 .build();
 
         Endstone = new Material.Builder(1603, "endstone")

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -131,7 +131,7 @@ public class RecyclingRecipes {
             RecipeMaps.EXTRACTOR_RECIPES.recipeBuilder()
                     .inputs(input.copy())
                     .fluidOutputs(m.getFluid((int) (ms.amount * L / M)))
-                    .duration((int) Math.max(1, ms.amount * ms.material.getMass() / M))
+                    .duration((int) Math.max(1, ms.amount * ms.material.getWorkability() / M))
                     .EUt(GTValues.VA[GTValues.LV] * multiplier)
                     .buildAndRegister();
 
@@ -151,8 +151,8 @@ public class RecyclingRecipes {
         // Calculate the duration based off of those two possible outputs.
         // - Sum the two Material amounts together (if both exist)
         // - Divide the sum by M
-        long duration = fluidMs.amount * fluidMs.material.getMass();
-        if (itemMs != null) duration += (itemMs.amount * itemMs.material.getMass());
+        long duration = fluidMs.amount * fluidMs.material.getWorkability();
+        if (itemMs != null) duration += (itemMs.amount * itemMs.material.getWorkability());
         duration = Math.max(1L, duration / M);
 
         // Build the final Recipe.
@@ -317,7 +317,7 @@ public class RecyclingRecipes {
         long duration = 0;
         for (ItemStack is : materials) {
             MaterialStack ms = OreDictUnifier.getMaterial(is);
-            if (ms != null) duration += ms.amount * ms.material.getMass();
+            if (ms != null) duration += ms.amount * ms.material.getWorkability();
         }
         return (int) Math.max(1L, duration / M);
     }

--- a/src/main/java/gregtech/loaders/recipe/handlers/DecompositionRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/DecompositionRecipeHandler.java
@@ -98,7 +98,7 @@ public class DecompositionRecipeHandler {
                     .EUt(material.getMaterialComponents().size() <= 2 ? VA[LV] : 2 * VA[LV]);
         } else {
             builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder()
-                    .duration((int) Math.ceil(material.getMass() * totalInputAmount * 1.5))
+                    .duration((int) Math.ceil(material.getWorkability() * totalInputAmount * 1.5))
                     .EUt(VA[LV]);
         }
         builder.outputs(outputs);

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -161,7 +161,7 @@ public class MaterialRecipeHandler {
                 RecipeMaps.VACUUM_RECIPES.recipeBuilder()
                         .input(ingotHot, material)
                         .output(ingot, material)
-                        .duration((int) material.getMass() * 3)
+                        .duration((int) material.getWorkability() * 3)
                         .buildAndRegister();
             } else {
                 RecipeMaps.VACUUM_RECIPES.recipeBuilder()
@@ -169,7 +169,7 @@ public class MaterialRecipeHandler {
                         .fluidInputs(Materials.LiquidHelium.getFluid(500))
                         .output(ingot, material)
                         .fluidOutputs(Materials.Helium.getFluid(250))
-                        .duration((int) material.getMass() * 3)
+                        .duration((int) material.getWorkability() * 3)
                         .buildAndRegister();
             }
         }
@@ -243,7 +243,7 @@ public class MaterialRecipeHandler {
                         .input(ingotPrefix, material)
                         .notConsumable(MetaItems.SHAPE_EXTRUDER_ROD)
                         .outputs(OreDictUnifier.get(OrePrefix.stick, material, 2))
-                        .duration((int) material.getMass() * 2)
+                        .duration((int) material.getWorkability() * 2)
                         .EUt(6 * getVoltageMultiplier(material))
                         .buildAndRegister();
             }
@@ -268,14 +268,14 @@ public class MaterialRecipeHandler {
                     .buildAndRegister();
         }
 
-        ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getMass())
+        ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getWorkability())
                 .input(ingot, material)
                 .notConsumable(MetaItems.SHAPE_MOLD_NUGGET.getStackForm())
                 .output(nugget, material, 9)
                 .buildAndRegister();
 
         if (!OreDictUnifier.get(block, material).isEmpty()) {
-            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getMass() * 9)
+            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getWorkability() * 9)
                     .input(block, material)
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT.getStackForm())
                     .output(ingot, material, 9)
@@ -296,13 +296,13 @@ public class MaterialRecipeHandler {
                             .circuitMeta(1)
                             .input(ingotPrefix, material)
                             .outputs(plateStack)
-                            .EUt(24).duration((int) (material.getMass()))
+                            .EUt(24).duration((int) (material.getWorkability()))
                             .buildAndRegister();
 
                     RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
                             .input(ingotPrefix, material, 3)
                             .outputs(GTUtility.copyAmount(2, plateStack))
-                            .EUt(16).duration((int) material.getMass())
+                            .EUt(16).duration((int) material.getWorkability())
                             .buildAndRegister();
 
                     ModHandler.addShapedRecipe(String.format("plate_%s", material),
@@ -316,7 +316,7 @@ public class MaterialRecipeHandler {
                         .input(ingotPrefix, material)
                         .notConsumable(MetaItems.SHAPE_EXTRUDER_PLATE)
                         .outputs(OreDictUnifier.get(OrePrefix.plate, material))
-                        .duration((int) material.getMass())
+                        .duration((int) material.getWorkability())
                         .EUt(8 * voltageMultiplier)
                         .buildAndRegister();
 
@@ -325,7 +325,7 @@ public class MaterialRecipeHandler {
                             .input(dust, material)
                             .notConsumable(MetaItems.SHAPE_EXTRUDER_PLATE)
                             .outputs(OreDictUnifier.get(OrePrefix.plate, material))
-                            .duration((int) material.getMass())
+                            .duration((int) material.getWorkability())
                             .EUt(8 * voltageMultiplier)
                             .buildAndRegister();
                 }
@@ -383,7 +383,7 @@ public class MaterialRecipeHandler {
                     .output(ingot, material)
                     .EUt(2).duration(300).buildAndRegister();
 
-            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getMass())
+            ALLOY_SMELTER_RECIPES.recipeBuilder().EUt(VA[ULV]).duration((int) material.getWorkability())
                     .input(nugget, material, 9)
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT.getStackForm())
                     .output(ingot, material)
@@ -394,7 +394,7 @@ public class MaterialRecipeHandler {
                         .notConsumable(MetaItems.SHAPE_MOLD_NUGGET)
                         .fluidInputs(material.getFluid(L))
                         .outputs(OreDictUnifier.get(orePrefix, material, 9))
-                        .duration((int) material.getMass())
+                        .duration((int) material.getWorkability())
                         .EUt(VA[ULV])
                         .buildAndRegister();
             }
@@ -435,7 +435,7 @@ public class MaterialRecipeHandler {
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
                     .fluidInputs(material.getFluid((int) (materialAmount * L / M)))
                     .outputs(blockStack)
-                    .duration((int) material.getMass()).EUt(VA[ULV])
+                    .duration((int) material.getWorkability()).EUt(VA[ULV])
                     .buildAndRegister();
         }
 
@@ -445,7 +445,7 @@ public class MaterialRecipeHandler {
                 RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                         .input(blockPrefix, material)
                         .outputs(GTUtility.copyAmount((int) (materialAmount / M), plateStack))
-                        .duration((int) (material.getMass() * 8L)).EUt(VA[LV])
+                        .duration((int) (material.getWorkability() * 8L)).EUt(VA[LV])
                         .buildAndRegister();
             }
         }

--- a/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
@@ -306,7 +306,7 @@ public class OreRecipeHandler {
         RecipeBuilder<?> builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder()
                 .input(dustPrefix, material)
                 .outputs(dustStack)
-                .duration((int) (material.getMass() * 4)).EUt(24);
+                .duration((int) (material.getWorkability() * 4)).EUt(24);
 
         if (byproduct.hasProperty(PropertyKey.DUST)) {
             builder.outputs(OreDictUnifier.get(OrePrefix.dustTiny, byproduct));

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -147,14 +147,14 @@ public class PartsRecipeHandler {
             RecipeMaps.WIREMILL_RECIPES.recipeBuilder()
                     .input(OrePrefix.wireGtSingle, material)
                     .outputs(OreDictUnifier.get(OrePrefix.wireFine, material, 4))
-                    .duration(200)
+                    .duration((int) material.getWorkability() * 3 / 2)
                     .EUt(VA[ULV])
                     .buildAndRegister();
         } else {
             RecipeMaps.WIREMILL_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material)
                     .outputs(OreDictUnifier.get(OrePrefix.wireFine, material, 8))
-                    .duration(400)
+                    .duration((int) material.getWorkability() * 3)
                     .EUt(VA[ULV])
                     .buildAndRegister();
         }

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -94,7 +94,7 @@ public class PartsRecipeHandler {
         RecipeMaps.LATHE_RECIPES.recipeBuilder()
                 .input(OrePrefix.bolt, material)
                 .outputs(screwStack)
-                .duration((int) Math.max(1, material.getMass() / 8L))
+                .duration((int) Math.max(1, material.getWorkability() / 8L))
                 .EUt(4)
                 .buildAndRegister();
 
@@ -112,7 +112,7 @@ public class PartsRecipeHandler {
         RecipeMaps.BENDER_RECIPES.recipeBuilder()
                 .input(plate, material)
                 .output(foilPrefix, material, 4)
-                .duration((int) material.getMass())
+                .duration((int) material.getWorkability())
                 .EUt(24)
                 .circuitMeta(1)
                 .buildAndRegister();
@@ -122,7 +122,7 @@ public class PartsRecipeHandler {
                     .input(ingot, material)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_FOIL)
                     .output(foilPrefix, material, 4)
-                    .duration((int) material.getMass())
+                    .duration((int) material.getWorkability())
                     .EUt(24)
                     .buildAndRegister();
 
@@ -130,7 +130,7 @@ public class PartsRecipeHandler {
                     .input(dust, material)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_FOIL)
                     .output(foilPrefix, material, 4)
-                    .duration((int) material.getMass())
+                    .duration((int) material.getWorkability())
                     .EUt(24)
                     .buildAndRegister();
         }
@@ -168,7 +168,7 @@ public class PartsRecipeHandler {
                     .input(OrePrefix.ingot, material, 4)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_GEAR)
                     .outputs(OreDictUnifier.get(gearPrefix, material))
-                    .duration((int) material.getMass() * 5)
+                    .duration((int) material.getWorkability() * 5)
                     .EUt(8 * voltageMultiplier)
                     .buildAndRegister();
 
@@ -176,7 +176,7 @@ public class PartsRecipeHandler {
                     .input(OrePrefix.ingot, material, 8)
                     .notConsumable(MetaItems.SHAPE_MOLD_GEAR)
                     .outputs(OreDictUnifier.get(gearPrefix, material))
-                    .duration((int) material.getMass() * 10)
+                    .duration((int) material.getWorkability() * 10)
                     .EUt(2 * voltageMultiplier)
                     .buildAndRegister();
 
@@ -185,7 +185,7 @@ public class PartsRecipeHandler {
                         .input(OrePrefix.dust, material, 4)
                         .notConsumable(MetaItems.SHAPE_EXTRUDER_GEAR)
                         .outputs(OreDictUnifier.get(gearPrefix, material))
-                        .duration((int) material.getMass() * 5)
+                        .duration((int) material.getWorkability() * 5)
                         .EUt(8 * voltageMultiplier)
                         .buildAndRegister();
             }
@@ -211,11 +211,11 @@ public class PartsRecipeHandler {
                         .input(OrePrefix.ingot, material)
                         .notConsumable(MetaItems.SHAPE_EXTRUDER_GEAR_SMALL)
                         .outputs(stack)
-                        .duration((int) material.getMass())
+                        .duration((int) material.getWorkability())
                         .EUt(material.getBlastTemperature() >= 2800 ? 256 : 64)
                         .buildAndRegister();
 
-                RecipeMaps.ALLOY_SMELTER_RECIPES.recipeBuilder().duration((int) material.getMass()).EUt(VA[LV])
+                RecipeMaps.ALLOY_SMELTER_RECIPES.recipeBuilder().duration((int) material.getWorkability()).EUt(VA[LV])
                         .input(ingot, material, 2)
                         .notConsumable(MetaItems.SHAPE_MOLD_GEAR_SMALL.getStackForm())
                         .output(gearSmall, material)
@@ -226,7 +226,7 @@ public class PartsRecipeHandler {
                             .input(OrePrefix.dust, material)
                             .notConsumable(MetaItems.SHAPE_EXTRUDER_GEAR_SMALL)
                             .outputs(stack)
-                            .duration((int) material.getMass())
+                            .duration((int) material.getWorkability())
                             .EUt(material.getBlastTemperature() >= 2800 ? 256 : 64)
                             .buildAndRegister();
                 }
@@ -293,7 +293,7 @@ public class PartsRecipeHandler {
                         "h", "P", "P", 'P', new UnificationEntry(plate, material));
             }
 
-            BENDER_RECIPES.recipeBuilder().EUt(96).duration((int) material.getMass() * 2)
+            BENDER_RECIPES.recipeBuilder().EUt(96).duration((int) material.getWorkability() * 2)
                     .input(plate, material, 2)
                     .output(doublePrefix, material)
                     .circuitMeta(2)
@@ -303,7 +303,7 @@ public class PartsRecipeHandler {
                     .input(ingot, material, 2)
                     .circuitMeta(2)
                     .output(doublePrefix, material)
-                    .duration((int) material.getMass() * 2)
+                    .duration((int) material.getWorkability() * 2)
                     .EUt(96)
                     .buildAndRegister();
         }
@@ -314,7 +314,7 @@ public class PartsRecipeHandler {
                 .input(OrePrefix.plate, material, 9)
                 .circuitMeta(9)
                 .output(orePrefix, material)
-                .duration((int) Math.max(material.getMass() * 9L, 1L))
+                .duration((int) Math.max(material.getWorkability() * 9L, 1L))
                 .EUt(96)
                 .buildAndRegister();
 
@@ -322,7 +322,7 @@ public class PartsRecipeHandler {
                 .input(OrePrefix.ingot, material, 9)
                 .circuitMeta(9)
                 .output(orePrefix, material)
-                .duration((int) Math.max(material.getMass() * 9L, 1L))
+                .duration((int) Math.max(material.getWorkability() * 9L, 1L))
                 .EUt(96)
                 .buildAndRegister();
     }
@@ -332,7 +332,7 @@ public class PartsRecipeHandler {
                 .input(OrePrefix.ingot, material)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_RING)
                 .outputs(OreDictUnifier.get(ringPrefix, material, 4))
-                .duration((int) material.getMass() * 2)
+                .duration((int) material.getWorkability() * 2)
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
@@ -346,7 +346,7 @@ public class PartsRecipeHandler {
                     .input(OrePrefix.dust, material)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_RING)
                     .outputs(OreDictUnifier.get(ringPrefix, material, 4))
-                    .duration((int) material.getMass() * 2)
+                    .duration((int) material.getWorkability() * 2)
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         }
@@ -357,7 +357,7 @@ public class PartsRecipeHandler {
                 OreDictUnifier.get(springSmall, material),
                 " s ", "fRx", 'R', new UnificationEntry(stick, material));
 
-        BENDER_RECIPES.recipeBuilder().duration((int) (material.getMass() / 2)).EUt(VA[ULV])
+        BENDER_RECIPES.recipeBuilder().duration((int) (material.getWorkability() / 2)).EUt(VA[ULV])
                 .input(stick, material)
                 .output(springSmall, material, 2)
                 .circuitMeta(1)
@@ -400,7 +400,7 @@ public class PartsRecipeHandler {
                 .input(ingot, material, 4)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_ROTOR)
                 .outputs(GTUtility.copy(stack))
-                .duration((int) material.getMass() * 4)
+                .duration((int) material.getWorkability() * 4)
                 .EUt(material.getBlastTemperature() >= 2800 ? 256 : 64)
                 .buildAndRegister();
 
@@ -409,7 +409,7 @@ public class PartsRecipeHandler {
                     .input(dust, material, 4)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_ROTOR)
                     .outputs(GTUtility.copy(stack))
-                    .duration((int) material.getMass() * 4)
+                    .duration((int) material.getWorkability() * 4)
                     .EUt(material.getBlastTemperature() >= 2800 ? 256 : 64)
                     .buildAndRegister();
         }
@@ -419,7 +419,7 @@ public class PartsRecipeHandler {
         if (material.hasProperty(PropertyKey.GEM) || material.hasProperty(PropertyKey.INGOT)) {
             RecipeBuilder<?> builder = RecipeMaps.LATHE_RECIPES.recipeBuilder()
                     .input(material.hasProperty(PropertyKey.GEM) ? OrePrefix.gem : OrePrefix.ingot, material)
-                    .duration((int) Math.max(material.getMass() * 2, 1))
+                    .duration((int) Math.max(material.getWorkability() * 2, 1))
                     .EUt(16);
 
             if (ConfigHolder.recipes.harderRods) {
@@ -436,7 +436,7 @@ public class PartsRecipeHandler {
             RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                     .input(stickPrefix, material)
                     .outputs(GTUtility.copyAmount(4, boltStack))
-                    .duration((int) Math.max(material.getMass() * 2L, 1L))
+                    .duration((int) Math.max(material.getWorkability() * 2L, 1L))
                     .EUt(4)
                     .buildAndRegister();
 
@@ -454,7 +454,7 @@ public class PartsRecipeHandler {
         RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                 .input(longStickPrefix, material)
                 .outputs(GTUtility.copyAmount(2, stickStack))
-                .duration((int) Math.max(material.getMass(), 1L)).EUt(4)
+                .duration((int) Math.max(material.getWorkability(), 1L)).EUt(4)
                 .buildAndRegister();
 
         ModHandler.addShapedRecipe(String.format("stick_long_%s", material),
@@ -482,7 +482,7 @@ public class PartsRecipeHandler {
         RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
                 .input(OrePrefix.stick, material, 2)
                 .outputs(stack)
-                .duration((int) Math.max(material.getMass(), 1L))
+                .duration((int) Math.max(material.getWorkability(), 1L))
                 .EUt(16)
                 .buildAndRegister();
 
@@ -491,7 +491,7 @@ public class PartsRecipeHandler {
                     .input(OrePrefix.ingot, material)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_ROD_LONG)
                     .outputs(stack)
-                    .duration((int) Math.max(material.getMass(), 1L))
+                    .duration((int) Math.max(material.getWorkability(), 1L))
                     .EUt(64)
                     .buildAndRegister();
 
@@ -500,7 +500,7 @@ public class PartsRecipeHandler {
                         .input(OrePrefix.dust, material)
                         .notConsumable(MetaItems.SHAPE_EXTRUDER_ROD_LONG)
                         .outputs(stack)
-                        .duration((int) Math.max(material.getMass(), 1L))
+                        .duration((int) Math.max(material.getWorkability(), 1L))
                         .EUt(64)
                         .buildAndRegister();
             }

--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -71,7 +71,7 @@ public class PipeRecipeHandler {
                 .input(OrePrefix.ingot, material, 1)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_TINY)
                 .outputs(GTUtility.copyAmount(2, pipeStack))
-                .duration((int) (material.getMass()))
+                .duration((int) (material.getWorkability()))
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
@@ -80,7 +80,7 @@ public class PipeRecipeHandler {
                     .input(OrePrefix.dust, material, 1)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_TINY)
                     .outputs(GTUtility.copyAmount(2, pipeStack))
-                    .duration((int) (material.getMass()))
+                    .duration((int) (material.getWorkability()))
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
@@ -96,7 +96,7 @@ public class PipeRecipeHandler {
                 .input(OrePrefix.ingot, material, 1)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_SMALL)
                 .outputs(pipeStack)
-                .duration((int) (material.getMass()))
+                .duration((int) (material.getWorkability()))
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
@@ -105,7 +105,7 @@ public class PipeRecipeHandler {
                     .input(OrePrefix.dust, material, 1)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_SMALL)
                     .outputs(pipeStack)
-                    .duration((int) (material.getMass()))
+                    .duration((int) (material.getWorkability()))
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
@@ -121,7 +121,7 @@ public class PipeRecipeHandler {
                 .input(OrePrefix.ingot, material, 3)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_NORMAL)
                 .outputs(pipeStack)
-                .duration((int) material.getMass() * 3)
+                .duration((int) material.getWorkability() * 3)
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
@@ -130,7 +130,7 @@ public class PipeRecipeHandler {
                     .input(OrePrefix.dust, material, 3)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_NORMAL)
                     .outputs(pipeStack)
-                    .duration((int) material.getMass() * 3)
+                    .duration((int) material.getWorkability() * 3)
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
@@ -146,7 +146,7 @@ public class PipeRecipeHandler {
                 .input(OrePrefix.ingot, material, 6)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_LARGE)
                 .outputs(pipeStack)
-                .duration((int) material.getMass() * 6)
+                .duration((int) material.getWorkability() * 6)
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
@@ -155,7 +155,7 @@ public class PipeRecipeHandler {
                     .input(OrePrefix.dust, material, 6)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_LARGE)
                     .outputs(pipeStack)
-                    .duration((int) material.getMass() * 6)
+                    .duration((int) material.getWorkability() * 6)
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
@@ -171,7 +171,7 @@ public class PipeRecipeHandler {
                 .input(OrePrefix.ingot, material, 12)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_HUGE)
                 .outputs(pipeStack)
-                .duration((int) material.getMass() * 24)
+                .duration((int) material.getWorkability() * 24)
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
@@ -180,7 +180,7 @@ public class PipeRecipeHandler {
                     .input(OrePrefix.dust, material, 12)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_HUGE)
                     .outputs(pipeStack)
-                    .duration((int) material.getMass() * 24)
+                    .duration((int) material.getWorkability() * 24)
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else if (OrePrefix.plateDouble.doGenerateItem(material)) {

--- a/src/main/java/gregtech/loaders/recipe/handlers/PolarizingRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PolarizingRecipeHandler.java
@@ -34,7 +34,7 @@ public class PolarizingRecipeHandler {
             RecipeMaps.POLARIZER_RECIPES.recipeBuilder() //polarizing
                     .input(polarizingPrefix, material)
                     .outputs(magneticStack)
-                    .duration((int) ((int) material.getMass() * polarizingPrefix.getMaterialAmount(material) / GTValues.M))
+                    .duration((int) ((int) material.getWorkability() * polarizingPrefix.getMaterialAmount(material) / GTValues.M))
                     .EUt(8 * getVoltageMultiplier(material))
                     .buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/ToolRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/ToolRecipeHandler.java
@@ -248,7 +248,7 @@ public class ToolRecipeHandler {
             RecipeMaps.LATHE_RECIPES.recipeBuilder()
                     .input(OrePrefix.gear, material)
                     .output(OrePrefix.toolHeadBuzzSaw, material)
-                    .duration((int) material.getMass() * 4)
+                    .duration((int) material.getWorkability() * 4)
                     .EUt(8 * getVoltageMultiplier(material))
                     .buildAndRegister();
         }
@@ -309,7 +309,7 @@ public class ToolRecipeHandler {
                     .input(OrePrefix.ingot, material, 3)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_AXE)
                     .outputs(OreDictUnifier.get(toolPrefix, material))
-                    .duration((int) material.getMass() * 3)
+                    .duration((int) material.getWorkability() * 3)
                     .EUt(8 * voltageMultiplier)
                     .buildAndRegister();
 
@@ -325,7 +325,7 @@ public class ToolRecipeHandler {
                     .input(OrePrefix.ingot, material, 2)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_HOE)
                     .outputs(OreDictUnifier.get(toolPrefix, material))
-                    .duration((int) material.getMass() * 2)
+                    .duration((int) material.getWorkability() * 2)
                     .EUt(8 * voltageMultiplier)
                     .buildAndRegister();
     }
@@ -340,7 +340,7 @@ public class ToolRecipeHandler {
                     .input(OrePrefix.ingot, material, 3)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PICKAXE)
                     .outputs(OreDictUnifier.get(toolPrefix, material))
-                    .duration((int) material.getMass() * 3)
+                    .duration((int) material.getWorkability() * 3)
                     .EUt(8 * voltageMultiplier)
                     .buildAndRegister();
 
@@ -356,7 +356,7 @@ public class ToolRecipeHandler {
                 .input(OrePrefix.ingot, material, 2)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_SAW)
                 .outputs(OreDictUnifier.get(OrePrefix.toolHeadSaw, material))
-                .duration((int) material.getMass() * 2)
+                .duration((int) material.getWorkability() * 2)
                 .EUt(8 * voltageMultiplier)
                 .buildAndRegister();
     }
@@ -375,7 +375,7 @@ public class ToolRecipeHandler {
                 .input(OrePrefix.ingot, material)
                 .notConsumable(MetaItems.SHAPE_EXTRUDER_SHOVEL)
                 .outputs(OreDictUnifier.get(toolPrefix, material))
-                .duration((int) material.getMass())
+                .duration((int) material.getWorkability())
                 .EUt(8 * voltageMultiplier)
                 .buildAndRegister();
     }
@@ -390,7 +390,7 @@ public class ToolRecipeHandler {
                     .input(OrePrefix.ingot, material, 2)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_SWORD)
                     .outputs(OreDictUnifier.get(toolPrefix, material))
-                    .duration((int) material.getMass() * 2)
+                    .duration((int) material.getWorkability() * 2)
                     .EUt(8 * voltageMultiplier)
                     .buildAndRegister();
     }
@@ -404,7 +404,7 @@ public class ToolRecipeHandler {
                         .input(OrePrefix.ingot, material, 6)
                         .notConsumable(MetaItems.SHAPE_EXTRUDER_HAMMER)
                         .outputs(OreDictUnifier.get(toolPrefix, material))
-                        .duration((int) material.getMass() * 6)
+                        .duration((int) material.getWorkability() * 6)
                         .EUt(8 * getVoltageMultiplier(material))
                         .buildAndRegister();
         }
@@ -423,7 +423,7 @@ public class ToolRecipeHandler {
                     .input(OrePrefix.ingot, material, 2)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_FILE)
                     .outputs(OreDictUnifier.get(toolPrefix, material))
-                    .duration((int) material.getMass() * 2)
+                    .duration((int) material.getWorkability() * 2)
                     .EUt(8 * getVoltageMultiplier(material))
                     .buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
@@ -70,14 +70,14 @@ public class WireRecipeHandler {
                 .input(prefix, material)
                 .notConsumable(SHAPE_EXTRUDER_WIRE)
                 .output(wireGtSingle, material, 2)
-                .duration((int) material.getMass() * 2)
+                .duration((int) material.getWorkability() * 2)
                 .EUt(6 * getVoltageMultiplier(material))
                 .buildAndRegister();
 
         WIREMILL_RECIPES.recipeBuilder()
                 .input(prefix, material)
                 .output(wireGtSingle, material, 2)
-                .duration((int) material.getMass())
+                .duration((int) material.getWorkability())
                 .EUt(getVoltageMultiplier(material))
                 .buildAndRegister();
 


### PR DESCRIPTION
## What
Added a Workability field to materials, which determines how long the material takes to be processed into different forms in machines.  

## Implementation Details
A field `workability` was added to material info. This is set in the material definition and can also be set by a setter.  
The getter for this field will return the workability, but if that has not been set, it will fall back to the atomic mass (like old behaviour). No attempt is made to calculate workability of composite materials based on their components.  
Almost all instances of `getMass()` in autogen recipe duration fields have been replaced by `getWorkability()`. The exception is EBF autogen recipes which remain as `getMass()`.  

## Outcome
Material processing durations can now be adjusted instead of relying only on their mass value.  
![image](https://user-images.githubusercontent.com/61507029/208589314-895c7c05-53cb-4da9-ac72-713a07e1edfc.png)


## Additional Information
Basic CT compat tested.
Actual workability numbers are mostly not in, this will require further balance analysis.

## Potential Compatibility Issues
Recipe duration changes.
Addons will have to update to this new system.