### PR TITLE
Fix item voiding when interacting with storage drawers

### DIFF
--- a/src/main/java/gregtech/api/util/GTTransferUtils.java
+++ b/src/main/java/gregtech/api/util/GTTransferUtils.java
@@ -84,11 +84,10 @@ public class GTTransferUtils {
             if (sourceStack.isEmpty()) {
                 continue;
             }
-            ItemStack remainder = insertItem(targetInventory, sourceStack, true);
+            ItemStack remainder = insertItem(targetInventory, sourceStack, false);
             int amountToInsert = sourceStack.getCount() - remainder.getCount();
             if (amountToInsert > 0) {
-                sourceStack = sourceInventory.extractItem(srcIndex, amountToInsert, false);
-                insertItem(targetInventory, sourceStack, false);
+                sourceInventory.extractItem(srcIndex, amountToInsert, false);
             }
         }
     }


### PR DESCRIPTION
[Work in progress]
It does not yet fix every case where this happens.

## What
It fixes an issue, where outputting to a storage drawer voids half of the items when the drawer has less space then we are trying to output to it.

## Implementation Details
I found the simulation of the insertion to be unnecessary as the same thing can be achived with just inserting it in the firstplace and when we know hov many items could be inserted we extract them from the output.

The issue is caused by the drawer having 2 slots, one of the is virtual and when simulating an insert we can insert the item both times, but when we actually go ahead and insert it only one time is possible.

## Outcome
It fixes an issue, where outputting to a storage drawer sometimes voids half of the items.
