### PR TITLE
Return instead of throwing if a non-neighbor calls neighborChanged

### DIFF
--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -199,7 +199,10 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                         break;
                     }
                 }
-                if (facing == null) throw new NullPointerException("Facing is null");
+                if (facing == null) {
+                    //not our neighbor
+                    return;
+                }
                 boolean open = pipeTile.isConnected(facing);
                 boolean canConnect = pipeTile.getCoverableImplementation().getCoverAtSide(facing) != null || canConnect(pipeTile, facing);
                 if (!open && canConnect && state.getBlock() != blockIn)


### PR DESCRIPTION
Works around THE EnderIO conduit bug (same as triggers the super fast snad), in which EndeioIO updates the neighbors of the block it checks.
So we ignore the update instead of throwing and crashing