### PR TITLE
Require one bucket for concrete crafting recipe

### DIFF
--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -22,6 +22,7 @@ import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.ShapedOreEnergyTransferRecipe;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.ConfigHolder;
+import gregtech.common.crafting.FluidReplaceRecipe;
 import gregtech.common.crafting.GTShapedOreRecipe;
 import gregtech.common.crafting.GTShapelessOreRecipe;
 import net.minecraft.block.Block;
@@ -278,6 +279,10 @@ public final class ModHandler {
         addShapedRecipe(false, regName, result, false, recipe);
     }
 
+    public static void addFluidReplaceRecipe(String regName, ItemStack result, Object... recipe) {
+        addFluidReplaceRecipe(regName, result, false, recipe);
+    }
+
     public static void addShapedNBTClearingRecipe(String regName, ItemStack result, Object... recipe) {
         addShapedRecipe(false, regName, result, true, recipe);
     }
@@ -307,6 +312,27 @@ public final class ModHandler {
 
         if (withUnificationData)
             OreDictUnifier.registerOre(result, getRecyclingIngredients(result.getCount(), recipe));
+    }
+
+    public static void addFluidReplaceRecipe(String regName, ItemStack result, boolean isNBTClearing, Object... recipe) {
+        boolean skip = false;
+        if (result.isEmpty()) {
+            GTLog.logger.error(new IllegalArgumentException("Result cannot be an empty ItemStack. Recipe: " + regName));
+            skip = true;
+        }
+        skip = skip || validateRecipe(regName, recipe);
+        if (skip) {
+            RecipeMap.setFoundInvalidRecipe(true);
+            return;
+        }
+
+        IRecipe shapedOreRecipe;
+        shapedOreRecipe = new FluidReplaceRecipe(isNBTClearing, null, result.copy(),
+                finalizeShapedRecipeInput(recipe))
+                .setMirrored(false) //make all recipes not mirrored by default
+                .setRegistryName(regName);
+
+        ForgeRegistries.RECIPES.register(shapedOreRecipe);
     }
 
     public static void addShapedEnergyTransferRecipe(String regName, ItemStack result, Predicate<ItemStack> chargePredicate, boolean overrideCharge, boolean transferMaxCharge, Object... recipe) {

--- a/src/main/java/gregtech/common/crafting/FluidReplaceRecipe.java
+++ b/src/main/java/gregtech/common/crafting/FluidReplaceRecipe.java
@@ -1,0 +1,98 @@
+package gregtech.common.crafting;
+
+import net.minecraft.init.Items;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A recipe which inputs a single Fluid Container, and outputs the same Fluid Container with a new contained Fluid
+ */
+public class FluidReplaceRecipe extends GTShapedOreRecipe {
+
+    public FluidReplaceRecipe(boolean isClearing, ResourceLocation group, @Nonnull ItemStack result, Object... recipe) {
+        super(isClearing, group, result, recipe);
+    }
+
+    @Nonnull
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(@Nonnull InventoryCrafting inv) {
+        if (isClearing) {
+            return NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+        } else {
+            // modified behavior from net.minecraftforge.common.ForgeHooks.defaultRecipeGetRemainingItems(inv)
+            NonNullList<ItemStack> ret = NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+            for (int i = 0; i < ret.size(); i++) {
+                ItemStack stack = inv.getStackInSlot(i);
+                // fluid containers are always consumed
+                if (stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
+                    ret.set(i, ItemStack.EMPTY);
+                } else ret.set(i, ForgeHooks.getContainerItem(stack));
+            }
+            return ret;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public ItemStack getCraftingResult(@Nonnull InventoryCrafting inv) {
+        IFluidHandlerItem recipeCap = output.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (recipeCap == null) throw new IllegalStateException("FluidReplaceRecipe output did not have an IFluidHandlerItem capability");
+
+        FluidStack outputFluid = recipeCap.drain(Integer.MAX_VALUE, false);
+        if (outputFluid == null) throw new IllegalStateException("FluidReplaceRecipe output did not have a fluid");
+        if (outputFluid.amount != 1000) throw new IllegalStateException("FluidReplaceRecipe output must have exactly 1000mB of fluid");
+
+        for (int i = 0; i < inv.getSizeInventory(); i++) {
+            ItemStack input = inv.getStackInSlot(i);
+            IFluidHandlerItem inputCap = input.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+            if (inputCap == null) continue;
+
+            // if the input has a fluid, it must only hold 1000mB
+            FluidStack inputFluid = inputCap.drain(Integer.MAX_VALUE, false);
+            if (inputFluid != null && inputFluid.amount != 1000) continue;
+
+            boolean isBucket;
+            ItemStack output;
+            if (isBucket(input.getItem())) {
+                output = new ItemStack(ForgeModContainer.getInstance().universalBucket);
+                isBucket = true;
+            } else {
+                output = new ItemStack(input.getItem(), 1, input.getMetadata());
+                isBucket = false;
+            }
+
+            IFluidHandlerItem outputCap = output.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+            if (outputCap == null) return ItemStack.EMPTY;
+
+            FluidStack drained = inputCap.drain(1000, false);
+            if (drained != null && drained.amount == 1000) {
+                if (isBucket) {
+                    if (FluidRegistry.hasBucket(outputFluid.getFluid())) {
+                        return FluidUtil.getFilledBucket(outputFluid.copy());
+                    }
+                } else if (outputCap.fill(outputFluid.copy(), true) == 1000) {
+                    return output;
+                }
+            }
+            return ItemStack.EMPTY;
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    private static boolean isBucket(@Nonnull Item item) {
+        return item == Items.WATER_BUCKET || item == Items.LAVA_BUCKET || item == Items.MILK_BUCKET || item == ForgeModContainer.getInstance().universalBucket;
+    }
+}

--- a/src/main/java/gregtech/common/crafting/FluidReplaceRecipe.java
+++ b/src/main/java/gregtech/common/crafting/FluidReplaceRecipe.java
@@ -69,19 +69,24 @@ public class FluidReplaceRecipe extends GTShapedOreRecipe {
                 output = new ItemStack(ForgeModContainer.getInstance().universalBucket);
                 isBucket = true;
             } else {
-                output = new ItemStack(input.getItem(), 1, input.getMetadata());
+                output = input.copy(); // copy the input to preserve its NBT
                 isBucket = false;
             }
 
             IFluidHandlerItem outputCap = output.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (outputCap == null) return ItemStack.EMPTY;
+            outputCap.drain(Integer.MAX_VALUE, true); // ensure the output is empty
 
             FluidStack drained = inputCap.drain(1000, false);
             if (drained != null && drained.amount == 1000) {
                 if (isBucket) {
+                    // if there is a bucket for the fluid, use the bucket
                     if (FluidRegistry.hasBucket(outputFluid.getFluid())) {
                         return FluidUtil.getFilledBucket(outputFluid.copy());
                     }
+
+                    // otherwise return nothing, as the input container is invalid
+                    return ItemStack.EMPTY;
                 } else if (outputCap.fill(outputFluid.copy(), true) == 1000) {
                     return output;
                 }

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
@@ -60,10 +60,9 @@ public class MetaTileEntityLoader {
         registerMachineRecipe(false, MetaTileEntities.HULL, "PLP", "CHC", 'P', HULL_PLATE, 'L', PLATE, 'C', CABLE, 'H', CASING);
 
         if (ConfigHolder.recipes.harderBrickRecipes) {
-            ModHandler.addShapedRecipe("bucket_of_concrete", FluidUtil.getFilledBucket(Materials.Concrete.getFluid(1000)),
-                    "CBS", "CWQ", " L ",
+            ModHandler.addFluidReplaceRecipe("bucket_of_concrete", FluidUtil.getFilledBucket(Materials.Concrete.getFluid(1000)),
+                    "C S", "CWQ", " L ",
                     'C', new UnificationEntry(OrePrefix.dust, Materials.Calcite),
-                    'B', new ItemStack(Items.BUCKET),
                     'S', new UnificationEntry(OrePrefix.dust, Materials.Stone),
                     'W', new ItemStack(Items.WATER_BUCKET),
                     'Q', new UnificationEntry(OrePrefix.dust, Materials.QuartzSand),


### PR DESCRIPTION
## What
This PR changes the manual crafting recipe for Concrete, to only require one bucket.

## Implementation Details
This implementation relies on a new recipe called `FluidReplaceRecipe`. It requires a recipe have a single fluid handler item in its inputs. It will output the item filled with the recipe output's fluid. Fluid must be exactly 1000mB for the output, and if the input has a fluid it must also be 1000. Otherwise, compatibility with vanilla buckets will break and input fluid voiding will occur. Therefore, the relevant exceptions are thrown.

## Outcome
Requires only one bucket in the manual concrete recipe.
