### PR TITLE
isolate RotorStats from ToolStats

### DIFF
--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
@@ -144,7 +144,6 @@ public class CTMaterialBuilder {
         return this;
     }
 
-
     @ZenMethod
     public CTMaterialBuilder toolStats(float speed, float damage, int durability, @Optional int enchantability) {
         if (enchantability == 0) {

--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
@@ -144,12 +144,18 @@ public class CTMaterialBuilder {
         return this;
     }
 
+
     @ZenMethod
     public CTMaterialBuilder toolStats(float speed, float damage, int durability, @Optional int enchantability) {
         if (enchantability == 0) {
             enchantability = 21; // Lowest enchantability by default
         }
         backingBuilder.toolStats(speed, damage, durability, enchantability);
+        return this;
+    }
+    @ZenMethod
+    public CTMaterialBuilder rotorStats(float speed, float damage, int durability) {
+        backingBuilder.rotorStats(speed, damage, durability);
         return this;
     }
 

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -727,6 +727,11 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        public Builder rotorStats(float speed, float damage, int durability) {
+            properties.setProperty(PropertyKey.ROTOR, new RotorProperty(speed, damage, durability));
+            return this;
+        }
+
         public Builder blastTemp(int temp) {
             properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp));
             return this;

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -169,7 +169,6 @@ public class ElementMaterials {
                 .flags(EXT_METAL)
                 .element(Elements.Co)
                 .toolStats(10.0f, 3.0f, 256, 21)
-                .rotorStats(10.0f, 3.0f, 256)
                 .cableProperties(GTValues.V[1], 2, 2)
                 .itemPipeProperties(2560, 2.0f)
                 .fluidTemp(1768)
@@ -531,7 +530,6 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(Elements.Pd)
                 .toolStats(8.0f, 2.0f, 512, 33)
-                .rotorStats(8.0f, 2.0f, 512)
                 .blastTemp(1828, GasTier.LOW, VA[HV], 900)
                 .build();
 
@@ -733,7 +731,6 @@ public class ElementMaterials {
                 .flags(STD_METAL, GENERATE_ROD)
                 .element(Elements.Th)
                 .toolStats(6.0f, 2.0f, 512, 33)
-                .rotorStats(6.0f, 2.0f, 512)
                 .fluidTemp(2023)
                 .build();
 
@@ -793,7 +790,6 @@ public class ElementMaterials {
                 .flags(EXT_METAL)
                 .element(Elements.U238)
                 .toolStats(6.0f, 3.0f, 512, 21)
-                .rotorStats(6.0f, 3.0f, 512)
                 .fluidTemp(1405)
                 .build();
 
@@ -803,7 +799,6 @@ public class ElementMaterials {
                 .flags(EXT_METAL)
                 .element(Elements.U235)
                 .toolStats(6.0f, 3.0f, 512, 33)
-                .rotorStats(6.0f, 3.0f, 512)
                 .fluidTemp(1405)
                 .build();
 
@@ -863,7 +858,6 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .element(Elements.Nq1)
                 .toolStats(6.0f, 4.0f, 1280, 21)
-                .rotorStats(6.0f, 4.0f, 1280)
                 .blastTemp(7000, GasTier.HIGH, VA[IV], 1000)
                 .build();
 
@@ -903,7 +897,6 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_GEAR)
                 .element(Elements.Dr)
                 .toolStats(16.0f, 5.0f, 5120, 21)
-                .rotorStats(16.0f, 5.0f, 5120)
                 .fluidPipeProperties(9625, 500, true, true, true, true)
                 .fluidTemp(7500)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -25,6 +25,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
                 .element(Elements.Al)
                 .toolStats(10.0f, 2.0f, 128, 21)
+                .rotorStats(10.0f, 2.0f, 128)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
                 .blastTemp(1700, GasTier.LOW)
@@ -156,6 +157,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_ROTOR)
                 .element(Elements.Cr)
                 .toolStats(12.0f, 3.0f, 512, 33)
+                .rotorStats(12.0f, 3.0f, 512)
                 .fluidPipeProperties(2180, 35, true, true, false, false)
                 .blastTemp(1700, GasTier.LOW)
                 .fluidTemp(2180)
@@ -167,6 +169,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL)
                 .element(Elements.Co)
                 .toolStats(10.0f, 3.0f, 256, 21)
+                .rotorStats(10.0f, 3.0f, 256)
                 .cableProperties(GTValues.V[1], 2, 2)
                 .itemPipeProperties(2560, 2.0f)
                 .fluidTemp(1768)
@@ -332,6 +335,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .element(Elements.Ir)
                 .toolStats(7.0f, 3.0f, 2560, 21)
+                .rotorStats(7.0f, 3.0f, 2560)
                 .fluidPipeProperties(3398, 250, true, false, true, false)
                 .blastTemp(4500, GasTier.HIGH, VA[IV], 1100)
                 .fluidTemp(2719)
@@ -343,6 +347,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_GEAR, GENERATE_SPRING_SMALL, GENERATE_SPRING, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, BLAST_FURNACE_CALCITE_TRIPLE)
                 .element(Elements.Fe)
                 .toolStats(7.0f, 2.5f, 256, 21)
+                .rotorStats(7.0f, 2.5f, 256)
                 .cableProperties(GTValues.V[2], 2, 3)
                 .fluidTemp(1811)
                 .build();
@@ -412,6 +417,7 @@ public class ElementMaterials {
                 .flags(STD_METAL, GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .element(Elements.Mn)
                 .toolStats(7.0f, 2.0f, 512, 21)
+                .rotorStats(7.0f, 2.0f, 512)
                 .fluidTemp(1519)
                 .build();
 
@@ -432,6 +438,7 @@ public class ElementMaterials {
                 .element(Elements.Mo)
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .toolStats(7.0f, 2.0f, 512, 33)
+                .rotorStats(7.0f, 2.0f, 512)
                 .fluidTemp(2896)
                 .build();
 
@@ -446,6 +453,7 @@ public class ElementMaterials {
                 .flags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .element(Elements.Nd)
                 .toolStats(7.0f, 2.0f, 512, 21)
+                .rotorStats(7.0f, 2.0f, 512)
                 .blastTemp(1297, GasTier.MID)
                 .build();
 
@@ -504,6 +512,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_FOIL)
                 .element(Elements.Os)
                 .toolStats(16.0f, 4.0f, 1280, 21)
+                .rotorStats(16.0f, 4.0f, 1280)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .itemPipeProperties(256, 8.0f)
                 .blastTemp(4500, GasTier.HIGH, VA[LuV], 1000)
@@ -522,6 +531,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(Elements.Pd)
                 .toolStats(8.0f, 2.0f, 512, 33)
+                .rotorStats(8.0f, 2.0f, 512)
                 .blastTemp(1828, GasTier.LOW, VA[HV], 900)
                 .build();
 
@@ -723,6 +733,7 @@ public class ElementMaterials {
                 .flags(STD_METAL, GENERATE_ROD)
                 .element(Elements.Th)
                 .toolStats(6.0f, 2.0f, 512, 33)
+                .rotorStats(6.0f, 2.0f, 512)
                 .fluidTemp(2023)
                 .build();
 
@@ -752,6 +763,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_GEAR, GENERATE_FRAME)
                 .element(Elements.Ti)
                 .toolStats(7.0f, 3.0f, 1600, 21)
+                .rotorStats(7.0f, 3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
                 .blastTemp(1941, GasTier.MID, VA[HV], 1500)
                 .build();
@@ -768,6 +780,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_GEAR)
                 .element(Elements.W)
                 .toolStats(7.0f, 3.0f, 2560, 21)
+                .rotorStats(7.0f, 3.0f, 2560)
                 .cableProperties(GTValues.V[5], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
                 .blastTemp(3600, GasTier.MID, VA[EV], 1800)
@@ -780,6 +793,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL)
                 .element(Elements.U238)
                 .toolStats(6.0f, 3.0f, 512, 21)
+                .rotorStats(6.0f, 3.0f, 512)
                 .fluidTemp(1405)
                 .build();
 
@@ -789,6 +803,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL)
                 .element(Elements.U235)
                 .toolStats(6.0f, 3.0f, 512, 33)
+                .rotorStats(6.0f, 3.0f, 512)
                 .fluidTemp(1405)
                 .build();
 
@@ -836,6 +851,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(Elements.Nq)
                 .toolStats(6.0f, 4.0f, 1280, 21)
+                .rotorStats(6.0f, 4.0f, 1280)
                 .cableProperties(GTValues.V[7], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
                 .blastTemp(5000, GasTier.HIGH, VA[IV], 600)
@@ -847,6 +863,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .element(Elements.Nq1)
                 .toolStats(6.0f, 4.0f, 1280, 21)
+                .rotorStats(6.0f, 4.0f, 1280)
                 .blastTemp(7000, GasTier.HIGH, VA[IV], 1000)
                 .build();
 
@@ -864,6 +881,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_BOLT_SCREW, GENERATE_FRAME)
                 .element(Elements.Nt)
                 .toolStats(24.0f, 12.0f, 655360, 21)
+                .rotorStats(24.0f, 12.0f, 655360)
                 .fluidPipeProperties(100_000, 5000, true, true, true, true)
                 .fluidTemp(100_000)
                 .build();
@@ -875,6 +893,7 @@ public class ElementMaterials {
                 .element(Elements.Tr)
                 .cableProperties(GTValues.V[8], 1, 8)
                 .toolStats(20.0f, 6.0f, 10240, 21)
+                .rotorStats(20.0f, 6.0f, 10240)
                 .fluidTemp(25000)
                 .build();
 
@@ -884,6 +903,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_GEAR)
                 .element(Elements.Dr)
                 .toolStats(16.0f, 5.0f, 5120, 21)
+                .rotorStats(16.0f, 5.0f, 5120)
                 .fluidPipeProperties(9625, 500, true, true, true, true)
                 .fluidTemp(7500)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -70,7 +70,6 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Silicon, 1, Fluorine, 2, Hydrogen, 2, Oxygen, 6)
                 .toolStats(7.0f, 3.0f, 256, 15)
-                .rotorStats(7.0f, 3.0f, 256)
                 .build();
 
         Bone = new Material.Builder(258, "bone")
@@ -212,7 +211,6 @@ public class FirstDegreeMaterials {
                         HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .components(Carbon, 1)
                 .toolStats(8.0f, 3.0f, 1280, 15)
-                .rotorStats(8.0f, 3.0f, 1280)
                 .build();
 
         Electrum = new Material.Builder(277, "electrum")
@@ -231,7 +229,6 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GENERATE_LENS)
                 .components(Beryllium, 3, Aluminium, 2, Silicon, 6, Oxygen, 18)
                 .toolStats(10.0f, 2.0f, 368, 15)
-                .rotorStats(10.0f, 2.0f, 368)
                 .build();
 
         Galena = new Material.Builder(279, "galena")
@@ -253,7 +250,6 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Oxygen, 3)
                 .toolStats(8.0f, 3.0f, 368, 15)
-                .rotorStats(8.0f, 3.0f, 368)
                 .build();
 
         Grossular = new Material.Builder(282, "grossular")
@@ -501,7 +497,6 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Chrome, 1, Aluminium, 2, Oxygen, 3)
                 .toolStats(8.5f, 3.0f, 256, 33)
-                .rotorStats(8.5f, 3.0f, 256)
                 .build();
 
         Salt = new Material.Builder(312, "salt")
@@ -524,7 +519,6 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Aluminium, 2, Oxygen, 3)
                 .toolStats(7.5f, 4.0f, 256, 15)
-                .rotorStats(7.5f, 4.0f, 256)
                 .build();
 
         Scheelite = new Material.Builder(315, "scheelite")
@@ -637,7 +631,6 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Silicon, 1, Fluorine, 1, Hydrogen, 2)
                 .toolStats(7.0f, 2.0f, 256, 15)
-                .rotorStats(7.0f, 2.0f, 256)
                 .build();
 
         Tungstate = new Material.Builder(330, "tungstate")

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -70,6 +70,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Silicon, 1, Fluorine, 2, Hydrogen, 2, Oxygen, 6)
                 .toolStats(7.0f, 3.0f, 256, 15)
+                .rotorStats(7.0f, 3.0f, 256)
                 .build();
 
         Bone = new Material.Builder(258, "bone")
@@ -85,6 +86,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE)
                 .components(Zinc, 1, Copper, 3)
                 .toolStats(8.0f, 3.0f, 152, 21)
+                .rotorStats(8.0f, 3.0f, 152)
                 .itemPipeProperties(2048, 1)
                 .fluidTemp(1160)
                 .build();
@@ -95,6 +97,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_SMALL_GEAR, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Tin, 1, Copper, 3)
                 .toolStats(6.0f, 2.5f, 192, 21)
+                .rotorStats(6.0f, 2.5f, 192)
                 .fluidPipeProperties(1696, 20, true)
                 .fluidTemp(1357)
                 .build();
@@ -209,6 +212,7 @@ public class FirstDegreeMaterials {
                         HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .components(Carbon, 1)
                 .toolStats(8.0f, 3.0f, 1280, 15)
+                .rotorStats(8.0f, 3.0f, 1280)
                 .build();
 
         Electrum = new Material.Builder(277, "electrum")
@@ -227,6 +231,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GENERATE_LENS)
                 .components(Beryllium, 3, Aluminium, 2, Silicon, 6, Oxygen, 18)
                 .toolStats(10.0f, 2.0f, 368, 15)
+                .rotorStats(10.0f, 2.0f, 368)
                 .build();
 
         Galena = new Material.Builder(279, "galena")
@@ -248,6 +253,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Oxygen, 3)
                 .toolStats(8.0f, 3.0f, 368, 15)
+                .rotorStats(8.0f, 3.0f, 368)
                 .build();
 
         Grossular = new Material.Builder(282, "grossular")
@@ -291,6 +297,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FRAME, GENERATE_GEAR)
                 .components(Iron, 2, Nickel, 1)
                 .toolStats(7.0f, 3.0f, 512, 21)
+                .rotorStats(7.0f, 3.0f, 512)
                 .addDefaultEnchant(Enchantments.BANE_OF_ARTHROPODS, 3)
                 .fluidTemp(1916)
                 .build();
@@ -318,6 +325,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL)
                 .components(Magnesium, 1, Aluminium, 2)
                 .toolStats(6.0f, 2.0f, 256, 21)
+                .rotorStats(6.0f, 2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .fluidTemp(929)
                 .build();
@@ -397,6 +405,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL)
                 .components(Copper, 1, Silver, 4)
                 .toolStats(13.0f, 2.0f, 196, 33)
+                .rotorStats(13.0f, 2.0f, 196)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1700, GasTier.LOW, VA[MV], 1000)
                 .fluidTemp(1258)
@@ -408,6 +417,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_RING)
                 .components(Copper, 1, Gold, 4)
                 .toolStats(14.0f, 2.0f, 152, 33)
+                .rotorStats(14.0f, 2.0f, 152)
                 .addDefaultEnchant(Enchantments.SMITE, 4)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1600, GasTier.LOW, VA[MV], 1000)
@@ -420,6 +430,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_GEAR)
                 .components(Gold, 1, Silver, 1, Copper, 3)
                 .toolStats(12.0f, 2.0f, 256, 21)
+                .rotorStats(12.0f, 2.0f, 256)
                 .addDefaultEnchant(Enchantments.SMITE, 2)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(2000, GasTier.LOW, VA[MV], 1000)
@@ -432,6 +443,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
                 .toolStats(8.0f, 3.0f, 256, 21)
+                .rotorStats(8.0f, 3.0f, 256)
                 .addDefaultEnchant(Enchantments.BANE_OF_ARTHROPODS, 5)
                 .blastTemp(1100, GasTier.LOW, VA[MV], 1000)
                 .fluidTemp(1036)
@@ -489,6 +501,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Chrome, 1, Aluminium, 2, Oxygen, 3)
                 .toolStats(8.5f, 3.0f, 256, 33)
+                .rotorStats(8.5f, 3.0f, 256)
                 .build();
 
         Salt = new Material.Builder(312, "salt")
@@ -511,6 +524,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Aluminium, 2, Oxygen, 3)
                 .toolStats(7.5f, 4.0f, 256, 15)
+                .rotorStats(7.5f, 4.0f, 256)
                 .build();
 
         Scheelite = new Material.Builder(315, "scheelite")
@@ -573,6 +587,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_LONG_ROD, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Iron, 6, Chrome, 1, Manganese, 1, Nickel, 1)
                 .toolStats(7.0f, 4.0f, 480, 33)
+                .rotorStats(7.0f, 4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
                 .blastTemp(1700, GasTier.LOW, VA[HV], 1100)
                 .fluidTemp(2011)
@@ -585,6 +600,7 @@ public class FirstDegreeMaterials {
                         GENERATE_SPRING_SMALL, GENERATE_FRAME, DISABLE_DECOMPOSITION, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Iron, 1)
                 .toolStats(6.0f, 3.0f, 512, 21)
+                .rotorStats(6.0f, 3.0f, 512)
                 .fluidPipeProperties(1855, 75, true)
                 .cableProperties(GTValues.V[4], 2, 2)
                 .blastTemp(1000, null, VA[MV], 800) // no gas tier for steel
@@ -621,6 +637,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Silicon, 1, Fluorine, 1, Hydrogen, 2)
                 .toolStats(7.0f, 2.0f, 256, 15)
+                .rotorStats(7.0f, 2.0f, 256)
                 .build();
 
         Tungstate = new Material.Builder(330, "tungstate")
@@ -637,6 +654,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_GEAR)
                 .components(Cobalt, 5, Chrome, 2, Nickel, 1, Molybdenum, 1)
                 .toolStats(9.0f, 4.0f, 2048, 33)
+                .rotorStats(9.0f, 4.0f, 2048)
                 .itemPipeProperties(128, 16)
                 .blastTemp(2700, GasTier.MID, VA[HV], 1300)
                 .fluidTemp(1980)
@@ -672,6 +690,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_GEAR, GENERATE_FOIL, MORTAR_GRINDABLE, GENERATE_RING, GENERATE_LONG_ROD, GENERATE_BOLT_SCREW, DISABLE_DECOMPOSITION, BLAST_FURNACE_CALCITE_TRIPLE)
                 .components(Iron, 1)
                 .toolStats(6.0f, 3.5f, 384, 21)
+                .rotorStats(6.0f, 3.5f, 384)
                 .fluidTemp(2011)
                 .build();
         Iron.getProperty(PropertyKey.INGOT).setSmeltingInto(WroughtIron);
@@ -749,6 +768,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Iridium, 3, Osmium, 1)
                 .toolStats(9.0f, 3.0f, 3152, 21)
+                .rotorStats(9.0f, 3.0f, 3152)
                 .itemPipeProperties(64, 32)
                 .blastTemp(4500, GasTier.HIGH, VA[LuV], 900)
                 .fluidTemp(3012)
@@ -1059,6 +1079,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_GEAR, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Tungsten, 1, Carbon, 1)
                 .toolStats(12.0f, 4.0f, 1280, 21)
+                .rotorStats(12.0f, 4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
                 .blastTemp(3058, GasTier.MID, VA[HV], 1500)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -38,6 +38,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_GEAR)
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(7.0f, 4.5f, 896, 21)
+                .rotorStats(7.0f, 4.5f, 896)
                 .blastTemp(1300, GasTier.LOW, VA[HV], 1000)
                 .build();
 
@@ -47,6 +48,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FRAME, GENERATE_GEAR)
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(7.5f, 5.0f, 1024, 21)
+                .rotorStats(7.5f, 5.0f, 1024)
                 .blastTemp(1400, GasTier.LOW, VA[HV], 1000)
                 .build();
 
@@ -84,6 +86,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(TungstenSteel, 5, Chrome, 1, Molybdenum, 2, Vanadium, 1)
                 .toolStats(10.0f, 5.5f, 4000, 21)
+                .rotorStats(10.0f, 5.5f, 4000)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .blastTemp(4200, GasTier.MID, VA[EV], 1300)
                 .build();
@@ -110,6 +113,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING)
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
                 .toolStats(10.0f, 8.0f, 5120, 21)
+                .rotorStats(10.0f, 8.0f, 5120)
                 .blastTemp(5000, GasTier.HIGH, VA[EV], 1400)
                 .build();
 
@@ -119,6 +123,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
                 .toolStats(15.0f, 7.0f, 3000, 21)
+                .rotorStats(15.0f, 7.0f, 3000)
                 .blastTemp(5000, GasTier.HIGH, VA[EV], 1500)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -38,7 +38,6 @@ public class HigherDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_GEAR)
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(7.0f, 4.5f, 896, 21)
-                .rotorStats(7.0f, 4.5f, 896)
                 .blastTemp(1300, GasTier.LOW, VA[HV], 1000)
                 .build();
 
@@ -48,7 +47,6 @@ public class HigherDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FRAME, GENERATE_GEAR)
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(7.5f, 5.0f, 1024, 21)
-                .rotorStats(7.5f, 5.0f, 1024)
                 .blastTemp(1400, GasTier.LOW, VA[HV], 1000)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -49,6 +49,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Magnesium, 2, Iron, 1, SiliconDioxide, 2)
                 .toolStats(7.5f, 3.0f, 312, 33)
+                .rotorStats(7.5f, 3.0f, 312)
                 .build();
 
         Opal = new Material.Builder(2005, "opal")
@@ -57,6 +58,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
                 .toolStats(7.5f, 3.0f, 312, 15)
+                .rotorStats(7.5f, 3.0f, 312)
                 .build();
 
         Amethyst = new Material.Builder(2006, "amethyst")
@@ -65,6 +67,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(SiliconDioxide, 4, Iron, 1)
                 .toolStats(7.5f, 3.0f, 312, 33)
+                .rotorStats(7.5f, 3.0f, 312)
                 .build();
 
         Lapis = new Material.Builder(2007, "lapis")
@@ -98,6 +101,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .components(Nickel, 1, BlackBronze, 1, Steel, 3)
                 .toolStats(6.5f, 6.5f, 768, 21)
+                .rotorStats(6.5f, 6.5f, 768)
                 .cableProperties(GTValues.V[4], 3, 2)
                 .blastTemp(1200, GasTier.LOW)
                 .build();
@@ -108,6 +112,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL)
                 .components(Steel, 1)
                 .toolStats(8.0f, 5.0f, 1280, 21)
+                .rotorStats(8.0f, 5.0f, 1280)
                 .blastTemp(1500, GasTier.LOW)
                 .build();
 
@@ -117,6 +122,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_DENSE, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Steel, 1, Tungsten, 1)
                 .toolStats(8.0f, 4.0f, 2560, 21)
+                .rotorStats(8.0f, 4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
                 .cableProperties(GTValues.V[5], 3, 2)
                 .blastTemp(3000, GasTier.MID, GTValues.VA[EV], 1000)
@@ -128,6 +134,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_GEAR)
                 .components(Brass, 7, Aluminium, 1, Cobalt, 1)
                 .toolStats(8.0f, 2.0f, 256, 21)
+                .rotorStats(8.0f, 2.0f, 256)
                 .itemPipeProperties(2048, 1)
                 .fluidTemp(1202)
                 .build();
@@ -145,6 +152,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Pyrope, 3, Almandine, 5, Spessartine, 8)
                 .toolStats(7.5f, 3.0f, 156, 33)
+                .rotorStats(7.5f, 3.0f, 156)
                 .build();
 
         GarnetYellow = new Material.Builder(2017, "garnet_yellow")
@@ -153,6 +161,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Andradite, 5, Grossular, 8, Uvarovite, 3)
                 .toolStats(7.5f, 3.0f, 156, 33)
+                .rotorStats(7.5f, 3.0f, 156)
                 .build();
 
         Marble = new Material.Builder(2018, "marble")
@@ -279,6 +288,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Vanadium, 1, Chrome, 1, Steel, 7)
                 .toolStats(7.0f, 3.0f, 1920, 21)
+                .rotorStats(7.0f, 3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
                 .blastTemp(1453, GasTier.LOW)
                 .fluidTemp(2073)
@@ -318,6 +328,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SPRING, GENERATE_RING, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_DENSE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Naquadah, 2, Osmiridium, 1, Trinium, 1)
                 .toolStats(8.0f, 5.0f, 5120, 21)
+                .rotorStats(8.0f, 5.0f, 5120)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, VA[LuV], 1000)
                 .build();
@@ -366,7 +377,8 @@ public class SecondDegreeMaterials {
                 .color(0x002040).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
-                .toolStats(6, 4, 80, 10, true)
+                .toolStats(6.0f, 4.0f, 80, 10, true)
+                .rotorStats(6.0f, 4.0f, 80)
                 .addDefaultEnchant(Enchantments.FIRE_ASPECT, 2)
                 .build();
 
@@ -463,6 +475,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE, GENERATE_SMALL_GEAR)
                 .components(Palladium, 3, Rhodium, 1)
                 .toolStats(12.0f, 3.0f, 1024, 33)
+                .rotorStats(12.0f, 3.0f, 1024)
                 .blastTemp(4500, GasTier.HIGH, VA[IV], 1200)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -49,7 +49,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Magnesium, 2, Iron, 1, SiliconDioxide, 2)
                 .toolStats(7.5f, 3.0f, 312, 33)
-                .rotorStats(7.5f, 3.0f, 312)
                 .build();
 
         Opal = new Material.Builder(2005, "opal")
@@ -58,7 +57,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
                 .toolStats(7.5f, 3.0f, 312, 15)
-                .rotorStats(7.5f, 3.0f, 312)
                 .build();
 
         Amethyst = new Material.Builder(2006, "amethyst")
@@ -67,7 +65,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(SiliconDioxide, 4, Iron, 1)
                 .toolStats(7.5f, 3.0f, 312, 33)
-                .rotorStats(7.5f, 3.0f, 312)
                 .build();
 
         Lapis = new Material.Builder(2007, "lapis")
@@ -152,7 +149,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Pyrope, 3, Almandine, 5, Spessartine, 8)
                 .toolStats(7.5f, 3.0f, 156, 33)
-                .rotorStats(7.5f, 3.0f, 156)
                 .build();
 
         GarnetYellow = new Material.Builder(2017, "garnet_yellow")
@@ -161,7 +157,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Andradite, 5, Grossular, 8, Uvarovite, 3)
                 .toolStats(7.5f, 3.0f, 156, 33)
-                .rotorStats(7.5f, 3.0f, 156)
                 .build();
 
         Marble = new Material.Builder(2018, "marble")
@@ -378,7 +373,6 @@ public class SecondDegreeMaterials {
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
                 .toolStats(6.0f, 4.0f, 80, 10, true)
-                .rotorStats(6.0f, 4.0f, 80)
                 .addDefaultEnchant(Enchantments.FIRE_ASPECT, 2)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -98,7 +98,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .components(Nickel, 1, BlackBronze, 1, Steel, 3)
                 .toolStats(6.5f, 6.5f, 768, 21)
-                .rotorStats(6.5f, 6.5f, 768)
                 .cableProperties(GTValues.V[4], 3, 2)
                 .blastTemp(1200, GasTier.LOW)
                 .build();
@@ -109,7 +108,6 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL)
                 .components(Steel, 1)
                 .toolStats(8.0f, 5.0f, 1280, 21)
-                .rotorStats(8.0f, 5.0f, 1280)
                 .blastTemp(1500, GasTier.LOW)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/properties/PropertyKey.java
+++ b/src/main/java/gregtech/api/unification/material/properties/PropertyKey.java
@@ -13,6 +13,7 @@ public class PropertyKey<T extends IMaterialProperty<T>> {
     public static final PropertyKey<OreProperty> ORE = new PropertyKey<>("ore", OreProperty.class);
     public static final PropertyKey<PlasmaProperty> PLASMA = new PropertyKey<>("plasma", PlasmaProperty.class);
     public static final PropertyKey<ToolProperty> TOOL = new PropertyKey<>("tool", ToolProperty.class);
+    public static final PropertyKey<RotorProperty> ROTOR = new PropertyKey<>("rotor", RotorProperty.class);
     public static final PropertyKey<WireProperties> WIRE = new PropertyKey<>("wire", WireProperties.class);
 
     private final String key;

--- a/src/main/java/gregtech/api/unification/material/properties/RotorProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/RotorProperty.java
@@ -1,0 +1,65 @@
+package gregtech.api.unification.material.properties;
+
+import javax.annotation.Nonnull;
+
+public class RotorProperty implements IMaterialProperty<RotorProperty> {
+
+    /**
+     * Speed of rotors made from this Material.
+     * <p>
+     * Default:
+     */
+    private float speed;
+
+    /**
+     * Attack damage of rotors made from this Material
+     * <p>
+     * Default:
+     */
+    private float damage;
+
+    /**
+     * Durability of rotors made from this Material.
+     * <p>
+     * Default:
+     */
+    private int durability;
+
+    public RotorProperty(float speed, float damage, int durability) {
+        this.speed = speed;
+        this.damage = damage;
+        this.durability = durability;
+    }
+
+    public float getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(float speed) {
+        if (speed <= 0) throw new IllegalArgumentException("Rotor Speed must be greater than zero!");
+        this.speed = speed;
+    }
+
+    public float getDamage() {
+        return damage;
+    }
+
+    public void setDamage(float damage) {
+        if (damage <= 0) throw new IllegalArgumentException("Rotor Attack Damage must be greater than zero!");
+        this.damage = damage;
+    }
+
+    public int getDurability() {
+        return durability;
+    }
+
+    public void setDurability(int durability) {
+        if (durability <= 0) throw new IllegalArgumentException("Rotor Durability must be greater than zero!");
+        this.durability = durability;
+    }
+
+    @Override
+    public void verifyProperty(@Nonnull MaterialProperties properties) {
+        if (!properties.hasProperty(PropertyKey.GEM)) properties.ensureSet(PropertyKey.INGOT, true);
+    }
+}

--- a/src/main/java/gregtech/api/unification/material/properties/RotorProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/RotorProperty.java
@@ -60,6 +60,6 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
 
     @Override
     public void verifyProperty(@Nonnull MaterialProperties properties) {
-        if (!properties.hasProperty(PropertyKey.GEM)) properties.ensureSet(PropertyKey.INGOT, true);
+        properties.ensureSet(PropertyKey.INGOT, true);
     }
 }

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -145,7 +145,7 @@ public class OrePrefix {
     // made of 4 Ingots.
     public static final OrePrefix toolHeadWrench = new OrePrefix("toolHeadWrench", M * 4, null, MaterialIconType.toolHeadWrench, ENABLE_UNIFICATION, hasNoCraftingToolProperty.and(mat -> mat.hasFlag(GENERATE_PLATE)));
     // made of 5 Ingots.
-    public static final OrePrefix turbineBlade = new OrePrefix("turbineBlade", M * 10, null, MaterialIconType.turbineBlade, ENABLE_UNIFICATION, hasToolProperty.and(m -> m.hasFlags(GENERATE_BOLT_SCREW, GENERATE_PLATE) && !m.hasProperty(PropertyKey.GEM)));
+    public static final OrePrefix turbineBlade = new OrePrefix("turbineBlade", M * 10, null, MaterialIconType.turbineBlade, ENABLE_UNIFICATION, hasRotorProperty.and(m -> m.hasFlags(GENERATE_BOLT_SCREW, GENERATE_PLATE) && !m.hasProperty(PropertyKey.GEM)));
 
     public static final OrePrefix paneGlass = new OrePrefix("paneGlass", -1, MarkerMaterials.Color.Colorless, null, SELF_REFERENCING, null);
     public static final OrePrefix blockGlass = new OrePrefix("blockGlass", -1, MarkerMaterials.Color.Colorless, null, SELF_REFERENCING, null);
@@ -223,6 +223,7 @@ public class OrePrefix {
         public static final Predicate<Material> hasDustProperty = mat -> mat.hasProperty(PropertyKey.DUST);
         public static final Predicate<Material> hasIngotProperty = mat -> mat.hasProperty(PropertyKey.INGOT);
         public static final Predicate<Material> hasBlastProperty = mat -> mat.hasProperty(PropertyKey.BLAST);
+        public static final Predicate<Material> hasRotorProperty = mat -> mat.hasProperty(PropertyKey.ROTOR);
     }
 
     static {

--- a/src/main/java/gregtech/common/items/behaviors/TurbineRotorBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/TurbineRotorBehavior.java
@@ -5,7 +5,7 @@ import gregtech.api.items.metaitem.stats.IItemDurabilityManager;
 import gregtech.api.items.metaitem.stats.IItemMaxStackSizeProvider;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
-import gregtech.api.unification.material.properties.ToolProperty;
+import gregtech.api.unification.material.properties.RotorProperty;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
@@ -19,14 +19,14 @@ public class TurbineRotorBehavior extends AbstractMaterialPartBehavior implement
     @Override
     public int getPartMaxDurability(ItemStack itemStack) {
         Material material = getPartMaterial(itemStack);
-        ToolProperty property = material.getProperty(PropertyKey.TOOL);
-        return property == null ? -1 : 800 * (int) Math.pow(property.getToolDurability(), 0.65);
+        RotorProperty property = material.getProperty(PropertyKey.ROTOR);
+        return property == null ? -1 : 800 * (int) Math.pow(property.getDurability(), 0.65);
     }
 
     public int getRotorEfficiency(ItemStack stack) {
         Material material = getPartMaterial(stack);
-        ToolProperty property = material.getProperty(PropertyKey.TOOL);
-        return property == null ? -1 : ((int) ((60 + property.getToolSpeed() * 8)) / 5 * 5);
+        RotorProperty property = material.getProperty(PropertyKey.ROTOR);
+        return property == null ? -1 : ((int) ((60 + property.getSpeed() * 8)) / 5 * 5);
     }
 
     public int getRotorDurabilityPercent(ItemStack itemStack) {
@@ -45,8 +45,8 @@ public class TurbineRotorBehavior extends AbstractMaterialPartBehavior implement
 
     public int getRotorPower(ItemStack stack) {
         Material material = getPartMaterial(stack);
-        ToolProperty property = material.getProperty(PropertyKey.TOOL);
-        return property == null ? -1 : (int) (40 + property.getToolAttackDamage() * 30);
+        RotorProperty property = material.getProperty(PropertyKey.ROTOR);
+        return property == null ? -1 : (int) (40 + property.getDamage() * 30);
     }
 
     @Override
@@ -63,16 +63,13 @@ public class TurbineRotorBehavior extends AbstractMaterialPartBehavior implement
 
     @Nullable
     public static TurbineRotorBehavior getInstanceFor(@Nonnull ItemStack itemStack) {
-        if (!(itemStack.getItem() instanceof MetaItem))
-            return null;
+        if (!(itemStack.getItem() instanceof MetaItem)) return null;
 
         MetaItem<?>.MetaValueItem valueItem = ((MetaItem<?>) itemStack.getItem()).getItem(itemStack);
-        if (valueItem == null)
-            return null;
+        if (valueItem == null) return null;
 
         IItemDurabilityManager durabilityManager = valueItem.getDurabilityManager();
-        if (!(durabilityManager instanceof TurbineRotorBehavior))
-            return null;
+        if (!(durabilityManager instanceof TurbineRotorBehavior)) return null;
 
         return (TurbineRotorBehavior) durabilityManager;
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -86,9 +86,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     @Override
     public void update() {
         super.update();
-
-        if (getWorld().isRemote)
-            return;
+        if (getWorld().isRemote) return;
 
         if (getOffsetTimer() % 20 == 0) {
             boolean isFrontFree = checkTurbineFaceFree();
@@ -104,8 +102,9 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
             if (currentSpeed < maxSpeed) {
                 setCurrentSpeed(currentSpeed + SPEED_INCREMENT);
             }
-            if (getOffsetTimer() % 20 == 0)
+            if (getOffsetTimer() % 20 == 0) {
                 damageRotor(1 + controller.getNumMaintenanceProblems());
+            }
         } else if (!hasRotor()) {
             setCurrentSpeed(0);
         } else if (currentSpeed > 0) {
@@ -162,8 +161,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     }
 
     private boolean onRotorHolderInteract(@Nonnull EntityPlayer player) {
-        if (player.isCreative())
-            return false;
+        if (player.isCreative()) return false;
 
         if (!getWorld().isRemote && isRotorSpinning) {
             float damageApplied = Math.min(1, currentSpeed / 1000);
@@ -230,8 +228,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     @Override
     public int getHolderPowerMultiplier() {
         int tierDifference = getTierDifference();
-        if (tierDifference == -1)
-            return -1;
+        if (tierDifference == -1) return -1;
 
         return (int) Math.pow(2, getTierDifference());
     }
@@ -246,8 +243,9 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     }
 
     private int getTierDifference() {
-        if (getController() instanceof ITieredMetaTileEntity)
+        if (getController() instanceof ITieredMetaTileEntity) {
             return getTier() - ((ITieredMetaTileEntity) getController()).getTier();
+        }
         return -1;
     }
 
@@ -364,8 +362,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         @Nullable
         private TurbineRotorBehavior getTurbineBehavior() {
             ItemStack stack = getStackInSlot(0);
-            if (stack.isEmpty())
-                return null;
+            if (stack.isEmpty()) return null;
 
             return TurbineRotorBehavior.getInstanceFor(stack);
         }
@@ -376,40 +373,35 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         }
 
         private int getRotorColor() {
-            if (!hasRotor())
-                return -1;
+            if (!hasRotor()) return -1;
             //noinspection ConstantConditions
             return getTurbineBehavior().getPartMaterial(getStackInSlot(0)).getMaterialRGB();
 
         }
 
         private int getRotorDurabilityPercent() {
-            if (!hasRotor())
-                return 0;
+            if (!hasRotor()) return 0;
 
             //noinspection ConstantConditions
             return getTurbineBehavior().getRotorDurabilityPercent(getStackInSlot(0));
         }
 
         private int getRotorEfficiency() {
-            if (!hasRotor())
-                return -1;
+            if (!hasRotor()) return -1;
 
             //noinspection ConstantConditions
             return getTurbineBehavior().getRotorEfficiency(getTurbineStack());
         }
 
         private int getRotorPower() {
-            if (!hasRotor())
-                return -1;
+            if (!hasRotor()) return -1;
 
             //noinspection ConstantConditions
             return getTurbineBehavior().getRotorPower(getTurbineStack());
         }
 
         private void damageRotor(int damageAmount) {
-            if (!hasRotor())
-                return;
+            if (!hasRotor()) return;
             //noinspection ConstantConditions
             getTurbineBehavior().applyRotorDamage(getStackInSlot(0), damageAmount);
         }
@@ -423,8 +415,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             ItemStack itemStack = super.extractItem(slot, amount, simulate);
-            if (!simulate && itemStack != ItemStack.EMPTY)
-                setRotorColor(-1);
+            if (!simulate && itemStack != ItemStack.EMPTY) setRotorColor(-1);
             return itemStack;
         }
     }


### PR DESCRIPTION
## What
This PR isolates Turbine Rotor stats from Tool Stats. This will allow tweaking balancing of each independently of each other. The previous stats for all materials with tools have been carried over for rotors, so existing behavior will not change. 

## Outcome
Separated RotorStats from ToolStats.
