### PR TITLE
fix default tool material when no material is specified

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -202,7 +202,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         String string = toolTag.getString(MATERIAL_KEY);
         Material material = GregTechAPI.MaterialRegistry.get(string);
         if (material == null) {
-            toolTag.setString(MATERIAL_KEY, (material = Materials.Neutronium).toString());
+            toolTag.setString(MATERIAL_KEY, (material = Materials.Iron).toString());
         }
         return material;
     }


### PR DESCRIPTION
Fix tools appearing as Neutronium when tools are used in CT recipes (changed to Iron, like our other defaults)