### PR TITLE
Fix FuelableInfoProvider calling client only method on server

### DIFF
--- a/src/main/java/gregtech/api/util/GTStringUtils.java
+++ b/src/main/java/gregtech/api/util/GTStringUtils.java
@@ -14,9 +14,14 @@ import gregtech.common.items.MetaItems;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
-public class GTStringUtils {
+import javax.annotation.Nonnull;
 
-    public static String prettyPrintItemStack(ItemStack stack) {
+public final class GTStringUtils {
+
+    private GTStringUtils() {/**/}
+
+    @Nonnull
+    public static String prettyPrintItemStack(@Nonnull ItemStack stack) {
         if (stack.getItem() instanceof MetaItem) {
             MetaItem<?> metaItem = (MetaItem<?>) stack.getItem();
             MetaItem.MetaValueItem metaValueItem = metaItem.getItem(stack);
@@ -57,5 +62,21 @@ public class GTStringUtils {
         }
         //noinspection ConstantConditions
         return stack.getItem().getRegistryName().toString() + " * " + stack.getCount() + " (Meta " + stack.getItemDamage() + ")";
+    }
+
+    /**
+     * Copied and pasted from {@link net.minecraft.util.StringUtils#ticksToElapsedTime(int)} in order to be accessible
+     * Server-Side
+     *
+     * @param ticks the amount of ticks to convert
+     * @return the time elapsed for the given number of ticks, in "mm:ss" format.
+     */
+    @Nonnull
+    public static String ticksToElapsedTime(int ticks) {
+        int seconds = ticks / 20;
+        int minutes = seconds / 60;
+        seconds = seconds % 60;
+        //noinspection StringConcatenationMissingWhitespace
+        return seconds < 10 ? minutes + ":0" + seconds : minutes + ":" + seconds;
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/FuelableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/FuelableInfoProvider.java
@@ -5,13 +5,13 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IFuelInfo;
 import gregtech.api.capability.IFuelable;
 import gregtech.api.capability.impl.ItemFuelInfo;
+import gregtech.api.util.GTStringUtils;
 import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.StringUtils;
 import net.minecraftforge.common.capabilities.Capability;
 
 import javax.annotation.Nonnull;
@@ -54,7 +54,7 @@ public class FuelableInfoProvider extends CapabilityInfoProvider<IFuelable> {
 
             int fuelMinConsumed = fuelInfo.getFuelMinConsumed();
             if (fuelRemaining < fuelMinConsumed) probeInfo.text(TextStyleClass.INFOIMP + "{*gregtech.top.fuel_min_consume*} " + fuelMinConsumed);
-            else probeInfo.text(TextStyleClass.INFO + StringUtils.ticksToElapsedTime((int) fuelInfo.getFuelBurnTimeLong()));
+            else probeInfo.text(TextStyleClass.INFO + GTStringUtils.ticksToElapsedTime((int) fuelInfo.getFuelBurnTimeLong()));
         }
     }
 }


### PR DESCRIPTION
## What
This PR fixes the FuelableInfoProvider calling a Client-Side only method on the server. While I was unable to reproduce #1270 myself, it is likely caused by looking at a small solid-fueled boiler with excess fuel inside it, while connected to a server. I believe this should resolve the error.

## Outcome
Fixes #1270.
