### PR TITLE
Refactor and expand HUD drawing to items

### DIFF
--- a/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
@@ -29,18 +29,12 @@ public abstract class ArmorLogicSuite implements ISpecialArmorLogic {
     protected final int tier;
     protected final long maxCapacity;
     protected final EntityEquipmentSlot SLOT;
-    @SideOnly(Side.CLIENT)
-    protected ArmorUtils.ModularHUD HUD;
 
     protected ArmorLogicSuite(int energyPerUse, long maxCapacity, int tier, EntityEquipmentSlot slot) {
         this.energyPerUse = energyPerUse;
         this.maxCapacity = maxCapacity;
         this.tier = tier;
         this.SLOT = slot;
-        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
-            //noinspection NewExpressionSideOnly
-            HUD = new ArmorUtils.ModularHUD();
-        }
     }
 
     @Override
@@ -133,24 +127,12 @@ public abstract class ArmorLogicSuite implements ISpecialArmorLogic {
     }
 
     @SideOnly(Side.CLIENT)
-    public boolean isNeedDrawHUD() {
-        return false;
-    }
-
-    @SideOnly(Side.CLIENT)
-    public void drawHUD(ItemStack stack) {
-        this.addCapacityHUD(stack);
-        this.HUD.draw();
-        this.HUD.reset();
-    }
-
-    @SideOnly(Side.CLIENT)
-    protected void addCapacityHUD(ItemStack stack) {
+    protected static void addCapacityHUD(ItemStack stack, ArmorUtils.ModularHUD hud) {
         IElectricItem cont = stack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (cont == null) return;
         if (cont.getCharge() == 0) return;
         float energyMultiplier = cont.getCharge() * 100.0F / cont.getMaxCharge();
-        this.HUD.newString(I18n.format("metaarmor.hud.energy_lvl", String.format("%.1f", energyMultiplier) + "%"));
+        hud.newString(I18n.format("metaarmor.hud.energy_lvl", String.format("%.1f", energyMultiplier) + "%"));
     }
 
     public int getEnergyPerUse() {

--- a/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
@@ -7,6 +7,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorMetaItem.ArmorMetaValueItem;
 import gregtech.api.items.metaitem.ElectricStats;
+import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -23,7 +24,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public abstract class ArmorLogicSuite implements ISpecialArmorLogic {
+public abstract class ArmorLogicSuite implements ISpecialArmorLogic, IItemHUDProvider {
 
     protected final int energyPerUse;
     protected final int tier;

--- a/src/main/java/gregtech/api/items/metaitem/stats/IItemHUDProvider.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/IItemHUDProvider.java
@@ -1,0 +1,38 @@
+package gregtech.api.items.metaitem.stats;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Provides a drawable HUD for the item
+ */
+public interface IItemHUDProvider extends IItemComponent {
+
+    /**
+     * @return if the HUD needs to be drawn
+     */
+    @SideOnly(Side.CLIENT)
+    boolean isNeedDrawHUD();
+
+    /**
+     * Draws the HUD
+     *
+     * @param stack the ItemStack to retrieve information from
+     */
+    @SideOnly(Side.CLIENT)
+    void drawHUD(ItemStack stack);
+
+    /**
+     * Checks and draws the hud for a provider
+     *
+     * @param provider the provider whose hud to draw
+     * @param stack    the stack the provider should use
+     */
+    @SideOnly(Side.CLIENT)
+    static void tryDrawHud(@Nonnull IItemHUDProvider provider, @Nonnull ItemStack stack) {
+        if (provider.isNeedDrawHUD()) provider.drawHUD(stack);
+    }
+}

--- a/src/main/java/gregtech/api/items/metaitem/stats/IItemHUDProvider.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/IItemHUDProvider.java
@@ -15,7 +15,7 @@ public interface IItemHUDProvider extends IItemComponent {
      * @return if the HUD needs to be drawn
      */
     @SideOnly(Side.CLIENT)
-    boolean isNeedDrawHUD();
+    boolean shouldDrawHUD();
 
     /**
      * Draws the HUD
@@ -23,7 +23,7 @@ public interface IItemHUDProvider extends IItemComponent {
      * @param stack the ItemStack to retrieve information from
      */
     @SideOnly(Side.CLIENT)
-    void drawHUD(ItemStack stack);
+    default void drawHUD(ItemStack stack) {/**/}
 
     /**
      * Checks and draws the hud for a provider
@@ -33,6 +33,6 @@ public interface IItemHUDProvider extends IItemComponent {
      */
     @SideOnly(Side.CLIENT)
     static void tryDrawHud(@Nonnull IItemHUDProvider provider, @Nonnull ItemStack stack) {
-        if (provider.isNeedDrawHUD()) provider.drawHUD(stack);
+        if (provider.shouldDrawHUD()) provider.drawHUD(stack);
     }
 }

--- a/src/main/java/gregtech/api/items/metaitem/stats/IItemHUDProvider.java
+++ b/src/main/java/gregtech/api/items/metaitem/stats/IItemHUDProvider.java
@@ -15,7 +15,9 @@ public interface IItemHUDProvider extends IItemComponent {
      * @return if the HUD needs to be drawn
      */
     @SideOnly(Side.CLIENT)
-    boolean shouldDrawHUD();
+    default boolean shouldDrawHUD() {
+        return true;
+    }
 
     /**
      * Draws the HUD

--- a/src/main/java/gregtech/client/event/ClientEventHandler.java
+++ b/src/main/java/gregtech/client/event/ClientEventHandler.java
@@ -2,6 +2,8 @@ package gregtech.client.event;
 
 import com.mojang.authlib.minecraft.MinecraftProfileTexture;
 import gregtech.api.GTValues;
+import gregtech.api.items.armor.ArmorLogicSuite;
+import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.util.CapesRegistry;
 import gregtech.client.particle.GTParticleManager;
@@ -11,12 +13,14 @@ import gregtech.client.renderer.handler.TerminalARRenderer;
 import gregtech.client.utils.DepthTextureUtil;
 import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityMonitorScreen;
+import gregtech.common.items.armor.PowerlessJetpack;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.event.*;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -103,6 +107,28 @@ public class ClientEventHandler {
     public static void onConfigChanged(ConfigChangedEvent.PostConfigChangedEvent event) {
         if (GTValues.MODID.equals(event.getModID()) && event.isWorldRunning()) {
             Minecraft.getMinecraft().renderGlobal.loadRenderers();
+        }
+    }
+
+    @SubscribeEvent
+    public static void onRenderArmorHUD(TickEvent.RenderTickEvent event) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.inGameHasFocus && mc.world != null && !mc.gameSettings.showDebugInfo && Minecraft.isGuiEnabled()) {
+            ItemStack stack = mc.player.inventory.armorItemInSlot(EntityEquipmentSlot.CHEST.getIndex());
+            if (stack.getItem() instanceof ArmorMetaItem) {
+                ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) stack.getItem()).getItem(stack);
+                if (valueItem.getArmorLogic() instanceof ArmorLogicSuite) {
+                    ArmorLogicSuite armorLogic = (ArmorLogicSuite) valueItem.getArmorLogic();
+                    if (armorLogic.isNeedDrawHUD()) {
+                        armorLogic.drawHUD(stack);
+                    }
+                } else if (valueItem.getArmorLogic() instanceof PowerlessJetpack) {
+                    PowerlessJetpack armorLogic = (PowerlessJetpack) valueItem.getArmorLogic();
+                    if (armorLogic.isNeedDrawHUD()) {
+                        armorLogic.drawHUD(stack);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/java/gregtech/common/items/armor/AdvancedJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedJetpack.java
@@ -3,7 +3,6 @@ package gregtech.common.items.armor;
 
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
-import gregtech.api.items.armor.ArmorUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import net.minecraft.client.resources.I18n;
@@ -103,13 +102,9 @@ public class AdvancedJetpack extends Jetpack {
     }
 
     @SideOnly(Side.CLIENT)
-    public boolean isNeedDrawHUD() {
-        return true;
-    }
-
     @Override
     public void drawHUD(ItemStack item) {
-        super.addCapacityHUD(item);
+        addCapacityHUD(item, this.HUD);
         IElectricItem cont = item.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (cont == null) return;
         if (!cont.canUse(energyPerUse)) return;

--- a/src/main/java/gregtech/common/items/armor/AdvancedJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedJetpack.java
@@ -5,7 +5,6 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -14,8 +13,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 
@@ -99,24 +96,6 @@ public class AdvancedJetpack extends Jetpack {
     @Override
     public float getFallDamageReduction() {
         return 2.0f;
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
-    public void drawHUD(ItemStack item) {
-        addCapacityHUD(item, this.HUD);
-        IElectricItem cont = item.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
-        if (cont == null) return;
-        if (!cont.canUse(energyPerUse)) return;
-        NBTTagCompound data = item.getTagCompound();
-        if (data != null) {
-            if (data.hasKey("hover")) {
-                String status = data.getBoolean("hover") ? "metaarmor.hud.status.enabled" : "metaarmor.hud.status.disabled";
-                this.HUD.newString(I18n.format("metaarmor.hud.hover_mode", I18n.format(status)));
-            }
-        }
-        this.HUD.draw();
-        this.HUD.reset();
     }
 
     @Override

--- a/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
@@ -15,6 +15,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.*;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
@@ -179,6 +181,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
         return super.onRightClick(world, player, hand);
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public void drawHUD(ItemStack item) {
         addCapacityHUD(item, this.HUD);

--- a/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
@@ -15,8 +15,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.*;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
@@ -179,12 +177,6 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
         }
 
         return super.onRightClick(world, player, hand);
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
-    public boolean isNeedDrawHUD() {
-        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedNanoMuscleSuite.java
@@ -182,13 +182,14 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
     }
 
     @SideOnly(Side.CLIENT)
+    @Override
     public boolean isNeedDrawHUD() {
         return true;
     }
 
     @Override
     public void drawHUD(ItemStack item) {
-        super.addCapacityHUD(item);
+        addCapacityHUD(item, this.HUD);
         IElectricItem cont = item.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (cont == null) return;
         if (!cont.canUse(energyPerUse)) return;

--- a/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
@@ -17,6 +17,8 @@ import net.minecraft.util.*;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
@@ -181,6 +183,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
         }
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public void drawHUD(ItemStack item) {
         addCapacityHUD(item, this.HUD);

--- a/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/AdvancedQuarkTechSuite.java
@@ -17,8 +17,6 @@ import net.minecraft.util.*;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
@@ -183,14 +181,9 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
         }
     }
 
-    @SideOnly(Side.CLIENT)
-    public boolean isNeedDrawHUD() {
-        return true;
-    }
-
     @Override
     public void drawHUD(ItemStack item) {
-        super.addCapacityHUD(item);
+        addCapacityHUD(item, this.HUD);
         IElectricItem cont = item.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         if (cont == null) return;
         if (!cont.canUse(energyPerUse)) return;

--- a/src/main/java/gregtech/common/items/armor/Jetpack.java
+++ b/src/main/java/gregtech/common/items/armor/Jetpack.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorLogicSuite;
 import gregtech.api.items.armor.ArmorUtils;
-import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import net.minecraft.client.resources.I18n;
@@ -25,14 +24,14 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public class Jetpack extends ArmorLogicSuite implements IJetpack, IItemHUDProvider {
+public class Jetpack extends ArmorLogicSuite implements IJetpack {
 
     @SideOnly(Side.CLIENT)
     protected ArmorUtils.ModularHUD HUD;
 
     public Jetpack(int energyPerUse, long capacity, int tier) {
         super(energyPerUse, capacity, tier, EntityEquipmentSlot.CHEST);
-        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
+        if (ArmorUtils.SIDE.isClient() && this.shouldDrawHUD()) {
             //noinspection NewExpressionSideOnly
             HUD = new ArmorUtils.ModularHUD();
         }
@@ -107,7 +106,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack, IItemHUDProvid
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean isNeedDrawHUD() {
+    public boolean shouldDrawHUD() {
         return true;
     }
 

--- a/src/main/java/gregtech/common/items/armor/Jetpack.java
+++ b/src/main/java/gregtech/common/items/armor/Jetpack.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorLogicSuite;
 import gregtech.api.items.armor.ArmorUtils;
+import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import net.minecraft.client.resources.I18n;
@@ -24,10 +25,17 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public class Jetpack extends ArmorLogicSuite implements IJetpack {
+public class Jetpack extends ArmorLogicSuite implements IJetpack, IItemHUDProvider {
+
+    @SideOnly(Side.CLIENT)
+    protected ArmorUtils.ModularHUD HUD;
 
     public Jetpack(int energyPerUse, long capacity, int tier) {
         super(energyPerUse, capacity, tier, EntityEquipmentSlot.CHEST);
+        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
+            //noinspection NewExpressionSideOnly
+            HUD = new ArmorUtils.ModularHUD();
+        }
     }
 
     @Override
@@ -106,7 +114,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     @SideOnly(Side.CLIENT)
     @Override
     public void drawHUD(ItemStack item) {
-        super.addCapacityHUD(item);
+        addCapacityHUD(item, this.HUD);
         NBTTagCompound data = item.getTagCompound();
         if (data != null) {
             if (data.hasKey("hover")) {

--- a/src/main/java/gregtech/common/items/armor/Jetpack.java
+++ b/src/main/java/gregtech/common/items/armor/Jetpack.java
@@ -106,12 +106,6 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean shouldDrawHUD() {
-        return true;
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
     public void drawHUD(ItemStack item) {
         addCapacityHUD(item, this.HUD);
         NBTTagCompound data = item.getTagCompound();

--- a/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
@@ -146,12 +146,6 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean shouldDrawHUD() {
-        return true;
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
     public void drawHUD(ItemStack item) {
         addCapacityHUD(item, this.HUD);
         this.HUD.draw();

--- a/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
@@ -3,6 +3,8 @@ package gregtech.common.items.armor;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorLogicSuite;
+import gregtech.api.items.armor.ArmorUtils;
+import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import gregtech.common.items.MetaItems;
@@ -26,10 +28,17 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
+public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist, IItemHUDProvider {
+
+    @SideOnly(Side.CLIENT)
+    protected ArmorUtils.ModularHUD HUD;
 
     public NanoMuscleSuite(EntityEquipmentSlot slot, int energyPerUse, long maxCapacity, int tier) {
         super(energyPerUse, maxCapacity, tier, slot);
+        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
+            //noinspection NewExpressionSideOnly
+            HUD = new ArmorUtils.ModularHUD();
+        }
     }
 
     @Override
@@ -137,13 +146,15 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
     }
 
     @SideOnly(Side.CLIENT)
+    @Override
     public boolean isNeedDrawHUD() {
         return true;
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public void drawHUD(ItemStack item) {
-        super.addCapacityHUD(item);
+        addCapacityHUD(item, this.HUD);
         this.HUD.draw();
         this.HUD.reset();
     }

--- a/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
+++ b/src/main/java/gregtech/common/items/armor/NanoMuscleSuite.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorLogicSuite;
 import gregtech.api.items.armor.ArmorUtils;
-import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import gregtech.common.items.MetaItems;
@@ -28,14 +27,14 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist, IItemHUDProvider {
+public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
 
     @SideOnly(Side.CLIENT)
     protected ArmorUtils.ModularHUD HUD;
 
     public NanoMuscleSuite(EntityEquipmentSlot slot, int energyPerUse, long maxCapacity, int tier) {
         super(energyPerUse, maxCapacity, tier, slot);
-        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
+        if (ArmorUtils.SIDE.isClient() && this.shouldDrawHUD()) {
             //noinspection NewExpressionSideOnly
             HUD = new ArmorUtils.ModularHUD();
         }
@@ -147,7 +146,7 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist, IIt
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean isNeedDrawHUD() {
+    public boolean shouldDrawHUD() {
         return true;
     }
 

--- a/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
+++ b/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
@@ -101,4 +101,9 @@ public class NightvisionGoggles extends ArmorLogicSuite {
             }
         }
     }
+
+    @Override
+    public boolean shouldDrawHUD() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
+++ b/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
@@ -15,6 +15,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -102,6 +104,7 @@ public class NightvisionGoggles extends ArmorLogicSuite {
         }
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public boolean shouldDrawHUD() {
         return false;

--- a/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
@@ -3,11 +3,11 @@ package gregtech.common.items.armor;
 import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.items.armor.ArmorMetaItem.ArmorMetaValueItem;
 import gregtech.api.items.armor.ArmorUtils;
-import gregtech.api.items.armor.IArmorLogic;
 import gregtech.api.items.armor.ISpecialArmorLogic;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.items.metaitem.stats.IItemCapabilityProvider;
 import gregtech.api.items.metaitem.stats.IItemDurabilityManager;
+import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.items.metaitem.stats.ISubItemHandler;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpack {
+public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDProvider {
 
     public final int tankCapacity = 16000;
 
@@ -119,6 +119,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
     }
 
     @SideOnly(Side.CLIENT)
+    @Override
     public void drawHUD(@Nonnull ItemStack item) {
         IFluidHandlerItem tank = item.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
         if (tank != null) {
@@ -145,6 +146,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IArmorLogic, IJetpa
     }
 
     @SideOnly(Side.CLIENT)
+    @Override
     public boolean isNeedDrawHUD() {
         return true;
     }

--- a/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
@@ -4,11 +4,7 @@ import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.items.armor.ArmorMetaItem.ArmorMetaValueItem;
 import gregtech.api.items.armor.ArmorUtils;
 import gregtech.api.items.armor.ISpecialArmorLogic;
-import gregtech.api.items.metaitem.stats.IItemBehaviour;
-import gregtech.api.items.metaitem.stats.IItemCapabilityProvider;
-import gregtech.api.items.metaitem.stats.IItemDurabilityManager;
-import gregtech.api.items.metaitem.stats.IItemHUDProvider;
-import gregtech.api.items.metaitem.stats.ISubItemHandler;
+import gregtech.api.items.metaitem.stats.*;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.unification.material.Materials;
@@ -143,12 +139,6 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDP
         }
         this.HUD.draw();
         this.HUD.reset();
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
-    public boolean shouldDrawHUD() {
-        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
@@ -147,7 +147,7 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDP
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean isNeedDrawHUD() {
+    public boolean shouldDrawHUD() {
         return true;
     }
 

--- a/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
@@ -286,13 +286,6 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean shouldDrawHUD() {
-        return true;
-    }
-
-
-    @SideOnly(Side.CLIENT)
-    @Override
     public void drawHUD(ItemStack item) {
         addCapacityHUD(item, this.HUD);
         this.HUD.draw();

--- a/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorLogicSuite;
 import gregtech.api.items.armor.ArmorUtils;
-import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import gregtech.common.items.MetaItems;
@@ -35,7 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist, IItemHUDProvider {
+public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
 
     protected static final Map<Potion, Integer> potionRemovalCost = new IdentityHashMap<>();
     private float charge = 0.0F;
@@ -47,7 +46,7 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist, IIte
         super(energyPerUse, capacity, tier, slot);
         potionRemovalCost.put(MobEffects.POISON, 10000);
         potionRemovalCost.put(MobEffects.WITHER, 25000);
-        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
+        if (ArmorUtils.SIDE.isClient() && this.shouldDrawHUD()) {
             //noinspection NewExpressionSideOnly
             HUD = new ArmorUtils.ModularHUD();
         }
@@ -287,7 +286,7 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist, IIte
 
     @SideOnly(Side.CLIENT)
     @Override
-    public boolean isNeedDrawHUD() {
+    public boolean shouldDrawHUD() {
         return true;
     }
 

--- a/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
+++ b/src/main/java/gregtech/common/items/armor/QuarkTechSuite.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.armor.ArmorLogicSuite;
 import gregtech.api.items.armor.ArmorUtils;
+import gregtech.api.items.metaitem.stats.IItemHUDProvider;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.input.KeyBind;
 import gregtech.common.items.MetaItems;
@@ -34,14 +35,22 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
+public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist, IItemHUDProvider {
+
     protected static final Map<Potion, Integer> potionRemovalCost = new IdentityHashMap<>();
     private float charge = 0.0F;
+
+    @SideOnly(Side.CLIENT)
+    protected ArmorUtils.ModularHUD HUD;
 
     public QuarkTechSuite(EntityEquipmentSlot slot, int energyPerUse, long capacity, int tier) {
         super(energyPerUse, capacity, tier, slot);
         potionRemovalCost.put(MobEffects.POISON, 10000);
         potionRemovalCost.put(MobEffects.WITHER, 25000);
+        if (ArmorUtils.SIDE.isClient() && this.isNeedDrawHUD()) {
+            //noinspection NewExpressionSideOnly
+            HUD = new ArmorUtils.ModularHUD();
+        }
     }
 
     @Override
@@ -277,13 +286,16 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
     }
 
     @SideOnly(Side.CLIENT)
+    @Override
     public boolean isNeedDrawHUD() {
         return true;
     }
 
+
+    @SideOnly(Side.CLIENT)
     @Override
     public void drawHUD(ItemStack item) {
-        super.addCapacityHUD(item);
+        addCapacityHUD(item, this.HUD);
         this.HUD.draw();
         this.HUD.reset();
     }


### PR DESCRIPTION
## What
This PR allows the Armor HUD to be provided by any MetaArmor piece, and expands the HUD functionality to be provided by MetaItems. 

It additionally fixes the armor HUD not being rendered. The code for this seems to have either never been added when porting the armors from Gregicality Legacy originally, or lost in a refactor. This PR re-adds it with some improvements.
 
## Outcome
Allows Items and any Armor piece to provide a HUD. Fixes the armor HUD not being rendered.
