### PR TITLE
Add a config option to disable blinking tooltips

### DIFF
--- a/src/main/java/gregtech/client/utils/TooltipHelper.java
+++ b/src/main/java/gregtech/client/utils/TooltipHelper.java
@@ -1,6 +1,7 @@
 package gregtech.client.utils;
 
 import gregtech.api.util.GTLog;
+import gregtech.common.ConfigHolder;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import org.lwjgl.input.Keyboard;
@@ -43,7 +44,7 @@ public class TooltipHelper {
      * @param codes The codes, in order, that this formatting code should oscillate through. MUST be at least 2.
      */
     public static GTFormatCode createNewCode(int rate, TextFormatting... codes) {
-        if (rate <= 0) {
+        if (rate <= 0 && !ConfigHolder.client.blinkingTooltips) {
             GTLog.logger.error("Could not create GT Format Code with rate {}, must be greater than zero!", rate);
             return null;
         }
@@ -57,7 +58,7 @@ public class TooltipHelper {
     }
 
     public static void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.phase == TickEvent.Phase.END) {
+        if (ConfigHolder.client.blinkingTooltips && event.phase == TickEvent.Phase.END) {
             CODES.forEach(GTFormatCode::updateIndex);
         }
     }

--- a/src/main/java/gregtech/client/utils/TooltipHelper.java
+++ b/src/main/java/gregtech/client/utils/TooltipHelper.java
@@ -44,7 +44,7 @@ public class TooltipHelper {
      * @param codes The codes, in order, that this formatting code should oscillate through. MUST be at least 2.
      */
     public static GTFormatCode createNewCode(int rate, TextFormatting... codes) {
-        if (rate <= 0 && !ConfigHolder.client.blinkingTooltips) {
+        if (rate <= 0) {
             GTLog.logger.error("Could not create GT Format Code with rate {}, must be greater than zero!", rate);
             return null;
         }
@@ -58,7 +58,7 @@ public class TooltipHelper {
     }
 
     public static void onClientTick(TickEvent.ClientTickEvent event) {
-        if (ConfigHolder.client.blinkingTooltips && event.phase == TickEvent.Phase.END) {
+        if (event.phase == TickEvent.Phase.END) {
             CODES.forEach(GTFormatCode::updateIndex);
         }
     }
@@ -83,7 +83,7 @@ public class TooltipHelper {
         }
 
         private void updateIndex() {
-            if (CLIENT_TIME % rate == 0) {
+            if (CLIENT_TIME % rate == 0 && !ConfigHolder.client.blinkingTooltips) {
                 if (index + 1 >= codes.length) index = 0;
                 else index++;
             }

--- a/src/main/java/gregtech/client/utils/TooltipHelper.java
+++ b/src/main/java/gregtech/client/utils/TooltipHelper.java
@@ -83,7 +83,7 @@ public class TooltipHelper {
         }
 
         private void updateIndex() {
-            if (CLIENT_TIME % rate == 0 && !ConfigHolder.client.blinkingTooltips) {
+            if (CLIENT_TIME % rate == 0 && !ConfigHolder.client.preventBlinkingTooltips) {
                 if (index + 1 >= codes.length) index = 0;
                 else index++;
             }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -321,6 +321,9 @@ public class ConfigHolder {
                 "13819135 (0xD2DCFF in decimal) is the classic blue from GT5 (default)."})
         public int defaultUIColor = 0xD2DCFF;
 
+        @Config.Comment("Whether some tooltips should be blinking for better visibility")
+        public boolean blinkingTooltips = true;
+
         public static class GuiConfig {
             @Config.Comment({"The scrolling speed of widgets", "Default: 13"})
             @Config.RangeInt(min = 1)

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -321,8 +321,8 @@ public class ConfigHolder {
                 "13819135 (0xD2DCFF in decimal) is the classic blue from GT5 (default)."})
         public int defaultUIColor = 0xD2DCFF;
 
-        @Config.Comment("Whether some tooltips should be blinking for better visibility")
-        public boolean blinkingTooltips = true;
+        @Config.Comment("Prevent tooltips from blinking for better visibility")
+        public boolean blinkingTooltips = false;
 
         public static class GuiConfig {
             @Config.Comment({"The scrolling speed of widgets", "Default: 13"})

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -322,7 +322,7 @@ public class ConfigHolder {
         public int defaultUIColor = 0xD2DCFF;
 
         @Config.Comment("Prevent tooltips from blinking for better visibility")
-        public boolean blinkingTooltips = false;
+        public boolean preventBlinkingTooltips = false;
 
         public static class GuiConfig {
             @Config.Comment({"The scrolling speed of widgets", "Default: 13"})


### PR DESCRIPTION
## What
Adds a config option to disable the blinking tooltips, as requested by some people on discord.


## Outcome
Adds a config option to disable the various blinking tooltips
