### PR TITLE
fix Mending/Unbreaking being allowed on GT armor

### DIFF
--- a/src/main/java/gregtech/api/items/armor/ArmorMetaItem.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorMetaItem.java
@@ -8,6 +8,7 @@ import gregtech.api.items.metaitem.stats.IItemComponent;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
@@ -204,6 +205,11 @@ public class ArmorMetaItem<T extends ArmorMetaItem<?>.ArmorMetaValueItem> extend
     public boolean canApplyAtEnchantingTable(@Nonnull ItemStack stack, @Nonnull Enchantment enchantment) {
         EntityEquipmentSlot slot = this.getEquipmentSlot(stack);
         if(slot == null || enchantment.type == null) {
+            return false;
+        }
+
+        IArmorLogic armorLogic = getArmorLogic(stack);
+        if (!armorLogic.canBreakWithDamage(stack) && enchantment.type == EnumEnchantmentType.BREAKABLE) {
             return false;
         }
 

--- a/src/main/java/gregtech/api/items/armor/IArmorLogic.java
+++ b/src/main/java/gregtech/api/items/armor/IArmorLogic.java
@@ -34,6 +34,10 @@ public interface IArmorLogic {
 
     EntityEquipmentSlot getEquipmentSlot(ItemStack itemStack);
 
+    default boolean canBreakWithDamage(ItemStack stack) {
+        return false;
+    }
+
     default void damageArmor(EntityLivingBase entity, ItemStack itemStack, DamageSource source, int damage, EntityEquipmentSlot equipmentSlot) {
 
     }


### PR DESCRIPTION
These armors cannot break, so these enchantments are useless. There is a method in `IArmorLogic` that can be overridden to allow these enchants to be applied (`canBreakWithDamage()`, representing that this armor does take actual durability loss and not just electricity/fuel)