### PR TITLE
Refactor and cleanup ModHandler

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -7,6 +7,7 @@ import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.util.GTLog;
+import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
 import net.minecraft.item.ItemStack;
@@ -136,7 +137,7 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
                 amount -= excessWater / STEAM_PER_WATER;
                 excessWater %= STEAM_PER_WATER;
 
-                FluidStack drainedWater = ModHandler.getBoilerFluidFromContainer(getInputTank(), (int) amount, true);
+                FluidStack drainedWater = GTUtility.getBoilerFluidFromContainer(getInputTank(), (int) amount, true);
                 if (amount != 0 && (drainedWater == null || drainedWater.amount < amount)) {
                     getMetaTileEntity().explodeMultiblock((currentHeat/getMaximumHeat()) * 8);
                 } else {

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -796,7 +796,7 @@ public final class ModHandler {
      * @return a Pair of the recipe, and the output
      */
     @Nonnull
-    public static Pair<IRecipe, ItemStack> getRecipeOutput(@Nullable World world, @Nullable ItemStack[] recipe) {
+    public static Pair<IRecipe, ItemStack> getRecipeOutput(@Nullable World world, @Nullable ItemStack... recipe) {
         if (recipe == null || recipe.length == 0) return ImmutablePair.of(null, ItemStack.EMPTY);
         if (world == null) world = DummyWorld.INSTANCE;
 

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -222,11 +222,11 @@ public final class ModHandler {
      * @param experience the experience of the recipe
      */
     public static void addSmeltingRecipe(@Nonnull ItemStack input, @Nonnull ItemStack output, float experience) {
-        if (input.isEmpty()) {
-            if (setErroredInvalidRecipe("Furnace Recipe Input cannot be an empty ItemStack")) return;
+        if (input.isEmpty() && setErroredInvalidRecipe("Furnace Recipe Input cannot be an empty ItemStack")) {
+            return;
         }
-        if (output.isEmpty()) {
-            if (setErroredInvalidRecipe("Furnace Recipe Output cannot be an empty ItemStack")) return;
+        if (output.isEmpty() && setErroredInvalidRecipe("Furnace Recipe Output cannot be an empty ItemStack")) {
+            return;
         }
 
         FurnaceRecipes recipes = FurnaceRecipes.instance();
@@ -792,12 +792,12 @@ public final class ModHandler {
 
     /**
      * @param world  the world to check the output from
-     * @param recipe the recipe to retrieve from
+     * @param recipe the recipe to retrieve from. Must not contain null values.
      * @return a Pair of the recipe, and the output
      */
     @Nonnull
-    public static Pair<IRecipe, ItemStack> getRecipeOutput(@Nullable World world, @Nonnull ItemStack... recipe) {
-        if (recipe.length == 0) return ImmutablePair.of(null, ItemStack.EMPTY);
+    public static Pair<IRecipe, ItemStack> getRecipeOutput(@Nullable World world, @Nullable ItemStack[] recipe) {
+        if (recipe == null || recipe.length == 0) return ImmutablePair.of(null, ItemStack.EMPTY);
         if (world == null) world = DummyWorld.INSTANCE;
 
         InventoryCrafting craftingGrid = new InventoryCrafting(new DummyContainer(), 3, 3);

--- a/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
+++ b/src/main/java/gregtech/api/util/ItemStackHashStrategy.java
@@ -44,6 +44,13 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack> {
                 .build();
     }
 
+    static ItemStackHashStrategy comparingItemDamageCount() {
+        return builder().compareItem(true)
+                .compareDamage(true)
+                .compareCount(true)
+                .build();
+    }
+
     /**
      * Builder pattern class for generating customized ItemStackHashStrategy
      */

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -13,6 +13,7 @@ import gregtech.api.items.gui.PlayerInventoryUIFactory;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
 import gregtech.api.modules.GregTechModule;
 import gregtech.api.modules.IGregTechModule;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 import gregtech.api.unification.OreDictUnifier;
@@ -147,6 +148,7 @@ public class CoreModule implements IGregTechModule {
         MetaItems.init();
         ToolItems.init();
         MetaFluids.init();
+        ModHandler.init();
 
         /* Start MetaTileEntity Registration */
         MTE_REGISTRY.unfreeze();
@@ -242,6 +244,8 @@ public class CoreModule implements IGregTechModule {
                 TemperatureProperty.registerCoilType(value.getCoilTemperature(), value.getMaterial(), name);
             }
         }
+
+        ModHandler.postInit();
     }
 
     @Override

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -46,8 +46,7 @@ public class VanillaOverrideRecipes {
         }
         removeCompressionRecipes();
         toolArmorRecipes();
-
-        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:tnt"));
+        alwaysRemovedRecipes();
     }
 
     private static void woodRecipes() {
@@ -233,7 +232,7 @@ public class VanillaOverrideRecipes {
      */
     private static void glassRecipes() {
         ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.SAND, 1, GTValues.W));
-        ModHandler.removeRecipes(new ItemStack(Items.GLASS_BOTTLE, 3));
+        ModHandler.removeRecipeByOutput(new ItemStack(Items.GLASS_BOTTLE, 3));
     }
 
     /**
@@ -1028,5 +1027,19 @@ public class VanillaOverrideRecipes {
         ModHandler.addShapedRecipe(regName, output, "P P", "PhP",
                 'P', new UnificationEntry(OrePrefix.plate, material)
         );
+    }
+
+    private static void alwaysRemovedRecipes() {
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:tnt"));
+
+        // always remove these, GT ore processing changes their output
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.COAL_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.IRON_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.GOLD_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.DIAMOND_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.EMERALD_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.LAPIS_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.REDSTONE_ORE));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.QUARTZ_ORE));
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -184,7 +184,7 @@ public class VanillaStandardRecipes {
         for (int i = 0; i < 16; i++) {
             // nerf glass panes
             if (ConfigHolder.recipes.hardGlassRecipes) {
-                ModHandler.removeRecipes(new ItemStack(Blocks.STAINED_GLASS_PANE, 16, i));
+                ModHandler.removeRecipeByOutput(new ItemStack(Blocks.STAINED_GLASS_PANE, 16, i));
             }
 
             ModHandler.addShapedRecipe("stained_glass_pane_" + i, new ItemStack(Blocks.STAINED_GLASS_PANE, 2, i), "sG", 'G', new ItemStack(Blocks.STAINED_GLASS, 1, i));
@@ -196,7 +196,7 @@ public class VanillaStandardRecipes {
         }
 
         if (ConfigHolder.recipes.hardGlassRecipes)
-            ModHandler.removeRecipes(new ItemStack(Blocks.GLASS_PANE, 16));
+            ModHandler.removeRecipeByOutput(new ItemStack(Blocks.GLASS_PANE, 16));
 
         ModHandler.addShapedRecipe("glass_pane", new ItemStack(Blocks.GLASS_PANE, 2), "sG", 'G', new ItemStack(Blocks.GLASS));
 

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -33,7 +33,7 @@ public class WoodMachineRecipes {
 
     private static void processLogOreDictionary() {
         List<ItemStack> allWoodLogs = OreDictUnifier.getAllWithOreDictionaryName("logWood").stream()
-                .flatMap(stack -> ModHandler.getAllSubItems(stack).stream())
+                .flatMap(stack -> GTUtility.getAllSubItems(stack).stream())
                 .collect(Collectors.toList());
 
         for (ItemStack stack : allWoodLogs) {
@@ -71,9 +71,9 @@ public class WoodMachineRecipes {
                     .buildAndRegister();
 
             ItemStack doorStack = ModHandler.getRecipeOutput(DummyWorld.INSTANCE,
-                    plankStack, plankStack, null,
-                    plankStack, plankStack, null,
-                    plankStack, plankStack, null).getRight();
+                    plankStack, plankStack, ItemStack.EMPTY,
+                    plankStack, plankStack, ItemStack.EMPTY,
+                    plankStack, plankStack, ItemStack.EMPTY).getRight();
 
             if (!doorStack.isEmpty()) {
                 ASSEMBLER_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -1,7 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
 import gregtech.api.GTValues;
-import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.MetaBlocks;
@@ -87,7 +86,7 @@ public class SeparationRecipes {
         for (Item item : ForgeRegistries.ITEMS.getValuesCollection()) {
             if (item instanceof ItemFood) {
                 ItemFood itemFood = (ItemFood) item;
-                Collection<ItemStack> subItems = ModHandler.getAllSubItems(new ItemStack(item, 1, GTValues.W));
+                Collection<ItemStack> subItems = GTUtility.getAllSubItems(new ItemStack(item, 1, GTValues.W));
                 for (ItemStack itemStack : subItems) {
                     int healAmount = itemFood.getHealAmount(itemStack);
                     float saturationModifier = itemFood.getSaturationModifier(itemStack);

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -95,7 +95,8 @@ public class MaterialRecipeHandler {
                 if (blastTemp <= 0) {
                     // smelting magnetic dusts is handled elsewhere
                     if (!mat.hasFlag(IS_MAGNETIC)) {
-                        ModHandler.addSmeltingRecipe(new UnificationEntry(dustPrefix, mat), ingotStack);
+                        // do not register inputs by ore dict here. Let other mods register their own dust -> ingots
+                        ModHandler.addSmeltingRecipe(OreDictUnifier.get(dustPrefix, mat), ingotStack);
                     }
                 } else {
                     IngotProperty ingotProperty = mat.getProperty(PropertyKey.INGOT);

--- a/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
@@ -49,7 +49,6 @@ public class OreRecipeHandler {
         OrePrefix.crushedCentrifuged.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCrushedCentrifuged);
         OrePrefix.dustImpure.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processDirtyDust);
         OrePrefix.dustPure.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processPureDust);
-        OrePrefix.dust.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processCleanDust);
     }
 
 
@@ -371,10 +370,6 @@ public class OreRecipeHandler {
                 .duration(8).EUt(4).buildAndRegister();
 
         processMetalSmelting(purePrefix, material, property);
-    }
-
-    public static void processCleanDust(OrePrefix dustPrefix, Material material, OreProperty property) {
-        processMetalSmelting(dustPrefix, material, property);
     }
 
     private static boolean doesMaterialUseNormalFurnace(Material material) {

--- a/src/test/java/gregtech/Bootstrap.java
+++ b/src/test/java/gregtech/Bootstrap.java
@@ -3,6 +3,7 @@ package gregtech;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.fluids.MetaFluids;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.items.MetaItems;
@@ -48,6 +49,7 @@ public final class Bootstrap {
         OrePrefix.runMaterialHandlers();
         MetaFluids.init();
         MetaItems.init();
+        ModHandler.init();
         bootstrapped = true;
     }
 }


### PR DESCRIPTION
## What
This PR refactors and cleans up ModHandler, to remove duplicated code and improve efficiency in a few places. It also improves the way invalid recipes are logged and handled depending on the config.

This PR also stops GT from registering duplicate furnace recipes of its own, which were discovered in the creation of this PR.

## Outcome
Refactors and cleans up ModHandler.

## Potential Compatibility Issues
Some methods in ModHandler were moved to GTUtility, where they would fit better. I don't expect other mods to be  using them due to their obscurity, but it is still a possibility that the method import would break for them if used after all.
