### PR TITLE
Use grid's slotX amount instead of hardcoded 9.

### DIFF
--- a/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListGridWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListGridWidget.java
@@ -93,7 +93,7 @@ public class ItemListGridWidget extends ScrollableListWidget {
             int widgetAmount = widgets.size();
             WidgetGroup widgetGroup = new WidgetGroup();
             for (int j = 0; j < slotAmountX; j++) {
-                Widget widget = new ItemListSlotWidget(j * 18, 0, this, widgetAmount * 9 + j);
+                Widget widget = new ItemListSlotWidget(j * 18, 0, this, widgetAmount * slotAmountX + j);
                 widgetGroup.addWidget(widget);
             }
             addWidget(widgetGroup);


### PR DESCRIPTION
Fixes #1472