### PR TITLE
Increase tool durability based on maximum aoe area

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -146,7 +146,8 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
 
         // Set other tool stats (durability)
         ToolProperty toolProperty = material.getProperty(PropertyKey.TOOL);
-        toolTag.setInteger(MAX_DURABILITY_KEY, toolProperty.getToolDurability());
+        int maxAOEArea = Math.max(getMaxAoEDefinition(stack).column, Math.max(getMaxAoEDefinition(stack).row, getMaxAoEDefinition(stack).layer));
+        toolTag.setInteger(MAX_DURABILITY_KEY, toolProperty.getToolDurability() * maxAOEArea);
         toolTag.setInteger(DURABILITY_KEY, 0);
         if (toolProperty.getUnbreakable()) {
             stackCompound.setBoolean(UNBREAKABLE_KEY, true);

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -26,7 +26,6 @@ import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.unification.material.properties.DustProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.properties.ToolProperty;
@@ -147,10 +146,8 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         // Set other tool stats (durability)
         ToolProperty toolProperty = material.getProperty(PropertyKey.TOOL);
         int maxAOEArea = Math.max(getMaxAoEDefinition(stack).column, Math.max(getMaxAoEDefinition(stack).row, getMaxAoEDefinition(stack).layer));
-        if (material.hasFlag(MaterialFlags.STURDY)) {
-            maxAOEArea *= 1.75;
-        }
-        toolTag.setInteger(MAX_DURABILITY_KEY, toolProperty.getToolDurability() * maxAOEArea);
+
+        toolTag.setInteger(MAX_DURABILITY_KEY, toolProperty.getToolDurability() * maxAOEArea * toolProperty.getDurabilityMultiplier());
         toolTag.setInteger(DURABILITY_KEY, 0);
         if (toolProperty.getUnbreakable()) {
             stackCompound.setBoolean(UNBREAKABLE_KEY, true);

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -147,6 +147,9 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         // Set other tool stats (durability)
         ToolProperty toolProperty = material.getProperty(PropertyKey.TOOL);
         int maxAOEArea = Math.max(getMaxAoEDefinition(stack).column, Math.max(getMaxAoEDefinition(stack).row, getMaxAoEDefinition(stack).layer));
+        if (material.hasFlag(MaterialFlags.STURDY)) {
+            maxAOEArea *= 1.75;
+        }
         toolTag.setInteger(MAX_DURABILITY_KEY, toolProperty.getToolDurability() * maxAOEArea);
         toolTag.setInteger(DURABILITY_KEY, 0);
         if (toolProperty.getUnbreakable()) {

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -156,8 +156,19 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             maxAOEArea = Math.max(aoeDefinition.column, Math.max(aoeDefinition.row, aoeDefinition.layer));
         }
 
-        int finalDurability = (toolProperty.getToolDurability() * toolProperty.getDurabilityMultiplier() + toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack)) * maxAOEArea;
-        toolTag.setInteger(MAX_DURABILITY_KEY, finalDurability);
+        int durability = toolProperty.getToolDurability() * toolProperty.getDurabilityMultiplier();
+
+        // Most Tool Definitions do not set a base durability, which will lead to ignoring the multiplier if present. So apply the multiplier to the material durability if that would happen
+        if (toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack) == 0) {
+            durability *= toolStats.getDurabilityMultiplier(stack);
+        }
+        else {
+            durability += toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack);
+        }
+
+        durability *= maxAOEArea;
+
+        toolTag.setInteger(MAX_DURABILITY_KEY, durability);
         toolTag.setInteger(DURABILITY_KEY, 0);
         if (toolProperty.getUnbreakable()) {
             stackCompound.setBoolean(UNBREAKABLE_KEY, true);
@@ -319,7 +330,11 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             return toolTag.getInteger(MAX_DURABILITY_KEY);
         }
         int maxAOE = Math.max(getMaxAoEDefinition(stack).column, Math.max(getMaxAoEDefinition(stack).row, getMaxAoEDefinition(stack).layer));
-        int maxDurability = (getMaterialDurability(stack) + toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack)) * maxAOE;
+        int maxDurability = getMaterialDurability(stack) * maxAOE;
+        int builderDurability = toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack);
+        maxDurability = builderDurability == 0 ? maxDurability * toolStats.getDurabilityMultiplier(stack) : maxDurability + builderDurability;
+
+        maxDurability *= maxAOE;
         toolTag.setInteger(MAX_DURABILITY_KEY, maxDurability);
         return maxDurability;
     }

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -150,31 +150,17 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         // Set other tool stats (durability)
         ToolProperty toolProperty = material.getProperty(PropertyKey.TOOL);
 
-        // Durability formuala we are working with:
-        // Final Durability = ((material durability * material durability multiplier) + (tool definition durability * definition durability multiplier)) * maximum Area of Effect
-
-        // Calculate the maximum AOE definition of the tool to multiply the final durability by
-        int maxAOEArea = 1;
-        if (aoeDefinition != AoESymmetrical.none()) {
-            maxAOEArea = Math.max(aoeDefinition.column, Math.max(aoeDefinition.row, aoeDefinition.layer));
-
-            // Check for tools with no AOE
-            if (maxAOEArea == 0) {
-                maxAOEArea = 1;
-            }
-        }
+        // Durability formula we are working with:
+        // Final Durability = (material durability * material durability multiplier) + (tool definition durability * definition durability multiplier)
 
         int durability = toolProperty.getToolDurability() * toolProperty.getDurabilityMultiplier();
 
         // Most Tool Definitions do not set a base durability, which will lead to ignoring the multiplier if present. So apply the multiplier to the material durability if that would happen
         if (toolStats.getBaseDurability(stack) == 0) {
             durability *= toolStats.getDurabilityMultiplier(stack);
-        }
-        else {
+        } else {
             durability += toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack);
         }
-
-        durability *= maxAOEArea;
 
         toolTag.setInteger(MAX_DURABILITY_KEY, durability);
         toolTag.setInteger(DURABILITY_KEY, 0);
@@ -336,21 +322,14 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         if (toolTag.hasKey(MAX_DURABILITY_KEY, Constants.NBT.TAG_INT)) {
             return toolTag.getInteger(MAX_DURABILITY_KEY);
         }
+
         IGTToolDefinition toolStats = getToolStats();
-        AoESymmetrical AOE = getMaxAoEDefinition(stack);
-        int maxAOE = Math.max(AOE.column, Math.max(AOE.row, AOE.layer));
-
-        // Account for cases with no AOE
-        if (maxAOE == 0) {
-            maxAOE = 1;
-        }
-
         int maxDurability = getMaterialDurability(stack);
-        int builderDurability = toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack);
-        // If there is no durability set in the tool builder, multiply the builder AOE multiplier to the material durability
-        maxDurability = builderDurability == 0 ? maxDurability * toolStats.getDurabilityMultiplier(stack) : maxDurability + builderDurability;
+        int builderDurability = (int) (toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack));
 
-        maxDurability *= maxAOE;
+        // If there is no durability set in the tool builder, multiply the builder AOE multiplier to the material durability
+        maxDurability = builderDurability == 0 ? (int) (maxDurability * toolStats.getDurabilityMultiplier(stack)) : maxDurability + builderDurability;
+
         toolTag.setInteger(MAX_DURABILITY_KEY, maxDurability);
         return maxDurability;
     }

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -143,9 +143,17 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         // Set Material
         toolTag.setString(MATERIAL_KEY, material.toString());
 
+        // Grab the definition here because we cannot use getMaxAoEDefinition as it is not initialized yet
+        AoESymmetrical aoeDefinition = getToolStats().getAoEDefinition(stack);
+
         // Set other tool stats (durability)
         ToolProperty toolProperty = material.getProperty(PropertyKey.TOOL);
-        int maxAOEArea = Math.max(getMaxAoEDefinition(stack).column, Math.max(getMaxAoEDefinition(stack).row, getMaxAoEDefinition(stack).layer));
+
+        // Multiply the durability based on the maximum AOE definition of the tool
+        int maxAOEArea = 1;
+        if (aoeDefinition != AoESymmetrical.none()) {
+            maxAOEArea = Math.max(aoeDefinition.column, Math.max(aoeDefinition.row, aoeDefinition.layer));
+        }
 
         toolTag.setInteger(MAX_DURABILITY_KEY, toolProperty.getToolDurability() * maxAOEArea * toolProperty.getDurabilityMultiplier());
         toolTag.setInteger(DURABILITY_KEY, 0);
@@ -164,7 +172,6 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         NBTTagCompound behaviourTag = getBehaviorsTag(stack);
         getToolStats().getBehaviors().forEach(behavior -> behavior.addBehaviorNBT(stack, behaviourTag));
 
-        AoESymmetrical aoeDefinition = getToolStats().getAoEDefinition(stack);
 
         if (aoeDefinition != AoESymmetrical.none()) {
             behaviourTag.setInteger(MAX_AOE_COLUMN_KEY, aoeDefinition.column);

--- a/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
@@ -55,8 +55,8 @@ public interface IGTToolDefinition {
         return 0;
     }
 
-    default int getDurabilityMultiplier(ItemStack stack) {
-        return 1;
+    default float getDurabilityMultiplier(ItemStack stack) {
+        return 1f;
     }
 
     default int getBaseQuality(ItemStack stack) {

--- a/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
@@ -55,6 +55,10 @@ public interface IGTToolDefinition {
         return 0;
     }
 
+    default int getDurabilityMultiplier(ItemStack stack) {
+        return 1;
+    }
+
     default int getBaseQuality(ItemStack stack) {
         return 0;
     }

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -28,7 +28,7 @@ public class ToolDefinitionBuilder {
     private boolean suitableForAttacking = false;
     private boolean suitableForCrafting = false;
     private int baseDurability = 0;
-    private int durabilityMultiplier = 1;
+    private float durabilityMultiplier = 1.0f;
     private int baseQuality = 0;
     private float attackDamage = 0F;
     private float baseEfficiency = 4F;
@@ -78,7 +78,7 @@ public class ToolDefinitionBuilder {
         return this;
     }
 
-    public ToolDefinitionBuilder durabilityMultiplier(int multiplier) {
+    public ToolDefinitionBuilder durabilityMultiplier(float multiplier) {
         this.durabilityMultiplier = multiplier;
         return this;
     }
@@ -190,7 +190,7 @@ public class ToolDefinitionBuilder {
             private final boolean suitableForAttacking = ToolDefinitionBuilder.this.suitableForAttacking;
             private final boolean suitableForCrafting = ToolDefinitionBuilder.this.suitableForCrafting;
             private final int baseDurability = ToolDefinitionBuilder.this.baseDurability;
-            private final int durabilityMultiplier = ToolDefinitionBuilder.this.durabilityMultiplier;
+            private final float durabilityMultiplier = ToolDefinitionBuilder.this.durabilityMultiplier;
             private final int baseQuality = ToolDefinitionBuilder.this.baseQuality;
             private final float attackDamage = ToolDefinitionBuilder.this.attackDamage;
             private final float baseEfficiency = ToolDefinitionBuilder.this.baseEfficiency;
@@ -263,7 +263,7 @@ public class ToolDefinitionBuilder {
             }
 
             @Override
-            public int getDurabilityMultiplier(ItemStack stack) {
+            public float getDurabilityMultiplier(ItemStack stack) {
                 return durabilityMultiplier;
             }
 

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -28,6 +28,7 @@ public class ToolDefinitionBuilder {
     private boolean suitableForAttacking = false;
     private boolean suitableForCrafting = false;
     private int baseDurability = 0;
+    private int durabilityMultiplier = 1;
     private int baseQuality = 0;
     private float attackDamage = 0F;
     private float baseEfficiency = 4F;
@@ -74,6 +75,11 @@ public class ToolDefinitionBuilder {
 
     public ToolDefinitionBuilder baseDurability(int baseDurability) {
         this.baseDurability = baseDurability;
+        return this;
+    }
+
+    public ToolDefinitionBuilder durabilityMultiplier(int multiplier) {
+        this.durabilityMultiplier = multiplier;
         return this;
     }
 
@@ -184,6 +190,7 @@ public class ToolDefinitionBuilder {
             private final boolean suitableForAttacking = ToolDefinitionBuilder.this.suitableForAttacking;
             private final boolean suitableForCrafting = ToolDefinitionBuilder.this.suitableForCrafting;
             private final int baseDurability = ToolDefinitionBuilder.this.baseDurability;
+            private final int durabilityMultiplier = ToolDefinitionBuilder.this.durabilityMultiplier;
             private final int baseQuality = ToolDefinitionBuilder.this.baseQuality;
             private final float attackDamage = ToolDefinitionBuilder.this.attackDamage;
             private final float baseEfficiency = ToolDefinitionBuilder.this.baseEfficiency;
@@ -253,6 +260,11 @@ public class ToolDefinitionBuilder {
             @Override
             public int getBaseDurability(ItemStack stack) {
                 return baseDurability;
+            }
+
+            @Override
+            public int getDurabilityMultiplier(ItemStack stack) {
+                return durabilityMultiplier;
             }
 
             @Override

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialPropertyExpansion.java
@@ -204,9 +204,10 @@ public class MaterialPropertyExpansion {
     }
 
     @ZenMethod
-    public static void addTools(Material m, float toolSpeed, float toolAttackDamage, float toolAttackSpeed, int toolDurability, @Optional int toolHarvestLevel, @Optional int toolEnchantability) {
+    public static void addTools(Material m, float toolSpeed, float toolAttackDamage, float toolAttackSpeed, int toolDurability, @Optional int toolHarvestLevel, @Optional int toolEnchantability, @Optional int durabilityMultiplier) {
         if (checkFrozen("add Tools to a material")) return;
         if (toolEnchantability == 0) toolEnchantability = 10;
+        if (durabilityMultiplier <= 0) durabilityMultiplier = 1;
         if (m.hasProperty(PropertyKey.TOOL)) {
             m.getProperty(PropertyKey.TOOL).setToolSpeed(toolSpeed);
             m.getProperty(PropertyKey.TOOL).setToolAttackDamage(toolAttackDamage);
@@ -214,8 +215,9 @@ public class MaterialPropertyExpansion {
             m.getProperty(PropertyKey.TOOL).setToolDurability(toolDurability);
             m.getProperty(PropertyKey.TOOL).setToolHarvestLevel(toolHarvestLevel);
             m.getProperty(PropertyKey.TOOL).setToolEnchantability(toolEnchantability);
+            m.getProperty(PropertyKey.TOOL).setDurabilityMultiplier(durabilityMultiplier);
         } else m.setProperty(PropertyKey.TOOL, ToolProperty.Builder.of(toolSpeed, toolAttackDamage, toolDurability, toolHarvestLevel)
-                .attackSpeed(toolAttackSpeed).enchantability(toolEnchantability).build());
+                .attackSpeed(toolAttackSpeed).enchantability(toolEnchantability).durabilityMultiplier(durabilityMultiplier).build());
     }
 
     @ZenMethod

--- a/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
@@ -268,4 +268,15 @@ public class MaterialFlags {
     public static final MaterialFlag HIGH_SIFTER_OUTPUT = new MaterialFlag.Builder("high_sifter_output")
             .requireProps(PropertyKey.GEM, PropertyKey.ORE)
             .build();
+
+    //////////////////
+    //     TOOL     //
+    //////////////////
+
+    /**
+     * Adds extra durability to tools made from this material
+     */
+    public static final MaterialFlag STURDY = new MaterialFlag.Builder("sturdy")
+            .requireProps(PropertyKey.TOOL)
+            .build();
 }

--- a/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
@@ -268,15 +268,4 @@ public class MaterialFlags {
     public static final MaterialFlag HIGH_SIFTER_OUTPUT = new MaterialFlag.Builder("high_sifter_output")
             .requireProps(PropertyKey.GEM, PropertyKey.ORE)
             .build();
-
-    //////////////////
-    //     TOOL     //
-    //////////////////
-
-    /**
-     * Adds extra durability to tools made from this material
-     */
-    public static final MaterialFlag STURDY = new MaterialFlag.Builder("sturdy")
-            .requireProps(PropertyKey.TOOL)
-            .build();
 }

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -65,6 +65,12 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     private boolean isMagnetic;
 
     /**
+     * A multiplier to the base durability for this material
+     * Mostly for modpack makers
+     */
+    private int durabilityMultiplier = 1;
+
+    /**
      * Enchantment to be applied to tools made from this Material.
      */
     private final Object2IntMap<Enchantment> enchantments = new Object2IntArrayMap<>();
@@ -156,6 +162,14 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
         return isMagnetic;
     }
 
+    public void setDurabilityMultiplier(int multiplier) {
+        this.durabilityMultiplier = multiplier;
+    }
+
+    public int getDurabilityMultiplier() {
+        return durabilityMultiplier;
+    }
+
     @Override
     public void verifyProperty(MaterialProperties properties) {
         if (!properties.hasProperty(PropertyKey.GEM)) properties.ensureSet(PropertyKey.INGOT, true);
@@ -204,6 +218,11 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
 
         public Builder magnetic() {
             toolProperty.setMagnetic(true);
+            return this;
+        }
+
+        public Builder durabilityMultiplier(int multiplier) {
+            toolProperty.setDurabilityMultiplier(multiplier);
             return this;
         }
 

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -106,13 +106,13 @@ public final class ToolItems {
         MINING_HAMMER = register(ItemGTTool.Builder.of(GTValues.MODID, "mining_hammer")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
                         .efficiencyMultiplier(0.4F).attackDamage(1.5F).attackSpeed(-3.2F)
-                        .durabilityMultiplier(9)
+                        .durabilityMultiplier(3)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .toolClasses(ToolClasses.PICKAXE));
         SPADE = register(ItemGTTool.Builder.of(GTValues.MODID, "spade")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
                         .efficiencyMultiplier(0.4F).attackDamage(1.5F).attackSpeed(-3.2F)
-                        .durabilityMultiplier(9)
+                        .durabilityMultiplier(3)
                         .behaviors(GrassPathBehavior.INSTANCE))
                 .toolClasses(ToolClasses.SHOVEL));
         WRENCH = register(ItemGTTool.Builder.of(GTValues.MODID, "wrench")
@@ -178,7 +178,7 @@ public final class ToolItems {
                 .toolClasses(ToolClasses.BUTCHERY_KNIFE));
         DRILL_LV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_lv")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
-                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(1.5f)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(3.0F)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_LV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -187,7 +187,7 @@ public final class ToolItems {
                 .electric(GTValues.LV));
         DRILL_MV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_mv")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 2)
-                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(3)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(4.0F)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_MV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -196,7 +196,7 @@ public final class ToolItems {
                 .electric(GTValues.MV));
         DRILL_HV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_hv")
                 .toolStats(b -> b.blockBreaking().aoe(2, 2, 4)
-                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(5)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(5.0F)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_HV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -205,7 +205,7 @@ public final class ToolItems {
                 .electric(GTValues.HV));
         DRILL_EV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_ev")
                 .toolStats(b -> b.blockBreaking().aoe(3, 3, 6)
-                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(9)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(6.0F)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_EV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -214,7 +214,7 @@ public final class ToolItems {
                 .electric(GTValues.EV));
         DRILL_IV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_iv")
                 .toolStats(b -> b.blockBreaking().aoe(4, 4, 8)
-                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(11)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(7.0F)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_IV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -106,13 +106,13 @@ public final class ToolItems {
         MINING_HAMMER = register(ItemGTTool.Builder.of(GTValues.MODID, "mining_hammer")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
                         .efficiencyMultiplier(0.4F).attackDamage(1.5F).attackSpeed(-3.2F)
-                        .durabilityMultiplier(3)
+                        .durabilityMultiplier(3.0F)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .toolClasses(ToolClasses.PICKAXE));
         SPADE = register(ItemGTTool.Builder.of(GTValues.MODID, "spade")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
                         .efficiencyMultiplier(0.4F).attackDamage(1.5F).attackSpeed(-3.2F)
-                        .durabilityMultiplier(3)
+                        .durabilityMultiplier(3.0F)
                         .behaviors(GrassPathBehavior.INSTANCE))
                 .toolClasses(ToolClasses.SHOVEL));
         WRENCH = register(ItemGTTool.Builder.of(GTValues.MODID, "wrench")
@@ -162,7 +162,7 @@ public final class ToolItems {
                 .toolClasses(ToolClasses.WIRE_CUTTER));
         SCYTHE = register(ItemGTSword.Builder.of(GTValues.MODID, "scythe")
                 .toolStats(b -> b.blockBreaking().attacking()
-                        .attackDamage(5.0F).attackSpeed(-3.0F)
+                        .attackDamage(5.0F).attackSpeed(-3.0F).durabilityMultiplier(3.0F)
                         .aoe(2, 2, 2)
                         .behaviors(HoeGroundBehavior.INSTANCE, HarvestCropsBehavior.INSTANCE).canApplyEnchantment(EnumEnchantmentType.DIGGER))
                 .toolClasses(ToolClasses.SCYTHE, ToolClasses.HOE));

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -106,11 +106,13 @@ public final class ToolItems {
         MINING_HAMMER = register(ItemGTTool.Builder.of(GTValues.MODID, "mining_hammer")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
                         .efficiencyMultiplier(0.4F).attackDamage(1.5F).attackSpeed(-3.2F)
+                        .durabilityMultiplier(9)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .toolClasses(ToolClasses.PICKAXE));
         SPADE = register(ItemGTTool.Builder.of(GTValues.MODID, "spade")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
                         .efficiencyMultiplier(0.4F).attackDamage(1.5F).attackSpeed(-3.2F)
+                        .durabilityMultiplier(9)
                         .behaviors(GrassPathBehavior.INSTANCE))
                 .toolClasses(ToolClasses.SHOVEL));
         WRENCH = register(ItemGTTool.Builder.of(GTValues.MODID, "wrench")
@@ -176,7 +178,7 @@ public final class ToolItems {
                 .toolClasses(ToolClasses.BUTCHERY_KNIFE));
         DRILL_LV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_lv")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 0)
-                        .attackDamage(1.0F).attackSpeed(-3.2F)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(1.5f)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_LV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -185,7 +187,7 @@ public final class ToolItems {
                 .electric(GTValues.LV));
         DRILL_MV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_mv")
                 .toolStats(b -> b.blockBreaking().aoe(1, 1, 2)
-                        .attackDamage(1.0F).attackSpeed(-3.2F)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(3)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_MV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -194,7 +196,7 @@ public final class ToolItems {
                 .electric(GTValues.MV));
         DRILL_HV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_hv")
                 .toolStats(b -> b.blockBreaking().aoe(2, 2, 4)
-                        .attackDamage(1.0F).attackSpeed(-3.2F)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(5)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_HV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -203,7 +205,7 @@ public final class ToolItems {
                 .electric(GTValues.HV));
         DRILL_EV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_ev")
                 .toolStats(b -> b.blockBreaking().aoe(3, 3, 6)
-                        .attackDamage(1.0F).attackSpeed(-3.2F)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(9)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_EV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)
@@ -212,7 +214,7 @@ public final class ToolItems {
                 .electric(GTValues.EV));
         DRILL_IV = register(ItemGTTool.Builder.of(GTValues.MODID, "drill_iv")
                 .toolStats(b -> b.blockBreaking().aoe(4, 4, 8)
-                        .attackDamage(1.0F).attackSpeed(-3.2F)
+                        .attackDamage(1.0F).attackSpeed(-3.2F).durabilityMultiplier(11)
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_IV)
                         .behaviors(TorchPlaceBehavior.INSTANCE))
                 .oreDict(ToolOreDicts.craftingToolDrill)


### PR DESCRIPTION
## What
Increases tool durability based on the maximum AOE Area of the tool, as there were many complaints that the durability was too low for AOE tools after the tool rework.

Other durability modifications are welcome, this was just to get the ball rolling.

## Outcome
Increases tool durability based on AOE area
