### PR TITLE
Fix full durability tool enchantment merging

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -377,6 +377,9 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
     }
 
     default boolean definition$getIsRepairable(ItemStack toRepair, ItemStack repair) {
+        // full durability tools in the left slot are not repairable
+        // this is needed so enchantment merging works when both tools are full durability
+        if (toRepair.getItemDamage() == 0) return false;
         if (repair.getItem() instanceof IGTTool) {
             return getToolMaterial(toRepair) == ((IGTTool) repair.getItem()).getToolMaterial(repair);
         }


### PR DESCRIPTION
## What
This PR fixes tool enchantment merging, when both tools are at full durability. It was caused by not fully replicating vanilla behavior when checking if GT tools were repairable.

## Outcome
Fixes tool enchantment merging when at full durability.
