### PR TITLE
Fix some issues with parallel logic

### DIFF
--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -121,9 +121,16 @@ public abstract class ParallelLogic {
             overlayedItemHandler.reset();
 
             int returnedAmount = 0;
+            int amountToInsert = 0;
 
             for (Map.Entry<ItemStackKey, Integer> entry : recipeOutputs.entrySet()) {
-                int amountToInsert = entry.getValue() * multiplier;
+                // Since multiplier starts at Int.MAX, check here for integer overflow
+                if(entry.getValue() != 0 && multiplier > Integer.MAX_VALUE / entry.getValue()) {
+                    amountToInsert = Integer.MAX_VALUE;
+                }
+                else {
+                    amountToInsert = entry.getValue() * multiplier;
+                }
                 returnedAmount = overlayedItemHandler.insertStackedItemStackKey(entry.getKey(), amountToInsert);
                 if (returnedAmount > 0) {
                     break;
@@ -242,7 +249,13 @@ public abstract class ParallelLogic {
             int amountLeft = 0;
 
             for (Map.Entry<FluidKey, Integer> entry : recipeFluidOutputs.entrySet()) {
-                amountLeft = entry.getValue() * multiplier;
+                // Since multiplier starts at Int.MAX, check here for integer overflow
+                if(entry.getValue() != 0 && multiplier > Integer.MAX_VALUE / entry.getValue()) {
+                    amountLeft = Integer.MAX_VALUE;
+                }
+                else {
+                    amountLeft = entry.getValue() * multiplier;
+                }
                 int inserted = overlayedFluidHandler.insertStackedFluidKey(entry.getKey(), amountLeft);
                 if (inserted > 0) {
                     amountLeft -= inserted;
@@ -447,7 +460,8 @@ public abstract class ParallelLogic {
             int limitByVoltage = Math.abs((int) (maxVoltage / recipeEUt));
             int parallelizable = Math.min(limitByVoltage, limitByOutput);
             if (parallelizable != 0)
-                recipeBuilder.append(currentRecipe, parallelizable, false);
+                // Use the minimum between the amount of recipes we can run with available inputs and amount of recipe outputs that can fit
+                recipeBuilder.append(currentRecipe, Math.min(parallelizable, multiplierByInputs), false);
         } else if (limitByOutput > 0) {
             recipeBuilder.append(currentRecipe, limitByOutput, false);
         }

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -65,17 +65,16 @@ public abstract class ParallelLogic {
         int modifiedFluidParallelAmount = Integer.MAX_VALUE;
 
         // If we are voiding both items and fluids, return the maximum number of parallels that can be performed from the inputs
-        if(voidItems && voidFluids) {
+        if (voidItems && voidFluids) {
             return parallelAmount;
         }
 
         // Check both normal item outputs and chanced item outputs
         if (recipe.getOutputs().size() > 0 || recipe.getChancedOutputs().size() > 0) {
             // If we are voiding items, reset the item limit to the maximum number of parallels
-            if(voidItems) {
+            if (voidItems) {
                 modifiedItemParallelAmount = parallelAmount;
-            }
-            else {
+            } else {
                 modifiedItemParallelAmount = limitParallelByItems(recipe, new OverlayedItemHandler(outputs), parallelAmount);
             }
 
@@ -88,15 +87,14 @@ public abstract class ParallelLogic {
         // TODO, check both regular and chanced fluid outputs when fluid outputs are implemented
         if (recipe.getFluidOutputs().size() > 0) {
             // If we are voiding fluids, reset the fluid limit to the maximum number of parallels
-            if(voidFluids) {
+            if (voidFluids) {
                 modifiedFluidParallelAmount = parallelAmount;
-            }
-            else {
+            } else {
                 modifiedFluidParallelAmount = limitParallelByFluids(recipe, new OverlayedFluidHandler(fluidOutputs), modifiedItemParallelAmount);
             }
 
             // If we are not voiding, and cannot fit any fluids, return 0
-            if(modifiedFluidParallelAmount == 0 && !voidFluids) {
+            if (modifiedFluidParallelAmount == 0 && !voidFluids) {
                 return 0;
             }
         }
@@ -125,10 +123,9 @@ public abstract class ParallelLogic {
 
             for (Map.Entry<ItemStackKey, Integer> entry : recipeOutputs.entrySet()) {
                 // Since multiplier starts at Int.MAX, check here for integer overflow
-                if(entry.getValue() != 0 && multiplier > Integer.MAX_VALUE / entry.getValue()) {
+                if (entry.getValue() != 0 && multiplier > Integer.MAX_VALUE / entry.getValue()) {
                     amountToInsert = Integer.MAX_VALUE;
-                }
-                else {
+                } else {
                     amountToInsert = entry.getValue() * multiplier;
                 }
                 returnedAmount = overlayedItemHandler.insertStackedItemStackKey(entry.getKey(), amountToInsert);
@@ -250,10 +247,9 @@ public abstract class ParallelLogic {
 
             for (Map.Entry<FluidKey, Integer> entry : recipeFluidOutputs.entrySet()) {
                 // Since multiplier starts at Int.MAX, check here for integer overflow
-                if(entry.getValue() != 0 && multiplier > Integer.MAX_VALUE / entry.getValue()) {
+                if (entry.getValue() != 0 && multiplier > Integer.MAX_VALUE / entry.getValue()) {
                     amountLeft = Integer.MAX_VALUE;
-                }
-                else {
+                } else {
                     amountLeft = entry.getValue() * multiplier;
                 }
                 int inserted = overlayedFluidHandler.insertStackedFluidKey(entry.getKey(), amountLeft);
@@ -329,7 +325,7 @@ public abstract class ParallelLogic {
 
         // Return the maximum parallel limit here if there are only non-consumed inputs, which are all found in the input bus
         // At this point, we would have already returned 0 if we were missing any non-consumable inputs, so we can omit that check
-        if(countableMap.isEmpty() && !notConsumableMap.isEmpty()) {
+        if (countableMap.isEmpty() && !notConsumableMap.isEmpty()) {
             return parallelAmount;
         }
 
@@ -411,7 +407,7 @@ public abstract class ParallelLogic {
 
         // Return the maximum parallel limit here if there are only non-consumed inputs, which are all found in the input bus
         // At this point, we would have already returned 0 if we were missing any non-consumable inputs, so we can omit that check
-        if(fluidCountMap.isEmpty() && !notConsumableMap.isEmpty()) {
+        if (fluidCountMap.isEmpty() && !notConsumableMap.isEmpty()) {
             return parallelAmount;
         }
 
@@ -478,7 +474,7 @@ public abstract class ParallelLogic {
      * @param exportInventory The {@link IItemHandlerModifiable} that contains the items to be used as outputs
      * @param parallelAmount  The maximum amount of recipes that can be performed at one time
      * @param maxVoltage      The maximum voltage of the machine
-     * @param voidable             The MetaTileEntity performing the parallel recipe
+     * @param voidable        The MetaTileEntity performing the parallel recipe
      * @return A {@link RecipeBuilder} containing the recipes that can be performed in parallel, limited by the ingredients available, and the output space available.
      */
     public static RecipeBuilder<?> appendItemRecipes(@Nonnull RecipeMap<?> recipeMap, @Nonnull IItemHandlerModifiable importInventory, @Nonnull IItemHandlerModifiable exportInventory, int parallelAmount, long maxVoltage, IVoidable voidable) {
@@ -530,7 +526,7 @@ public abstract class ParallelLogic {
 
             //how much we can add to the output inventory
             int limitByOutput = Integer.MAX_VALUE;
-            if(!voidable.canVoidRecipeItemOutputs()) {
+            if (!voidable.canVoidRecipeItemOutputs()) {
                 // Limit by the number of recipe outputs and chanced outputs, to simulate cases where 100% chanced outputs were obtained
                 limitByOutput = limitParallelByItemsIncremental(recipeBuilder.getAllItemOutputs(), matchingRecipe.getOutputs(), overlayedItemHandler, ingredientRatio);
             }


### PR DESCRIPTION
## What
Fixes some issues with parallel logic after #1279 

Specifically adds back the `min` check between the number of recipes that can fit into the output and the number of recipes that can be run from the inputs.

In addition, prevents some Integer overflows when attempting to find the maximum number of parallels from available items and fluids. These occurred because the initial multiplier was set at `Integer.MAX_VALUE`


## Outcome
Fixes some issues with parallel logic, noticed especially with fluid only recipes.
