### PR TITLE
improve logging for recipe conflicts

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -3,6 +3,7 @@ package gregtech.api;
 import gregtech.GregTechVersion;
 import gregtech.api.util.XSTR;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.oredict.OreDictionary;
 
 import java.time.LocalDate;
@@ -124,6 +125,13 @@ public class GTValues {
     public static boolean isClientSide() {
         if (isClient == null) isClient = FMLCommonHandler.instance().getSide().isClient();
         return isClient;
+    }
+
+    private static Boolean isDeobf;
+
+    public static boolean isDeobfEnvironment() {
+        if (isDeobf == null) isDeobf = FMLLaunchHandler.isDeobfuscatedEnvironment();
+        return isDeobf;
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -731,10 +731,26 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                             return v;
                         } else {
                             if (recipe.getIsCTRecipe()) {
-                                CraftTweakerAPI.logError(String.format("Recipe: %s for Recipe Map %s is a duplicate and was not added", CTRecipeHelper.getRecipeAddLine(this, recipe), this.unlocalizedName));
+                                CraftTweakerAPI.logError(String.format("Recipe duplicate or conflict found in RecipeMap %s and was not added. See next lines for details.", this.unlocalizedName));
+
+                                CraftTweakerAPI.logError(String.format("Attempted to add Recipe: %s", CTRecipeHelper.getRecipeAddLine(this, recipe)));
+
+                                if (v.left().isPresent()) {
+                                    CraftTweakerAPI.logError(String.format("Which conflicts with: %s", CTRecipeHelper.getRecipeAddLine(this, v.left().get())));
+                                } else {
+                                    CraftTweakerAPI.logError("Could not identify exact duplicate/conflict.");
+                                }
                             }
-                            if (ConfigHolder.misc.debug) {
-                                GTLog.logger.warn("Recipe: {} for Recipe Map {} is a duplicate and was not added", recipe.toString(), this.unlocalizedName);
+                            if (ConfigHolder.misc.debug || GTValues.isDeobfEnvironment()) {
+                                GTLog.logger.warn("Recipe duplicate or conflict found in RecipeMap {} and was not added. See next lines for details", this.unlocalizedName);
+
+                                GTLog.logger.warn("Attempted to add Recipe: {}", recipe.toString());
+
+                                if (v.left().isPresent()) {
+                                    GTLog.logger.warn("Which conflicts with: {}", v.left().get().toString());
+                                } else {
+                                    GTLog.logger.warn("Could not find exact duplicate/conflict.");
+                                }
                             }
                         }
                     } else {

--- a/src/main/java/gregtech/api/recipes/ingredients/GTRecipeOreInput.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/GTRecipeOreInput.java
@@ -124,4 +124,10 @@ public class GTRecipeOreInput extends GTRecipeInput {
         if (this.nbtCondition != null && !this.nbtCondition.equals(other.nbtCondition)) return false;
         return ore == other.ore;
     }
+
+    @Override
+    public String toString() {
+        //noinspection StringConcatenationMissingWhitespace
+        return amount + "x" + OreDictionary.getOreName(ore);
+    }
 }


### PR DESCRIPTION
## What
This PR improves logging for recipe conflicts. Attempting to add a conflicting recipe now displays the exact conflict if it is possible to retrieve, and states otherwise as well.

This should improve debugging clarity for both Modpack Developers using CraftTweaker, as well as Mod Authors.

## Implementation Details
This PR also adds a new method in GTValues, for checking if the current environment is deobfuscated. It additionally adds a toString() implementation for GTRecipeOreInput, which makes logged information about recipes much more clear.

## Outcome
Improves recipe conflict logging.

## Additional Information
A recipe conflict can be created with Crafttweaker with the following code. It conflicts with the Assembler recipe for the Hopper using Iron Plates and a Chest.
```zenscript
<recipemap:assembler>.recipeBuilder()
    .inputs(<ore:chestWood>, <ore:plateIron> * 6)
    .outputs(<minecraft:iron_ingot>)
    .duration(150)
    .EUt(16)
    .buildAndRegister();
```
