### PR TITLE
Fix server-side sound registration problems from #1285

### DIFF
--- a/src/main/java/gregtech/core/sound/internal/SoundManager.java
+++ b/src/main/java/gregtech/core/sound/internal/SoundManager.java
@@ -20,10 +20,18 @@ public class SoundManager implements ISoundManager {
 
     private static final SoundManager INSTANCE = new SoundManager();
 
-    @SideOnly(Side.CLIENT)
+    // This cannot be marked `@SideOnly(Side.CLIENT)`, because the server will report it as a missing field
+    // when `INSTANCE` is instantiated on the server side
     private final Object2ObjectMap<BlockPos, ISound> soundMap = new Object2ObjectOpenHashMap<>();
 
     private SoundManager() {
+//        if (FMLCommonHandler.instance().getEffectiveSide() == Side.CLIENT) {
+//            // the soundMap is always client side, so initialize it properly here
+//            soundMap = new Object2ObjectOpenHashMap<>();
+//        } else {
+//            // the soundMap is never accessed on the server side, so instantiating as null is fine
+//            soundMap = null;
+//        }
     }
 
     public static SoundManager getInstance() {
@@ -46,6 +54,7 @@ public class SoundManager implements ISoundManager {
         return registerSound(containerId, soundName);
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public ISound startTileSound(ResourceLocation soundName, float volume, BlockPos pos) {
         ISound sound = soundMap.get(pos);
@@ -59,6 +68,7 @@ public class SoundManager implements ISoundManager {
         return sound;
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public void stopTileSound(BlockPos pos) {
         ISound sound = soundMap.get(pos);

--- a/src/main/java/gregtech/core/sound/internal/SoundManager.java
+++ b/src/main/java/gregtech/core/sound/internal/SoundManager.java
@@ -24,15 +24,7 @@ public class SoundManager implements ISoundManager {
     // when `INSTANCE` is instantiated on the server side
     private final Object2ObjectMap<BlockPos, ISound> soundMap = new Object2ObjectOpenHashMap<>();
 
-    private SoundManager() {
-//        if (FMLCommonHandler.instance().getEffectiveSide() == Side.CLIENT) {
-//            // the soundMap is always client side, so initialize it properly here
-//            soundMap = new Object2ObjectOpenHashMap<>();
-//        } else {
-//            // the soundMap is never accessed on the server side, so instantiating as null is fine
-//            soundMap = null;
-//        }
-    }
+    private SoundManager() {/**/}
 
     public static SoundManager getInstance() {
         return INSTANCE;


### PR DESCRIPTION
## What
In #1285, a bug was introduced where setting `GregTechAPI.soundManager` on the server would result in numerous logged exceptions. This would also prevent clients from joining the server, despite it "successfully" launching.

## Implementation Details
This fix required two changes. First, the `@SideOnly(Side.CLIENT)` annotations needed to be applied to `startTileSound` and `stopTileSound` in `SoundManager`. It appears that this forge annotation does not get applied to methods implementing/overriding other methods with it.

This first fix led to a second error, where `SoundManager`'s `soundMap` could not be found on the server. This was due to it being marked Client-Side only, but still initialized on the server. Changing this field to be on both sides fixed this issue.

## Outcome
Fixed server-side bug introduced in #1285.
