### PR TITLE
Fix Behavior tag getting applied to non-tools

### DIFF
--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -92,7 +92,7 @@ public class ToolEventHandlers {
         EntityPlayer player = event.getHarvester();
         if (player != null) {
             ItemStack stack = player.getHeldItemMainhand();
-            if (!stack.hasTagCompound() || !(stack.getTagCompound() instanceof IGTTool)) {
+            if (!stack.hasTagCompound() || !(stack.getItem() instanceof IGTTool)) {
                 return;
             }
             if (!event.isSilkTouching()) {

--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -92,7 +92,7 @@ public class ToolEventHandlers {
         EntityPlayer player = event.getHarvester();
         if (player != null) {
             ItemStack stack = player.getHeldItemMainhand();
-            if (!stack.hasTagCompound()) {
+            if (!stack.hasTagCompound() || !(stack.getTagCompound() instanceof IGTTool)) {
                 return;
             }
             if (!event.isSilkTouching()) {


### PR DESCRIPTION
## What
Fixes another case of an empty GT.Behaviors tag being applied to a non tool item. Closes #1439 

## Outcome
Fixes behavior tag being applied to a non tool item
