### PR TITLE
Some optimizations

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FluidTankList.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidTankList.java
@@ -26,15 +26,18 @@ public class FluidTankList implements IFluidHandler, IMultipleTankHandler, INBTS
     protected IFluidTankProperties[] properties;
     private final boolean allowSameFluidFill;
     private IFluidTankProperties[] fluidTankProperties;
+    private final int hashCode;
 
     public FluidTankList(boolean allowSameFluidFill, IFluidTank... fluidTanks) {
         this.fluidTanks = Arrays.asList(fluidTanks);
         this.allowSameFluidFill = allowSameFluidFill;
+        this.hashCode = Arrays.hashCode(fluidTanks);
     }
 
     public FluidTankList(boolean allowSameFluidFill, List<? extends IFluidTank> fluidTanks) {
         this.fluidTanks = new ArrayList<>(fluidTanks);
         this.allowSameFluidFill = allowSameFluidFill;
+        this.hashCode = Arrays.hashCode(fluidTanks.toArray());
     }
 
     public FluidTankList(boolean allowSameFluidFill, FluidTankList parent, IFluidTank... additionalTanks) {
@@ -42,6 +45,14 @@ public class FluidTankList implements IFluidHandler, IMultipleTankHandler, INBTS
         this.fluidTanks.addAll(parent.fluidTanks);
         this.fluidTanks.addAll(Arrays.asList(additionalTanks));
         this.allowSameFluidFill = allowSameFluidFill;
+        int hash = Objects.hash(parent);
+        hash = 31 * hash + Arrays.hashCode(additionalTanks);
+        this.hashCode = hash;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
     }
 
     public List<IFluidTank> getFluidTanks() {

--- a/src/main/java/gregtech/api/recipes/ingredients/CraftTweakerItemInputWrapper.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/CraftTweakerItemInputWrapper.java
@@ -59,17 +59,22 @@ public class CraftTweakerItemInputWrapper extends GTRecipeInput {
             return false;
         }
 
-        IItemStack[] itemArray = this.ingredient.getItemArray();
-        if (itemArray.length == 0) return true;
-
-        return ingredient.getItems().stream().anyMatch(ii -> {
-            if (ii.getAmount() > itemStack.getCount()) {
-                final ItemStack is = itemStack.copy();
-                is.setCount(ii.getAmount());
-                return ii.matches(CraftTweakerMC.getIItemStackForMatching(is, ii.getMetadata() == GTValues.W));
+        for (IItemStack iiStack : this.ingredient.getItems()) {
+            if (iiStack.getAmount() > itemStack.getCount()) {
+                final int oldCount = itemStack.getCount();
+                itemStack.setCount(iiStack.getAmount());
+                if (iiStack.matches(CraftTweakerMC.getIItemStackForMatching(itemStack, iiStack.getMetadata() == GTValues.W))) {
+                    itemStack.setCount(oldCount);
+                    return true;
+                }
+                itemStack.setCount(oldCount);
+                return false;
             }
-            return ii.matches(CraftTweakerMC.getIItemStackForMatching(itemStack, ii.getMetadata() == GTValues.W));
-        });
+            if (iiStack.matches(CraftTweakerMC.getIItemStackForMatching(itemStack, iiStack.getMetadata() == GTValues.W))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/GTHashMaps.java
+++ b/src/main/java/gregtech/api/util/GTHashMaps.java
@@ -3,6 +3,7 @@ package gregtech.api.util;
 import gregtech.api.recipes.FluidKey;
 import gregtech.api.recipes.KeySharedStack;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -10,12 +11,7 @@ import net.minecraftforge.items.IItemHandler;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import static gregtech.api.util.Predicates.not;
 
 public class GTHashMaps {
     /**
@@ -25,7 +21,7 @@ public class GTHashMaps {
      * @return a {@link Map} of {@link ItemStackKey} and {@link Integer} as amount on the inventory
      */
     public static Map<ItemStackKey, Integer> fromItemHandler(IItemHandler inputs) {
-        final Map<ItemStackKey, Integer> map = new Object2IntLinkedOpenHashMap<>();
+        final Object2IntMap<ItemStackKey> map = new Object2IntLinkedOpenHashMap<>();
 
         // Create a single stack of the combined count for each item
 
@@ -33,7 +29,7 @@ public class GTHashMaps {
             ItemStack stack = inputs.getStackInSlot(i);
             if (!stack.isEmpty()) {
                 ItemStackKey key = KeySharedStack.getRegisteredStack(stack);
-                map.put(key, map.get(key) + stack.getCount());
+                map.put(key, map.getInt(key) + stack.getCount());
             }
         }
 
@@ -46,15 +42,15 @@ public class GTHashMaps {
      * @param inputs The inventory handler of the inventory
      * @return a {@link Map} of {@link ItemStackKey} and {@link Integer} as amount on the inventory
      */
-    public static Map<ItemStackKey, Integer> fromItemStackCollection(Collection<ItemStack> inputs) {
-        final Map<ItemStackKey, Integer> map = new Object2IntLinkedOpenHashMap<>();
+    public static Map<ItemStackKey, Integer> fromItemStackCollection(Iterable<ItemStack> inputs) {
+        final Object2IntMap<ItemStackKey> map = new Object2IntLinkedOpenHashMap<>();
 
         // Create a single stack of the combined count for each item
 
         for (ItemStack stack : inputs) {
             if (!stack.isEmpty()) {
                 ItemStackKey key = KeySharedStack.getRegisteredStack(stack);
-                map.put(key, map.get(key) + stack.getCount());
+                map.put(key, map.getInt(key) + stack.getCount());
             }
         }
 
@@ -68,7 +64,7 @@ public class GTHashMaps {
      * @return a {@link Set} of unique {@link FluidKey}s for each fluid in the handler. Will be oversized stacks if required
      */
     public static Map<FluidKey, Integer> fromFluidHandler(IFluidHandler fluidInputs) {
-        final Map<FluidKey, Integer> map = new Object2IntLinkedOpenHashMap<>();
+        final Object2IntMap<FluidKey> map = new Object2IntLinkedOpenHashMap<>();
 
         // Create a single stack of the combined count for each item
 
@@ -76,7 +72,7 @@ public class GTHashMaps {
             FluidStack fluidStack = fluidInputs.getTankProperties()[i].getContents();
             if (fluidStack != null && fluidStack.amount > 0) {
                 FluidKey key = new FluidKey(fluidStack);
-                map.put(key, map.get(key) + fluidStack.amount);
+                map.put(key, map.getInt(key) + fluidStack.amount);
             }
         }
 
@@ -90,14 +86,14 @@ public class GTHashMaps {
      * @return a {@link Set} of unique {@link FluidKey}s for each fluid in the handler. Will be oversized stacks if required
      */
     public static Map<FluidKey, Integer> fromFluidCollection(Collection<FluidStack> fluidInputs) {
-        final Map<FluidKey, Integer> map = new Object2IntLinkedOpenHashMap<>();
+        final Object2IntMap<FluidKey> map = new Object2IntLinkedOpenHashMap<>();
 
         // Create a single stack of the combined count for each item
 
         for (FluidStack fluidStack : fluidInputs) {
             if (fluidStack != null && fluidStack.amount > 0) {
                 FluidKey key = new FluidKey(fluidStack);
-                map.put(key, map.get(key) + fluidStack.amount);
+                map.put(key, map.getInt(key) + fluidStack.amount);
             }
         }
 

--- a/src/main/java/gregtech/api/util/GTHashMaps.java
+++ b/src/main/java/gregtech/api/util/GTHashMaps.java
@@ -32,8 +32,8 @@ public class GTHashMaps {
         for (int i = 0; i < inputs.getSlots(); i++) {
             ItemStack stack = inputs.getStackInSlot(i);
             if (!stack.isEmpty()) {
-                map.computeIfPresent(KeySharedStack.getRegisteredStack(stack), (k, v) -> v + stack.getCount());
-                map.computeIfAbsent(KeySharedStack.getRegisteredStack(stack), (v) -> stack.getCount());
+                ItemStackKey key = KeySharedStack.getRegisteredStack(stack);
+                map.put(key, map.get(key) + stack.getCount());
             }
         }
 
@@ -53,8 +53,8 @@ public class GTHashMaps {
 
         for (ItemStack stack : inputs) {
             if (!stack.isEmpty()) {
-                map.computeIfPresent(KeySharedStack.getRegisteredStack(stack), (k, v) -> v + stack.getCount());
-                map.computeIfAbsent(KeySharedStack.getRegisteredStack(stack), (v) -> stack.getCount());
+                ItemStackKey key = KeySharedStack.getRegisteredStack(stack);
+                map.put(key, map.get(key) + stack.getCount());
             }
         }
 
@@ -75,8 +75,8 @@ public class GTHashMaps {
         for (int i = 0; i < fluidInputs.getTankProperties().length; i++) {
             FluidStack fluidStack = fluidInputs.getTankProperties()[i].getContents();
             if (fluidStack != null && fluidStack.amount > 0) {
-                map.computeIfPresent(new FluidKey(fluidStack), (k, v) -> v + fluidStack.amount);
-                map.computeIfAbsent(new FluidKey(fluidStack), (v) -> fluidStack.amount);
+                FluidKey key = new FluidKey(fluidStack);
+                map.put(key, map.get(key) + fluidStack.amount);
             }
         }
 
@@ -96,8 +96,8 @@ public class GTHashMaps {
 
         for (FluidStack fluidStack : fluidInputs) {
             if (fluidStack != null && fluidStack.amount > 0) {
-                map.computeIfPresent(new FluidKey(fluidStack), (k, v) -> v + fluidStack.amount);
-                map.computeIfAbsent(new FluidKey(fluidStack), (v) -> fluidStack.amount);
+                FluidKey key = new FluidKey(fluidStack);
+                map.put(key, map.get(key) + fluidStack.amount);
             }
         }
 

--- a/src/main/java/gregtech/api/util/GTTransferUtils.java
+++ b/src/main/java/gregtech/api/util/GTTransferUtils.java
@@ -188,7 +188,7 @@ public class GTTransferUtils {
             }
         }
 
-        for (Integer slot : emptySlots) {
+        for (int slot : emptySlots) {
             stack = handler.insertItem(slot, stack, simulate);
             if (stack.isEmpty()) {
                 return ItemStack.EMPTY;

--- a/src/main/java/gregtech/api/util/GTTransferUtils.java
+++ b/src/main/java/gregtech/api/util/GTTransferUtils.java
@@ -2,6 +2,8 @@ package gregtech.api.util;
 
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.recipes.FluidKey;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidActionResult;
 import net.minecraftforge.fluids.FluidStack;
@@ -13,7 +15,6 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -172,7 +173,7 @@ public class GTTransferUtils {
             return insertToEmpty(handler, stack, simulate);
         }
 
-        List<Integer> emptySlots = new ArrayList<>();
+        IntList emptySlots = new IntArrayList();
         int slots = handler.getSlots();
 
         for (int i = 0; i < slots; i++) {

--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -75,7 +75,7 @@ public class OverlayedFluidHandler {
             // if the fluid key matches the tank, insert the fluid
             OverlayedTank overlayedTank = this.overlayedTanks[i];
             if (toInsert.equals(overlayedTank.getFluidKey())) {
-                if ((tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]) || !this.allowSameFluidFill)) {
+                if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
                     if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
                         NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
                         if (!(uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert))) {
@@ -107,7 +107,7 @@ public class OverlayedFluidHandler {
                 OverlayedTank overlayedTank = this.overlayedTanks[i];
                 // if the tank is empty
                 if (overlayedTank.getFluidKey() == null) {
-                    if ((tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]) || !this.allowSameFluidFill)) {
+                    if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
                         IMultipleTankHandler mth = (IMultipleTankHandler) overlayed;
                         if (mth.getTankAt(i) instanceof NotifiableFluidTankFromList) {
                             NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) mth.getTankAt(i);

--- a/src/main/java/gregtech/api/util/OverlayedItemHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedItemHandler.java
@@ -50,6 +50,7 @@ public class OverlayedItemHandler {
 
 
     public int insertStackedItemStackKey(ItemStackKey key, int amountToInsert) {
+        int lastKnownPopulatedSlot = 0;
         //loop through all slots, looking for ones matching the key
         for (int i = 0; i < this.slots.length; i++) {
             //populate the slot if it's not already populated
@@ -65,11 +66,18 @@ public class OverlayedItemHandler {
                     amountToInsert -= insertedAmount;
                 }
             }
+            lastKnownPopulatedSlot = i;
+
+            // early exit if finished inserting everything
+            if (amountToInsert == 0) {
+                return 0;
+            }
         }
-        //if the amountToInsert is still greater than 0, we need to insert it into a new slot
+
+        // if the amountToInsert is still greater than 0, we need to insert it into a new slot
         if (amountToInsert > 0) {
-            //loop through all slots, again, looking for empty ones.
-            for (int i = 0; i < this.slots.length; i++) {
+            //loop through all slots, starting from after the last seen slot with items in it, looking for empty ones.
+            for (int i = lastKnownPopulatedSlot + 1; i < this.slots.length; i++) {
                 OverlayedItemHandlerSlot slot = this.slots[i];
                 //if the slot is empty
                 if (slot.getItemStackKey() == null) {

--- a/src/main/java/gregtech/api/util/OverlayedItemHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedItemHandler.java
@@ -55,8 +55,9 @@ public class OverlayedItemHandler {
         for (int i = 0; i < this.slots.length; i++) {
             //populate the slot if it's not already populated
             initSlot(i);
-            //if its the same item
-            if (this.slots[i].getItemStackKey() == key) {
+            // if it's the same item or there is no item in the slot
+            ItemStackKey slotKey = this.slots[i].getItemStackKey();
+            if (slotKey == key || slotKey == null) {
                 //if the slot its not full
                 int canInsertUpTo = this.slots[i].slotLimit - this.slots[i].count;
                 if (canInsertUpTo > 0) {

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -24,6 +24,7 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
 import gregtech.common.covers.filter.ItemFilterContainer;
 import gregtech.common.pipelike.itempipe.tile.TileEntityItemPipe;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
@@ -41,7 +42,10 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
 
@@ -345,7 +349,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
     }
 
     protected Map<ItemStackKey, TypeItemInfo> countInventoryItemsByType(IItemHandler inventory) {
-        Map<ItemStackKey, TypeItemInfo> result = new HashMap<>();
+        Map<ItemStackKey, TypeItemInfo> result = new Object2ObjectOpenHashMap<>();
         for (int srcIndex = 0; srcIndex < inventory.getSlots(); srcIndex++) {
             ItemStack itemStack = inventory.getStackInSlot(srcIndex);
             if (itemStack.isEmpty()) {
@@ -371,7 +375,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
     }
 
     protected Map<Object, GroupItemInfo> countInventoryItemsByMatchSlot(IItemHandler inventory) {
-        HashMap<Object, GroupItemInfo> result = new HashMap<>();
+        Map<Object, GroupItemInfo> result = new Object2ObjectOpenHashMap<>();
         for (int srcIndex = 0; srcIndex < inventory.getSlots(); srcIndex++) {
             ItemStack itemStack = inventory.getStackInSlot(srcIndex);
             if (itemStack.isEmpty()) {

--- a/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
@@ -11,6 +11,7 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
 import gregtech.common.covers.filter.FluidFilter;
 import gregtech.common.covers.filter.FluidFilterContainer;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -27,7 +28,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.logging.log4j.message.FormattedMessage;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 
@@ -210,7 +214,7 @@ public class CoverFluidRegulator extends CoverPump {
                                                            Predicate<IFluidTankProperties> tankTypeFilter,
                                                            Predicate<FluidStack> fluidTypeFilter) {
 
-        final Map<FluidStack, Integer> summedFluids = new HashMap<>();
+        final Map<FluidStack, Integer> summedFluids = new Object2IntOpenHashMap<>();
         Arrays.stream(handler.getTankProperties())
                 .filter(tankTypeFilter)
                 .map(IFluidTankProperties::getContents)

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -30,6 +30,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockPos.PooledMutableBlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.common.capabilities.Capability;
@@ -134,10 +135,8 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
     }
 
     protected int doTransferFluids(int transferLimit) {
-        PooledMutableBlockPos blockPos = PooledMutableBlockPos.retain();
-        blockPos.setPos(coverHolder.getPos()).move(attachedSide);
-        TileEntity tileEntity = coverHolder.getWorld().getTileEntity(blockPos);
-        blockPos.release();
+        BlockPos pos = coverHolder.getPos().offset(attachedSide);
+        TileEntity tileEntity = coverHolder.getWorld().getTileEntity(pos);
         IFluidHandler fluidHandler = tileEntity == null ? null : tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, attachedSide.getOpposite());
         IFluidHandler myFluidHandler = coverHolder.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, attachedSide);
         if (fluidHandler == null || myFluidHandler == null) {

--- a/src/main/java/gregtech/common/covers/filter/FilterTypeRegistry.java
+++ b/src/main/java/gregtech/common/covers/filter/FilterTypeRegistry.java
@@ -5,15 +5,15 @@ import com.google.common.collect.HashBiMap;
 import gregtech.api.unification.stack.ItemAndMetadata;
 import gregtech.api.util.GTLog;
 import gregtech.common.items.MetaItems;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.item.ItemStack;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class FilterTypeRegistry {
 
-    private static final Map<ItemAndMetadata, Integer> itemFilterIdByStack = new HashMap<>();
-    private static final Map<ItemAndMetadata, Integer> fluidFilterIdByStack = new HashMap<>();
+    private static final Map<ItemAndMetadata, Integer> itemFilterIdByStack = new Object2IntOpenHashMap<>();
+    private static final Map<ItemAndMetadata, Integer> fluidFilterIdByStack = new Object2IntOpenHashMap<>();
     private static final BiMap<Integer, Class<? extends ItemFilter>> itemFilterById = HashBiMap.create();
     private static final BiMap<Integer, Class<? extends FluidFilter>> fluidFilterById = HashBiMap.create();
 

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -17,6 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -29,7 +30,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
 
     private final List<OreDictExprFilter.MatchRule> matchRules = new ArrayList<>();
     private static final Hash.Strategy<ItemStack> strategy = ItemStackHashStrategy.builder().compareItem(true).compareDamage(true).build();
-    private final Object2BooleanOpenCustomHashMap<ItemStack> recentlyChecked = new Object2BooleanOpenCustomHashMap<>(strategy);
+    private final Map<ItemStack, Boolean> recentlyChecked = new Object2BooleanOpenCustomHashMap<>(strategy);
 
     protected void setOreDictFilterExpression(String oreDictFilterExpression) {
         this.oreDictFilterExpression = oreDictFilterExpression;

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -7,13 +7,13 @@ import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.unification.stack.ItemAndMetadata;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IStringSerializable;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -117,7 +117,7 @@ public class SmartItemFilter extends ItemFilter {
         CENTRIFUGE("cover.smart_item_filter.filtering_mode.centrifuge", RecipeMaps.CENTRIFUGE_RECIPES),
         SIFTER("cover.smart_item_filter.filtering_mode.sifter", RecipeMaps.SIFTER_RECIPES);
 
-        private final Map<ItemAndMetadata, Integer> transferStackSizesCache = new HashMap<>();
+        private final Map<ItemAndMetadata, Integer> transferStackSizesCache = new Object2IntOpenHashMap<>();
         public final String localeName;
         public final RecipeMap<?> recipeMap;
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -93,14 +93,13 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
         if (ticksPerCycle == 0 || getOffsetTimer() % ticksPerCycle != 0 || fluidTank.getFluid() == null
                 || getWorld().isRemote || !active) return;
 
-        FluidStack stack = fluidTank.getFluid().copy();
-
         TileEntity tile = getWorld().getTileEntity(getPos().offset(this.getOutputFacing()));
         if (tile != null) {
             IFluidHandler fluidHandler = tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getOutputFacing().getOpposite());
             if (fluidHandler == null || fluidHandler.getTankProperties().length == 0)
                 return;
 
+            FluidStack stack = fluidTank.getFluid().copy();
             stack.amount = mBPerCycle;
             int canInsertAmount = fluidHandler.fill(stack, false);
             stack.amount = Math.min(mBPerCycle, canInsertAmount);


### PR DESCRIPTION
Optimizations found from investigating spark profiles, and then looking further in a few areas

- Do not copy internal FluidStack in creative tank unless we have a handler to output to
- Check `allowSameFluidFill` before a call to `Set#contains()` in `OverlayedFluidHandler`
- Add a `hashCode()` implementation to `FluidTankList`
- Slightly cleanup `GTHashMaps` and `GTTransferUtils`
- Skip known empty slots in `OverlayedItemHandler`
- Optimize `CraftTweakerItemInputWrapper#acceptsStack()`
- Slight `CoverPump` improvement