### PR TITLE
Fix visual bug with BlockGlassCasing

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
@@ -43,6 +43,13 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
     }
 
     @Override
+    public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer) {
+        return getState(state) == CasingType.TEMPERED_GLASS ?
+                BlockRenderLayer.TRANSLUCENT == layer :
+                BlockRenderLayer.CUTOUT == layer;
+    }
+
+    @Override
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("deprecation")
     public boolean isOpaqueCube(IBlockState state) {


### PR DESCRIPTION
## What
This PR fixes a visual bug associated with all variants of BlockGlassCasing, caused by incorrect render layer specification.

## Implementation Details
`canRenderInLayer` method is overridden in order to render the block on correct layer.
* Tempered Glass is rendered on `TRANSLUCENT` layer.
* All other variants are rendered on `CUTOUT` layer.

## Additional Information
The visual bug does not occur with items, as item rendering is handled separately. Also, the visual bug does not occur on runClient; I suspect another mod present in dev env is "fixing" the issue. (Maybe CTM? I have no idea)

Regardless of the mod interaction, the issue should be patched, as a clean instance with just CCL and GT still displays the visual bug.

## Potential Compatibility Issues
Probably none.

<details>
  <summary>Spoiler: Before and after the patch</summary>

  ![2023-02-17 07_59_05](https://user-images.githubusercontent.com/6449909/219508000-09881d8e-89cf-43f4-8b3b-d841b58a811c.png)

  ![2023-02-17 07_57_49](https://user-images.githubusercontent.com/6449909/219508026-55b77b5d-1702-4324-82ea-662575b379a1.png)
</details>

Edit: Turns out this issue were already documented in #1393.