### PR TITLE
Fix incorrect event handler registration

### DIFF
--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -129,7 +129,6 @@ public class CoreModule implements IGregTechModule {
         if (Loader.isModLoaded(GTValues.MODID_CT)) {
             logger.info("Running early CraftTweaker initialization scripts...");
             runEarlyCraftTweakerScripts();
-            MinecraftForge.EVENT_BUS.register(this);
         }
 
         // Fire Post-Material event, intended for when Materials need to be iterated over in-full before freezing

--- a/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
+++ b/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
@@ -29,13 +29,11 @@ public class ChestGenHooks {
 
     private static final LootCondition[] NO_CONDITIONS = new LootCondition[0];
 
-    private static final ChestGenHooks instance = new ChestGenHooks();
-
     private ChestGenHooks() {
     }
 
     public static void init() {
-        MinecraftForge.EVENT_BUS.register(instance);
+        MinecraftForge.EVENT_BUS.register(ChestGenHooks.class);
     }
 
     @SubscribeEvent
@@ -45,7 +43,7 @@ public class ChestGenHooks {
             List<LootEntryItem> entryItems = lootEntryItems.get(event.getName());
             for (LootEntryItem entry : entryItems) {
                 try {
-                    if(ConfigHolder.misc.debug) {
+                    if (ConfigHolder.misc.debug) {
                         GTLog.logger.info("adding {} to lootTable", entry.getEntryName());
                     }
                     mainPool.addEntry(entry);


### PR DESCRIPTION
## What
This PR fixes a part of event handler registration broken in a recent commit. Additionally, this PR removes one unnecessary registration.

## Outcome
`worldgen.addLoot` option and `worldgen.increaseDungeonLoot` option, which broke due to the incorrect event handler registration, will work again.

## Additional Information
I've looked into every occurrence of `MinecraftForge.EVENT_BUS.register` on the project and deemed there was no further issues. At least on surface level.

