### PR TITLE
Add config for blocking TileEntities from world acceleration

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -59,9 +59,9 @@ public class ConfigHolder {
         @Config.Comment({"Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.", "Default: true"})
         public boolean enableWorldAccelerators = true;
 
-        @Config.Comment({"List for TileEntities that the World Accelerator should not be able to accelerate.",
+        @Config.Comment({"List of TileEntities that the World Accelerator should not accelerate.",
                 "GregTech TileEntities are always blocked.",
-                "Entries must be in a fully qualified format. For example: gregtech.api.metatileentity.interfaces.IGregTechTileEntity",
+                "Entries must be in a fully qualified format. For example: appeng.tile.networking.TileController",
                 "Default: none"})
         public String[] worldAcceleratorBlacklist = new String[0];
 

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -59,6 +59,12 @@ public class ConfigHolder {
         @Config.Comment({"Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.", "Default: true"})
         public boolean enableWorldAccelerators = true;
 
+        @Config.Comment({"List for TileEntities that the World Accelerator should not be able to accelerate.",
+                "GregTech TileEntities are always blocked.",
+                "Entries must be in a fully qualified format. For example: gregtech.api.metatileentity.interfaces.IGregTechTileEntity",
+                "Default: none"})
+        public String[] worldAcceleratorBlacklist = new String[0];
+
         @Config.Comment({"Whether to use GT6-style pipe and cable connections, meaning they will not auto-connect " +
                 "unless placed directly onto another pipe or cable.", "Default: true"})
         public boolean gt6StylePipesCables = true;


### PR DESCRIPTION
## What
This PR adds a blacklist for the world accelerator. This will allow modpack developers to block specific TEs from being accelerated, for balance or any other reason.

## Implementation Details
The current implementation requires iterating through each entry in the map's ValueSet, as there's no way to check `Class#isInstance` with a hash-based operation, to my knowledge. Could there be a faster implementation for this?

## Outcome
Allows TileEntities to be blocked from world acceleration.
