### PR TITLE
Fix different variants of BlockGlassCasing getting connected together

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
@@ -2,7 +2,6 @@ package gregtech.common.blocks;
 
 import gregtech.api.block.VariantActiveBlock;
 import gregtech.api.items.toolitem.ToolClasses;
-import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -57,6 +56,7 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public boolean isFullCube(IBlockState state) {
         return false;
     }
@@ -64,11 +64,12 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
     @Override
     @SideOnly(Side.CLIENT)
     @SuppressWarnings("deprecation")
-    public boolean shouldSideBeRendered(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
-        IBlockState iblockstate = blockAccess.getBlockState(pos.offset(side));
-        Block block = iblockstate.getBlock();
+    public boolean shouldSideBeRendered(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
+        IBlockState sideState = world.getBlockState(pos.offset(side));
 
-        return block != this && super.shouldSideBeRendered(blockState, blockAccess, pos, side);
+        return sideState.getBlock() == this ?
+                getState(sideState) != getState(state) :
+                super.shouldSideBeRendered(state, world, pos, side);
     }
 
     public enum CasingType implements IStringSerializable {


### PR DESCRIPTION
## What
This PR makes all variants of BlockGlassCasing render their connected side if it's connected to different variations of BlockGlassCasing. This new face culling behavior preserves most of the original behavior, while preventing visually awkward cases where different variations of glass casings cull each others on connected side.

## Outcome
Aesthetics
