### PR TITLE
Fix crash with cleanroom and terminal

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -97,6 +97,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     /**
      * @return structure pattern of this multiblock
      */
+    @Nonnull
     protected abstract BlockPattern createStructurePattern();
 
     public abstract ICubeRenderer getBaseTexture(IMultiblockPart sourcePart);


### PR DESCRIPTION
## What
This PR fixes a crash caused by using the multiblock app in the terminal with a cleanroom. It occurred because the structure pattern was returning null for the cleanroom. 

This PR adds the `@Nonnull` annotation to the base method, to help better prevent crashes like this for future multiblocks. 

## Outcome
Fixed crash with the cleanroom and the terminal.
