### PR TITLE
Add CT support for full material fluidPipeProperties

### DIFF
--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
@@ -243,6 +243,12 @@ public class CTMaterialBuilder {
     }
 
     @ZenMethod
+    public CTMaterialBuilder fluidPipeProperties(int maxTemp, int throughput, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
+        backingBuilder.fluidPipeProperties(maxTemp, throughput, gasProof, acidProof, cryoProof, plasmaProof);
+        return this;
+    }
+
+    @ZenMethod
     public CTMaterialBuilder itemPipeProperties(int priority, float stacksPerSec) {
         backingBuilder.itemPipeProperties(priority, stacksPerSec);
         return this;

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -597,9 +597,7 @@ public class Material implements Comparable<Material> {
         public Builder polymer(int harvestLevel) {
             DustProperty prop = properties.getProperty(PropertyKey.DUST);
             if (prop == null) dust(harvestLevel, 0);
-            else {
-                if (prop.getHarvestLevel() == 2) prop.setHarvestLevel(harvestLevel);
-            }
+            else if (prop.getHarvestLevel() == 2) prop.setHarvestLevel(harvestLevel);
             properties.ensureSet(PropertyKey.POLYMER);
             properties.ensureSet(PropertyKey.FLUID);
             return this;


### PR DESCRIPTION
## What
Adds CT support for the full builder method for FluidPipeProperties, allowing modpack authors to specific acid, cryogenic, and plasma transport properties. Docs will be updated upon merge.

## Outcome
Adds CT support for the full builder method for FluidPipeProperties.
