### PR TITLE
Allow customization of multiblock preview background and font color

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -315,11 +315,26 @@ public class ConfigHolder {
 
         @Config.Comment({"The default color to overlay onto machines.", "16777215 (0xFFFFFF in decimal) is no coloring (like GTCE).",
                 "13819135 (0xD2DCFF in decimal) is the classic blue from GT5 (default)."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
         public int defaultPaintingColor = 0xD2DCFF;
 
         @Config.Comment({"The default color to overlay onto Machine (and other) UIs.", "16777215 (0xFFFFFF) is no coloring (like GTCE).",
                 "13819135 (0xD2DCFF in decimal) is the classic blue from GT5 (default)."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
         public int defaultUIColor = 0xD2DCFF;
+
+        // requires mc restart, color is set upon jei plugin registration
+        @Config.Comment({"The color to use as a background for the Multiblock Preview JEI Page.",
+                "Default: 13027014 (0xC6C6C6), which is JEI's background color."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
+        @Config.RequiresMcRestart
+        public int multiblockPreviewColor = 0xC6C6C6;
+
+        // does not require mc restart, drawn dynamically
+        @Config.Comment({"The color to use for the text in the Multiblock Preview JEI Page.",
+                "Default: 3355443 (0x333333), which is minecraft's dark gray color."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
+        public int multiblockPreviewFontColor = 0x333333;
 
         public static class GuiConfig {
             @Config.Comment({"The scrolling speed of widgets", "Default: 13"})

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -21,6 +21,7 @@ import gregtech.client.renderer.scene.ImmediateWorldSceneRenderer;
 import gregtech.client.renderer.scene.WorldSceneRenderer;
 import gregtech.client.utils.RenderUtil;
 import gregtech.client.utils.TrackedDummyWorld;
+import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -367,7 +368,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
         List<String> lines = fontRenderer.listFormattedStringToWidth(localizedName, recipeWidth - 10);
         for (int i = 0; i < lines.size(); i++) {
-            fontRenderer.drawString(lines.get(i), (recipeWidth - fontRenderer.getStringWidth(lines.get(i))) / 2, fontRenderer.FONT_HEIGHT * i, 0x333333);
+            fontRenderer.drawString(lines.get(i), (recipeWidth - fontRenderer.getStringWidth(lines.get(i))) / 2, fontRenderer.FONT_HEIGHT * i, ConfigHolder.client.multiblockPreviewFontColor);
         }
     }
 
@@ -553,7 +554,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
 
         TrackedDummyWorld world = new TrackedDummyWorld();
         ImmediateWorldSceneRenderer worldSceneRenderer = new ImmediateWorldSceneRenderer(world);
-        worldSceneRenderer.setClearColor(0xC6C6C6);
+        worldSceneRenderer.setClearColor(ConfigHolder.client.multiblockPreviewColor);
         world.addBlocks(blockMap);
 
         Vector3f size = world.getSize();


### PR DESCRIPTION
## What
This PR allows customization of the Multiblock preview's background and font color. This is useful for resourcepacks, which change the color of the gui and want to keep color consistency. Font color customization is added in order to maintain readable text if using a background with too little contrast with the default color for the font.

## Outcome
Allow customization of multiblock preview background and font color.
