### PR TITLE
Set detector/activator rails to use circuit 5 instead of 4

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -1098,7 +1098,7 @@ public class VanillaStandardRecipes {
                 .input(OrePrefix.stick, Iron, 12)
                 .input(stick, Wood)
                 .input(dust, Redstone)
-                .circuitMeta(4)
+                .circuitMeta(5)
                 .outputs(new ItemStack(Blocks.DETECTOR_RAIL, 12))
                 .duration(100).EUt(VA[LV]).buildAndRegister();
 
@@ -1106,7 +1106,7 @@ public class VanillaStandardRecipes {
                 .input(stick, Iron, 12)
                 .input(stick, Wood, 2)
                 .inputs(new ItemStack(Blocks.REDSTONE_TORCH))
-                .circuitMeta(4)
+                .circuitMeta(5)
                 .outputs(new ItemStack(Blocks.ACTIVATOR_RAIL, 12))
                 .duration(100).EUt(VA[LV]).buildAndRegister();
 


### PR DESCRIPTION
## What
Currently, the detector and activator rail recipes use circuit 4 in the assembler, conflicting with any mods (such as GregTech Food Option) that attempt to add iron frame box recipes through the material system. 

## Outcome
Sets detector/activator rails to use circuit 5 in the assembler rather than circuit 4.

## Potential Compatibility Issues
I doubt that any mods would be using circuit 5 with iron rods at the moment, but if so, that would also cause another recipe conflict.
