### PR TITLE
Fix the recipe removal button not showing without CT installed

### DIFF
--- a/src/main/java/gregtech/api/util/CTRecipeHelper.java
+++ b/src/main/java/gregtech/api/util/CTRecipeHelper.java
@@ -191,18 +191,6 @@ public class CTRecipeHelper {
         return builder.toString();
     }
 
-    public static String getFirstOutputString(Recipe recipe) {
-        String output = "";
-        if (!recipe.getOutputs().isEmpty()) {
-            ItemStack item = recipe.getOutputs().get(0);
-            output = item.getDisplayName() + " * " + item.getCount();
-        } else if (!recipe.getFluidOutputs().isEmpty()) {
-            FluidStack fluid = recipe.getFluidOutputs().get(0);
-            output = fluid.getLocalizedName() + " * " + fluid.amount;
-        }
-        return output;
-    }
-
     public static String getCtItemString(GTRecipeInput recipeInput) {
         StringBuilder builder = new StringBuilder();
         ItemStack itemStack = null;

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -17,7 +17,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
 import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
@@ -1210,22 +1209,4 @@ public class GTUtility {
     public static boolean isPointWithinRange(int initialX, int initialY, int width, int height, int pointX, int pointY) {
         return initialX <= pointX && pointX <= initialX + width && initialY <= pointY && pointY <= initialY + height;
     }
-
-    /**
-     * @param recipe the recipe to retrieve from
-     * @return the first output in a human-readable form
-     */
-    @Nonnull
-    public static String getFirstOutputString(@Nonnull Recipe recipe) {
-        String output = "";
-        if (!recipe.getOutputs().isEmpty()) {
-            ItemStack item = recipe.getOutputs().get(0);
-            output = item.getDisplayName() + " * " + item.getCount();
-        } else if (!recipe.getFluidOutputs().isEmpty()) {
-            FluidStack fluid = recipe.getFluidOutputs().get(0);
-            output = fluid.getLocalizedName() + " * " + fluid.amount;
-        }
-        return output;
-    }
-
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -17,6 +17,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
 import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
@@ -1209,4 +1210,22 @@ public class GTUtility {
     public static boolean isPointWithinRange(int initialX, int initialY, int width, int height, int pointX, int pointY) {
         return initialX <= pointX && pointX <= initialX + width && initialY <= pointY && pointY <= initialY + height;
     }
+
+    /**
+     * @param recipe the recipe to retrieve from
+     * @return the first output in a human-readable form
+     */
+    @Nonnull
+    public static String getFirstOutputString(@Nonnull Recipe recipe) {
+        String output = "";
+        if (!recipe.getOutputs().isEmpty()) {
+            ItemStack item = recipe.getOutputs().get(0);
+            output = item.getDisplayName() + " * " + item.getCount();
+        } else if (!recipe.getFluidOutputs().isEmpty()) {
+            FluidStack fluid = recipe.getFluidOutputs().get(0);
+            output = fluid.getLocalizedName() + " * " + fluid.amount;
+        }
+        return output;
+    }
+
 }

--- a/src/main/java/gregtech/integration/RecipeCompatUtil.java
+++ b/src/main/java/gregtech/integration/RecipeCompatUtil.java
@@ -1,0 +1,33 @@
+package gregtech.integration;
+
+import gregtech.api.recipes.Recipe;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Contains utilities for recipe compatibility with scripting mods
+ */
+public final class RecipeCompatUtil {
+
+    private RecipeCompatUtil() {/**/}
+
+    /**
+     * @param recipe the recipe to retrieve from
+     * @return the first output in a human-readable form
+     */
+    @Nonnull
+    public static String getFirstOutputString(@Nonnull Recipe recipe) {
+        String output = "";
+        if (!recipe.getOutputs().isEmpty()) {
+            ItemStack item = recipe.getOutputs().get(0);
+            output = item.getDisplayName() + " * " + item.getCount();
+        } else if (!recipe.getFluidOutputs().isEmpty()) {
+            FluidStack fluid = recipe.getFluidOutputs().get(0);
+            output = fluid.getLocalizedName() + " * " + fluid.amount;
+        }
+        return output;
+    }
+
+}

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -136,7 +136,10 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
     @Override
     public void initExtras() {
-        BooleanSupplier creativePlayerCtPredicate = () -> Minecraft.getMinecraft().player != null && Minecraft.getMinecraft().player.isCreative() && Loader.isModLoaded(GTValues.MODID_CT);
+        // do not add the X button if no tweaker mod is present
+        if (!Loader.isModLoaded(GTValues.MODID_CT) && !GroovyScriptCompat.isLoaded()) return;
+
+        BooleanSupplier creativePlayerCtPredicate = () -> Minecraft.getMinecraft().player != null && Minecraft.getMinecraft().player.isCreative();
         final String mod = GroovyScriptCompat.isLoaded() ? "GroovyScript" : "CraftTweaker";
         buttons.add(new JeiButton(166, 2, 10, 10)
                 .setTextures(GuiTextures.BUTTON_CLEAR_GRID)
@@ -145,7 +148,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                     String recipeLine = GroovyScriptCompat.isLoaded() ?
                             GroovyScriptCompat.getRecipeRemoveLine(recipeMap, recipe) :
                             CTRecipeHelper.getRecipeRemoveLine(recipeMap, recipe);
-                    String output = CTRecipeHelper.getFirstOutputString(recipe);
+                    String output = GTUtility.getFirstOutputString(recipe);
                     if (!output.isEmpty()) {
                         output = "// " + output + "\n";
                     }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -14,6 +14,7 @@ import gregtech.api.util.ClipboardUtil;
 import gregtech.api.util.GTUtility;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.integration.GroovyScriptCompat;
+import gregtech.integration.RecipeCompatUtil;
 import gregtech.integration.jei.utils.AdvancedRecipeWrapper;
 import gregtech.integration.jei.utils.JeiButton;
 import mezz.jei.api.ingredients.IIngredients;
@@ -148,7 +149,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                     String recipeLine = GroovyScriptCompat.isLoaded() ?
                             GroovyScriptCompat.getRecipeRemoveLine(recipeMap, recipe) :
                             CTRecipeHelper.getRecipeRemoveLine(recipeMap, recipe);
-                    String output = GTUtility.getFirstOutputString(recipe);
+                    String output = RecipeCompatUtil.getFirstOutputString(recipe);
                     if (!output.isEmpty()) {
                         output = "// " + output + "\n";
                     }


### PR DESCRIPTION
## What
This PR fixes the recipe removal button not showing with only GroovyScript installed.

## Implementation Details
`CTRecipeHelper#getFirstOutputString` was moved to `GTUtility` as compat for both scripting mods utilize it, and should prevent any potential classloading issues if CT is not installed and this method is utilized.

## Outcome
Fixes the recipe removal button not showing without CT installed.

## Potential Compatibility Issues
Because of the aforementioned method being moved, addons depending on it may have broken imports. This should be trivial to fix on their end, but it is still of note. It is very unlikely addons will use this method, but it is still a possibility.
