### PR TITLE
Fix Electric Wrenches not having the toolWrench oreDict

### DIFF
--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -263,7 +263,7 @@ public final class ToolItems {
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_LV))
                 .sound(GTSoundEvents.WRENCH_TOOL, true)
                 .oreDict(ToolOreDict.toolWrench)
-                .oreDict("craftingToolWrench")
+                .secondaryOreDicts("craftingToolWrench")
                 .toolClasses(ToolClasses.WRENCH)
                 .electric(GTValues.LV));
         WRENCH_HV = register(ItemGTTool.Builder.of(GTValues.MODID, "wrench_hv")
@@ -274,7 +274,7 @@ public final class ToolItems {
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_HV))
                 .sound(GTSoundEvents.WRENCH_TOOL, true)
                 .oreDict(ToolOreDict.toolWrench)
-                .oreDict("craftingToolWrench")
+                .secondaryOreDicts("craftingToolWrench")
                 .toolClasses(ToolClasses.WRENCH)
                 .electric(GTValues.HV));
         WRENCH_IV = register(ItemGTTool.Builder.of(GTValues.MODID, "wrench_iv")
@@ -285,7 +285,7 @@ public final class ToolItems {
                         .brokenStack(ToolHelper.SUPPLY_POWER_UNIT_IV))
                 .sound(GTSoundEvents.WRENCH_TOOL, true)
                 .oreDict(ToolOreDict.toolWrench)
-                .oreDict("craftingToolWrench")
+                .secondaryOreDicts("craftingToolWrench")
                 .toolClasses(ToolClasses.WRENCH)
                 .electric(GTValues.IV));
         BUZZSAW = register(ItemGTTool.Builder.of(GTValues.MODID, "buzzsaw")


### PR DESCRIPTION
## What
Fixes https://github.com/GregTechCEu/GregTech/issues/1503. This is needed to ensure that crafting recipes, both native and made by CT, using the toolWrench oreDict, can use electric wrenches in their substitution. In GTCEu master right now, this is not the case, and you cannot use an electric wrench in the crafting of a machine hull.

## Implementation Details
Changes the double calling of .oreDict in the electric wrench definitions to one calling of oreDict, and one of .secondaryOreDicts. I believe this works as a material/item can only have one oreDict. This is in line with the other electric and normal tools.

## Outcome
Electric Wrenches having the toolWrench oreDict.

## Additional Information
I created the issue, but while playing around, found the fix. I was not intending to fix the issue before I found the fix.

## Potential Compatibility Issues
None that I know of.
