### PR TITLE
Simplify regex pattern for allowed chars in OreDictionaryItemFilter

### DIFF
--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -30,6 +30,8 @@ import java.util.regex.Pattern;
 
 public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
 
+    private static final Pattern ALLOWED_CHARS = Pattern.compile(".[0-9]*");
+
     public long minEU, maxEU;
     private int outputAmount;
     private boolean inverted;
@@ -107,7 +109,7 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
         group.addWidget(new TextFieldWidget2(72, 5 + 2 * (SIZE + PADDING), 4 * SIZE, SIZE,
                 this::getMaxValue, this::setMaxValue)
                     .setMaxLength(19)
-                    .setAllowedChars(Pattern.compile(".[0-9]*"))
+                    .setAllowedChars(ALLOWED_CHARS)
                     .setPostFix(" EU")
         );
 
@@ -117,7 +119,7 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
         group.addWidget(new TextFieldWidget2(72, 5 + 3 * (SIZE + PADDING), 4 * SIZE, SIZE,
                 this::getMinValue, this::setMinValue)
                     .setMaxLength(19)
-                    .setAllowedChars(Pattern.compile(".[0-9]*"))
+                    .setAllowedChars(ALLOWED_CHARS)
                     .setPostFix(" EU")
         );
 

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -23,6 +23,8 @@ import java.util.regex.Pattern;
 
 public class OreDictionaryItemFilter extends ItemFilter {
 
+    private static final Pattern ALLOWED_CHARS = Pattern.compile("[0-9a-zA-Z* &|^!()]*");
+
     protected String oreDictFilterExpression = "";
     private String testMsg = "";
     private boolean testResult;
@@ -50,7 +52,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
                 .setTooltip("cover.ore_dictionary_filter.info"));
         widgetGroup.accept(new ImageWidget(10, 25, 156, 14, GuiTextures.DISPLAY));
         widgetGroup.accept(new TextFieldWidget2(14, 29, 152, 12, () -> oreDictFilterExpression, this::setOreDictFilterExpression)
-                .setAllowedChars(Pattern.compile("[0-9a-zA-Z* &|^!()]*"))
+                .setAllowedChars(ALLOWED_CHARS)
                 .setMaxLength(64)
                 .setScale(0.75f)
                 .setValidator(input -> {

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -50,7 +50,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
                 .setTooltip("cover.ore_dictionary_filter.info"));
         widgetGroup.accept(new ImageWidget(10, 25, 156, 14, GuiTextures.DISPLAY));
         widgetGroup.accept(new TextFieldWidget2(14, 29, 152, 12, () -> oreDictFilterExpression, this::setOreDictFilterExpression)
-                .setAllowedChars(Pattern.compile("[(!]* *[0-9a-zA-Z*]* *\\)*( *[&|^]? *[(!]* *[0-9a-zA-Z*]* *\\)*)*"))
+                .setAllowedChars(Pattern.compile("[0-9a-zA-Z* &|^!()]*"))
                 .setMaxLength(64)
                 .setScale(0.75f)
                 .setValidator(input -> {


### PR DESCRIPTION
## What
Simplify regex pattern in OreDictionaryItemFilter as it is used only to check if last typed char can be input in given text field. More info in #1480 

## Implementation Details
I am not sure why old regex pattern was so complicated given that it allowed writing invalid syntax.

Optimize regex pattern compilation for allowed chars to be conts.

## Outcome
Fixes: #1480 

## Additional Information
All allowed characters can still be typed, proof:
![image](https://user-images.githubusercontent.com/3093101/217211765-8cf91412-c074-4cd4-ba38-aa512db5bf4c.png)

## Potential Compatibility Issues
I don't expect any..