### PR TITLE
Add method for recycling recipes to use nbt conditions

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -124,4 +124,10 @@ public class GregtechDataCodes {
     // Creative Energy
     public static final int UPDATE_IO_SPEED = 1;
 
+
+    // NBT Keys
+
+    // From MetaTileEntityHolder
+    public static final String CUSTOM_NAME = "CustomName";
+
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -11,14 +11,15 @@ import com.google.common.base.Preconditions;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.block.machines.BlockMachine;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.gui.IUIHolder;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.core.network.packets.PacketRecoverMTE;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.client.particle.GTNameTagParticle;
 import gregtech.client.particle.GTParticleManager;
+import gregtech.core.network.packets.PacketRecoverMTE;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -116,7 +117,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     @Override
     public void readFromNBT(@Nonnull NBTTagCompound compound) {
         super.readFromNBT(compound);
-        customName = compound.getString("CustomName");
+        customName = compound.getString(GregtechDataCodes.CUSTOM_NAME);
         if (compound.hasKey("MetaId", NBT.TAG_STRING)) {
             String metaTileEntityIdRaw = compound.getString("MetaId");
             ResourceLocation metaTileEntityId = new ResourceLocation(metaTileEntityIdRaw);
@@ -142,7 +143,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     @Override
     public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
         super.writeToNBT(compound);
-        compound.setString("CustomName", getName());
+        compound.setString(GregtechDataCodes.CUSTOM_NAME, getName());
         if (metaTileEntity != null) {
             compound.setString("MetaId", metaTileEntity.metaTileEntityId.toString());
             NBTTagCompound metaTileEntityData = new NBTTagCompound();

--- a/src/main/java/gregtech/api/recipes/ingredients/nbtmatch/NBTMatcher.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/nbtmatch/NBTMatcher.java
@@ -131,6 +131,17 @@ public interface NBTMatcher {
         return false;
     };
 
+    /**
+     * Return true if NBT isn't present or is the provided key is present
+     */
+    NBTMatcher NOT_PRESENT_OR_HAS_KEY = (tag, condition) -> {
+        if (tag == null) {
+            return true;
+        }
+
+        return hasKey(tag, condition.nbtKey, condition.tagType.typeId);
+    };
+
     boolean evaluate(NBTTagCompound nbtTagCompound, NBTCondition nbtCondition);
 
     default boolean evaluate(ItemStack stack, NBTCondition nbtCondition) {

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -2,12 +2,14 @@ package gregtech.loaders.recipe;
 
 import com.google.common.collect.ImmutableList;
 import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.recipes.ingredients.nbtmatch.NBTCondition;
 import gregtech.api.recipes.ingredients.nbtmatch.NBTMatcher;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTTagType;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
@@ -507,7 +509,9 @@ public class RecyclingRecipes {
         MetaTileEntity mte = GTUtility.getMetaTileEntity(input);
         if (mte != null) {
             builder.clearInputs();
-            builder.inputNBT(mte, NBTMatcher.ANY, NBTCondition.ANY);
+            // Don't use ANY to avoid issues with Drums, Super Chests, and other MTEs that hold an inventory
+            NBTCondition condition = NBTCondition.create(NBTTagType.STRING, GregtechDataCodes.CUSTOM_NAME, "");
+            builder.inputNBT(mte, NBTMatcher.NOT_PRESENT_OR_HAS_KEY, condition);
         }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -2,7 +2,6 @@ package gregtech.loaders.recipe;
 
 import com.google.common.collect.ImmutableList;
 import gregtech.api.GTValues;
-import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
@@ -35,6 +34,8 @@ import static gregtech.api.GTValues.M;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 
 public class RecyclingRecipes {
+
+    private static final NBTCondition RENAMED_NBT = NBTCondition.create(NBTTagType.COMPOUND, "display", "");
 
     // TODO - Fix recipe order with some things (noticed Hermetic Casings)
     // TODO - Figure out solution to LuV+ components
@@ -510,8 +511,7 @@ public class RecyclingRecipes {
         if (mte != null) {
             builder.clearInputs();
             // Don't use ANY to avoid issues with Drums, Super Chests, and other MTEs that hold an inventory
-            NBTCondition condition = NBTCondition.create(NBTTagType.STRING, GregtechDataCodes.CUSTOM_NAME, "");
-            builder.inputNBT(mte, NBTMatcher.NOT_PRESENT_OR_HAS_KEY, condition);
+            builder.inputNBT(mte, NBTMatcher.NOT_PRESENT_OR_HAS_KEY, RENAMED_NBT);
         }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -2,8 +2,12 @@ package gregtech.loaders.recipe;
 
 import com.google.common.collect.ImmutableList;
 import gregtech.api.GTValues;
+import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.builders.SimpleRecipeBuilder;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTCondition;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTMatcher;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
@@ -105,12 +109,16 @@ public class RecyclingRecipes {
         if (outputs.size() == 0) return;
 
         // Build the final Recipe.
-        RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
+        RecipeBuilder<SimpleRecipeBuilder> recipe = RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
                 .inputs(input.copy())
                 .outputs(outputs)
                 .duration(calculateDuration(outputs))
-                .EUt(2 * multiplier)
-                .buildAndRegister();
+                .EUt(2 * multiplier);
+
+        cleanInputNBT(input, recipe);
+
+        recipe.buildAndRegister();
+
     }
 
     private static void registerExtractorRecycling(ItemStack input, List<MaterialStack> materials, int multiplier, @Nullable OrePrefix prefix) {
@@ -169,6 +177,7 @@ public class RecyclingRecipes {
             extractorBuilder.output(outputPrefix, itemMs.material, (int) (itemMs.amount / M));
         }
 
+        cleanInputNBT(input, extractorBuilder);
         extractorBuilder.buildAndRegister();
     }
 
@@ -209,12 +218,14 @@ public class RecyclingRecipes {
         if (outputs.size() == 0) return;
 
         // Build the final Recipe.
-        RecipeMaps.ARC_FURNACE_RECIPES.recipeBuilder()
+        RecipeBuilder<SimpleRecipeBuilder> recipe = RecipeMaps.ARC_FURNACE_RECIPES.recipeBuilder()
                 .inputs(input.copy())
                 .outputs(outputs)
                 .duration(calculateDuration(outputs))
-                .EUt(GTValues.VA[GTValues.LV])
-                .buildAndRegister();
+                .EUt(GTValues.VA[GTValues.LV]);
+
+        cleanInputNBT(input, recipe);
+        recipe.buildAndRegister();
     }
 
     private static MaterialStack getArcSmeltingResult(MaterialStack materialStack) {
@@ -482,5 +493,21 @@ public class RecyclingRecipes {
 
     private static boolean isAshMaterial(MaterialStack ms) {
         return ms.material == Materials.Ash || ms.material == Materials.DarkAsh || ms.material == Materials.Carbon;
+    }
+
+    /**
+     * Performs various NBT matching on the provided input and adds the result to the provided RecipeBuilder
+     *
+     * @param input The input itemStack
+     * @param builder The RecipeBuilder to add the NBT condition to
+     */
+    private static void cleanInputNBT(ItemStack input, RecipeBuilder<?> builder) {
+
+        // Ignore String tag from naming machines
+        MetaTileEntity mte = GTUtility.getMetaTileEntity(input);
+        if (mte != null) {
+            builder.clearInputs();
+            builder.inputNBT(mte, NBTMatcher.ANY, NBTCondition.ANY);
+        }
     }
 }


### PR DESCRIPTION
## What
This PR adds a method for recycling recipes to provide nbt conditions based on the typr of input that is trying to be recycled. Currently this is used to ignore nbt from machines that have been renamed, which Closes #1442 


## Outcome
Add a method for recycling recipes to provide nbt conditions
