### PR TITLE
bug(multiblocks):fixed large miners using 7 eu/t

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -130,7 +130,7 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
 
     @Override
     public boolean drainEnergy(boolean simulate) {
-        long energyToDrain = GTValues.VA[GTUtility.getTierByVoltage(getEnergyTier())];
+        long energyToDrain = GTValues.VA[getEnergyTier()];
         long resultEnergy = energyContainer.getEnergyStored() - energyToDrain;
         if (resultEnergy >= 0L && resultEnergy <= energyContainer.getEnergyCapacity()) {
             if (!simulate)


### PR DESCRIPTION
Set to be on teir, because multiblock miners are more stronk than singleblock miners

## What
Multiblock miners currently use 7 eu/t

## Implementation Details
There was an extra `getTierByVoltage` call, that turned the tier into a voltage tier, this was a bug.

## Outcome
Multiblock miners now actually use the correct eu/t

## Additional Information
Singleblock miners use `tier -1`, this sets multiblock miners to `tier`