### PR TITLE
Fix Vanilla ores spawning, fixes #1495

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -109,7 +109,7 @@ public class WorldGenRegistry {
         registerVeinPopulator("surface_block", SurfaceBlockPopulator::new);
 
         GameRegistry.registerWorldGenerator(WorldGeneratorImpl.INSTANCE, 1);
-        MinecraftForge.ORE_GEN_BUS.register(WorldGeneratorImpl.INSTANCE);
+        MinecraftForge.ORE_GEN_BUS.register(WorldGeneratorImpl.class);
         try {
             reinitializeRegisteredVeins();
         } catch (IOException | RuntimeException exception) {

--- a/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
+++ b/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
@@ -1,7 +1,6 @@
 package gregtech.api.worldgen.generator;
 
 import com.google.common.collect.ImmutableSet;
-import gregtech.api.GTValues;
 import gregtech.common.ConfigHolder;
 import gregtech.common.worldgen.WorldGenRubberTree;
 import net.minecraft.init.Biomes;
@@ -15,7 +14,6 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType;
 import net.minecraftforge.fml.common.IWorldGenerator;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -25,7 +23,6 @@ import java.util.Set;
 
 import static net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType.*;
 
-@Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class WorldGeneratorImpl implements IWorldGenerator {
 
     public static final WorldGeneratorImpl INSTANCE = new WorldGeneratorImpl();
@@ -36,10 +33,8 @@ public class WorldGeneratorImpl implements IWorldGenerator {
 
     private WorldGeneratorImpl() { }
 
-    // Must be a non-static method, as this class is put on the event bus as a method.
-    @SuppressWarnings("MethodMayBeStatic")
     @SubscribeEvent(priority = EventPriority.HIGH)
-    public void onOreGenerate(OreGenEvent.GenerateMinable event) {
+    public static void onOreGenerate(OreGenEvent.GenerateMinable event) {
         EventType eventType = event.getType();
         if (ConfigHolder.worldgen.disableVanillaOres && ORE_EVENT_TYPES.contains(eventType)) {
             event.setResult(Result.DENY);

--- a/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
+++ b/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
@@ -37,6 +37,7 @@ public class WorldGeneratorImpl implements IWorldGenerator {
     private WorldGeneratorImpl() { }
 
     // Must be a non-static method, as this class is put on the event bus as a method.
+    @SuppressWarnings("MethodMayBeStatic")
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onOreGenerate(OreGenEvent.GenerateMinable event) {
         EventType eventType = event.getType();

--- a/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
+++ b/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
@@ -36,6 +36,7 @@ public class WorldGeneratorImpl implements IWorldGenerator {
 
     private WorldGeneratorImpl() { }
 
+    // Must be a non-static method, as this class is put on the event bus as a method.
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onOreGenerate(OreGenEvent.GenerateMinable event) {
         EventType eventType = event.getType();

--- a/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
+++ b/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
@@ -1,6 +1,7 @@
 package gregtech.api.worldgen.generator;
 
 import com.google.common.collect.ImmutableSet;
+import gregtech.api.GTValues;
 import gregtech.common.ConfigHolder;
 import gregtech.common.worldgen.WorldGenRubberTree;
 import net.minecraft.init.Biomes;
@@ -14,6 +15,7 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType;
 import net.minecraftforge.fml.common.IWorldGenerator;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -23,6 +25,7 @@ import java.util.Set;
 
 import static net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType.*;
 
+@Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class WorldGeneratorImpl implements IWorldGenerator {
 
     public static final WorldGeneratorImpl INSTANCE = new WorldGeneratorImpl();
@@ -34,7 +37,7 @@ public class WorldGeneratorImpl implements IWorldGenerator {
     private WorldGeneratorImpl() { }
 
     @SubscribeEvent(priority = EventPriority.HIGH)
-    public static void onOreGenerate(OreGenEvent.GenerateMinable event) {
+    public void onOreGenerate(OreGenEvent.GenerateMinable event) {
         EventType eventType = event.getType();
         if (ConfigHolder.worldgen.disableVanillaOres && ORE_EVENT_TYPES.contains(eventType)) {
             event.setResult(Result.DENY);


### PR DESCRIPTION
## What
Fixes an issue where Vanilla ores would spawn, even when the config to turn it off was on.

The issue was simply that the method was made static in #1330, and since the WorldGeneratorImpl class is put on the event bus as an object, this prevents this listener from being registered. As the mistake of marking this method as static is understandable, a comment has been added explicitly telling people to not do that again.

## Outcome
Fixes #1495.
