### PR TITLE
Fix Missing Dust-> Ingot smelting recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -130,6 +130,17 @@ public class MaterialRecipeHandler {
                         .outputs(OreDictUnifier.get(OrePrefix.plate, mat))
                         .buildAndRegister();
             }
+
+            // Some Ores with Direct Smelting Results have neither ingot nor gem properties
+            if (oreProperty != null) {
+                Material smeltingResult = oreProperty.getDirectSmeltResult();
+                if (smeltingResult != null) {
+                    ItemStack ingotStack = OreDictUnifier.get(OrePrefix.ingot, smeltingResult);
+                    if (!ingotStack.isEmpty()) {
+                        ModHandler.addSmeltingRecipe(OreDictUnifier.get(dustPrefix, mat), ingotStack);
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -51,6 +51,7 @@ public class MaterialRecipeHandler {
 
     public static void processDust(OrePrefix dustPrefix, Material mat, DustProperty property) {
         ItemStack dustStack = OreDictUnifier.get(dustPrefix, mat);
+        OreProperty oreProperty = mat.hasProperty(PropertyKey.ORE) ? mat.getProperty(PropertyKey.ORE): null;
         if (mat.hasProperty(PropertyKey.GEM)) {
             ItemStack gemStack = OreDictUnifier.get(OrePrefix.gem, mat);
             ItemStack smallDarkAshStack = OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh);
@@ -85,11 +86,24 @@ public class MaterialRecipeHandler {
                         .buildAndRegister();
             }
 
+            if (oreProperty != null) {
+                Material smeltingResult = oreProperty.getDirectSmeltResult();
+                if (smeltingResult != null) {
+                    ModHandler.addSmeltingRecipe(OreDictUnifier.get(dustPrefix, mat), OreDictUnifier.get(OrePrefix.ingot, smeltingResult));
+                }
+            }
+
         } else if (mat.hasProperty(PropertyKey.INGOT)) {
             if (!mat.hasAnyOfFlags(FLAMMABLE, NO_SMELTING)) {
 
                 boolean hasHotIngot = OrePrefix.ingotHot.doGenerateItem(mat);
                 ItemStack ingotStack = OreDictUnifier.get(hasHotIngot ? OrePrefix.ingotHot : OrePrefix.ingot, mat);
+                if (ingotStack.isEmpty() && oreProperty != null) {
+                    Material smeltingResult = oreProperty.getDirectSmeltResult();
+                    if (smeltingResult != null) {
+                        ingotStack = OreDictUnifier.get(OrePrefix.ingot, smeltingResult);
+                    }
+                }
                 int blastTemp = mat.getBlastTemperature();
 
                 if (blastTemp <= 0) {


### PR DESCRIPTION
## What
Fixes Missing Dust ->Ingot smelting recipes. Closes #1499 

In the ModHandler Refactor PR, Tech removed the dust prefix processing from OreRecipeHandler because it was causing duplicate smelting recipes. However, that meant that some smelting recipes for Gem Materials, but which had a smeltInto property, were now missing.

I have added back a check for these recipes. I added them in MaterialRecipeHandler#ProcessDust to keep all the dust processing in the same place.


## Outcome
Fixes missing dust -> ingot smelting recipes
