### PR TITLE
Replace model lookup in VariantActiveBlock with manual layer checking

### DIFF
--- a/src/main/java/gregtech/api/block/VariantActiveBlock.java
+++ b/src/main/java/gregtech/api/block/VariantActiveBlock.java
@@ -4,10 +4,10 @@ import gregtech.api.GTValues;
 import gregtech.api.util.GTUtility;
 import gregtech.client.model.IModelSupplier;
 import gregtech.client.model.SimpleStateMapper;
+import gregtech.client.utils.BloomEffectUtil;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
-import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
@@ -15,48 +15,36 @@ import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
 import net.minecraft.util.BlockRenderLayer;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
 import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import team.chisel.ctm.client.state.CTMExtendedState;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
 
 import static gregtech.common.blocks.MetaBlocks.statePropertiesToString;
 
-@Mod.EventBusSubscriber(Side.CLIENT)
 public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends VariantBlock<T> implements IModelSupplier {
 
     public static final ModelResourceLocation MODEL_LOCATION = new ModelResourceLocation(new ResourceLocation(GTValues.MODID, "active_blocks"), "inventory");
     public static final Object2ObjectOpenHashMap<Integer, ObjectSet<BlockPos>> ACTIVE_BLOCKS = new Object2ObjectOpenHashMap<>();
-    private static final List<VariantActiveBlock<?>> INSTANCES = new ArrayList<>();
-    public static final Object2ObjectOpenHashMap<Block, ObjectOpenHashSet<BlockRenderLayer>> block2blockRenderLayerMap = new Object2ObjectOpenHashMap<>();
     public static final PropertyBool ACTIVE_DEPRECATED = PropertyBool.create("active");
     public static final UnlistedBooleanProperty ACTIVE = new UnlistedBooleanProperty("active");
 
     public VariantActiveBlock(Material materialIn) {
         super(materialIn);
-        INSTANCES.add(this);
     }
 
     @Override
@@ -72,7 +60,7 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
 
     @Override
     public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer) {
-        return block2blockRenderLayerMap.containsKey(state.getBlock()) && block2blockRenderLayerMap.get(state.getBlock()).contains(layer);
+        return layer == BlockRenderLayer.CUTOUT || layer == BloomEffectUtil.getRealBloomLayer();
     }
 
     @Nonnull
@@ -129,29 +117,6 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
             //ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(this), this.getMetaFromState(state), new ModelResourceLocation(this.getRegistryName(), "active=true," + statePropertiesToString(state.getProperties())));
             //ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(this), this.getMetaFromState(state), new ModelResourceLocation(this.getRegistryName(), "active=false," + statePropertiesToString(state.getProperties())));
             ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(this), this.getMetaFromState(state), new ModelResourceLocation(this.getRegistryName(), statePropertiesToString(state.getProperties())));
-        }
-    }
-
-    @SubscribeEvent(priority = EventPriority.LOWEST) // low priority to capture all event-registered models
-    public static void onModelBake(ModelBakeEvent event) {
-        block2blockRenderLayerMap.clear();
-        //Go over all VariantActiveBlock instances, then going over their model, and if they have a quad
-        //to render on that render layer, add it to the map.
-        for (Block b : INSTANCES) {
-            for (IBlockState state : b.getBlockState().getValidStates()) {
-                IBakedModel bakedModel = event.getModelRegistry().getObject(new ModelResourceLocation(b.getRegistryName(), statePropertiesToString(state.getProperties())));
-                if (bakedModel != null) {
-                    for (BlockRenderLayer layer : BlockRenderLayer.values()) {
-                        for (EnumFacing facing : EnumFacing.VALUES) {
-                            if (bakedModel.getQuads(state, facing, 0).size() > 0) {
-                                block2blockRenderLayerMap.putIfAbsent(b, new ObjectOpenHashSet<>());
-                                block2blockRenderLayerMap.get(b).add(layer);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -6,6 +6,7 @@ import gregtech.api.block.VariantItemBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
+import gregtech.client.utils.BloomEffectUtil;
 import gregtech.client.utils.TooltipHelper;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
@@ -13,6 +14,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLiving.SpawnPlacementType;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -34,6 +36,11 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
         setSoundType(SoundType.METAL);
         setHarvestLevel(ToolClasses.WRENCH, 2);
         setDefaultState(getState(CoilType.CUPRONICKEL));
+    }
+
+    @Override
+    public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer) {
+        return layer == BlockRenderLayer.SOLID || layer == BloomEffectUtil.getRealBloomLayer();
     }
 
     @Override


### PR DESCRIPTION
## What
This PR replaces the runtime model lookup done in `VariantActiveBlock` with manually checking given layer with hardcoded candidates.

## Implementation Details
As shown in #1513, the current approach does not work properly if CTM is not present. Even if CTM is present, the firebox does not correctly light up when `casingsActiveEmissiveTextures` is turned on.

<details>
  <summary>Spoiler: Current Firebox models [Attachment 1], and expected result [Attachment 2] (created with this PR)</summary>
  
![2023-02-20 22_22_14](https://user-images.githubusercontent.com/6449909/220131731-a2feba90-3823-4efd-9526-d1f3717b52a8.png)
![2023-02-20 22_22_53](https://user-images.githubusercontent.com/6449909/220131758-e846e639-2c76-4197-907e-ed8846c0bdb6.png)

  * The build in screenshot was modified to display active and inactive variants next to eachother.

</details>

The reason model lookup was done in the first place is because of the visual glitch occurred on Laminated Glass (#1263). This is caused by mismatching layer specification between `canRenderInLayer()` method in block and texture `.mcmeta` file. As there wouldn't be any problem if both `canRenderInLayer()` and `.mcmeta` expected the same render layer, there is no need to dynamically check the block models.

## Outcome
This PR fixes numerous visual glitches occurring when CTM is not present, such as incorrect bloom effects.

Removal of the model lookup should speed up the game by a tiny bit. With this change the VariantActiveBlock cache can be safely removed, as no other place required it.

Not to mention this PR fixes #1497.

## Potential Compatibility Issues
Addons that use `VariantActiveBlock` might experience visual glitch due to the change made in base class; failing to specify correct layer in `canRenderInLayer` will result in invisible blocks, similar to #1263.

Considering that the current approach is not without its flaws, I think this change is worth doing. If this PR is to be accepted, addon devs should be aware of the change.

<details>
  <summary>Spoiler: Every instance of VariantActiveBlock variations, both with and without CTM.</summary>

![2023-02-20 22_24_08](https://user-images.githubusercontent.com/6449909/220133157-c6e5584a-d11b-4024-b639-52462eaceed9.png)
![2023-02-20 22_27_37](https://user-images.githubusercontent.com/6449909/220133168-2f98a865-5d78-46b7-9117-6cd9a874cdab.png)

  * The build in screenshot was modified to display active and inactive variants next to eachother.

</details>