### PR TITLE
Zero initial EUt of multiplied parallel logic

### DIFF
--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -440,7 +440,12 @@ public abstract class ParallelLogic {
         if (multiplierByInputs == 0) {
             return null;
         }
-        RecipeBuilder<?> recipeBuilder = recipeMap.recipeBuilder();
+        // Make a copy of the recipe builder and zero the EUt, since we append
+        // the total multiplied EUt, and not doing so may add an extra multiple
+        // for the EUt (for example, x2 recipes but x3 EUt) if the original
+        // recipe builder already has a cost applied. Don't also zero the
+        // duration as it doesn't get multiplied.
+        RecipeBuilder<?> recipeBuilder = recipeMap.recipeBuilder().EUt(0);
 
         boolean voidItems = voidable.canVoidRecipeItemOutputs();
         boolean voidFluids = voidable.canVoidRecipeFluidOutputs();


### PR DESCRIPTION
## What
As in #1120, parallel logic sometimes has an initial EUt in its copied recipe map, which results in higher energy consumption than intended.

## Implementation Details
Ensure that the EUt of the copied recipe map is 0.

## Outcome
Washing/macerating 2 ores will not consume the energy cost of 3 recipes.    
Fixes (properly): gregtechceu/gregicality-multiblocks#19