### PR TITLE
Change Energy Hatch in Cleanroom to LV in JEI Preview

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -667,7 +667,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
                 .where('G', MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.CLEANROOM_GLASS))
                 .where('S', MetaTileEntities.CLEANROOM, EnumFacing.SOUTH)
                 .where(' ', Blocks.AIR.getDefaultState())
-                .where('E', MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.HV], EnumFacing.SOUTH)
+                .where('E', MetaTileEntities.ENERGY_INPUT_HATCH[GTValues.LV], EnumFacing.SOUTH)
                 .where('I', MetaTileEntities.PASSTHROUGH_HATCH_ITEM, EnumFacing.NORTH)
                 .where('L', MetaTileEntities.PASSTHROUGH_HATCH_FLUID, EnumFacing.NORTH)
                 .where('H', MetaTileEntities.HULL[GTValues.HV], EnumFacing.NORTH)


### PR DESCRIPTION
## What
This prevents people getting confused and thinking the cleanroom needs HV power to run, which has happened multiple times, despite the tooltip.

Similar to https://github.com/GregTechCEu/GregTech/pull/1334, and since that is changed, I believe this should be too.

## Implementation Details
The Multiblock Shape Info for the cleanroom has the energy hatch's voltage changed to LV.

## Outcome
Changed the Energy Hatch of the Cleanroom to LV in the JEI Preview (was HV)

## Additional Information
Before (This is on the release, so energy hatch limit is still 3, but nothing of this was changed, at least that I know of):
![2023-01-05_19 52 02](https://user-images.githubusercontent.com/103940576/210739975-c6b3f157-70bd-45bc-bf2d-0d80bbbdfbb6.png)

After:
![2023-01-05_20 46 55](https://user-images.githubusercontent.com/103940576/210750471-ece3edc1-b079-4203-8b77-45d6c5eb2b1d.png)

## Potential Compatibility Issues
None that I know of.
