### PR TITLE
feat(multiblocks):rebalanced multiblock explosions to be based off voltage

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -138,7 +138,7 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
 
                 FluidStack drainedWater = ModHandler.getBoilerFluidFromContainer(getInputTank(), (int) amount, true);
                 if (amount != 0 && (drainedWater == null || drainedWater.amount < amount)) {
-                    getMetaTileEntity().explodeMultiblock();
+                    getMetaTileEntity().explodeMultiblock(8);
                 } else {
                     setLastTickSteam(generatedSteam);
                     getOutputTank().fill(ModHandler.getSteam(generatedSteam), true);

--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -138,7 +138,7 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
 
                 FluidStack drainedWater = ModHandler.getBoilerFluidFromContainer(getInputTank(), (int) amount, true);
                 if (amount != 0 && (drainedWater == null || drainedWater.amount < amount)) {
-                    getMetaTileEntity().explodeMultiblock(8);
+                    getMetaTileEntity().explodeMultiblock((currentHeat/getMaximumHeat()) * 8);
                 } else {
                     setLastTickSteam(generatedSteam);
                     getOutputTank().fill(ModHandler.getSteam(generatedSteam), true);

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -406,12 +406,12 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
         return 0xFFFFFF;
     }
 
-    public void explodeMultiblock() {
+    public void explodeMultiblock(float explosionPower) {
         List<IMultiblockPart> parts = new ArrayList<>(getMultiblockParts());
         for (IMultiblockPart part : parts) {
             part.removeFromMultiBlock(this);
-            ((MetaTileEntity) part).doExplosion(8);
+            ((MetaTileEntity) part).doExplosion(explosionPower);
         }
-        doExplosion(8);
+        doExplosion(explosionPower);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -165,7 +165,7 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
     @Override
     public void doExplosion(float explosionPower) {
         if (getController() != null)
-            getController().explodeMultiblock();
+            getController().explodeMultiblock(explosionPower);
         else {
             super.doExplosion(explosionPower);
         }


### PR DESCRIPTION
## What
dan said I could make multiblock explosions based off the voltage, so I did

## Implementation Details
The explosion value is passed into the explosion function.
Also the steam boilers now have variable explosion size based on how hot they are, with max heat causing an explosion of the current size

## Outcome
LV hatches now wont wipe an entire chunk, but dont overvolt UV hatches if you like your base
