### PR TITLE
Allow Groovyscript to use multiplication for MaterialStacks

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -310,8 +310,9 @@ public class Material implements Comparable<Material> {
         return materialInfo.metaItemSubId;
     }
 
+    // must be named multiply for GroovyScript to allow `mat * quantity -> MaterialStack`
     @ZenOperator(OperatorType.MUL)
-    public MaterialStack createMaterialStack(long amount) {
+    public MaterialStack multiply(long amount) {
         return new MaterialStack(this, amount);
     }
 
@@ -681,6 +682,11 @@ public class Material implements Comparable<Material> {
                         (Integer) components[i + 1]
                 ));
             }
+            return this;
+        }
+
+        public Builder components(MaterialStack... components) {
+            composition = Arrays.asList(components);
             return this;
         }
 

--- a/src/main/java/gregtech/integration/jei/GTOreInfo.java
+++ b/src/main/java/gregtech/integration/jei/GTOreInfo.java
@@ -36,7 +36,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 
-import static gregtech.api.GTValues.*;
+import static gregtech.api.GTValues.M;
+import static gregtech.api.GTValues.MODID_CC;
 
 public class GTOreInfo implements IRecipeWrapper {
 
@@ -228,7 +229,7 @@ public class GTOreInfo implements IRecipeWrapper {
         if (veinPopulator instanceof SurfaceRockPopulator) {
             mat = ((SurfaceRockPopulator) veinPopulator).getMaterial();
             // Create a Tiny Dust for the Identifier.
-            stack = OreDictUnifier.getDust(mat.createMaterialStack(M / 9));
+            stack = OreDictUnifier.getDust(mat.multiply(M / 9));
             return stack.isEmpty() ? new ItemStack(Items.AIR) : stack;
         }
         // Surface Block support


### PR DESCRIPTION
## What
This PR allows Groovyscript to use multiplication in order to create MaterialStacks, in the same way we already allow CraftTweaker. An example of this in Groovy would be `material("copper") * 5` for a MaterialStack of 5 Copper.

This PR also adds another method to the MaterialBuilder, which will allow groovy (and other addons) to more easily register materials using material stacks, instead of alternating materials and numbers as varargs.

## Implementation Details
The method GrS looks for must be called `multiply`, so the method intended for CT was simply renamed. CT compat is still maintained, due to the annotation.

## Outcome
Allows Groovyscript to create MaterialStacks with multiplication.

