### PR TITLE
Null Check RayTraceResult

### DIFF
--- a/src/main/java/gregtech/common/items/behaviors/CoverPlaceBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/CoverPlaceBehavior.java
@@ -29,6 +29,9 @@ public class CoverPlaceBehavior implements IItemBehaviour {
             return EnumActionResult.PASS;
         }
         EnumFacing coverSide = ICoverable.rayTraceCoverableSide(coverable, player);
+        if (coverSide == null) {
+            return EnumActionResult.PASS;
+        }
         if (coverable.getCoverAtSide(coverSide) != null || !coverable.canPlaceCoverOnSide(coverSide)) {
             return EnumActionResult.PASS;
         }


### PR DESCRIPTION
## What
Adds a Null Check to the Ray Trace Result when placing a cover, since the method can return null.
This is aimed at preventing #1505 but I have not tested it at all

## Outcome
Adds a null check to the Ray Trace Result when placing a cover
