### PR TITLE
Some defensive JEI integration code

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.util.GTLog;
 import gregtech.integration.jei.GTJeiPlugin;
 import gregtech.integration.jei.recipe.RecipeMapCategory;
 import net.minecraft.client.Minecraft;
@@ -48,6 +49,10 @@ public class RecipeProgressWidget extends ProgressWidget {
             }
             else {
                 categoryID.add(RecipeMapCategory.getCategoryMap().get(recipeMap).getUid());
+            }
+            if (GTJeiPlugin.jeiRuntime == null) {
+                GTLog.logger.error("GTCEu JEI integration has crashed, this is not a good thing");
+                return false;
             }
             GTJeiPlugin.jeiRuntime.getRecipesGui().showCategories(categoryID);
             return true;


### PR DESCRIPTION
## What
Adds a defensive check for if our JEI runtime has not crashed, as certain mods may cause issues with our JEI integration and adding a check here can prevent a game crash. Closes #1421 in that the game crash is prevented, but the run time will still crash, as has been known to do with the specified mod in the issue.


## Outcome
Prevent game crashes using JEI integration in some rare cases
