### PR TITLE
Prevent decomposition of acids for hydrogen production

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -1104,17 +1104,20 @@ public class FirstDegreeMaterials {
         NitricAcid = new Material.Builder(401, "nitric_acid")
                 .fluid(FluidTypes.ACID)
                 .color(0xCCCC00)
+                .flags(DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 1, Nitrogen, 1, Oxygen, 3)
                 .build();
 
         SulfuricAcid = new Material.Builder(402, "sulfuric_acid")
                 .fluid(FluidTypes.ACID)
+                .flags(DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 2, Sulfur, 1, Oxygen, 4)
                 .build();
 
         PhosphoricAcid = new Material.Builder(403, "phosphoric_acid")
                 .fluid(FluidTypes.ACID)
                 .color(0xDCDC01)
+                .flags(DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 3, Phosphorus, 1, Oxygen, 4)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -404,7 +404,7 @@ public class OrganicChemistryMaterials {
                 .build();
 
         PhthalicAcid = new Material.Builder(1057, "phthalic_acid")
-                .fluid(FluidTypes.ACID, true)
+                .fluid(FluidTypes.ACID)
                 .color(0xD1D1D1)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 8, Hydrogen, 6, Oxygen, 4)


### PR DESCRIPTION
## What
This PR prevents decomposition of a few acids, which would allow for very easy production of hydrogen outside of the intended routes. The other acids left untouched, such as Hydrochloric or Hydrofluoric Acid, do not exhibit this behavior, so they can still be decomposed.

## Outcome
Prevent decomposition of acids for hydrogen production.
