### PR TITLE
Fix and improve dynamic resource discovery

### DIFF
--- a/src/main/java/gregtech/api/gui/resources/ResourceHelper.java
+++ b/src/main/java/gregtech/api/gui/resources/ResourceHelper.java
@@ -2,9 +2,12 @@ package gregtech.api.gui.resources;
 
 import gregtech.api.GTValues;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,10 +17,14 @@ import java.util.Map;
  * <p>
  * Modified for improved performance.
  */
-public class ResourceHelper {
+public final class ResourceHelper {
+
+    public static final String RESOURCE_PREFIX = GTValues.MODID + ":";
 
     private static final Map<String, ResourceLocation> cachedResources = new HashMap<>();
-    public static final String RESOURCE_PREFIX = GTValues.MODID + ":";
+    private static final String DIR_FORMAT = "textures/%s.png";
+
+    private ResourceHelper() {/**/}
 
     public static void bindTexture(ResourceLocation texture) {
         Minecraft.getMinecraft().renderEngine.bindTexture(texture);
@@ -30,6 +37,7 @@ public class ResourceHelper {
         return cachedResources.get(rs);
     }
 
+    @SuppressWarnings("unused")
     public static ResourceLocation getResourceRAW(String rs) {
         if (!cachedResources.containsKey(rs)) {
             cachedResources.put(rs, new ResourceLocation(rs));
@@ -50,11 +58,65 @@ public class ResourceHelper {
         return true;
     }
 
+    /**
+     * @param modid           the modid of the texture
+     * @param textureResource the location of the texture
+     * @param format          if the location should be formatted to include "textures/" and ".png"
+     * @return if the resource exists
+     */
+    public static boolean doResourcepacksHaveTexture(@Nonnull String modid, @Nonnull String textureResource, boolean format) {
+        if (format) textureResource = String.format(DIR_FORMAT, textureResource);
+        return doResourcepacksHaveTexture(modid, textureResource);
+    }
+
+    /**
+     * @param modid           the modid of the texture, formatted with "textures/" and ".png"
+     * @param textureResource the location of the texture
+     * @return if the resource exists
+     */
+    public static boolean doResourcepacksHaveTexture(@Nonnull String modid, @Nonnull String textureResource) {
+        return doResourcepacksHaveTexture(new ResourceLocation(modid, textureResource));
+    }
+
+    /**
+     * @param textureResource the location of the texture, formatted with "textures/" and ".png"
+     * @return if the resource exists
+     */
+    public static boolean doResourcepacksHaveTexture(@Nonnull ResourceLocation textureResource) {
+        // check minecraft for null for CI environments
+        //noinspection ConstantValue
+        if (FMLCommonHandler.instance().getEffectiveSide().isClient() && Minecraft.getMinecraft() != null) {
+            IResourceManager manager = Minecraft.getMinecraft().getResourceManager();
+            try {
+                // check if the texture file exists
+                manager.getResource(textureResource);
+                return true;
+            } catch (IOException ignored) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Does not check resourcepacks, only the file loading in the mod's folder
+     *
+     * @param modid           the modid of the texture
+     * @param textureResource the location of the texture
+     * @return if the resource exists
+     */
     public static boolean isTextureExist(@Nonnull String modid, @Nonnull String textureResource) {
         URL url = ResourceHelper.class.getResource(String.format("/assets/%s/textures/%s.png", modid, textureResource));
         return url != null;
     }
 
+    /**
+     * Does not check resourcepacks, only the file loading in the mod's folder
+     *
+     * @param textureResource the location of the texture
+     * @return if the resource exists
+     */
+    @SuppressWarnings("unused")
     public static boolean isTextureExist(@Nonnull ResourceLocation textureResource) {
         return isTextureExist(textureResource.getNamespace(), textureResource.getPath());
     }

--- a/src/main/java/gregtech/api/gui/resources/ResourceHelper.java
+++ b/src/main/java/gregtech/api/gui/resources/ResourceHelper.java
@@ -4,7 +4,8 @@ import gregtech.api.GTValues;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -64,32 +65,35 @@ public final class ResourceHelper {
      * @param format          if the location should be formatted to include "textures/" and ".png"
      * @return if the resource exists
      */
+    @SideOnly(Side.CLIENT)
     public static boolean doResourcepacksHaveTexture(@Nonnull String modid, @Nonnull String textureResource, boolean format) {
         if (format) textureResource = String.format(DIR_FORMAT, textureResource);
-        return doResourcepacksHaveTexture(modid, textureResource);
+        return doResourcepacksHaveResource(modid, textureResource);
     }
 
     /**
-     * @param modid           the modid of the texture, formatted with "textures/" and ".png"
-     * @param textureResource the location of the texture
+     * @param modid           the modid of the texture, formatted with the root dir and file extension
+     * @param resource the location of the resource
      * @return if the resource exists
      */
-    public static boolean doResourcepacksHaveTexture(@Nonnull String modid, @Nonnull String textureResource) {
-        return doResourcepacksHaveTexture(new ResourceLocation(modid, textureResource));
+    @SideOnly(Side.CLIENT)
+    public static boolean doResourcepacksHaveResource(@Nonnull String modid, @Nonnull String resource) {
+        return doResourcepacksHaveResource(new ResourceLocation(modid, resource));
     }
 
     /**
-     * @param textureResource the location of the texture, formatted with "textures/" and ".png"
+     * @param resource the location of the resource, formatted with the root dir and file extension
      * @return if the resource exists
      */
-    public static boolean doResourcepacksHaveTexture(@Nonnull ResourceLocation textureResource) {
+    @SideOnly(Side.CLIENT)
+    public static boolean doResourcepacksHaveResource(@Nonnull ResourceLocation resource) {
         // check minecraft for null for CI environments
         //noinspection ConstantValue
-        if (FMLCommonHandler.instance().getEffectiveSide().isClient() && Minecraft.getMinecraft() != null) {
+        if (Minecraft.getMinecraft() != null) {
             IResourceManager manager = Minecraft.getMinecraft().getResourceManager();
             try {
                 // check if the texture file exists
-                manager.getResource(textureResource);
+                manager.getResource(resource);
                 return true;
             } catch (IOException ignored) {
                 return false;

--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
@@ -6,7 +6,6 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import gregtech.api.GTValues;
 import gregtech.api.gui.resources.ResourceHelper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
@@ -116,13 +115,10 @@ public class MaterialIconType {
         }
 
         MaterialIconSet iconSet = materialIconSet;
-        //noinspection ConstantConditions
-        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient() &&
-                Minecraft.getMinecraft() != null) { // check minecraft for null for CI environments
-
+        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient()) {
             while (!iconSet.isRootIconset) {
                 ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("textures/blocks/material_sets/%s/%s.png", iconSet.name, this.name));
-                if (ResourceHelper.doResourcepacksHaveTexture(location)) {
+                if (ResourceHelper.doResourcepacksHaveResource(location)) {
                     break;
                 } else {
                     iconSet = iconSet.parentIconset;
@@ -143,12 +139,10 @@ public class MaterialIconType {
 
         MaterialIconSet iconSet = materialIconSet;
         //noinspection ConstantConditions
-        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient() &&
-                Minecraft.getMinecraft() != null) { // check minecraft for null for CI environments
-
+        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient()) {
             while (!iconSet.isRootIconset) {
                 ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("models/item/material_sets/%s/%s.json", iconSet.name, this.name));
-                if (ResourceHelper.doResourcepacksHaveTexture(location)) {
+                if (ResourceHelper.doResourcepacksHaveResource(location)) {
                     break;
                 } else {
                     iconSet = iconSet.parentIconset;

--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
@@ -5,13 +5,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import gregtech.api.GTValues;
+import gregtech.api.gui.resources.ResourceHelper;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -120,13 +119,12 @@ public class MaterialIconType {
         //noinspection ConstantConditions
         if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient() &&
                 Minecraft.getMinecraft() != null) { // check minecraft for null for CI environments
-            IResourceManager manager = Minecraft.getMinecraft().getResourceManager();
+
             while (!iconSet.isRootIconset) {
-                try {
-                    // check if the texture file exists
-                    manager.getResource(new ResourceLocation(GTValues.MODID, String.format("textures/blocks/material_sets/%s/%s.png", iconSet.name, this.name)));
+                ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("textures/blocks/material_sets/%s/%s.png", iconSet.name, this.name));
+                if (ResourceHelper.doResourcepacksHaveTexture(location)) {
                     break;
-                } catch (IOException ignored) {
+                } else {
                     iconSet = iconSet.parentIconset;
                 }
             }
@@ -147,13 +145,12 @@ public class MaterialIconType {
         //noinspection ConstantConditions
         if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient() &&
                 Minecraft.getMinecraft() != null) { // check minecraft for null for CI environments
-            IResourceManager manager = Minecraft.getMinecraft().getResourceManager();
+
             while (!iconSet.isRootIconset) {
-                try {
-                    // check if the model file exists
-                    manager.getResource(new ResourceLocation(GTValues.MODID, String.format("models/item/material_sets/%s/%s.json", iconSet.name, this.name)));
+                ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("models/item/material_sets/%s/%s.json", iconSet.name, this.name));
+                if (ResourceHelper.doResourcepacksHaveTexture(location)) {
                     break;
-                } catch (IOException ignored) {
+                } else {
                     iconSet = iconSet.parentIconset;
                 }
             }

--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
@@ -98,6 +98,12 @@ public class MaterialIconType {
     private static final Table<MaterialIconType, MaterialIconSet, ResourceLocation> ITEM_MODEL_CACHE = HashBasedTable.create();
     private static final Table<MaterialIconType, MaterialIconSet, ResourceLocation> BLOCK_TEXTURE_CACHE = HashBasedTable.create();
 
+    private static final String BLOCK_TEXTURE_PATH_FULL = "textures/blocks/material_sets/%s/%s.png";
+    private static final String BLOCK_TEXTURE_PATH = "blocks/material_sets/%s/%s";
+
+    private static final String ITEM_MODEL_PATH_FULL = "models/item/material_sets/%s/%s.json";
+    private static final String ITEM_MODEL_PATH = "material_sets/%s/%s";
+
     public final String name;
     public final int id;
 
@@ -110,38 +116,35 @@ public class MaterialIconType {
 
     @Nonnull
     public ResourceLocation getBlockTexturePath(@Nonnull MaterialIconSet materialIconSet) {
-        if (BLOCK_TEXTURE_CACHE.contains(this, materialIconSet)) {
-            return BLOCK_TEXTURE_CACHE.get(this, materialIconSet);
-        }
-
-        MaterialIconSet iconSet = materialIconSet;
-        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient()) {
-            while (!iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("textures/blocks/material_sets/%s/%s.png", iconSet.name, this.name));
-                if (ResourceHelper.doResourcepacksHaveResource(location)) {
-                    break;
-                } else {
-                    iconSet = iconSet.parentIconset;
-                }
-            }
-        }
-        ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("blocks/material_sets/%s/%s", iconSet.name, this.name));
-        BLOCK_TEXTURE_CACHE.put(this, materialIconSet, location);
-
-        return location;
+        return recurseIconsetPath(materialIconSet, BLOCK_TEXTURE_CACHE, BLOCK_TEXTURE_PATH_FULL, BLOCK_TEXTURE_PATH);
     }
 
     @Nonnull
     public ResourceLocation getItemModelPath(@Nonnull MaterialIconSet materialIconSet) {
-        if (ITEM_MODEL_CACHE.contains(this, materialIconSet)) {
-            return ITEM_MODEL_CACHE.get(this, materialIconSet);
+        return recurseIconsetPath(materialIconSet, ITEM_MODEL_CACHE, ITEM_MODEL_PATH_FULL, ITEM_MODEL_PATH);
+    }
+
+    /**
+     * Find the location of the asset associated with the iconset or its parents as a fallback
+     *
+     * @param materialIconSet the starting IconSet to get the location for
+     * @param cache           the cache to store the value in
+     * @param fullPath        the full path to the asset with formatting (%s) for IconSet and IconType names
+     * @param path            the abbreviated path to the asset with formatting (%s) for IconSet and IconType names
+     * @return the location of the asset
+     */
+    @Nonnull
+    public ResourceLocation recurseIconsetPath(@Nonnull MaterialIconSet materialIconSet,
+                                               @Nonnull Table<MaterialIconType, MaterialIconSet, ResourceLocation> cache,
+                                               @Nonnull String fullPath, @Nonnull String path) {
+        if (cache.contains(this, materialIconSet)) {
+            return cache.get(this, materialIconSet);
         }
 
         MaterialIconSet iconSet = materialIconSet;
-        //noinspection ConstantConditions
         if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient()) {
             while (!iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("models/item/material_sets/%s/%s.json", iconSet.name, this.name));
+                ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format(fullPath, iconSet.name, this.name));
                 if (ResourceHelper.doResourcepacksHaveResource(location)) {
                     break;
                 } else {
@@ -150,8 +153,8 @@ public class MaterialIconType {
             }
         }
 
-        ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format("material_sets/%s/%s", iconSet.name, this.name));
-        ITEM_MODEL_CACHE.put(this, materialIconSet, location);
+        ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format(path, iconSet.name, this.name));
+        cache.put(this, iconSet, location);
 
         return location;
     }

--- a/src/main/java/gregtech/client/renderer/ICubeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/ICubeRenderer.java
@@ -65,7 +65,7 @@ public interface ICubeRenderer extends IIconRegister {
 
     @Nullable
     static TextureAtlasSprite getResource(@Nonnull TextureMap textureMap, @Nonnull String modid, @Nonnull String name) {
-        if (ResourceHelper.isTextureExist(modid, name)) {
+        if (ResourceHelper.doResourcepacksHaveTexture(modid, name, true)) {
             return textureMap.registerSprite(new ResourceLocation(modid, name));
         }
         return null;

--- a/src/main/java/gregtech/client/renderer/ICubeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/ICubeRenderer.java
@@ -64,6 +64,7 @@ public interface ICubeRenderer extends IIconRegister {
     }
 
     @Nullable
+    @SideOnly(Side.CLIENT)
     static TextureAtlasSprite getResource(@Nonnull TextureMap textureMap, @Nonnull String modid, @Nonnull String name) {
         if (ResourceHelper.doResourcepacksHaveTexture(modid, name, true)) {
             return textureMap.registerSprite(new ResourceLocation(modid, name));

--- a/src/main/java/gregtech/client/renderer/texture/Textures.java
+++ b/src/main/java/gregtech/client/renderer/texture/Textures.java
@@ -291,12 +291,9 @@ public class Textures {
     @SideOnly(Side.CLIENT)
     public static void register(TextureMap textureMap) {
         GTLog.logger.info("Loading meta tile entity texture sprites...");
-        long start = System.nanoTime();
         for (IIconRegister iconRegister : iconRegisters) {
             iconRegister.registerIcons(textureMap);
         }
-        long delta = System.nanoTime() - start;
-        GTLog.logger.fatal("Loading took {}ns", delta);
 
         RESTRICTIVE_OVERLAY = textureMap.registerSprite(new ResourceLocation(GTValues.MODID, "blocks/pipe/pipe_restrictive"));
         PIPE_BLOCKED_OVERLAY = textureMap.registerSprite(new ResourceLocation(GTValues.MODID, "blocks/pipe/pipe_blocked"));

--- a/src/main/java/gregtech/client/renderer/texture/Textures.java
+++ b/src/main/java/gregtech/client/renderer/texture/Textures.java
@@ -291,9 +291,12 @@ public class Textures {
     @SideOnly(Side.CLIENT)
     public static void register(TextureMap textureMap) {
         GTLog.logger.info("Loading meta tile entity texture sprites...");
+        long start = System.nanoTime();
         for (IIconRegister iconRegister : iconRegisters) {
             iconRegister.registerIcons(textureMap);
         }
+        long delta = System.nanoTime() - start;
+        GTLog.logger.fatal("Loading took {}ns", delta);
 
         RESTRICTIVE_OVERLAY = textureMap.registerSprite(new ResourceLocation(GTValues.MODID, "blocks/pipe/pipe_restrictive"));
         PIPE_BLOCKED_OVERLAY = textureMap.registerSprite(new ResourceLocation(GTValues.MODID, "blocks/pipe/pipe_blocked"));

--- a/src/main/java/gregtech/client/renderer/texture/cube/SimpleOrientedCubeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/SimpleOrientedCubeRenderer.java
@@ -60,9 +60,9 @@ public class SimpleOrientedCubeRenderer implements ICubeRenderer {
         for (CubeSide cubeSide : CubeSide.VALUES) {
             String fullPath = String.format("blocks/%s/%s", basePath, cubeSide.name().toLowerCase());
             this.sprites.put(cubeSide, textureMap.registerSprite(new ResourceLocation(modID, fullPath)));
-            ResourceLocation emissiveLocation = new ResourceLocation(modID, fullPath + "_emissive");
-            if (ResourceHelper.isTextureExist(emissiveLocation)) {
-                this.spritesEmissive.put(cubeSide, textureMap.registerSprite(emissiveLocation));
+            String emissive = fullPath + EMISSIVE;
+            if (ResourceHelper.doResourcepacksHaveTexture(modID, emissive, true)) {
+                this.spritesEmissive.put(cubeSide, textureMap.registerSprite(new ResourceLocation(modID, emissive)));
             }
         }
     }

--- a/src/main/java/gregtech/client/renderer/texture/cube/SimpleOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/SimpleOverlayRenderer.java
@@ -50,9 +50,9 @@ public class SimpleOverlayRenderer implements ICubeRenderer {
             basePath = split[1];
         }
         this.sprite = textureMap.registerSprite(new ResourceLocation(modID, "blocks/" + basePath));
-        ResourceLocation emissiveLocation = new ResourceLocation(modID, "blocks/" + basePath + "_emissive");
-        if (ResourceHelper.isTextureExist(emissiveLocation)) {
-            this.spriteEmissive = textureMap.registerSprite(emissiveLocation);
+        String emissive = "blocks/" + basePath + EMISSIVE;
+        if (ResourceHelper.doResourcepacksHaveTexture(modID, emissive, true)) {
+            this.spriteEmissive = textureMap.registerSprite(new ResourceLocation(modID, emissive));
         }
     }
 

--- a/src/main/java/gregtech/client/renderer/texture/cube/SimpleSidedCubeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/SimpleSidedCubeRenderer.java
@@ -70,9 +70,9 @@ public class SimpleSidedCubeRenderer implements ICubeRenderer {
             ResourceLocation resourceLocation = new ResourceLocation(modID, String.format("blocks/%s/%s", basePath, faceName));
             sprites.put(overlayFace, textureMap.registerSprite(resourceLocation));
 
-            ResourceLocation emissiveLocation = new ResourceLocation(modID, String.format("blocks/%s/%s_emissive", basePath, faceName));
-            if (ResourceHelper.isTextureExist(emissiveLocation)) {
-                spritesEmissive.put(overlayFace, textureMap.registerSprite(emissiveLocation));
+            String emissive = String.format("blocks/%s/%s_emissive", basePath, faceName);
+            if (ResourceHelper.doResourcepacksHaveTexture(modID, emissive, true)) {
+                spritesEmissive.put(overlayFace, textureMap.registerSprite(new ResourceLocation(modID, emissive)));
             }
         }
     }


### PR DESCRIPTION
## What
This PR fixes and improves dynamic resource discovery. 

First, it fixes a bug introduced in #1449 where GT did not check resourcepacks for assets not present in the base mod. For example, a resourcepack attempting to add a `SIDE` texture for the Wiremill, which by default only has `FRONT` and `TOP`, would not load the `SIDE` texture, because it was not present in the mod's asset directory.

Next, it slightly improves performance discovering these assets as well. The old approach for searching resourcepacks which involved ignoring IOExceptions turns out to be slightly faster (by ~73ms in my testing) than the current approach.

## Outcome
Fixes and improves dynamic resource discovery.
