### PR TITLE
stricter equals

### DIFF
--- a/src/main/java/gregtech/api/recipes/map/MapItemStackIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapItemStackIngredient.java
@@ -31,7 +31,7 @@ public class MapItemStackIngredient extends AbstractMapIngredient {
     public static Collection<AbstractMapIngredient> from(GTRecipeInput r) {
         ObjectArrayList<AbstractMapIngredient> list = new ObjectArrayList<>();
         for (ItemStack s : r.getInputStacks()) {
-            list.add(new MapItemStackIngredient(s,r));
+            list.add(new MapItemStackIngredient(s, r));
         }
         return list;
     }
@@ -40,7 +40,13 @@ public class MapItemStackIngredient extends AbstractMapIngredient {
     public boolean equals(Object o) {
         if (super.equals(o)) {
             MapItemStackIngredient other = (MapItemStackIngredient) o;
-            return other.gtRecipeInput.acceptsStack(this.stack);
+            if (this.stack.getItem() != other.stack.getItem()) {
+                return false;
+            }
+            if (this.meta != other.meta) {
+                return false;
+            }
+            return ItemStack.areItemStackTagsEqual(this.stack, other.stack);
         }
         return false;
     }

--- a/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
@@ -29,7 +29,7 @@ public class MapItemStackNBTIngredient extends MapItemStackIngredient {
     public static Collection<AbstractMapIngredient> from(GTRecipeInput r) {
         ObjectArrayList<AbstractMapIngredient> list = new ObjectArrayList<>();
         for (ItemStack s : r.getInputStacks()) {
-            list.add(new MapItemStackNBTIngredient(s,r));
+            list.add(new MapItemStackNBTIngredient(s, r));
         }
         return list;
     }
@@ -48,7 +48,18 @@ public class MapItemStackNBTIngredient extends MapItemStackIngredient {
         }
         if (obj instanceof MapItemStackNBTIngredient) {
             MapItemStackNBTIngredient other = (MapItemStackNBTIngredient) obj;
-            return other.gtRecipeInput.acceptsStack(this.stack);
+            if (this.stack.getItem() != other.stack.getItem()) {
+                return false;
+            }
+            if (this.meta != other.meta) {
+                return false;
+            }
+            if (this.matcher != null && !this.matcher.equals(other.matcher)) return false;
+            if (this.condition != null && !this.condition.equals(other.condition)) return false;
+            if (other.matcher != null) {
+                return other.matcher.evaluate(this.stack, other.condition);
+            }
+            return true;
         }
         return false;
     }

--- a/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
@@ -54,12 +54,19 @@ public class MapItemStackNBTIngredient extends MapItemStackIngredient {
             if (this.meta != other.meta) {
                 return false;
             }
-            if (this.matcher != null && !this.matcher.equals(other.matcher)) return false;
-            if (this.condition != null && !this.condition.equals(other.condition)) return false;
-            if (other.matcher != null) {
-                return other.matcher.evaluate(this.stack, other.condition);
+            if (this.matcher != null && other.matcher != null) {
+                if (!this.matcher.equals(other.matcher)) {
+                    return false;
+                }
             }
-            return true;
+            if (this.condition != null && other.condition != null) {
+                if (!this.condition.equals(other.condition)) {
+                    return false;
+                }
+            }
+            //NBT condition is only available on the MapItemStackNBTIngredient created by from the Recipe, so
+            //the evaluate method is called from the comparing MapItemStackNBTIngredient that is on the RecipeMap
+            return ItemStack.areItemsEqual(stack, other.stack) && other.matcher.evaluate(this.stack, other.condition);
         }
         return false;
     }


### PR DESCRIPTION
## What
This PR fixes the inconsistent recipe conflict ( "sandstone assembler recipe"). Due to not strict enough equals check, the map with the ingredients picked the bucket with the oredicted sandstone Ingredient for testing, and it returns it due to failure of the equals method (in this case it should've returned false).

## Implementation Details
Made equals comparison stricter

## Outcome
Assembler sandstone recipes present always instead of sometimes.