### PR TITLE
Improve performance of MetaItem#getItem

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -27,7 +27,7 @@ import gregtech.client.utils.ToolChargeBarRenderer;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.shorts.Short2ObjectAVLTreeMap;
+import it.unimi.dsi.fastutil.shorts.Short2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
@@ -69,7 +69,6 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
-import java.util.List;
 
 /**
  * MetaItem is item that can have up to Short.MAX_VALUE items inside one id.
@@ -92,8 +91,8 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return Collections.unmodifiableList(META_ITEMS);
     }
 
-    protected final Short2ObjectMap<T> metaItems = new Short2ObjectAVLTreeMap<>();
     private final Map<String, T> names = new Object2ObjectOpenHashMap<>();
+    protected final Short2ObjectMap<T> metaItems = new Short2ObjectLinkedOpenHashMap<>();
     protected final Short2ObjectMap<ModelResourceLocation> metaItemsModels = new Short2ObjectOpenHashMap<>();
     protected final Short2ObjectMap<ModelResourceLocation[]> specialItemsModels = new Short2ObjectOpenHashMap<>();
     protected static final ModelResourceLocation MISSING_LOCATION = new ModelResourceLocation("builtin/missing", "inventory");


### PR DESCRIPTION
## What
`MetaItem#getItem(short)` and `MetaItem#getItem(ItemStack)` can sometimes be called a lot of times, for example in armor logic. This PR changes the backing `metaItems` map from a `TreeMap` to a `LinkedHashMap`. This improves performance of getItem() with an O(1) lookup as opposed to a tree's O(logn). The `LinkedHashMap` also retains the original intended behavior of using a tree map, so items in JEI are still appropriately in order.

## Outcome
Improves performance of MetaItem#getItem.
