### PR TITLE
Fix tool crafting repair

### DIFF
--- a/src/main/java/gregtech/asm/GregTechTransformer.java
+++ b/src/main/java/gregtech/asm/GregTechTransformer.java
@@ -142,8 +142,10 @@ public class GregTechTransformer implements IClassTransformer, Opcodes {
             }
             case RecipeRepairItemVisitor.TARGET_CLASS_NAME: {
                 ClassReader classReader = new ClassReader(basicClass);
-                ClassWriter classWriter = new ClassWriter(0);
-                classReader.accept(new TargetClassVisitor(classWriter, RecipeRepairItemVisitor.TARGET_METHOD, RecipeRepairItemVisitor::new), 0);
+                ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+                ClassNode classNode = new ClassNode();
+                classReader.accept(classNode, 0);
+                RecipeRepairItemVisitor.handleClassNode(classNode).accept(classWriter);
                 return classWriter.toByteArray();
             }
         }

--- a/src/main/java/gregtech/asm/GregTechTransformer.java
+++ b/src/main/java/gregtech/asm/GregTechTransformer.java
@@ -1,9 +1,9 @@
 package gregtech.asm;
 
 import gregtech.api.GTValues;
-import gregtech.common.ConfigHolder;
 import gregtech.asm.util.TargetClassVisitor;
 import gregtech.asm.visitors.*;
+import gregtech.common.ConfigHolder;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.common.Loader;
@@ -27,7 +27,6 @@ public class GregTechTransformer implements IClassTransformer, Opcodes {
                 ClassWriter classWriter = new ClassWriter(0);
                 classReader.accept(new TargetClassVisitor(classWriter, JEIVisitor.TARGET_METHOD, JEIVisitor::new), 0);
                 return classWriter.toByteArray();
-
             }
             case ConcretePowderVisitor.TARGET_CLASS_NAME:
                 if (ConfigHolder.recipes.disableConcreteInWorld) {
@@ -139,6 +138,12 @@ public class GregTechTransformer implements IClassTransformer, Opcodes {
                 RenderItemVisitor.transform(methods);
                 ClassWriter classWriter = new ClassWriter(0);
                 classNode.accept(classWriter);
+                return classWriter.toByteArray();
+            }
+            case RecipeRepairItemVisitor.TARGET_CLASS_NAME: {
+                ClassReader classReader = new ClassReader(basicClass);
+                ClassWriter classWriter = new ClassWriter(0);
+                classReader.accept(new TargetClassVisitor(classWriter, RecipeRepairItemVisitor.TARGET_METHOD, RecipeRepairItemVisitor::new), 0);
                 return classWriter.toByteArray();
             }
         }

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -10,9 +10,10 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class RecipeRepairItemHooks {
 
-    public static boolean matchesGTTool(InventoryCrafting inv, World worldIn) {
+    public static boolean matches(InventoryCrafting inv) {
         // from MC
         List<ItemStack> list = Lists.newArrayList();
 
@@ -40,7 +41,7 @@ public class RecipeRepairItemHooks {
         return list.size() == 2;
     }
 
-    public static ItemStack resultGTTool(InventoryCrafting inv) {
+    public static ItemStack getCraftingResult(InventoryCrafting inv) {
         List<ItemStack> list = Lists.newArrayList();
 
         for (int i = 0; i < inv.getSizeInventory(); ++i) {

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -6,6 +6,9 @@ import gregtech.api.items.toolitem.ToolHelper;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.event.ForgeEventFactory;
 
 import java.util.List;
 
@@ -101,5 +104,19 @@ public class RecipeRepairItemHooks {
         }
 
         return ItemStack.EMPTY;
+    }
+
+    public static NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
+        NonNullList<ItemStack> list = NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+        for (int i = 0; i < list.size(); i++) {
+            ItemStack stack = inv.getStackInSlot(i);
+            if (stack.getItem() instanceof IGTTool) {
+                // bypass GT tools not disappearing in crafting recipes
+                ForgeEventFactory.onPlayerDestroyItem(ForgeHooks.getCraftingPlayer(), stack, null);
+            } else {
+                list.set(i, ForgeHooks.getContainerItem(stack));
+            }
+        }
+        return list;
     }
 }

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -1,0 +1,38 @@
+package gregtech.asm.hooks;
+
+import com.google.common.collect.Lists;
+import gregtech.api.items.toolitem.IGTTool;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+public class RecipeRepairItemHooks {
+
+    public static boolean matchesGTTool(InventoryCrafting inv) {
+        System.out.println("Hello from hook");
+        // from MC
+        List<ItemStack> list = Lists.newArrayList();
+
+        for (int i = 0; i < inv.getSizeInventory(); ++i) {
+            ItemStack itemstack = inv.getStackInSlot(i);
+
+            if (!itemstack.isEmpty()) {
+                list.add(itemstack);
+
+                if (list.size() > 1) {
+                    ItemStack stack = list.get(0);
+                    if (!stack.getItem().isRepairable()) return false;
+                    if (stack.getCount() != 1 || itemstack.getCount() != 1) return false;
+                    if (stack.getItem() instanceof IGTTool) {
+                        // whatever the gt logic is
+                    } else if (itemstack.getItem() != stack.getItem()) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return list.size() == 2;
+    }
+}

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -67,39 +67,27 @@ public class RecipeRepairItemHooks {
             ItemStack second = list.get(1);
 
             if (first.getItem() == second.getItem() && first.getCount() == 1 && second.getCount() == 1 && first.getItem().isRepairable()) {
+                int j = first.getMaxDamage() - first.getItemDamage();
+                int k = first.getMaxDamage() - second.getItemDamage();
+                int l = j + k + first.getMaxDamage() * 5 / 100;
+                int i1 = first.getMaxDamage() - l;
+
+                if (i1 < 0) {
+                    i1 = 0;
+                }
+
                 if (first.getItem() instanceof IGTTool && second.getItem() instanceof IGTTool) {
-                    NBTTagCompound firstTag = ToolHelper.getToolTag(first);
-                    NBTTagCompound secondTag = ToolHelper.getToolTag(second);
-
-                    int firstMaxDurability = firstTag.getInteger(ToolHelper.MAX_DURABILITY_KEY);
-                    int firstDurability = firstTag.getInteger(ToolHelper.DURABILITY_KEY);
-
-                    int secondDurability = secondTag.getInteger(ToolHelper.DURABILITY_KEY);
-
-                    int j = firstTag.getInteger(ToolHelper.MAX_DURABILITY_KEY) - firstDurability;
-                    int k = firstMaxDurability - secondDurability;
-                    int l = j + k + firstMaxDurability * 5 / 100;
-                    int i1 = firstMaxDurability - l;
-
-                    if (i1 < 0) i1 = 0;
-
+                    // two GT tools, so use own logic to produce the correct output
                     IGTTool tool = (IGTTool) first.getItem();
                     ItemStack output = tool.get(tool.getToolMaterial(first));
 
                     NBTTagCompound outputTag = ToolHelper.getToolTag(output);
                     outputTag.setInteger(ToolHelper.DURABILITY_KEY, i1);
-                    return output;
-                } else {
-                    int j = first.getMaxDamage() - first.getItemDamage();
-                    int k = first.getMaxDamage() - second.getItemDamage();
-                    int l = j + k + first.getMaxDamage() * 5 / 100;
-                    int i1 = first.getMaxDamage() - l;
 
-                    if (i1 < 0) {
-                        i1 = 0;
-                    }
-                    return new ItemStack(first.getItem(), 1, i1);
+                    return output;
                 }
+
+                return new ItemStack(first.getItem(), 1, i1);
             }
         }
 

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -2,15 +2,17 @@ package gregtech.asm.hooks;
 
 import com.google.common.collect.Lists;
 import gregtech.api.items.toolitem.IGTTool;
+import gregtech.api.items.toolitem.ToolHelper;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 
 import java.util.List;
 
 public class RecipeRepairItemHooks {
 
-    public static boolean matchesGTTool(InventoryCrafting inv) {
-        System.out.println("Hello from hook");
+    public static boolean matchesGTTool(InventoryCrafting inv, World worldIn) {
         // from MC
         List<ItemStack> list = Lists.newArrayList();
 
@@ -24,15 +26,63 @@ public class RecipeRepairItemHooks {
                     ItemStack stack = list.get(0);
                     if (!stack.getItem().isRepairable()) return false;
                     if (stack.getCount() != 1 || itemstack.getCount() != 1) return false;
-                    if (stack.getItem() instanceof IGTTool) {
-                        // whatever the gt logic is
-                    } else if (itemstack.getItem() != stack.getItem()) {
-                        return false;
+                    if (itemstack.getItem() != stack.getItem()) return false;
+                    if (itemstack.getItem() instanceof IGTTool && stack.getItem() instanceof IGTTool) {
+                        // require the same materials
+                        IGTTool first = (IGTTool) itemstack.getItem();
+                        IGTTool second = (IGTTool) stack.getItem();
+                        return first.getToolMaterial(itemstack) == second.getToolMaterial(stack);
                     }
                 }
             }
         }
 
         return list.size() == 2;
+    }
+
+    public static ItemStack resultGTTool(InventoryCrafting inv) {
+        List<ItemStack> list = Lists.newArrayList();
+
+        for (int i = 0; i < inv.getSizeInventory(); ++i) {
+            ItemStack itemstack = inv.getStackInSlot(i);
+
+            if (!itemstack.isEmpty()) {
+                list.add(itemstack);
+
+                if (list.size() > 1) {
+                    ItemStack stack = list.get(0);
+                    if (itemstack.getItem() != stack.getItem()) return ItemStack.EMPTY;
+                    if (stack.getCount() != 1 || itemstack.getCount() != 1) return ItemStack.EMPTY;
+                    if (!stack.getItem().isRepairable()) return ItemStack.EMPTY;
+                }
+            }
+        }
+
+        if (list.size() == 2) {
+            ItemStack first = list.get(0);
+            ItemStack second = list.get(1);
+
+            if (first.getItem() == second.getItem() && first.getCount() == 1 && second.getCount() == 1 && first.getItem().isRepairable()) {
+                int j = first.getMaxDamage() - first.getItemDamage();
+                int k = first.getMaxDamage() - second.getItemDamage();
+                int l = j + k + first.getMaxDamage() * 5 / 100;
+                int i1 = first.getMaxDamage() - l;
+
+                if (i1 < 0) {
+                    i1 = 0;
+                }
+
+                if (first.getItem() instanceof IGTTool && second.getItem() instanceof IGTTool) {
+                    ItemStack output = first.copy();
+                    NBTTagCompound toolTag = ToolHelper.getToolTag(output);
+                    toolTag.setInteger(ToolHelper.DURABILITY_KEY, i1);
+                    return output;
+                }
+
+                return new ItemStack(first.getItem(), 1, i1);
+            }
+        }
+
+        return ItemStack.EMPTY;
     }
 }

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -34,6 +34,10 @@ public class RecipeRepairItemHooks {
                         // require the same materials
                         IGTTool first = (IGTTool) itemstack.getItem();
                         IGTTool second = (IGTTool) stack.getItem();
+
+                        // electric tools are invalid
+                        if (first.isElectric() || second.isElectric()) return false;
+
                         return first.getToolMaterial(itemstack) == second.getToolMaterial(stack);
                     }
                 }
@@ -57,7 +61,14 @@ public class RecipeRepairItemHooks {
                     if (itemstack.getItem() != stack.getItem()) return ItemStack.EMPTY;
                     if (stack.getCount() != 1 || itemstack.getCount() != 1) return ItemStack.EMPTY;
                     if (!stack.getItem().isRepairable()) return ItemStack.EMPTY;
-                    if (!(itemstack.getItem() instanceof IGTTool) || !(stack.getItem() instanceof IGTTool)) return ItemStack.EMPTY;
+
+                    // electric tools are invalid
+                    if (itemstack.getItem() instanceof IGTTool && ((IGTTool) itemstack.getItem()).isElectric()) {
+                        return ItemStack.EMPTY;
+                    }
+                    if (stack.getItem() instanceof IGTTool && ((IGTTool) stack.getItem()).isElectric()) {
+                        return ItemStack.EMPTY;
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -6,7 +6,6 @@ import gregtech.api.items.toolitem.ToolHelper;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.world.World;
 
 import java.util.List;
 
@@ -55,6 +54,7 @@ public class RecipeRepairItemHooks {
                     if (itemstack.getItem() != stack.getItem()) return ItemStack.EMPTY;
                     if (stack.getCount() != 1 || itemstack.getCount() != 1) return ItemStack.EMPTY;
                     if (!stack.getItem().isRepairable()) return ItemStack.EMPTY;
+                    if (!(itemstack.getItem() instanceof IGTTool) || !(stack.getItem() instanceof IGTTool)) return ItemStack.EMPTY;
                 }
             }
         }
@@ -64,23 +64,39 @@ public class RecipeRepairItemHooks {
             ItemStack second = list.get(1);
 
             if (first.getItem() == second.getItem() && first.getCount() == 1 && second.getCount() == 1 && first.getItem().isRepairable()) {
-                int j = first.getMaxDamage() - first.getItemDamage();
-                int k = first.getMaxDamage() - second.getItemDamage();
-                int l = j + k + first.getMaxDamage() * 5 / 100;
-                int i1 = first.getMaxDamage() - l;
-
-                if (i1 < 0) {
-                    i1 = 0;
-                }
-
                 if (first.getItem() instanceof IGTTool && second.getItem() instanceof IGTTool) {
-                    ItemStack output = first.copy();
-                    NBTTagCompound toolTag = ToolHelper.getToolTag(output);
-                    toolTag.setInteger(ToolHelper.DURABILITY_KEY, i1);
-                    return output;
-                }
+                    NBTTagCompound firstTag = ToolHelper.getToolTag(first);
+                    NBTTagCompound secondTag = ToolHelper.getToolTag(second);
 
-                return new ItemStack(first.getItem(), 1, i1);
+                    int firstMaxDurability = firstTag.getInteger(ToolHelper.MAX_DURABILITY_KEY);
+                    int firstDurability = firstTag.getInteger(ToolHelper.DURABILITY_KEY);
+
+                    int secondDurability = secondTag.getInteger(ToolHelper.DURABILITY_KEY);
+
+                    int j = firstTag.getInteger(ToolHelper.MAX_DURABILITY_KEY) - firstDurability;
+                    int k = firstMaxDurability - secondDurability;
+                    int l = j + k + firstMaxDurability * 5 / 100;
+                    int i1 = firstMaxDurability - l;
+
+                    if (i1 < 0) i1 = 0;
+
+                    IGTTool tool = (IGTTool) first.getItem();
+                    ItemStack output = tool.get(tool.getToolMaterial(first));
+
+                    NBTTagCompound outputTag = ToolHelper.getToolTag(output);
+                    outputTag.setInteger(ToolHelper.DURABILITY_KEY, i1);
+                    return output;
+                } else {
+                    int j = first.getMaxDamage() - first.getItemDamage();
+                    int k = first.getMaxDamage() - second.getItemDamage();
+                    int l = j + k + first.getMaxDamage() * 5 / 100;
+                    int i1 = first.getMaxDamage() - l;
+
+                    if (i1 < 0) {
+                        i1 = 0;
+                    }
+                    return new ItemStack(first.getItem(), 1, i1);
+                }
             }
         }
 

--- a/src/main/java/gregtech/asm/visitors/RecipeRepairItemVisitor.java
+++ b/src/main/java/gregtech/asm/visitors/RecipeRepairItemVisitor.java
@@ -11,13 +11,13 @@ public class RecipeRepairItemVisitor implements Opcodes {
 
     private static final ObfMapping MATCHES_METHOD = new ObfMapping(TARGET_CLASS_NAME, "func_77569_a",
             "(Lnet/minecraft/inventory/InventoryCrafting;Lnet/minecraft/world/World;)Z").toRuntime();
-    private static final String MATCHES_HOOK_SIGNATURE = "(Lnet/minecraft/inventory/InventoryCrafting;Lnet/minecraft/world/World;)Z";
-    private static final String MATCHES_HOOK_METHOD_NAME = "matchesGTTool";
+    private static final String MATCHES_HOOK_SIGNATURE = "(Lnet/minecraft/inventory/InventoryCrafting;)Z";
+    private static final String MATCHES_HOOK_METHOD_NAME = "matches";
 
     private static final ObfMapping RESULT_METHOD = new ObfMapping(TARGET_CLASS_NAME, "func_77572_b",
             "(Lnet/minecraft/inventory/InventoryCrafting;)Lnet/minecraft/item/ItemStack;").toRuntime();
     private static final String RESULT_HOOK_SIGNATURE = "(Lnet/minecraft/inventory/InventoryCrafting;)Lnet/minecraft/item/ItemStack;";
-    private static final String RESULT_HOOK_METHOD_NAME = "resultGTTool";
+    private static final String RESULT_HOOK_METHOD_NAME = "getCraftingResult";
 
     public static ClassNode handleClassNode(ClassNode classNode) {
         int done = 0;
@@ -28,7 +28,6 @@ public class RecipeRepairItemVisitor implements Opcodes {
             if (m.name.equals(MATCHES_METHOD.s_name) && m.desc.equals(MATCHES_METHOD.s_desc)) {
                 InsnList insns = new InsnList();
                 insns.add(new VarInsnNode(ALOAD, 1));
-                insns.add(new VarInsnNode(ALOAD, 2));
                 insns.add(new MethodInsnNode(INVOKESTATIC, HOOK_CLASS_NAME, MATCHES_HOOK_METHOD_NAME, MATCHES_HOOK_SIGNATURE, false));
                 insns.add(new InsnNode(IRETURN));
                 AbstractInsnNode first = m.instructions.getFirst();

--- a/src/main/java/gregtech/asm/visitors/RecipeRepairItemVisitor.java
+++ b/src/main/java/gregtech/asm/visitors/RecipeRepairItemVisitor.java
@@ -19,10 +19,15 @@ public class RecipeRepairItemVisitor implements Opcodes {
     private static final String RESULT_HOOK_SIGNATURE = "(Lnet/minecraft/inventory/InventoryCrafting;)Lnet/minecraft/item/ItemStack;";
     private static final String RESULT_HOOK_METHOD_NAME = "getCraftingResult";
 
+    private static final ObfMapping REMAINING_METHOD = new ObfMapping(TARGET_CLASS_NAME, "func_179532_b",
+            "(Lnet/minecraft/inventory/InventoryCrafting;)Lnet/minecraft/util/NonNullList;").toRuntime();
+    private static final String REMAINING_HOOK_SIGNATURE = "(Lnet/minecraft/inventory/InventoryCrafting;)Lnet/minecraft/util/NonNullList;";
+    private static final String REMAINING_HOOK_METHOD_NAME = "getRemainingItems";
+
     public static ClassNode handleClassNode(ClassNode classNode) {
         int done = 0;
         for (MethodNode m : classNode.methods) {
-            if (done == 2) break;
+            if (done == 3) break;
 
             // matches() method
             if (m.name.equals(MATCHES_METHOD.s_name) && m.desc.equals(MATCHES_METHOD.s_desc)) {
@@ -40,6 +45,17 @@ public class RecipeRepairItemVisitor implements Opcodes {
                 InsnList insns = new InsnList();
                 insns.add(new VarInsnNode(ALOAD, 1));
                 insns.add(new MethodInsnNode(INVOKESTATIC, HOOK_CLASS_NAME, RESULT_HOOK_METHOD_NAME, RESULT_HOOK_SIGNATURE, false));
+                insns.add(new InsnNode(ARETURN));
+                AbstractInsnNode first = m.instructions.getFirst();
+                m.instructions.insertBefore(first, insns);
+                done++;
+            }
+
+            // getRemainingItems() method
+            if (m.name.equals(REMAINING_METHOD.s_name) && m.desc.equals(REMAINING_METHOD.s_desc)) {
+                InsnList insns = new InsnList();
+                insns.add(new VarInsnNode(ALOAD, 1));
+                insns.add(new MethodInsnNode(INVOKESTATIC, HOOK_CLASS_NAME, REMAINING_HOOK_METHOD_NAME, REMAINING_HOOK_SIGNATURE, false));
                 insns.add(new InsnNode(ARETURN));
                 AbstractInsnNode first = m.instructions.getFirst();
                 m.instructions.insertBefore(first, insns);

--- a/src/main/java/gregtech/asm/visitors/RecipeRepairItemVisitor.java
+++ b/src/main/java/gregtech/asm/visitors/RecipeRepairItemVisitor.java
@@ -1,0 +1,46 @@
+package gregtech.asm.visitors;
+
+import gregtech.asm.util.ObfMapping;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class RecipeRepairItemVisitor extends MethodVisitor implements Opcodes {
+
+    public static final String TARGET_CLASS_NAME = "net/minecraft/item/crafting/RecipeRepairItem";
+    public static final ObfMapping TARGET_METHOD = new ObfMapping(TARGET_CLASS_NAME, "matches", targetSignature()).toRuntime();
+
+    private static final String MATCHES_HOOK_OWNER = "gregtech/asm/hooks/RecipeRepairItemHooks";
+    private static final String MATCHES_HOOK_SIGNATURE = tooltipSignature();
+    private static final String MATCHES_HOOK_METHOD_NAME = "matchesGTTool";
+
+    public RecipeRepairItemVisitor(MethodVisitor mv) {
+        super(org.objectweb.asm.Opcodes.ASM5, mv);
+    }
+
+    // Need to call RecipeRepairItemHooks#matchesGTTool(InventoryCrafting)
+    @Override
+    public void visitCode() {
+        mv.visitVarInsn(ALOAD, 1); // InventoryCrafting inv
+        mv.visitVarInsn(ALOAD, 2); //  World worldIn
+
+        // statically call matchesGTTool(InventoryCrafting)
+        mv.visitMethodInsn(INVOKESTATIC, MATCHES_HOOK_OWNER, MATCHES_HOOK_METHOD_NAME, MATCHES_HOOK_SIGNATURE, false);
+
+        mv.visitInsn(IRETURN);
+    }
+
+    // public boolean matches(InventoryCrafting inv, World worldIn)
+    private static String targetSignature() {
+        return "(" +
+                "Lnet/minecraft/inventory/InventoryCrafting;" + // InventoryCrafting inv
+                "Lnet/minecraft/world/World;" + //  World worldIn
+                ")Z"; // return boolean
+    }
+
+    // public boolean matchesGTTool(InventoryCrafting inv)
+    private static String tooltipSignature() {
+        return "(" +
+                "Lnet/minecraft/inventory/InventoryCrafting;" + // InventoryCrafting inv
+                ")Z"; // return void
+    }
+}


### PR DESCRIPTION
## What
Fixes known tool crafting repair issues:

1. No longer produces neutronium tools as output.

2. Prevents mixing tool materials when repairing.

3. Blocks electric tools from crafting table repair.

## Outcome
Fixes tool crafting repair.

## Potential Compatibility Issues
In order to implement this, much ASM was required, but should not cause incompatibility with other mods.
