### PR TITLE
Fix cover access AGAIN

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -287,12 +287,23 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         if (metaTileEntity == null || rayTraceResult == null) {
             return false;
         }
-        boolean toolClickResult = metaTileEntity.onToolClick(playerIn, itemStack.getItem().getToolClasses(itemStack),
+        // when clicking cover with screwdriver or soft mallet, interact with cover
+        boolean toolClickResult = false;
+        if (itemStack.getItem().getToolClasses(itemStack).contains(ToolClasses.SCREWDRIVER)) {
+            toolClickResult = metaTileEntity.onCoverScrewdriverClick(playerIn, hand, rayTraceResult);
+        }
+        else if (itemStack.getItem().getToolClasses(itemStack).contains(ToolClasses.SOFT_MALLET)) {
+            toolClickResult = metaTileEntity.onCoverSoftMalletClick(playerIn, hand, rayTraceResult);
+        }
+        // if not interacting with cover, interact with the TileEntity
+        toolClickResult = toolClickResult || metaTileEntity.onToolClick(playerIn, itemStack.getItem().getToolClasses(itemStack),
                 hand, ICoverable.determineGridSideHit(rayTraceResult), rayTraceResult);
-        // damage the tool and play sounds
-        if (toolClickResult) postToolClick(itemStack, playerIn);
+        // damage the tool and play sounds if used
+        if (toolClickResult) {
+            postToolClick(itemStack, playerIn);
+        }
         // if the tool did something, we don't bother with covers
-        // otherwise we handle cover clicking
+        // otherwise we handle cover clicking without tools
         return toolClickResult || metaTileEntity.onCoverRightClick(playerIn, hand, rayTraceResult);
     }
 

--- a/src/main/java/gregtech/api/cover/CoverBehavior.java
+++ b/src/main/java/gregtech/api/cover/CoverBehavior.java
@@ -170,6 +170,10 @@ public abstract class CoverBehavior implements IUIHolder {
         return EnumActionResult.PASS;
     }
 
+    public EnumActionResult onSoftMalletClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
+        return EnumActionResult.PASS;
+    }
+
     /**
      * Will be called for each capability request to meta tile entity
      * Cover can override meta tile entity capabilities, modify their values, or deny accessing them

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -380,7 +380,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     public final boolean onCoverScrewdriverClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult result) {
         EnumFacing hitFacing = ICoverable.determineGridSideHit(result);
         boolean accessingActiveOutputSide = false;
-        if (this.getCapability(GregtechTileCapabilities.CAPABILITY_ACTIVE_OUTPUT_SIDE, hitFacing) != null) {
+        if ( this.getCapability(GregtechTileCapabilities.CAPABILITY_ACTIVE_OUTPUT_SIDE, hitFacing) != null) {
             accessingActiveOutputSide = playerIn.isSneaking();
         }
         EnumFacing coverSide = ICoverable.traceCoverSide(result);
@@ -391,6 +391,21 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
             return coverResult == EnumActionResult.SUCCESS;
         }
         return onScrewdriverClick(playerIn, hand, result.sideHit, result);
+    }
+    public final boolean onCoverSoftMalletClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult result) {
+        EnumFacing hitFacing = ICoverable.determineGridSideHit(result);
+        boolean accessingActiveOutputSide = false;
+        if ( this.getCapability(GregtechTileCapabilities.CAPABILITY_ACTIVE_OUTPUT_SIDE, hitFacing) != null) {
+            accessingActiveOutputSide = playerIn.isSneaking();
+        }
+        EnumFacing coverSide = ICoverable.traceCoverSide(result);
+        CoverBehavior coverBehavior = coverSide == null ? null : getCoverAtSide(coverSide);
+        EnumActionResult coverResult = coverBehavior == null ? EnumActionResult.PASS :
+                accessingActiveOutputSide ? EnumActionResult.PASS : coverBehavior.onSoftMalletClick(playerIn, hand, result);
+        if (coverResult != EnumActionResult.PASS) {
+            return coverResult == EnumActionResult.SUCCESS;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/gregtech/common/covers/CoverFluidVoiding.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidVoiding.java
@@ -1,5 +1,6 @@
 package gregtech.common.covers;
 
+import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
@@ -15,7 +16,9 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.common.covers.filter.FluidFilterContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
@@ -69,6 +72,12 @@ public class CoverFluidVoiding extends CoverPump {
     @Override
     public void renderCover(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline, Cuboid6 plateBox, BlockRenderLayer layer) {
         Textures.FLUID_VOIDING.renderSided(attachedSide, plateBox, renderState, pipeline, translation);
+    }
+
+    @Override
+    public EnumActionResult onSoftMalletClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
+        this.isWorkingAllowed = !this.isWorkingAllowed;
+        return EnumActionResult.SUCCESS;
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverItemVoiding.java
+++ b/src/main/java/gregtech/common/covers/CoverItemVoiding.java
@@ -1,5 +1,6 @@
 package gregtech.common.covers;
 
+import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
@@ -14,7 +15,9 @@ import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -80,6 +83,12 @@ public class CoverItemVoiding extends CoverConveyor {
     @Override
     public void renderCover(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline, Cuboid6 plateBox, BlockRenderLayer layer) {
         Textures.ITEM_VOIDING.renderSided(attachedSide, plateBox, renderState, pipeline, translation);
+    }
+
+    @Override
+    public EnumActionResult onSoftMalletClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
+        this.isWorkingAllowed = !this.isWorkingAllowed;
+        return EnumActionResult.SUCCESS;
     }
 
     @Override


### PR DESCRIPTION
## What
This PR fixes a bug that blocks access to covers placed on a TileEntity with GUI or other function like drums.

## Implementation Details
This PR adds `onCoverScrewdriverClick()` and `onCoverSoftMalletClick()` method for corresponding tools before the operation of opening the GUI of the TileEntity.

## Outcome
When right-clicking covers with screwdriver, the GUI of the cover instead of the TileEntity behind it can be opened.
Additionally, the voiding covers can also be activated properly with soft mallet.

## Potential Compatibility Issues
Probably none, but may have issue with certain addons.
