### PR TITLE
Fix Missing Text when holding item on mouse

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
@@ -169,7 +169,9 @@ public class ModularUIGui extends GuiContainer implements IRenderContext {
                 itemStack = itemStack.copy();
                 itemStack.setCount(this.dragSplittingRemnant);
             }
-            this.drawItemStack(itemStack, mouseX - guiLeft - 8, mouseY - guiTop - dragOffset, "");
+            // This null is eventually nullable, 2 calls deep
+            //noinspection DataFlowIssue
+            this.drawItemStack(itemStack, mouseX - guiLeft - 8, mouseY - guiTop - dragOffset, null);
         }
     }
 


### PR DESCRIPTION
## What
Fixes Missing Text for stacksize when holding an itemstack on the mouse cursor.
Closes #1500 

This String is eventually nullable further in the call chain

## Outcome
Fixes missing Text when holding itemstack on mouse cursor