### PR TITLE
Copy NBT for GroovyScript removal recipes

### DIFF
--- a/src/main/java/gregtech/integration/GroovyScriptCompat.java
+++ b/src/main/java/gregtech/integration/GroovyScriptCompat.java
@@ -6,6 +6,7 @@ import com.cleanroommc.groovyscript.brackets.BracketHandlerManager;
 import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
+import crafttweaker.mc1120.data.NBTConverter;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.items.metaitem.MetaItem;
@@ -222,12 +223,12 @@ public class GroovyScriptCompat {
                 builder.append(")");
             }
 
-            /*if (itemStack.serializeNBT().hasKey("tag")) {
+            if (itemStack.serializeNBT().hasKey("tag")) {
                 String nbt = NBTConverter.from(itemStack.serializeNBT().getCompoundTag("tag"), false).toString();
                 if (nbt.length() > 0) {
                     builder.append(".withTag(").append(nbt).append(")");
                 }
-            }*/
+            }
         }
 
         if (recipeInput.getAmount() > 1) {

--- a/src/main/java/gregtech/integration/GroovyScriptCompat.java
+++ b/src/main/java/gregtech/integration/GroovyScriptCompat.java
@@ -5,8 +5,9 @@ import com.cleanroommc.groovyscript.api.GroovyLog;
 import com.cleanroommc.groovyscript.brackets.BracketHandlerManager;
 import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
 import com.cleanroommc.groovyscript.compat.mods.ModSupport;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.ingredient.NbtHelper;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
-import crafttweaker.mc1120.data.NBTConverter;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.items.metaitem.MetaItem;
@@ -169,11 +170,7 @@ public class GroovyScriptCompat {
         if (recipe.getFluidInputs().size() > 0) {
             builder.append("[");
             for (GTRecipeInput fluidIngredient : recipe.getFluidInputs()) {
-                // TODO update grs since the current version results in a crash when mekanism is not installed
-                //builder.append(IngredientHelper.asGroovyCode(fluidIngredient.getInputFluidStack(), false));
-                builder.append("fluid('")
-                        .append(fluidIngredient.getInputFluidStack().getFluid().getName())
-                        .append("')");
+                builder.append(IngredientHelper.asGroovyCode(fluidIngredient.getInputFluidStack(), false));
 
                 if (fluidIngredient.getAmount() > 1) {
                     builder.append(" * ")
@@ -211,23 +208,13 @@ public class GroovyScriptCompat {
         }
         if (itemStack != null) {
             if (itemId == null) {
-                // TODO update grs since the current version results in a crash when mekanism is not installed
-                //builder.append(IngredientHelper.asGroovyCode(itemStack, false, false));
-                builder.append("item('")
-                        .append(itemStack.getItem().getRegistryName())
-                        .append("'");
-                if (itemStack.getMetadata() != 0) {
-                    builder.append(", ")
-                            .append(itemStack.getMetadata());
-                }
-                builder.append(")");
+                builder.append(IngredientHelper.asGroovyCode(itemStack, false));
             }
 
-            if (itemStack.serializeNBT().hasKey("tag")) {
-                String nbt = NBTConverter.from(itemStack.serializeNBT().getCompoundTag("tag"), false).toString();
-                if (nbt.length() > 0) {
-                    builder.append(".withTag(").append(nbt).append(")");
-                }
+            if (itemStack.getTagCompound() != null) {
+                builder.append(".withNbt(")
+                        .append(NbtHelper.toGroovyCode(itemStack.getTagCompound(), false, false))
+                        .append(")");
             }
         }
 


### PR DESCRIPTION
## What
Ensures that item NBT is copied from recipe inputs when using the Creative mode recipe `X` button in JEI, so that recipe removal can actually work.

Not sure if this is the correct way to do this for GroovyScript Syntax.


## Outcome
Copy NBT for GroovyScript recipe removals
