### PR TITLE
Do not allow inventory repair for two full durability tools

### DIFF
--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -88,6 +88,9 @@ public class RecipeRepairItemHooks {
                 }
 
                 if (first.getItem() instanceof IGTTool && second.getItem() instanceof IGTTool) {
+                    // do not allow repairing tools if both are full durability
+                    if (first.getItemDamage() == 0 && second.getItemDamage() == 0) return ItemStack.EMPTY;
+
                     // two GT tools, so use own logic to produce the correct output
                     IGTTool tool = (IGTTool) first.getItem();
                     ItemStack output = tool.get(tool.getToolMaterial(first));


### PR DESCRIPTION
## What
Fixes inventory tool repair so it does not produce an output if both tools are full durability.

## Outcome
Changes inventory repair to not allow two full durability tools.
