### PR TITLE
fix tools applying incompatible enchantments

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/ItemGTSword.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTSword.java
@@ -139,7 +139,7 @@ public class ItemGTSword extends ItemSword implements IGTTool {
 
     @Override
     public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
-        return definition$canApplyAtEnchantingTable(stack, enchantment) || super.canApplyAtEnchantingTable(stack, enchantment);
+        return definition$canApplyAtEnchantingTable(stack, enchantment);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTTool.java
@@ -269,7 +269,7 @@ public class ItemGTTool extends ItemTool implements IGTTool {
 
     @Override
     public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
-        return definition$canApplyAtEnchantingTable(stack, enchantment) || super.canApplyAtEnchantingTable(stack, enchantment);
+        return definition$canApplyAtEnchantingTable(stack, enchantment);
     }
 
     @Override

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -60,7 +60,7 @@ public class ToolItems {
                         .toolStats(b -> b.blockBreaking().attacking())
                         .toolClasses(ToolClasses.SWORD));
         PICKAXE = register(ItemGTTool.Builder.of(GTValues.MODID, "pickaxe")
-                .toolStats(b -> b.blockBreaking().attacking().behaviors(new TorchPlaceBehavior()))
+                .toolStats(b -> b.blockBreaking().behaviors(new TorchPlaceBehavior()))
                 .toolClasses(ToolClasses.PICKAXE));
         SHOVEL = register(ItemGTTool.Builder.of(GTValues.MODID, "shovel")
                 .toolStats(b -> b.blockBreaking().behaviors(new GrassPathBehavior()))
@@ -74,7 +74,7 @@ public class ToolItems {
                 .toolStats(b -> b.behaviors(new HoeGroundBehavior()))
                 .toolClasses(ToolClasses.HOE));
         SAW = register(ItemGTTool.Builder.of(GTValues.MODID, "saw")
-                .toolStats(b -> b.attacking().crafting().behaviors(new HarvestIceBehavior()))
+                .toolStats(b -> b.crafting().behaviors(new HarvestIceBehavior()))
                 .oreDict(ToolOreDicts.craftingToolSaw)
                 .symbol('s')
                 .toolClasses(ToolClasses.SAW));


### PR DESCRIPTION
## What
Fixes tools applying incompatible enchantments. For example, the flint mortar will now no longer have fire aspect because it is not suitable for attacking. Previously, it would be applied.

## Outcome
Fixes tools applying incompatible enchantments.
