### PR TITLE
Only allow crafting tools in crafting station tool inventory

### DIFF
--- a/src/main/java/gregtech/common/inventory/handlers/ToolItemStackHandler.java
+++ b/src/main/java/gregtech/common/inventory/handlers/ToolItemStackHandler.java
@@ -1,5 +1,6 @@
 package gregtech.common.inventory.handlers;
 
+import gregtech.api.items.toolitem.IGTTool;
 import gregtech.api.unification.OreDictUnifier;
 import net.minecraft.item.ItemStack;
 
@@ -14,9 +15,13 @@ public class ToolItemStackHandler extends SingleItemStackHandler {
     @Override
     @Nonnull
     public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-        if (stack.isItemStackDamageable() &&
-                (!stack.getItem().getToolClasses(stack).isEmpty() ||
-                        OreDictUnifier.getOreDictionaryNames(stack).stream().anyMatch(s -> s.startsWith("craftingTool")))) {
+        if (stack.getItem().getToolClasses(stack).isEmpty()) return stack;
+        if (stack.getItem() instanceof IGTTool && ((IGTTool) stack.getItem()).getToolStats().isSuitableForCrafting(stack)) {
+            return super.insertItem(slot, stack, simulate);
+        }
+
+        if (stack.isItemStackDamageable() && OreDictUnifier.getOreDictionaryNames(stack).stream()
+                .anyMatch(s -> s.startsWith("craftingTool"))) {
             return super.insertItem(slot, stack, simulate);
         }
         return stack;


### PR DESCRIPTION
## What
This PR makes the Crafting Station only allow crafting tools in its tool inventory. This means tools such as wrenches are allowed, but blocks tools like Pickaxes from entering the tool slots.

## Outcome
Only allows crafting tools in the Crafting Station tool inventory.
