### PR TITLE
Fix tools losing their oredicts after being damaged

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -540,6 +540,14 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
     }
 
     default int definition$getDamage(ItemStack stack) {
+        // bypass the Forge OreDictionary using ItemStack#getItemDamage instead of ItemStack#getMetadata
+        // this will allow tools to retain their oredicts when durability changes.
+        // No normal tool ItemStack a player has should ever have a metadata value other than 0
+        // so this should not cause unexpected behavior for them
+        if (stack.getMetadata() == GTValues.W) {
+            return GTValues.W;
+        }
+
         NBTTagCompound toolTag = getToolTag(stack);
         if (toolTag.hasKey(DURABILITY_KEY, Constants.NBT.TAG_INT)) {
             return toolTag.getInteger(DURABILITY_KEY);


### PR DESCRIPTION
## What
This PR fixes tools losing their oredicts after being damaged. This was caused by the Forge Oredictionary using `ItemStack#getItemDamage` instead of `ItemStack#getMetadata`. Meaning that tools with damage would create different hashes and not have any corresponding ore dictionaries in the registry. This PR fixes this by returning the wildcard metadata value if it is present on the ItemStack.

## Outcome
Fixes tools losing their oredicts after being damaged. Closes #1452.
