### PR TITLE
Tool property builder, magnetic stat

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -174,7 +174,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             behaviourTag.setInteger(AOE_LAYER_KEY, aoeDefinition.layer);
         }
 
-        if (material.hasFlag(MaterialFlags.IS_MAGNETIC)) {
+        if (toolProperty.isMagnetic()) {
             behaviourTag.setBoolean(RELOCATE_MINED_BLOCKS_KEY, true);
         }
 

--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
@@ -146,8 +146,9 @@ public class CTMaterialBuilder {
     }
 
     @ZenMethod
-    public CTMaterialBuilder toolStats(float speed, float damage, int durability, int harvestLevel) {
-        backingBuilder.toolStats(ToolProperty.Builder.of(speed, damage, durability, harvestLevel).build());
+    public CTMaterialBuilder toolStats(float speed, float damage, int durability, int harvestLevel, @Optional int enchantability) {
+        if (enchantability == 0) enchantability = 10;
+        backingBuilder.toolStats(ToolProperty.Builder.of(speed, damage, durability, harvestLevel).enchantability(enchantability).build());
         return this;
     }
     @ZenMethod

--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialBuilder.java
@@ -10,6 +10,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.info.MaterialFlag;
 import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.material.properties.BlastProperty;
+import gregtech.api.unification.material.properties.ToolProperty;
 import gregtech.api.unification.stack.MaterialStack;
 import net.minecraft.enchantment.Enchantment;
 import stanhebben.zenscript.annotations.Optional;
@@ -145,11 +146,8 @@ public class CTMaterialBuilder {
     }
 
     @ZenMethod
-    public CTMaterialBuilder toolStats(float speed, float damage, int durability, @Optional int enchantability) {
-        if (enchantability == 0) {
-            enchantability = 21; // Lowest enchantability by default
-        }
-        backingBuilder.toolStats(speed, damage, durability, enchantability);
+    public CTMaterialBuilder toolStats(float speed, float damage, int durability, int harvestLevel) {
+        backingBuilder.toolStats(ToolProperty.Builder.of(speed, damage, durability, harvestLevel).build());
         return this;
     }
     @ZenMethod

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
@@ -187,7 +187,7 @@ public class MaterialPropertyExpansion {
     }
 
     @ZenMethod
-    public static void addTools(Material m, float toolSpeed, float toolAttackDamage, float toolAttackSpeed, int toolDurability, @Optional int toolHarvestLevel, @Optional int toolEnchantability, @Optional boolean shouldIgnoreCraftingTools) {
+    public static void addTools(Material m, float toolSpeed, float toolAttackDamage, float toolAttackSpeed, int toolDurability, @Optional int toolHarvestLevel, @Optional int toolEnchantability) {
         if (checkFrozen("add Tools to a material")) return;
         if (toolEnchantability == 0) toolEnchantability = 10;
         if (m.hasProperty(PropertyKey.TOOL)) {
@@ -197,8 +197,8 @@ public class MaterialPropertyExpansion {
             m.getProperty(PropertyKey.TOOL).setToolDurability(toolDurability);
             m.getProperty(PropertyKey.TOOL).setToolHarvestLevel(toolHarvestLevel);
             m.getProperty(PropertyKey.TOOL).setToolEnchantability(toolEnchantability);
-            m.getProperty(PropertyKey.TOOL).setShouldIgnoreCraftingTools(shouldIgnoreCraftingTools);
-        } else m.setProperty(PropertyKey.TOOL, new ToolProperty(toolSpeed, toolAttackDamage, toolAttackSpeed, toolDurability, toolHarvestLevel, toolEnchantability, shouldIgnoreCraftingTools));
+        } else m.setProperty(PropertyKey.TOOL, ToolProperty.Builder.of(toolSpeed, toolAttackDamage, toolDurability, toolHarvestLevel)
+                .attackSpeed(toolAttackSpeed).enchantability(toolEnchantability).build());
     }
 
     @ZenMethod

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -718,20 +718,12 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        public Builder toolStats(float speed, float damage, int durability, int harvestLevel) {
-            return toolStats(speed, damage, 0.0F, durability, harvestLevel, 22, false);
-        }
-
-        public Builder toolStats(float speed, float damage, int durability, int harvestLevel, int enchantability) {
-            return toolStats(speed, damage, 0.0F, durability, harvestLevel, enchantability, false);
-        }
-
-        public Builder toolStats(float speed, float damage, float attackSpeed, int durability, int harvestLevel, int enchantability) {
-            return toolStats(speed, damage, attackSpeed, durability, harvestLevel, enchantability, false);
-        }
-
-        public Builder toolStats(float speed, float damage, float attackSpeed, int durability, int harvestLevel, int enchantability, boolean ignoreCraftingTools) {
-            properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, attackSpeed, durability, harvestLevel, enchantability, ignoreCraftingTools));
+        /**
+         * Replaced the old toolStats methods which took many parameters.
+         * Use {@link ToolProperty.Builder} instead to create a Tool Property.
+         */
+        public Builder toolStats(ToolProperty toolProperty) {
+            properties.setProperty(PropertyKey.TOOL, toolProperty);
             return this;
         }
 
@@ -873,6 +865,8 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        // TODO Clean this up post 2.5 release
+        @Deprecated
         public Builder addDefaultEnchant(Enchantment enchant, int level) {
             if (!properties.hasProperty(PropertyKey.TOOL)) // cannot assign default here
                 throw new IllegalArgumentException("Material cannot have an Enchant without Tools!");

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -5,6 +5,7 @@ import gregtech.api.fluids.fluidType.FluidTypes;
 import gregtech.api.unification.Elements;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
+import gregtech.api.unification.material.properties.ToolProperty;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
@@ -24,7 +25,8 @@ public class ElementMaterials {
                 .color(0x80C8F0)
                 .flags(EXT2_METAL, GENERATE_GEAR, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE)
                 .element(Elements.Al)
-                .toolStats(6.0f, 7.5f, 768, 2, 14)
+                .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
+                        .enchantability(14).build())
                 .rotorStats(10.0f, 2.0f, 128)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
@@ -342,7 +344,8 @@ public class ElementMaterials {
                 .color(0xC8C8C8).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_GEAR, GENERATE_SPRING_SMALL, GENERATE_SPRING, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, BLAST_FURNACE_CALCITE_TRIPLE)
                 .element(Elements.Fe)
-                .toolStats(2.0f, 2.0f, 256, 2, 14)
+                .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 256, 2)
+                        .enchantability(14).build())
                 .rotorStats(7.0f, 2.5f, 256)
                 .cableProperties(GTValues.V[2], 2, 3)
                 .fluidTemp(1811)
@@ -750,7 +753,8 @@ public class ElementMaterials {
                 .color(0xDCA0F0).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_GEAR, GENERATE_FRAME)
                 .element(Elements.Ti)
-                .toolStats(8.0f, 6.0f, 1536, 3, 14)
+                .toolStats(ToolProperty.Builder.of(8.0F, 6.0F, 1536, 3)
+                        .enchantability(14).build())
                 .rotorStats(7.0f, 3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
                 .blastTemp(1941, GasTier.MID, VA[HV], 1500)
@@ -860,7 +864,8 @@ public class ElementMaterials {
                 .color(0xFAFAFA)
                 .flags(EXT_METAL, GENERATE_BOLT_SCREW, GENERATE_FRAME)
                 .element(Elements.Nt)
-                .toolStats(180.0f, 100.0f, 0.5f, 65535, 6, 33)
+                .toolStats(ToolProperty.Builder.of(180.0F, 100.0F, 65535, 6)
+                        .attackSpeed(0.5F).enchantability(33).magnetic().unbreakable().build())
                 .rotorStats(24.0f, 12.0f, 655360)
                 .fluidPipeProperties(100_000, 5000, true, true, true, true)
                 .fluidTemp(100_000)
@@ -881,7 +886,8 @@ public class ElementMaterials {
                 .color(0x4BAFAF).iconSet(BRIGHT)
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_GEAR)
                 .element(Elements.Dr)
-                .toolStats(14.0f, 12.0f, 0.3f, 8192, 5, 33)
+                .toolStats(ToolProperty.Builder.of(14.0F, 12.0F, 8192, 5)
+                        .attackSpeed(0.3F).enchantability(33).magnetic().build())
                 .fluidPipeProperties(9625, 500, true, true, true, true)
                 .fluidTemp(7500)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -5,6 +5,7 @@ import gregtech.api.fluids.fluidType.FluidTypes;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import gregtech.api.unification.material.properties.PropertyKey;
+import gregtech.api.unification.material.properties.ToolProperty;
 import net.minecraft.init.Enchantments;
 
 import static gregtech.api.GTValues.*;
@@ -93,7 +94,8 @@ public class FirstDegreeMaterials {
                 .color(0xFF8000).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_FRAME, GENERATE_SMALL_GEAR, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Tin, 1, Copper, 3)
-                .toolStats(3.0f, 2.0f, 192, 2, 18)
+                .toolStats(ToolProperty.Builder.of(3.0F, 2.0F, 192, 2)
+                        .enchantability(18).build())
                 .rotorStats(6.0f, 2.5f, 192)
                 .fluidPipeProperties(1696, 20, true)
                 .fluidTemp(1357)
@@ -208,7 +210,8 @@ public class FirstDegreeMaterials {
                 .flags(GENERATE_BOLT_SCREW, GENERATE_LENS, GENERATE_GEAR, NO_SMASHING, NO_SMELTING,
                         HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .components(Carbon, 1)
-                .toolStats(6.0f, 7.0f, 0.1f, 768, 3, 18)
+                .toolStats(ToolProperty.Builder.of(6.0F, 7.0F, 768, 3)
+                        .attackSpeed(0.1F).enchantability(18).build())
                 .build();
 
         Electrum = new Material.Builder(277, "electrum")
@@ -288,10 +291,11 @@ public class FirstDegreeMaterials {
                 .color(0xB4B478).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FRAME, GENERATE_GEAR)
                 .components(Iron, 2, Nickel, 1)
-                .toolStats(4.0f, 3.0f, 384, 2, 18)
+                .toolStats(ToolProperty.Builder.of(4.0F, 3.0F, 384, 2)
+                        .enchantability(18)
+                        .enchantment(Enchantments.BANE_OF_ARTHROPODS, 3)
+                        .enchantment(Enchantments.EFFICIENCY, 1).build())
                 .rotorStats(7.0f, 3.0f, 512)
-                .addDefaultEnchant(Enchantments.BANE_OF_ARTHROPODS, 3)
-                .addDefaultEnchant(Enchantments.EFFICIENCY, 1)
                 .fluidTemp(1916)
                 .build();
 
@@ -396,8 +400,9 @@ public class FirstDegreeMaterials {
                 .color(0xFADCE1).iconSet(SHINY)
                 .flags(EXT2_METAL)
                 .components(Copper, 1, Silver, 4)
-                .toolStats(3.0f, 8.0f, 0.3f, 768, 2, 33)
-                .addDefaultEnchant(Enchantments.SMITE, 3)
+                .toolStats(ToolProperty.Builder.of(3.0F, 8.0F, 768, 2)
+                        .attackSpeed(0.3F).enchantability(33)
+                        .enchantment(Enchantments.SMITE, 3).build())
                 .rotorStats(13.0f, 2.0f, 196)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1700, GasTier.LOW, VA[MV], 1000)
@@ -409,9 +414,10 @@ public class FirstDegreeMaterials {
                 .color(0xFFE61E).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_RING)
                 .components(Copper, 1, Gold, 4)
-                .toolStats(12.0f, 2.0f, 768, 2, 33)
+                .toolStats(ToolProperty.Builder.of(12.0F, 2.0F, 768, 2)
+                        .enchantability(33)
+                        .enchantment(Enchantments.FORTUNE, 2).build())
                 .rotorStats(14.0f, 2.0f, 152)
-                .addDefaultEnchant(Enchantments.FORTUNE, 2)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1600, GasTier.LOW, VA[MV], 1000)
                 .fluidTemp(1341)
@@ -571,7 +577,8 @@ public class FirstDegreeMaterials {
                 .color(0xC8C8DC).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_LONG_ROD, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Iron, 6, Chrome, 1, Manganese, 1, Nickel, 1)
-                .toolStats(7.0f, 5.0f, 1024, 3, 14)
+                .toolStats(ToolProperty.Builder.of(7.0F, 5.0F, 1024, 3)
+                        .enchantability(14).build())
                 .rotorStats(7.0f, 4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
                 .blastTemp(1700, GasTier.LOW, VA[HV], 1100)
@@ -584,7 +591,8 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_SPRING,
                         GENERATE_SPRING_SMALL, GENERATE_FRAME, DISABLE_DECOMPOSITION, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Iron, 1)
-                .toolStats(5.0f, 3.0f, 512, 3, 14)
+                .toolStats(ToolProperty.Builder.of(5.0F, 3.0F, 512, 3)
+                        .enchantability(14).build())
                 .rotorStats(6.0f, 3.0f, 512)
                 .fluidPipeProperties(1855, 75, true)
                 .cableProperties(GTValues.V[4], 2, 2)
@@ -636,7 +644,8 @@ public class FirstDegreeMaterials {
                 .color(0xB4B4E6).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_GEAR)
                 .components(Cobalt, 5, Chrome, 2, Nickel, 1, Molybdenum, 1)
-                .toolStats(10.0f, 7.0f, 0.1f, 2048, 4, 21)
+                .toolStats(ToolProperty.Builder.of(10.0F, 7.0F, 2048, 4)
+                        .attackSpeed(0.1F).enchantability(21).build())
                 .rotorStats(9.0f, 4.0f, 2048)
                 .itemPipeProperties(128, 16)
                 .blastTemp(2700, GasTier.MID, VA[HV], 1300)
@@ -672,7 +681,8 @@ public class FirstDegreeMaterials {
                 .color(0xC8B4B4).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_GEAR, GENERATE_FOIL, MORTAR_GRINDABLE, GENERATE_RING, GENERATE_LONG_ROD, GENERATE_BOLT_SCREW, DISABLE_DECOMPOSITION, BLAST_FURNACE_CALCITE_TRIPLE)
                 .components(Iron, 1)
-                .toolStats(2.0f, 2.0f, -0.2f, 384, 2, 5)
+                .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 384, 2)
+                        .attackSpeed(-0.2F).enchantability(5).build())
                 .rotorStats(6.0f, 3.5f, 384)
                 .fluidTemp(2011)
                 .build();
@@ -1060,7 +1070,8 @@ public class FirstDegreeMaterials {
                 .color(0x330066).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_GEAR, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Tungsten, 1, Carbon, 1)
-                .toolStats(60.0f, 2.0f, 1024, 4, 21)
+                .toolStats(ToolProperty.Builder.of(60.0F, 2.0F, 1024, 4)
+                        .enchantability(21).build())
                 .rotorStats(12.0f, 4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
                 .blastTemp(3058, GasTier.MID, VA[HV], 1500)

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -3,6 +3,7 @@ package gregtech.api.unification.material.materials;
 import gregtech.api.GTValues;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
+import gregtech.api.unification.material.properties.ToolProperty;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
@@ -37,7 +38,8 @@ public class HigherDegreeMaterials {
                 .color(0x8C6464).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_GEAR)
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
-                .toolStats(7.0f, 6.0f, 0.1f, 2560, 3, 21)
+                .toolStats(ToolProperty.Builder.of(7.0F, 6.0F, 2560, 3)
+                        .attackSpeed(0.1F).enchantability(21).build())
                 .blastTemp(1300, GasTier.LOW, VA[HV], 1000)
                 .build();
 
@@ -46,7 +48,8 @@ public class HigherDegreeMaterials {
                 .color(0x64648C).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FRAME, GENERATE_GEAR)
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
-                .toolStats(15.0f, 6.0f, 0.1f, 1024, 3, 33)
+                .toolStats(ToolProperty.Builder.of(15.0F, 6.0F, 1024, 3)
+                        .attackSpeed(0.1F).enchantability(33).build())
                 .blastTemp(1400, GasTier.LOW, VA[HV], 1000)
                 .build();
 
@@ -109,7 +112,8 @@ public class HigherDegreeMaterials {
                 .color(0x336600).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING)
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
-                .toolStats(5.0f, 10.0f, 0.3f, 3072, 4, 33)
+                .toolStats(ToolProperty.Builder.of(5.0F, 10.0F, 3072, 4)
+                        .attackSpeed(0.3F).enchantability(33).build())
                 .rotorStats(10.0f, 8.0f, 5120)
                 .blastTemp(5000, GasTier.HIGH, VA[EV], 1400)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
+++ b/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
@@ -2,7 +2,6 @@ package gregtech.api.unification.material.materials;
 
 import gregtech.api.unification.material.properties.OreProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
-import gregtech.api.unification.material.properties.ToolProperty;
 
 import static gregtech.api.unification.material.Materials.*;
 
@@ -405,8 +404,5 @@ public class MaterialFlagAddition {
 
         oreProp = Pyrochlore.getProperty(PropertyKey.ORE);
         oreProp.setOreByProducts(Apatite, Calcium, Niobium);
-
-        ToolProperty toolProp = Neutronium.getProperty(PropertyKey.TOOL);
-        toolProp.setUnbreakable(true);
     }
 }

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -5,6 +5,7 @@ import gregtech.api.fluids.fluidType.FluidTypes;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import gregtech.api.unification.material.properties.PropertyKey;
+import gregtech.api.unification.material.properties.ToolProperty;
 import net.minecraft.init.Enchantments;
 
 import static gregtech.api.GTValues.*;
@@ -103,9 +104,10 @@ public class SecondDegreeMaterials {
                 .color(0x6E6E6E).iconSet(METALLIC)
                 .flags(EXT_METAL)
                 .components(Steel, 1)
-                .toolStats(6.0f, 4.0f, 0.3f, 1024, 3, 33)
-                .addDefaultEnchant(Enchantments.LOOTING, 3)
-                .addDefaultEnchant(Enchantments.FORTUNE, 3)
+                .toolStats(ToolProperty.Builder.of(6.0F, 4.0F, 1024, 3)
+                        .attackSpeed(0.3F).enchantability(33)
+                        .enchantment(Enchantments.LOOTING, 3)
+                        .enchantment(Enchantments.FORTUNE, 3).build())
                 .blastTemp(1500, GasTier.LOW)
                 .build();
 
@@ -114,7 +116,8 @@ public class SecondDegreeMaterials {
                 .color(0x6464A0).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_DENSE, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Steel, 1, Tungsten, 1)
-                .toolStats(9.0f, 7.0f, 2048, 4, 14)
+                .toolStats(ToolProperty.Builder.of(9.0F, 7.0F, 2048, 4)
+                        .enchantability(14).build())
                 .rotorStats(8.0f, 4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
                 .cableProperties(GTValues.V[5], 3, 2)
@@ -126,7 +129,8 @@ public class SecondDegreeMaterials {
                 .color(0xB4B4A0).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_GEAR)
                 .components(Brass, 7, Aluminium, 1, Cobalt, 1)
-                .toolStats(2.5f, 2.0f, -0.2f, 1024, 2, 5)
+                .toolStats(ToolProperty.Builder.of(2.5F, 2.0F, 1024, 2)
+                        .attackSpeed(-0.2F).enchantability(5).build())
                 .rotorStats(8.0f, 2.0f, 256)
                 .itemPipeProperties(2048, 1)
                 .fluidTemp(1202)
@@ -276,7 +280,8 @@ public class SecondDegreeMaterials {
                 .color(0xc0c0c0).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Vanadium, 1, Chrome, 1, Steel, 7)
-                .toolStats(3.0f, 3.0f, -0.2f, 1536, 3, 5)
+                .toolStats(ToolProperty.Builder.of(3.0F, 3.0F, 1536, 3)
+                        .attackSpeed(-0.2F).enchantability(5).build())
                 .rotorStats(7.0f, 3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
                 .blastTemp(1453, GasTier.LOW)
@@ -316,7 +321,8 @@ public class SecondDegreeMaterials {
                 .color(0x282828).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_SPRING, GENERATE_RING, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_DENSE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(Naquadah, 2, Osmiridium, 1, Trinium, 1)
-                .toolStats(40.0f, 12.0f, 0.3f, 3072, 5, 33)
+                .toolStats(ToolProperty.Builder.of(40.0F, 12.0F, 3072, 5)
+                        .attackSpeed(0.3F).enchantability(33).magnetic().build())
                 .rotorStats(8.0f, 5.0f, 5120)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, VA[LuV], 1000)
@@ -366,8 +372,9 @@ public class SecondDegreeMaterials {
                 .color(0x002040).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
-                .toolStats(0.0f, 1.0f, 0.0f, 64, 1, 5, true)
-                .addDefaultEnchant(Enchantments.FIRE_ASPECT, 2)
+                .toolStats(ToolProperty.Builder.of(0.0F, 1.0F, 64, 1)
+                        .enchantability(5).ignoreCraftingTools()
+                        .enchantment(Enchantments.FIRE_ASPECT, 2).build())
                 .build();
 
         Air = new Material.Builder(2050, "air")

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -7,46 +7,46 @@ import net.minecraft.enchantment.Enchantment;
 public class ToolProperty implements IMaterialProperty<ToolProperty> {
 
     /**
-     * Speed of tools made from this Material.
+     * Harvest speed of tools made from this Material.
      * <p>
      * Default: 1.0F
      */
-    private float toolSpeed;
+    private float harvestSpeed;
 
     /**
      * Attack damage of tools made from this Material
      * <p>
      * Default: 1.0F
      */
-    private float toolAttackDamage;
+    private float attackDamage;
 
     /**
      * Attack speed of tools made from this Material
      * <p>
      * Default: 0.0F
      */
-    private float toolAttackSpeed;
+    private float attackSpeed;
 
     /**
      * Durability of tools made from this Material.
      * <p>
      * Default: 100
      */
-    private int toolDurability;
+    private int durability;
 
     /**
      * Harvest level of tools made of this Material.
      * <p>
      * Default: 2 (Iron).
      */
-    private int toolHarvestLevel;
+    private int harvestLevel;
 
     /**
      * Enchantability of tools made from this Material.
      * <p>
      * Default: 10
      */
-    private int toolEnchantability;
+    private int enchantability = 10;
 
     /**
      * If crafting tools should not be made from this material
@@ -54,86 +54,78 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     private boolean ignoreCraftingTools;
 
     /**
-     * If tools of made this material should be unbreakable and ignore durability checks.
+     * If tools made of this material should be unbreakable and ignore durability checks.
      */
     private boolean isUnbreakable;
 
     /**
+     * If tools made of this material should be "magnetic," meaning items go
+     * directly into the player's inventory instead of dropping on the ground.
+     */
+    private boolean isMagnetic;
+
+    /**
      * Enchantment to be applied to tools made from this Material.
-     * <p>
-     * Default: none.
      */
     private final Object2IntMap<Enchantment> enchantments = new Object2IntArrayMap<>();
 
-    public ToolProperty(float toolSpeed, float toolAttackDamage, float toolAttackSpeed, int toolDurability, int toolHarvestLevel, int toolEnchantability, boolean ignoreCraftingTools) {
-        this.toolSpeed = toolSpeed;
-        this.toolAttackDamage = toolAttackDamage;
-        this.toolAttackSpeed = toolAttackSpeed;
-        this.toolDurability = toolDurability;
-        this.toolHarvestLevel = toolHarvestLevel;
-        this.toolEnchantability = toolEnchantability;
-        this.ignoreCraftingTools = ignoreCraftingTools;
+    public ToolProperty(float harvestSpeed, float attackDamage, int durability, int harvestLevel) {
+        this.harvestSpeed = harvestSpeed;
+        this.attackDamage = attackDamage;
+        this.durability = durability;
+        this.harvestLevel = harvestLevel;
     }
 
-    /**
-     * Default values constructor.
-     */
     public ToolProperty() {
-        this(1.0f, 1.0f, 0.0f, 100, 2, 10, false);
+        this(1.0F, 1.0F, 100, 2);
     }
 
     public float getToolSpeed() {
-        return toolSpeed;
+        return harvestSpeed;
     }
 
     public void setToolSpeed(float toolSpeed) {
-        if (toolSpeed <= 0) throw new IllegalArgumentException("Tool Speed must be greater than zero!");
-        this.toolSpeed = toolSpeed;
+        this.harvestSpeed = toolSpeed;
     }
 
     public float getToolAttackDamage() {
-        return toolAttackDamage;
+        return attackDamage;
     }
 
     public void setToolAttackDamage(float toolAttackDamage) {
-        if (toolAttackDamage <= 0) throw new IllegalArgumentException("Tool Attack Damage must be greater than zero!");
-        this.toolAttackDamage = toolAttackDamage;
+        this.attackDamage = toolAttackDamage;
     }
 
     public float getToolAttackSpeed() {
-        return toolAttackSpeed;
+        return attackSpeed;
     }
 
     public void setToolAttackSpeed(float toolAttackSpeed) {
-        if (toolAttackSpeed <= 0) throw new IllegalArgumentException("Tool Attack Speed must be greater than zero!");
-        this.toolAttackSpeed = toolAttackSpeed;
+        this.attackSpeed = toolAttackSpeed;
     }
 
     public int getToolDurability() {
-        return toolDurability;
+        return durability;
     }
 
     public void setToolDurability(int toolDurability) {
-        if (toolDurability <= 0) throw new IllegalArgumentException("Tool Durability must be greater than zero!");
-        this.toolDurability = toolDurability;
+        this.durability = toolDurability;
     }
 
     public int getToolHarvestLevel() {
-        return this.toolHarvestLevel;
+        return this.harvestLevel;
     }
 
     public void setToolHarvestLevel(int toolHarvestLevel) {
-        if (toolHarvestLevel < 0) throw new IllegalArgumentException("Tool Harvest level must be greater than or equal to zero!");
-        this.toolHarvestLevel = toolHarvestLevel;
+        this.harvestLevel = toolHarvestLevel;
     }
 
     public int getToolEnchantability() {
-        return toolEnchantability;
+        return enchantability;
     }
 
     public void setToolEnchantability(int toolEnchantability) {
-        if (toolEnchantability <= 0) throw new IllegalArgumentException("Tool Enchantability must be greater than zero!");
-        this.toolEnchantability = toolEnchantability;
+        this.enchantability = toolEnchantability;
     }
 
     public boolean getShouldIgnoreCraftingTools() {
@@ -156,6 +148,14 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
         return enchantments;
     }
 
+    public void setMagnetic(boolean isMagnetic) {
+        this.isMagnetic = isMagnetic;
+    }
+
+    public boolean isMagnetic() {
+        return isMagnetic;
+    }
+
     @Override
     public void verifyProperty(MaterialProperties properties) {
         if (!properties.hasProperty(PropertyKey.GEM)) properties.ensureSet(PropertyKey.INGOT, true);
@@ -163,5 +163,52 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
 
     public void addEnchantmentForTools(Enchantment enchantment, int level) {
         enchantments.put(enchantment, level);
+    }
+
+    public static class Builder {
+
+        private final ToolProperty toolProperty;
+
+        public static Builder of(float harvestSpeed, float attackDamage, int durability, int harvestLevel) {
+            return new Builder(harvestSpeed, attackDamage, durability, harvestLevel);
+        }
+
+        private Builder(float harvestSpeed, float attackDamage, int durability, int harvestLevel) {
+            toolProperty = new ToolProperty(harvestSpeed, attackDamage, durability, harvestLevel);
+        }
+
+        public Builder enchantability(int enchantability) {
+            toolProperty.setToolEnchantability(enchantability);
+            return this;
+        }
+
+        public Builder attackSpeed(float attackSpeed) {
+            toolProperty.setToolAttackSpeed(attackSpeed);
+            return this;
+        }
+
+        public Builder ignoreCraftingTools() {
+            toolProperty.setShouldIgnoreCraftingTools(true);
+            return this;
+        }
+
+        public Builder unbreakable() {
+            toolProperty.setUnbreakable(true);
+            return this;
+        }
+
+        public Builder enchantment(Enchantment enchantment, int level) {
+            toolProperty.addEnchantmentForTools(enchantment, level);
+            return this;
+        }
+
+        public Builder magnetic() {
+            toolProperty.setMagnetic(true);
+            return this;
+        }
+
+        public ToolProperty build() {
+            return toolProperty;
+        }
     }
 }


### PR DESCRIPTION
- Reworks `toolStats` method on material builder to take a ToolProperty, and creates a Builder object for tool properties. Done because the number of fields for that property was getting out of hand. Eventually I want to do this for more things (ores, components at least) and try to reduce extraneous methods that apply to specific properties, and instead do them in builders like this, though that can wait for post-2.5
- Adds the magnetic property to Neutronium, Duranium, and Naquadah Alloy, as per our design spec (Magnetic Neodymium not yet completed)