### PR TITLE
Fixes #1416 with new lathe recipes for stone rods

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -377,6 +377,21 @@ public class VanillaStandardRecipes {
                 .duration(50).EUt(VA[ULV])
                 .buildAndRegister();
 
+        if (ConfigHolder.recipes.harderRods) {
+            LATHE_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.COBBLESTONE))
+                    .output(OrePrefix.stick, Materials.Stone, 1)
+                    .output(dustSmall, Stone, 2)
+                    .duration(20).EUt(VA[ULV])
+                    .buildAndRegister();
+        } else {
+            LATHE_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.COBBLESTONE))
+                    .output(OrePrefix.stick, Materials.Stone, 2)
+                    .duration(20).EUt(VA[ULV])
+                    .buildAndRegister();
+        }
+
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plank, Wood, 6)
                 .inputs(new ItemStack(Items.BOOK, 3))

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -377,21 +377,6 @@ public class VanillaStandardRecipes {
                 .duration(50).EUt(VA[ULV])
                 .buildAndRegister();
 
-        if (ConfigHolder.recipes.harderRods) {
-            LATHE_RECIPES.recipeBuilder()
-                    .inputs(new ItemStack(Blocks.COBBLESTONE))
-                    .output(OrePrefix.stick, Materials.Stone, 1)
-                    .output(dustSmall, Stone, 2)
-                    .duration(20).EUt(VA[ULV])
-                    .buildAndRegister();
-        } else {
-            LATHE_RECIPES.recipeBuilder()
-                    .inputs(new ItemStack(Blocks.COBBLESTONE))
-                    .output(OrePrefix.stick, Materials.Stone, 2)
-                    .duration(20).EUt(VA[ULV])
-                    .buildAndRegister();
-        }
-
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plank, Wood, 6)
                 .inputs(new ItemStack(Items.BOOK, 3))
@@ -1188,6 +1173,32 @@ public class VanillaStandardRecipes {
                 .inputs(new ItemStack(Items.SLIME_BALL, 9))
                 .outputs(new ItemStack(Blocks.SLIME_BLOCK))
                 .duration(300).EUt(2).buildAndRegister();
+
+        if (ConfigHolder.recipes.harderRods) {
+            LATHE_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.COBBLESTONE))
+                    .output(OrePrefix.stick, Materials.Stone, 1)
+                    .output(dustSmall, Stone, 2)
+                    .duration(20).EUt(VA[ULV])
+                    .buildAndRegister();
+            LATHE_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.STONE))
+                    .output(OrePrefix.stick, Materials.Stone, 1)
+                    .output(dustSmall, Stone, 2)
+                    .duration(20).EUt(VA[ULV])
+                    .buildAndRegister();
+        } else {
+            LATHE_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.COBBLESTONE))
+                    .output(OrePrefix.stick, Materials.Stone, 2)
+                    .duration(20).EUt(VA[ULV])
+                    .buildAndRegister();
+            LATHE_RECIPES.recipeBuilder()
+                    .inputs(new ItemStack(Blocks.STONE))
+                    .output(OrePrefix.stick, Materials.Stone, 2)
+                    .duration(20).EUt(VA[ULV])
+                    .buildAndRegister();
+        }
 
         PACKER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.NETHER_WART, 9))


### PR DESCRIPTION
## Outcome
Fixes: #1416 (No recipe for stone rod)
The harder rod setting is also implemented for this recipe.
In addition, the lathe recipe accepts both cobblestone and stone as input.

## Potential Compatibility Issues
This should not cause any compatibility issues.
