### PR TITLE
Make possible for addons to add machine items in other creative tabs

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -440,7 +440,9 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     @Override
     public void getSubBlocks(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> items) {
         for (MetaTileEntity metaTileEntity : GregTechAPI.MTE_REGISTRY) {
-            metaTileEntity.getSubItems(tab, items);
+            if (metaTileEntity.isInCreativeTab(tab)) {
+                metaTileEntity.getSubItems(tab, items);
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -1,6 +1,8 @@
 package gregtech.api.block.machines;
 
+import com.google.common.base.Preconditions;
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.pipenet.block.BlockPipe;
@@ -8,15 +10,18 @@ import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.util.GTUtility;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.common.ConfigHolder;
+import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -31,8 +36,34 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class MachineItemBlock extends ItemBlock {
+
+    private static final Set<CreativeTabs> ADDITIONAL_CREATIVE_TABS = new ObjectArraySet<>();
+
+    /**
+     * Adds another creative tab for the machine item. Additional tabs added by this method are checked along with
+     * default tabs ({@link GregTechAPI#MACHINE} and {@link CreativeTabs#SEARCH}) during
+     * {@link net.minecraft.item.Item#getSubItems(CreativeTabs, NonNullList) Item#getSubItems()} operation.<br>
+     * Note that, for machines to be properly registered on the creative tab, a matching implementation of
+     * {@link MetaTileEntity#isInCreativeTab(CreativeTabs)} should be provided as well.
+     *
+     * @param creativeTab Creative tab to be checked during {@link net.minecraft.item.Item#getSubItems(CreativeTabs, NonNullList)}
+     * @throws NullPointerException     If {@code creativeTab == null}
+     * @throws IllegalArgumentException If {@code creativeTab == GregTechAPI.TAB_GREGTECH || creativeTab == CreativeTabs.SEARCH}
+     *
+     * @see MetaTileEntity#isInCreativeTab(CreativeTabs)
+     */
+    public static void addCreativeTab(CreativeTabs creativeTab) {
+        Preconditions.checkNotNull(creativeTab, "creativeTab");
+        if (creativeTab == GregTechAPI.TAB_GREGTECH) {
+            throw new IllegalArgumentException("Adding " + GregTechAPI.TAB_GREGTECH.tabLabel + " as additional creative tab is redundant.");
+        } else if (creativeTab == CreativeTabs.SEARCH) {
+            throw new IllegalArgumentException("Adding " + CreativeTabs.SEARCH.tabLabel + " as additional creative tab is redundant.");
+        }
+        ADDITIONAL_CREATIVE_TABS.add(creativeTab);
+    }
 
     public MachineItemBlock(BlockMachine block) {
         super(block);
@@ -146,5 +177,12 @@ public class MachineItemBlock extends ItemBlock {
         if (ConfigHolder.misc.debug) {
             tooltip.add(String.format("MetaTileEntity Id: %s", metaTileEntity.metaTileEntityId.toString()));
         }
+    }
+
+    @Override
+    public CreativeTabs[] getCreativeTabs() {
+        CreativeTabs[] tabs = ADDITIONAL_CREATIVE_TABS.toArray(new CreativeTabs[ADDITIONAL_CREATIVE_TABS.size() + 1]);
+        tabs[tabs.length - 1] = getCreativeTab();
+        return tabs;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -294,6 +294,20 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         subItems.add(getStackForm());
     }
 
+    /**
+     * Check if this MTE belongs in certain creative tab. To add machines in custom creative tab, the creative tab
+     * should be registered via {@link gregtech.api.block.machines.MachineItemBlock#addCreativeTab(CreativeTabs)
+     * MachineItemBlock#addCreativeTab(CreativeTabs)} beforehand.
+     *
+     * @param creativeTab The creative tab to check
+     * @return Whether this MTE belongs in the creative tab or not
+     *
+     * @see gregtech.api.block.machines.MachineItemBlock#addCreativeTab(CreativeTabs) MachineItemBlock#addCreativeTab(CreativeTabs)
+     */
+    public boolean isInCreativeTab(CreativeTabs creativeTab) {
+        return creativeTab == CreativeTabs.SEARCH || creativeTab == GregTechAPI.TAB_GREGTECH;
+    }
+
     public String getItemSubTypeId(ItemStack itemStack) {
         return "";
     }


### PR DESCRIPTION
## What
This PR introduces a method to add machines in creative tabs other than `gregtech.main`.

This feature is only intended for addons - specifically, only custom MTEs; providing ways to arbitrarily change creative tabs for existing MTEs is not the goal of this PR.

## Implementation Details
Creative tab checking is now handled by MTEs directly, by newly created method `MetaTileEntity#isInCreativeTab(CreativeTabs)`. This method can be overridden, allowing fine controls on which creative tab the machine is added. The method is called on `BlockMachine#getSubBlocks()` so that previous implementations of `MetaTileEntity#getSubItems()` function the same way.

To minimize performance impact, each additional creative tabs for machines must be manually registered by `MachineItemBlock#addCreativeTab(CreativeTabs)`. This approach should retain performance on unmodified instance as-is.

## Potential Compatibility Issues
Compatibility issue should be minimal, as the interaction between previous `MetaTileEntity#getSubItems()` implementations and newly added API produces identical result to previous code.

I did not observe any performance degradation from my own testing, but considering it was done with just one extra tab registered, it is not a definite answer.