### PR TITLE
Relocate SlotUtil

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/PhantomSlotUtil.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomSlotUtil.java
@@ -1,10 +1,12 @@
-package gregtech.api.util;
+package gregtech.api.gui.widgets;
 
 import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-public class SlotUtil {
+public final class PhantomSlotUtil {
+
+    private PhantomSlotUtil() {/**/}
 
     public static ItemStack slotClickPhantom(Slot slot, int mouseButton, ClickType clickTypeIn, ItemStack stackHeld) {
         ItemStack stack = ItemStack.EMPTY;

--- a/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
@@ -2,7 +2,6 @@ package gregtech.api.gui.widgets;
 
 import com.google.common.collect.Lists;
 import gregtech.api.gui.ingredient.IGhostIngredientTarget;
-import gregtech.api.util.SlotUtil;
 import gregtech.client.utils.TooltipHelper;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
 import net.minecraft.entity.player.EntityPlayer;
@@ -67,7 +66,7 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
     @Override
     public ItemStack slotClick(int dragType, ClickType clickTypeIn, EntityPlayer player) {
         ItemStack stackHeld = player.inventory.getItemStack();
-        return SlotUtil.slotClickPhantom(slotReference, dragType, clickTypeIn, stackHeld);
+        return PhantomSlotUtil.slotClickPhantom(slotReference, dragType, clickTypeIn, stackHeld);
     }
 
     @Override
@@ -94,7 +93,7 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
                     int mouseButton = Mouse.getEventButton();
                     boolean shiftDown = TooltipHelper.isShiftDown();
                     ClickType clickType = shiftDown ? ClickType.QUICK_MOVE : ClickType.PICKUP;
-                    SlotUtil.slotClickPhantom(slotReference, mouseButton, clickType, (ItemStack) ingredient);
+                    PhantomSlotUtil.slotClickPhantom(slotReference, mouseButton, clickType, (ItemStack) ingredient);
                     writeClientAction(1, buffer -> {
                         buffer.writeItemStack((ItemStack) ingredient);
                         buffer.writeVarInt(mouseButton);
@@ -117,7 +116,7 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
             int mouseButton = buffer.readVarInt();
             boolean shiftKeyDown = buffer.readBoolean();
             ClickType clickType = shiftKeyDown ? ClickType.QUICK_MOVE : ClickType.PICKUP;
-            SlotUtil.slotClickPhantom(slotReference, mouseButton, clickType, stackHeld);
+            PhantomSlotUtil.slotClickPhantom(slotReference, mouseButton, clickType, stackHeld);
         } else if (id == 2) {
             slotReference.putStack(ItemStack.EMPTY);
         }


### PR DESCRIPTION
## What
This PR relocates `SlotUtil` from `api.util` to `api.gui.widgets`, and renames it to `PhantomSlotUtil` to more accurately describe its purpose. It is only used for the implementation of `PhantomSlotWidget`. This will help clean up the `util` the package.

## Outcome
Relocates SlotUtil to `api.gui.widgets` for improved organization, and renames it to PhantomSlotUtil.

## Potential Compatibility Issues
Given that this class is in the `api` package, other mods may depend on it. This is very unlikely given that it only has applications with `PhantomSlotWidget`. The widget class does not take any instances of this class as parameters, and therefore SlotUtil likely will not be contained in any imports either. There is always a possibility of addons using it however, but fixing it should be trivial as it is just a package move and class rename.
