### PR TITLE
Fix BlockMachine ignoring MTE harvest tool/level

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -125,7 +125,9 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
 
     @Override
     public float getPlayerRelativeBlockHardness(@Nonnull IBlockState state, @Nonnull EntityPlayer player, @Nonnull World worldIn, @Nonnull BlockPos pos) {
-        return super.getPlayerRelativeBlockHardness(state.getBlock().getActualState(state, worldIn, pos), player, worldIn, pos);
+        // make sure our extended block state info is here for callers (since forge does not do it for us in this case)
+        state = state.getBlock().getActualState(state, worldIn, pos);
+        return super.getPlayerRelativeBlockHardness(state, player, worldIn, pos);
     }
 
     @Nonnull

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -367,6 +367,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             if (result != 0) {
                 // prevent exploits with instantly breakable blocks
                 IBlockState state = player.world.getBlockState(pos);
+                state = state.getBlock().getActualState(state, player.world, pos);
                 boolean effective = false;
                 for (String type : getToolClasses(stack)) {
                     if (state.getBlock().isToolEffective(type, state)) {

--- a/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
@@ -23,7 +23,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.block.*;
-import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentDurability;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -47,15 +46,12 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IShearable;
-import net.minecraftforge.common.property.IExtendedBlockState;
-import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.event.ForgeEventFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Supplier;
@@ -454,19 +450,6 @@ public final class ToolHelper {
 
     // encompasses all vanilla special case tool checks for harvesting
     public static boolean isToolEffective(IBlockState state, Set<String> toolClasses, int harvestLevel) {
-        System.out.println("State:");
-        System.out.println("Properties:");
-        for (Map.Entry<IProperty<?>, Comparable<?>> prop : state.getProperties().entrySet()) {
-            System.out.println("Name: " + prop.getKey().getName() + ", Value: " + prop.getValue());
-        }
-        if (state instanceof IExtendedBlockState) {
-            IExtendedBlockState extState = (IExtendedBlockState) state;
-            System.out.println("Unlisted:");
-            for (Map.Entry<IUnlistedProperty<?>, Optional<?>> prop : extState.getUnlistedProperties().entrySet()) {
-                System.out.println("Name: " + prop.getKey().getName() + ", Value: " + prop.getValue().orElse(null));
-            }
-        }
-
         Block block = state.getBlock();
         if (toolClasses.contains(block.getHarvestTool(state))) {
             return block.getHarvestLevel(state) <= harvestLevel;

--- a/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.block.*;
+import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentDurability;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -46,6 +47,8 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IShearable;
+import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.event.ForgeEventFactory;
 
 import javax.annotation.Nonnull;
@@ -451,6 +454,19 @@ public final class ToolHelper {
 
     // encompasses all vanilla special case tool checks for harvesting
     public static boolean isToolEffective(IBlockState state, Set<String> toolClasses, int harvestLevel) {
+        System.out.println("State:");
+        System.out.println("Properties:");
+        for (Map.Entry<IProperty<?>, Comparable<?>> prop : state.getProperties().entrySet()) {
+            System.out.println("Name: " + prop.getKey().getName() + ", Value: " + prop.getValue());
+        }
+        if (state instanceof IExtendedBlockState) {
+            IExtendedBlockState extState = (IExtendedBlockState) state;
+            System.out.println("Unlisted:");
+            for (Map.Entry<IUnlistedProperty<?>, Optional<?>> prop : extState.getUnlistedProperties().entrySet()) {
+                System.out.println("Name: " + prop.getKey().getName() + ", Value: " + prop.getValue().orElse(null));
+            }
+        }
+
         Block block = state.getBlock();
         if (toolClasses.contains(block.getHarvestTool(state))) {
             return block.getHarvestLevel(state) <= harvestLevel;

--- a/src/main/java/gregtech/asm/GregTechTransformer.java
+++ b/src/main/java/gregtech/asm/GregTechTransformer.java
@@ -157,6 +157,12 @@ public class GregTechTransformer implements IClassTransformer, Opcodes {
                 DamageSourceVisitor.handleClassNode(classNode).accept(classWriter);
                 return classWriter.toByteArray();
             }
+            case TheOneProbeVisitor.TARGET_CLASS_NAME: {
+                ClassReader classReader = new ClassReader(basicClass);
+                ClassWriter classWriter = new ClassWriter(0);
+                classReader.accept(new TargetClassVisitor(classWriter, TheOneProbeVisitor.TARGET_METHOD, TheOneProbeVisitor::new), 0);
+                return classWriter.toByteArray();
+            }
         }
         if (EnchantmentCanApplyVisitor.CLASS_TO_MAPPING_MAP.containsKey(internalName)) {
             ObfMapping methodMapping = EnchantmentCanApplyVisitor.CLASS_TO_MAPPING_MAP.get(internalName);

--- a/src/main/java/gregtech/asm/hooks/TheOneProbeHooks.java
+++ b/src/main/java/gregtech/asm/hooks/TheOneProbeHooks.java
@@ -1,0 +1,19 @@
+package gregtech.asm.hooks;
+
+import gregtech.api.block.machines.BlockMachine;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@SuppressWarnings("unused")
+public class TheOneProbeHooks {
+
+    @SuppressWarnings("deprecation")
+    public static IBlockState getActualState(World world, BlockPos pos) {
+        IBlockState state = world.getBlockState(pos);
+        if (state.getBlock() instanceof BlockMachine) {
+            state = state.getBlock().getActualState(state, world, pos);
+        }
+        return state;
+    }
+}

--- a/src/main/java/gregtech/asm/visitors/TheOneProbeVisitor.java
+++ b/src/main/java/gregtech/asm/visitors/TheOneProbeVisitor.java
@@ -1,0 +1,39 @@
+package gregtech.asm.visitors;
+
+import gregtech.asm.util.ObfMapping;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.AdviceAdapter;
+
+public class TheOneProbeVisitor extends MethodVisitor implements Opcodes {
+
+    public static final String TARGET_CLASS_NAME = "mcjty/theoneprobe/network/PacketGetInfo";
+    public static final ObfMapping TARGET_METHOD = new ObfMapping(TARGET_CLASS_NAME, "getProbeInfo", getSignature());
+
+    private static final ObfMapping GET_BLOCK_STATE_METHOD = new ObfMapping("net/minecraft/world/World",
+            "func_180495_p", "(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/state/IBlockState;").toRuntime();
+
+    public TheOneProbeVisitor(MethodVisitor mv) {
+        super(ASM5, mv);
+    }
+
+    @Override
+    public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+        if (opcode == INVOKEVIRTUAL && name.equals(GET_BLOCK_STATE_METHOD.s_name) && desc.equals(GET_BLOCK_STATE_METHOD.s_desc)) {
+            visitMethodInsn(INVOKESTATIC, "gregtech/asm/hooks/TheOneProbeHooks", "getActualState",
+                    "(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/state/IBlockState;", false);
+        } else super.visitMethodInsn(opcode, owner, name, desc, itf);
+    }
+
+    private static String getSignature() {
+        return "("
+                + "Lnet/minecraft/entity/player/EntityPlayer;"
+                + "Lmcjty/theoneprobe/api/ProbeMode;"
+                + "Lnet/minecraft/world/World;"
+                + "Lnet/minecraft/util/math/BlockPos;"
+                + "Lnet/minecraft/util/EnumFacing;"
+                + "Lnet/minecraft/util/math/Vec3d;"
+                + "Lnet/minecraft/item/ItemStack;"
+                + ")Lmcjty/theoneprobe/apiimpl/ProbeInfo;";
+    }
+}

--- a/src/main/java/gregtech/common/items/behaviors/TricorderBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/TricorderBehavior.java
@@ -1,6 +1,5 @@
 package gregtech.common.items.behaviors;
 
-import com.google.common.collect.UnmodifiableIterator;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.capability.*;
@@ -33,6 +32,8 @@ import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
+import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
@@ -40,6 +41,8 @@ import net.minecraftforge.fluids.IFluidTank;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class TricorderBehavior implements IItemBehaviour {
 
@@ -69,6 +72,7 @@ public class TricorderBehavior implements IItemBehaviour {
         return EnumActionResult.SUCCESS;
     }
 
+    @SuppressWarnings("deprecation")
     public List<ITextComponent> getScannerInfo(EntityPlayer player, World world, BlockPos pos) {
         int energyCost = 100;
 
@@ -76,7 +80,9 @@ public class TricorderBehavior implements IItemBehaviour {
 
         TileEntity tileEntity = world.getTileEntity(pos);
 
-        Block block = world.getBlockState(pos).getBlock();
+        IBlockState state = world.getBlockState(pos);
+        state = state.getBlock().getActualState(state, world, pos);
+        Block block = state.getBlock();
 
         // coordinates of the block
 
@@ -89,20 +95,25 @@ public class TricorderBehavior implements IItemBehaviour {
 
         // hardness and blast resistance
         list.add(new TextComponentTranslation("behavior.tricorder.block_hardness",
-                new TextComponentTranslation(GTUtility.formatNumbers(block.blockHardness)).setStyle(new Style().setColor(TextFormatting.YELLOW)),
+                new TextComponentTranslation(GTUtility.formatNumbers(block.getBlockHardness(state, world, pos))).setStyle(new Style().setColor(TextFormatting.YELLOW)),
                 new TextComponentTranslation(GTUtility.formatNumbers(block.getExplosionResistance(player))).setStyle(new Style().setColor(TextFormatting.YELLOW))
         ));
 
         if (debugLevel > 2) {
-            IBlockState state = world.getBlockState(pos);
-            UnmodifiableIterator<IProperty<?>> propertyItr = state.getProperties().keySet().iterator();
-            IProperty prop;
-            while (propertyItr.hasNext()) {
-                prop = propertyItr.next();
+            for (Map.Entry<IProperty<?>, Comparable<?>> prop : state.getProperties().entrySet()) {
                 list.add(new TextComponentTranslation("behavior.tricorder.state",
-                        new TextComponentTranslation(prop.getName()),
-                        new TextComponentTranslation(state.getValue(prop).toString()).setStyle(new Style().setColor(TextFormatting.AQUA))
-                ));
+                        new TextComponentTranslation(prop.getKey().getName()),
+                        new TextComponentTranslation(prop.getValue().toString()).setStyle(new Style().setColor(TextFormatting.AQUA))));
+            }
+            if (state instanceof IExtendedBlockState) {
+                IExtendedBlockState extState = (IExtendedBlockState) state;
+                for (Map.Entry<IUnlistedProperty<?>, Optional<?>> prop : extState.getUnlistedProperties().entrySet()) {
+                    if (prop.getValue().isPresent()) {
+                        list.add(new TextComponentTranslation("behavior.tricorder.state",
+                                new TextComponentTranslation(prop.getKey().getName()),
+                                new TextComponentTranslation(prop.getValue().get().toString()).setStyle(new Style().setColor(TextFormatting.AQUA))));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This fix works decently, but is mostly going back to how it was done in CE. It should be changed, but the correct way to do it is to do different instances of BlockMachine for different harvest levels/harvest tools, as well as different Block Materials, different block hardness/resistance, sound type, etc., which would take a larger refactor that should be done later