### PR TITLE
Fixes for Advanced Energy Detector

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1155,6 +1155,23 @@ public class GTUtility {
     }
 
     /**
+     * Compares a value against a min and max, with an option to invert the logic. Has latching functionality.
+     * @param value value to be compared
+     * @param maxValue the max that the value can be
+     * @param minValue the min that the value can be
+     * @param isInverted whether to invert the logic of this method
+     * @param output the output value the function modifies
+     */
+    public static int computeLatchedRedstoneBetweenValues(float value, float maxValue, float minValue, boolean isInverted, int output) {
+        if (value >= maxValue) {
+            output = isInverted ? 15 : 0; // value above maxValue should normally be 0, otherwise 15
+        } else if (value <= minValue) {
+            output = isInverted ? 0 : 15; // value below minValue should normally be 15, otherwise 0
+        }
+        return output;
+    }
+
+    /**
      * @param fluidHandler the handler to drain from
      * @param doDrain      if the handler should be actually drained
      * @return a valid boiler fluid from a container, with amount=1

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1115,10 +1115,10 @@ public class GTUtility {
     }
 
     /**
-     * Tries to parse a string into an int, returning a default value if it fails.
+     * Tries to parse a string into a long, returning a default value if it fails.
      * @param val string to parse
      * @param defaultValue default value to return
-     * @return returns an int from the parsed string, otherwise the default value
+     * @return returns a long from the parsed string, otherwise the default value
      */
     public static long tryParseLong(String val, long defaultValue){
         try {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1159,14 +1159,14 @@ public class GTUtility {
      * @param value value to be compared
      * @param maxValue the max that the value can be
      * @param minValue the min that the value can be
-     * @param isInverted whether to invert the logic of this method
      * @param output the output value the function modifies
+     * @return returns the modified output value
      */
     public static int computeLatchedRedstoneBetweenValues(float value, float maxValue, float minValue, boolean isInverted, int output) {
         if (value >= maxValue) {
-            output = isInverted ? 15 : 0; // value above maxValue should normally be 0, otherwise 15
+            output = !isInverted ? 0 : 15; // value above maxValue should normally be 0, otherwise 15
         } else if (value <= minValue) {
-            output = isInverted ? 0 : 15; // value below minValue should normally be 15, otherwise 0
+            output = !isInverted ? 15 : 0; // value below minValue should normally be 15, otherwise 0
         }
         return output;
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1115,6 +1115,21 @@ public class GTUtility {
     }
 
     /**
+     * Tries to parse a string into an int, returning a default value if it fails.
+     * @param val string to parse
+     * @param defaultValue default value to return
+     * @return returns an int from the parsed string, otherwise the default value
+     */
+    public static long tryParseLong(String val, long defaultValue){
+        try {
+            return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+            GTLog.logger.warn(e);
+        }
+        return defaultValue;
+    }
+
+    /**
      * Compares a value against a min and max, with an option to invert the logic
      * @param value value to be compared
      * @param maxValue the max that the value can be

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
@@ -18,7 +18,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 
 public class CoverDetectorEnergy extends CoverBehavior implements ITickable {
 
-    private boolean isInverted;
+    protected boolean isInverted;
 
     public CoverDetectorEnergy(ICoverable coverHolder, EnumFacing attachedSide) {
         super(coverHolder, attachedSide);

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -6,8 +6,6 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.GregtechCapabilities;
-import gregtech.api.capability.GregtechTileCapabilities;
-import gregtech.api.capability.IControllable;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.cover.CoverWithUI;
 import gregtech.api.cover.ICoverable;
@@ -22,7 +20,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.*;
-import net.minecraftforge.common.capabilities.Capability;
 
 import javax.annotation.Nonnull;
 
@@ -43,7 +40,6 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = DEFAULT_MIN_EU;
         this.maxValue = DEFAULT_MAX_EU;
         this.outputAmount = 0;
-        // this.isEnabled = true;
         this.usePercent = false;
 
         // surely this is a good idea :clueless:
@@ -253,7 +249,6 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         tagCompound.setLong("maxEU", this.maxValue);
         tagCompound.setLong("minEU", this.minValue);
         tagCompound.setInteger("outputAmount", this.outputAmount);
-        // tagCompound.setBoolean("isEnabled", this.isEnabled);
         tagCompound.setBoolean("usePercent", this.usePercent);
         return tagCompound;
     }
@@ -264,7 +259,6 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = tagCompound.getLong("minEU");
         this.maxValue = tagCompound.getLong("maxEU");
         this.outputAmount = tagCompound.getInteger("outputAmount");
-        // this.isEnabled = tagCompound.getBoolean("isEnabled");
         this.usePercent = tagCompound.getBoolean("usePercent");
     }
 
@@ -274,7 +268,6 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         packetBuffer.writeLong(this.minValue);
         packetBuffer.writeLong(this.maxValue);
         packetBuffer.writeInt(this.outputAmount);
-        // packetBuffer.writeBoolean(this.isEnabled);
         packetBuffer.writeBoolean(this.usePercent);
     }
 
@@ -284,7 +277,6 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = packetBuffer.readLong();
         this.maxValue = packetBuffer.readLong();
         this.outputAmount = packetBuffer.readInt();
-        // this.isEnabled = packetBuffer.readBoolean();
         this.usePercent = packetBuffer.readBoolean();
     }
 }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -69,8 +69,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
                 if (energyContainer.getEnergyCapacity() > 0) {
                     compareValue((float) energyContainer.getEnergyStored() / energyContainer.getEnergyCapacity() * 100, maxValue, minValue);
                 } else {
-                    setRedstoneSignalOutput(isInverted ? 0 : 15);
-                    return;
+                    this.outputAmount = isInverted ? 0 : 15;
                 }
             } else {
                 compareValue(energyContainer.getEnergyStored(), maxValue, minValue);

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -9,7 +9,6 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.CoverWithUI;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.GuiTextures;

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -234,6 +234,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         tagCompound.setLong("maxEU", this.maxValue);
         tagCompound.setLong("minEU", this.minValue);
         tagCompound.setInteger("outputAmount", this.outputAmount);
+        tagCompound.setBoolean("isInverted", this.isInverted);
         tagCompound.setBoolean("usePercent", this.usePercent);
         return tagCompound;
     }
@@ -244,6 +245,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = tagCompound.getLong("minEU");
         this.maxValue = tagCompound.getLong("maxEU");
         this.outputAmount = tagCompound.getInteger("outputAmount");
+        this.isInverted = tagCompound.getBoolean("inverted");
         this.usePercent = tagCompound.getBoolean("usePercent");
     }
 
@@ -253,6 +255,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         packetBuffer.writeLong(this.minValue);
         packetBuffer.writeLong(this.maxValue);
         packetBuffer.writeInt(this.outputAmount);
+        packetBuffer.writeBoolean(this.isInverted);
         packetBuffer.writeBoolean(this.usePercent);
     }
 
@@ -262,6 +265,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = packetBuffer.readLong();
         this.maxValue = packetBuffer.readLong();
         this.outputAmount = packetBuffer.readInt();
+        this.isInverted = packetBuffer.readBoolean();
         this.usePercent = packetBuffer.readBoolean();
     }
 }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -162,28 +162,14 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
     }
 
     private void setMinValue(String val){
-        long parsedValue;
-
-        if (usePercent) {
-            parsedValue = GTUtility.tryParseLong(val, DEFAULT_MIN_PERCENT);
-        } else {
-            parsedValue = GTUtility.tryParseLong(val, DEFAULT_MIN_EU);
-        }
+        long parsedValue = GTUtility.tryParseLong(val, usePercent ? DEFAULT_MIN_PERCENT : DEFAULT_MIN_EU);
 
         this.minValue = Math.min(this.maxValue - 1, Math.max(0, parsedValue));
     }
 
     private void setMaxValue(String val){
-        long parsedValue;
-        long maxUpperLimit;
-
-        if (usePercent) {
-            parsedValue = GTUtility.tryParseLong(val, DEFAULT_MAX_PERCENT);
-            maxUpperLimit = 100;
-        } else {
-            parsedValue = GTUtility.tryParseLong(val, DEFAULT_MAX_EU);
-            maxUpperLimit = Long.MAX_VALUE;
-        }
+        long parsedValue = GTUtility.tryParseLong(val, usePercent ? DEFAULT_MAX_PERCENT : DEFAULT_MAX_EU);
+        long maxUpperLimit = usePercent ? 100 : Long.MAX_VALUE;
 
         this.maxValue = Math.max(this.minValue + 1, Math.min(parsedValue, maxUpperLimit));
     }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -94,6 +94,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         group.addWidget(new ImageWidget(72, 2 * (SIZE + PADDING), 8 * SIZE, SIZE, GuiTextures.DISPLAY));
 
         // surely this is a good idea :clueless:
+        // construct widgets that need to be updated
         this.widgetsToUpdate = constructWidgetsToUpdate();
 
         // change modes between percent and discrete EU

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -64,41 +64,19 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         if (energyContainer != null) {
             if (usePercent) {
                 if (energyContainer.getEnergyCapacity() > 0) {
-                    compareValue((float) energyContainer.getEnergyStored() / energyContainer.getEnergyCapacity() * 100, maxValue, minValue);
+                    float ratio = (float) energyContainer.getEnergyStored() / energyContainer.getEnergyCapacity();
+                    this.outputAmount = GTUtility.computeLatchedRedstoneBetweenValues(ratio * 100, this.maxValue, this.minValue, this.isInverted, this.outputAmount);
+                    // compareValue((float) energyContainer.getEnergyStored() / energyContainer.getEnergyCapacity() * 100, maxValue, minValue);
                 } else {
                     this.outputAmount = isInverted ? 0 : 15;
                 }
             } else {
-                compareValue(energyContainer.getEnergyStored(), maxValue, minValue);
+                this.outputAmount = GTUtility.computeLatchedRedstoneBetweenValues(energyContainer.getEnergyStored(),
+                        this.maxValue, this.minValue, this.isInverted, this.outputAmount);
+                // compareValue(energyContainer.getEnergyStored(), maxValue, minValue);
             }
-            setRedstoneSignalOutput(outputAmount);
         }
-    }
-
-    /**
-     * Compares the discrete value to min and max, and sets the output value accordingly.
-     * <p>
-     * Behaves like an SR Latch.
-     */
-    private void compareValue(long value, long maxValue, long minValue) {
-        if (value >= maxValue) {
-            this.outputAmount = isInverted ? 15 : 0;
-        } else if (value <= minValue) {
-            this.outputAmount = isInverted ? 0 : 15;
-        }
-    }
-
-    /**
-     * Compares the ratio value to min and max, and sets the output value accordingly.
-     * <p>
-     * Behaves like an SR Latch.
-     */
-    private void compareValue(float value, long maxValue, long minValue) {
-        if (value >= maxValue) {
-            this.outputAmount = isInverted ? 15 : 0;
-        } else if (value <= minValue) {
-            this.outputAmount = isInverted ? 0 : 15;
-        }
+        setRedstoneSignalOutput(outputAmount);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -201,7 +201,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         tagCompound.setLong("maxEU", this.maxValue);
         tagCompound.setLong("minEU", this.minValue);
         tagCompound.setInteger("outputAmount", this.outputAmount);
-        tagCompound.setBoolean("isInverted", this.isInverted);
+        tagCompound.setBoolean("inverted", this.isInverted);
         tagCompound.setBoolean("usePercent", this.usePercent);
         return tagCompound;
     }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -26,11 +26,8 @@ import net.minecraft.util.*;
 import net.minecraftforge.common.capabilities.Capability;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
 
-
-public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverWithUI, ITickable, IControllable {
+public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements CoverWithUI, IControllable {
 
     private static final int PADDING = 5, SIZE = 18;
 
@@ -38,9 +35,8 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
     private static final int DEFAULT_MIN_PERCENT = 33, DEFAULT_MAX_PERCENT = 66;
 
     public long minValue, maxValue;
-    private long maxValueUpperLimit;
     private int outputAmount;
-    private boolean inverted, isEnabled, usePercent;
+    private boolean isEnabled, usePercent;
     private final WidgetGroup widgetsToUpdate;
 
     public CoverDetectorEnergyAdvanced (ICoverable coverHolder, EnumFacing attachedSide) {
@@ -48,18 +44,11 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
         this.minValue = DEFAULT_MIN_EU;
         this.maxValue = DEFAULT_MAX_EU;
         this.outputAmount = 0;
-        this.inverted = false;
         this.isEnabled = true;
         this.usePercent = false;
-        // this.maxValueUpperLimit = Long.MAX_VALUE;
 
         // surely this is a good idea :clueless:
         this.widgetsToUpdate = constructWidgetsToUpdate();
-    }
-
-    @Override
-    public boolean canAttach() {
-        return coverHolder.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null) != null;
     }
 
     @Override
@@ -85,7 +74,7 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
                 if (energyContainer.getEnergyCapacity() > 0) {
                     compareValue((float) energyContainer.getEnergyStored() / energyContainer.getEnergyCapacity() * 100, maxValue, minValue);
                 } else {
-                    setRedstoneSignalOutput(inverted ? 0 : 15);
+                    setRedstoneSignalOutput(isInverted ? 0 : 15);
                     return;
                 }
             } else {
@@ -102,9 +91,9 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
      */
     private void compareValue(long value, long maxValue, long minValue) {
         if (value >= maxValue) {
-            this.outputAmount = inverted ? 15 : 0;
+            this.outputAmount = isInverted ? 15 : 0;
         } else if (value <= minValue) {
-            this.outputAmount = inverted ? 0 : 15;
+            this.outputAmount = isInverted ? 0 : 15;
         }
     }
 
@@ -115,9 +104,9 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
      */
     private void compareValue(float value, long maxValue, long minValue) {
         if (value >= maxValue) {
-            this.outputAmount = inverted ? 15 : 0;
+            this.outputAmount = isInverted ? 15 : 0;
         } else if (value <= minValue) {
-            this.outputAmount = inverted ? 0 : 15;
+            this.outputAmount = isInverted ? 0 : 15;
         }
     }
 
@@ -206,11 +195,11 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
     }
 
     private boolean isInverted(){
-        return this.inverted;
+        return this.isInverted;
     }
 
     private void setInverted(boolean b){
-        this.inverted = b;
+        this.isInverted = b;
     }
 
     private boolean isUsePercent(){
@@ -258,11 +247,6 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
         return this.usePercent ? " %" : " EU";
     }
 
-    @Override
-    public boolean canConnectRedstone() {
-        return true;
-    }
-
     @Nonnull
     @Override
     public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound tagCompound) {
@@ -270,7 +254,6 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
         tagCompound.setLong("maxEU", this.maxValue);
         tagCompound.setLong("minEU", this.minValue);
         tagCompound.setInteger("outputAmount", this.outputAmount);
-        tagCompound.setBoolean("inverted", this.inverted);
         tagCompound.setBoolean("isEnabled", this.isEnabled);
         tagCompound.setBoolean("usePercent", this.usePercent);
         return tagCompound;
@@ -282,27 +265,26 @@ public class CoverDetectorEnergyAdvanced extends CoverBehavior implements CoverW
         this.minValue = tagCompound.getLong("minEU");
         this.maxValue = tagCompound.getLong("maxEU");
         this.outputAmount = tagCompound.getInteger("outputAmount");
-        this.inverted = tagCompound.getBoolean("inverted");
         this.isEnabled = tagCompound.getBoolean("isEnabled");
         this.usePercent = tagCompound.getBoolean("usePercent");
     }
 
     @Override
     public void writeInitialSyncData(@Nonnull PacketBuffer packetBuffer) {
+        super.writeInitialSyncData(packetBuffer);
         packetBuffer.writeLong(this.minValue);
         packetBuffer.writeLong(this.maxValue);
         packetBuffer.writeInt(this.outputAmount);
-        packetBuffer.writeBoolean(this.inverted);
         packetBuffer.writeBoolean(this.isEnabled);
         packetBuffer.writeBoolean(this.usePercent);
     }
 
     @Override
     public void readInitialSyncData(@Nonnull PacketBuffer packetBuffer) {
+        super.readInitialSyncData(packetBuffer);
         this.minValue = packetBuffer.readLong();
         this.maxValue = packetBuffer.readLong();
         this.outputAmount = packetBuffer.readInt();
-        this.inverted = packetBuffer.readBoolean();
         this.isEnabled = packetBuffer.readBoolean();
         this.usePercent = packetBuffer.readBoolean();
     }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -33,7 +33,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
     public long minValue, maxValue;
     private int outputAmount;
     private boolean usePercent;
-    private final WidgetGroup widgetsToUpdate;
+    private WidgetGroup widgetsToUpdate;
 
     public CoverDetectorEnergyAdvanced (ICoverable coverHolder, EnumFacing attachedSide) {
         super(coverHolder, attachedSide);
@@ -41,9 +41,6 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.maxValue = DEFAULT_MAX_EU;
         this.outputAmount = 0;
         this.usePercent = false;
-
-        // surely this is a good idea :clueless:
-        this.widgetsToUpdate = constructWidgetsToUpdate();
     }
 
     @Override
@@ -118,7 +115,8 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         group.addWidget(new LabelWidget(10, 5 + 2 * (SIZE + PADDING), "cover.advanced_energy_detector.max"));
         group.addWidget(new ImageWidget(72, 2 * (SIZE + PADDING), 8 * SIZE, SIZE, GuiTextures.DISPLAY));
 
-        updateSyncedWidgets(); // update widgets on UI creation
+        // surely this is a good idea :clueless:
+        this.widgetsToUpdate = constructWidgetsToUpdate();
 
         // change modes between percent and discrete EU
         group.addWidget(new LabelWidget(10, 5 + 3 * (SIZE + PADDING), "cover.advanced_energy_detector.modes_label"));
@@ -142,13 +140,14 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
 
     private WidgetGroup constructWidgetsToUpdate() {
         WidgetGroup sync = new WidgetGroup();
+
         sync.addWidget(new TextFieldWidget2(76, 5 + (SIZE + PADDING), 8 * SIZE, SIZE, this::getMinValue, this::setMinValue)
-                .setMaxLength(19)
                 .setAllowedChars(TextFieldWidget2.NATURAL_NUMS)
+                .setMaxLength(this.getLength())
                 .setPostFix(this.getPostFix()));
         sync.addWidget(new TextFieldWidget2(76, 5 + 2 * (SIZE + PADDING), 8 * SIZE, SIZE, this::getMaxValue, this::setMaxValue)
-                .setMaxLength(19)
                 .setAllowedChars(TextFieldWidget2.NATURAL_NUMS)
+                .setMaxLength(this.getLength())
                 .setPostFix(this.getPostFix()));
         return sync;
     }
@@ -188,43 +187,32 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
 
     private void setUsePercent(boolean b){
         this.usePercent =  b;
-        int length;
 
         if (this.usePercent){ // using percent
             this.minValue = DEFAULT_MIN_PERCENT;
             this.maxValue = DEFAULT_MAX_PERCENT;
-            length = 3;
         } else { // using discrete EU
             this.minValue = DEFAULT_MIN_EU;
             this.maxValue = DEFAULT_MAX_EU;
-            length = 19;
         }
 
         // update widgets
-        updateSyncedWidgets(length);
-    }
-
-    private void updateSyncedWidgets(int length) {
-        for (Widget widget : this.widgetsToUpdate.widgets) {
-            if (widget instanceof TextFieldWidget2) {
-                ((TextFieldWidget2) widget).setPostFix(null); // clear postfix
-                ((TextFieldWidget2) widget).setPostFix(this.getPostFix());
-                ((TextFieldWidget2) widget).setMaxLength(length);
-            }
-        }
+        updateSyncedWidgets();
     }
 
     private void updateSyncedWidgets() {
-        for (Widget widget : this.widgetsToUpdate.widgets) {
-            if (widget instanceof TextFieldWidget2) {
-                ((TextFieldWidget2) widget).setPostFix(null); // clear postfix
-                ((TextFieldWidget2) widget).setPostFix(this.getPostFix());
-            }
+        for (Widget widget : widgetsToUpdate.widgets) {
+            ((TextFieldWidget2) widget).setPostFix(getPostFix());
+            ((TextFieldWidget2) widget).setMaxLength(getLength());
         }
     }
 
     private String getPostFix(){
-        return this.usePercent ? " %" : " EU";
+        return usePercent ? " %" : " EU";
+    }
+
+    private int getLength() {
+        return usePercent ? 3 : 19;
     }
 
     @Nonnull

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergyAdvanced.java
@@ -26,7 +26,7 @@ import net.minecraftforge.common.capabilities.Capability;
 
 import javax.annotation.Nonnull;
 
-public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements CoverWithUI, IControllable {
+public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements CoverWithUI {
 
     private static final int PADDING = 5, SIZE = 18;
 
@@ -35,7 +35,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
 
     public long minValue, maxValue;
     private int outputAmount;
-    private boolean isEnabled, usePercent;
+    private boolean usePercent;
     private final WidgetGroup widgetsToUpdate;
 
     public CoverDetectorEnergyAdvanced (ICoverable coverHolder, EnumFacing attachedSide) {
@@ -43,7 +43,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = DEFAULT_MIN_EU;
         this.maxValue = DEFAULT_MAX_EU;
         this.outputAmount = 0;
-        this.isEnabled = true;
+        // this.isEnabled = true;
         this.usePercent = false;
 
         // surely this is a good idea :clueless:
@@ -65,7 +65,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
 
     @Override
     public void update() {
-        if (coverHolder.getOffsetTimer() % 20 != 0 || !isEnabled) return;
+        if (coverHolder.getOffsetTimer() % 20 != 0) return;
 
         IEnergyContainer energyContainer = coverHolder.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);
         if (energyContainer != null) {
@@ -253,7 +253,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         tagCompound.setLong("maxEU", this.maxValue);
         tagCompound.setLong("minEU", this.minValue);
         tagCompound.setInteger("outputAmount", this.outputAmount);
-        tagCompound.setBoolean("isEnabled", this.isEnabled);
+        // tagCompound.setBoolean("isEnabled", this.isEnabled);
         tagCompound.setBoolean("usePercent", this.usePercent);
         return tagCompound;
     }
@@ -264,7 +264,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = tagCompound.getLong("minEU");
         this.maxValue = tagCompound.getLong("maxEU");
         this.outputAmount = tagCompound.getInteger("outputAmount");
-        this.isEnabled = tagCompound.getBoolean("isEnabled");
+        // this.isEnabled = tagCompound.getBoolean("isEnabled");
         this.usePercent = tagCompound.getBoolean("usePercent");
     }
 
@@ -274,7 +274,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         packetBuffer.writeLong(this.minValue);
         packetBuffer.writeLong(this.maxValue);
         packetBuffer.writeInt(this.outputAmount);
-        packetBuffer.writeBoolean(this.isEnabled);
+        // packetBuffer.writeBoolean(this.isEnabled);
         packetBuffer.writeBoolean(this.usePercent);
     }
 
@@ -284,27 +284,7 @@ public class CoverDetectorEnergyAdvanced extends CoverDetectorEnergy implements 
         this.minValue = packetBuffer.readLong();
         this.maxValue = packetBuffer.readLong();
         this.outputAmount = packetBuffer.readInt();
-        this.isEnabled = packetBuffer.readBoolean();
+        // this.isEnabled = packetBuffer.readBoolean();
         this.usePercent = packetBuffer.readBoolean();
-    }
-
-    @Override
-    public boolean isWorkingEnabled() {
-        return this.isEnabled;
-    }
-
-    @Override
-    public void setWorkingEnabled(boolean isActivationAllowed) {
-        this.isEnabled = isActivationAllowed;
-        setRedstoneSignalOutput(0);
-    }
-
-    @Override
-    public <T> T getCapability(Capability<T> capability, T defaultValue) {
-        if (capability == GregtechTileCapabilities.CAPABILITY_CONTROLLABLE) {
-            return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE.cast(this);
-        }
-
-        return defaultValue;
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1216,12 +1216,16 @@ cover.ender_fluid_link.private.tooltip.enabled=Switch to public tank mode
 cover.ender_fluid_link.incomplete_hex=Inputted color is incomplete!/nIt will be applied once complete (all 8 hex digits)/nClosing the gui will lose edits!
 
 cover.advanced_energy_detector.label=Advanced Energy Detector
-cover.advanced_energy_detector.min=Minimum EU
-cover.advanced_energy_detector.max=Maximum EU
+cover.advanced_energy_detector.min=Minimum:
+cover.advanced_energy_detector.max=Maximum:
 cover.advanced_energy_detector.invert_tooltip=Toggle to invert the redstone logic/nBy default, redstone is emitted when less than the minimum EU, and stops emitting when greater than the max EU
 cover.advanced_energy_detector.invert_label=Inverted:
 cover.advanced_energy_detector.normal=Normal
 cover.advanced_energy_detector.inverted=Inverted
+cover.advanced_energy_detector.modes_tooltip=Change between using discrete EU values or percentages for comparing min/max against an attached energy storage.
+cover.advanced_energy_detector.modes_label=Mode:
+cover.advanced_energy_detector.mode_eu=Discrete EU
+cover.advanced_energy_detector.mode_percent=Percentage
 
 cover.advanced_fluid_detector.label=Advanced Fluid Detector
 cover.advanced_fluid_detector.invert_tooltip=Toggle to invert the redstone logic/nBy default, redstone stops emitting when less than the minimum L of fluid, and starts emitting when greater than the min L of fluid up to the set maximum


### PR DESCRIPTION
## What
A PR for some adjustments to the Advanced Energy Detector to be on par (at least GUI-wise) with the other advanced detectors. Also implements functionality to use percentages instead of discrete EU values.

## Implementation Details
Changes GUI of Advanced Energy Detector to match other advanced detectors (fluid/item).
Make text fields wide enough to fit Long numbers (turns out they're quite big).
Prevent negative numbers for min/max EU
Utilize `tryParseLong()` in GTUtility to parse input strings
Properly manage parsed value being negative
Implement a percentage mode for comparison
Add GUI and lang for new modes

## Outcome
Advanced Energy Detector's GUI makes sense and follows the same design as the other advanced detectors
Invalid input strings are properly handled
Users can now use percentage mode to configure the energy detector easily when dealing with large energy values

## Additional Information
Adds `tryParseLong()` to GTUtility, to parse a string into a Long, falling back to a default value

## Potential Compatibility Issues
none afaik
