### PR TITLE
Add Autoclave recipe for Clay (balls) from Clay Dust and Distilled Water

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -1149,6 +1149,12 @@ public class VanillaStandardRecipes {
                 .outputs(new ItemStack(Items.CLAY_BALL))
                 .duration(600).EUt(24).buildAndRegister();
 
+        AUTOCLAVE_RECIPES.recipeBuilder()
+                .input(OrePrefix.dust, Materials.Clay)
+                .fluidInputs(Materials.DistilledWater.getFluid(250))
+                .outputs(new ItemStack(Items.CLAY_BALL))
+                .duration(300).EUt(24).buildAndRegister();
+
         COMPRESSOR_RECIPES.recipeBuilder()
                 .input(dust, Redstone, 9)
                 .output(block, Redstone)


### PR DESCRIPTION
## What
Add Autoclave recipe for Clay (balls) from Clay Dust and Distilled Water as requested in #1469 

## Implementation Details
It is using same amount out of liquids and voltage as normal water recipe, processing time is halved.

## Outcome
Resolves #1469 

## Additional Information
New recipe:
![image](https://user-images.githubusercontent.com/3093101/217252320-ae91067b-8b40-467e-a3f0-71c62991cc08.png)

Water version for comparison:
![image](https://user-images.githubusercontent.com/3093101/217252443-858cefbf-6e7a-43f1-969e-6c9f55870d74.png)

## Potential Compatibility Issues
None expected.