### PR TITLE
Fix accidental regression preventing use of wrench or cutters

### DIFF
--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -326,8 +326,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
         }
 
         EnumFacing coverSide = ICoverable.traceCoverSide(hit);
-        CoverBehavior coverBehavior = pipeTile.getCoverableImplementation().getCoverAtSide(coverSide);
-        if (coverBehavior == null) {
+        if (coverSide == null) {
             return activateFrame(world, state, pos, entityPlayer, hand, hit, pipeTile);
         }
 
@@ -338,6 +337,11 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                 case FAIL:
                     return false;
             }
+        }
+
+        CoverBehavior coverBehavior = pipeTile.getCoverableImplementation().getCoverAtSide(coverSide);
+        if (coverBehavior == null) {
+            return activateFrame(world, state, pos, entityPlayer, hand, hit, pipeTile);
         }
 
         if (itemStack.getItem().getToolClasses(itemStack).contains(ToolClasses.SCREWDRIVER)) {


### PR DESCRIPTION
## What
Fixes an accidental regression preventing the use of wirecutters or a wrench to modify the connections of a wire/pipe. This was introduced in #1424 where I attempted to cleanup what I thought was some duplicate behavior. This is just a straight revert of the small changes made, and the section of code can be looked at again at a later date.


## Outcome
Fix being unable to use wirecutters/wrenches to modify the connections of wires/pipes
