### PR TITLE
Handle invalid metaitems gracefully

### DIFF
--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -172,7 +172,8 @@ public class MetaPrefixItem extends StandardMetaItem {
                 float heatDamage = prefix.heatDamageFunction.apply(material.getBlastTemperature());
                 ItemStack armor = entity.getItemStackFromSlot(EntityEquipmentSlot.CHEST);
                 if (!armor.isEmpty() && armor.getItem() instanceof ArmorMetaItem<?>) {
-                    heatDamage *= ((ArmorMetaItem<?>) armor.getItem()).getItem(armor).getArmorLogic().getHeatResistance();
+                    ArmorMetaItem<?>.ArmorMetaValueItem metaValueItem = ((ArmorMetaItem<?>) armor.getItem()).getItem(armor);
+                    if (metaValueItem != null) heatDamage *= metaValueItem.getArmorLogic().getHeatResistance();
                 }
 
                 if (heatDamage > 0.0) {

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -223,14 +223,17 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         return Collections.unmodifiableCollection(metaItems.values());
     }
 
+    @Nullable
     public final T getItem(short metaValue) {
         return metaItems.get(formatRawItemDamage(metaValue));
     }
 
+    @Nullable
     public final T getItem(String valueName) {
         return names.get(valueName);
     }
 
+    @Nullable
     public final T getItem(ItemStack itemStack) {
         return getItem((short) (itemStack.getItemDamage() - metaItemOffset));
     }

--- a/src/main/java/gregtech/api/util/CTRecipeHelper.java
+++ b/src/main/java/gregtech/api/util/CTRecipeHelper.java
@@ -23,8 +23,8 @@ public class CTRecipeHelper {
     @Nullable
     public static String getMetaItemId(ItemStack item) {
         if (item.getItem() instanceof MetaItem) {
-            MetaItem<?> metaItem = (MetaItem<?>) item.getItem();
-            return metaItem.getItem(item).unlocalizedName;
+            MetaItem<?>.MetaValueItem metaValueItem = ((MetaItem<?>) item.getItem()).getItem(item);
+            if (metaValueItem != null) return metaValueItem.unlocalizedName;
         }
         if (item.getItem() instanceof ItemBlock) {
             Block block = ((ItemBlock) item.getItem()).getBlock();

--- a/src/main/java/gregtech/client/event/ClientEventHandler.java
+++ b/src/main/java/gregtech/client/event/ClientEventHandler.java
@@ -19,9 +19,9 @@ import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEn
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.*;
@@ -134,6 +134,7 @@ public class ClientEventHandler {
     private static void renderHUDMetaArmor(@Nonnull ItemStack stack) {
         if (stack.getItem() instanceof ArmorMetaItem) {
             ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) stack.getItem()).getItem(stack);
+            if (valueItem == null) return;
             if (valueItem.getArmorLogic() instanceof IItemHUDProvider) {
                 IItemHUDProvider.tryDrawHud((IItemHUDProvider) valueItem.getArmorLogic(), stack);
             }
@@ -143,6 +144,7 @@ public class ClientEventHandler {
     private static void renderHUDMetaItem(@Nonnull ItemStack stack) {
         if (stack.getItem() instanceof MetaItem<?>) {
             MetaItem<?>.MetaValueItem valueItem = ((MetaItem<?>) stack.getItem()).getItem(stack);
+            if (valueItem == null) return;
             for (IItemBehaviour behaviour : valueItem.getBehaviours()) {
                 if (behaviour instanceof IItemHUDProvider) {
                     IItemHUDProvider.tryDrawHud((IItemHUDProvider) behaviour, stack);

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -148,13 +148,19 @@ public class EventHandlers {
                 return;
 
             if (!armor.isEmpty() && armor.getItem() instanceof ArmorMetaItem<?>) {
-                ((ArmorMetaItem<?>) armor.getItem()).getItem(armor).getArmorLogic().damageArmor(player, armor, DamageSource.FALL, (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
-                player.fallDistance = 0;
-                event.setCanceled(true);
+                ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) armor.getItem()).getItem(armor);
+                if (valueItem != null) {
+                    valueItem.getArmorLogic().damageArmor(player, armor, DamageSource.FALL, (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
+                    player.fallDistance = 0;
+                    event.setCanceled(true);
+                }
             } else if (!jet.isEmpty() && jet.getItem() instanceof ArmorMetaItem<?> && GTUtility.getOrCreateNbtCompound(jet).hasKey("flyMode")) {
-                ((ArmorMetaItem<?>) jet.getItem()).getItem(jet).getArmorLogic().damageArmor(player, jet, DamageSource.FALL, (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
-                player.fallDistance = 0;
-                event.setCanceled(true);
+                ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) jet.getItem()).getItem(jet);
+                if (valueItem != null) {
+                    valueItem.getArmorLogic().damageArmor(player, jet, DamageSource.FALL, (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
+                    player.fallDistance = 0;
+                    event.setCanceled(true);
+                }
             }
         }
     }
@@ -169,14 +175,15 @@ public class EventHandlers {
         if (!(stack.getItem() instanceof ArmorMetaItem) || stack.getItem().equals(event.getTo().getItem()))
             return;
 
-        ArmorMetaItem<?> armorMetaItem = (ArmorMetaItem<?>) stack.getItem();
-        if (armorMetaItem.getItem(stack).isItemEqual(MetaItems.NIGHTVISION_GOGGLES.getStackForm()) ||
-                armorMetaItem.getItem(stack).isItemEqual(MetaItems.NANO_HELMET.getStackForm()) ||
-                armorMetaItem.getItem(stack).isItemEqual(MetaItems.QUANTUM_HELMET.getStackForm())) {
+        ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) stack.getItem()).getItem(stack);
+        if (valueItem == null) return;
+        if (valueItem.isItemEqual(MetaItems.NIGHTVISION_GOGGLES.getStackForm()) ||
+                valueItem.isItemEqual(MetaItems.NANO_HELMET.getStackForm()) ||
+                valueItem.isItemEqual(MetaItems.QUANTUM_HELMET.getStackForm())) {
             event.getEntityLiving().removePotionEffect(MobEffects.NIGHT_VISION);
         }
-        if (armorMetaItem.getItem(stack).isItemEqual(MetaItems.QUANTUM_CHESTPLATE.getStackForm()) ||
-                armorMetaItem.getItem(stack).isItemEqual(MetaItems.QUANTUM_CHESTPLATE_ADVANCED.getStackForm())) {
+        if (valueItem.isItemEqual(MetaItems.QUANTUM_CHESTPLATE.getStackForm()) ||
+                valueItem.isItemEqual(MetaItems.QUANTUM_CHESTPLATE_ADVANCED.getStackForm())) {
             event.getEntity().isImmuneToFire = false;
         }
     }
@@ -187,8 +194,12 @@ public class EventHandlers {
         if (event.phase == TickEvent.Phase.START && !event.player.isSpectator() && !(event.player instanceof EntityOtherPlayerMP) && !(event.player instanceof FakePlayer)) {
             ItemStack feetEquip = event.player.getItemStackFromSlot(EntityEquipmentSlot.FEET);
             if (!lastFeetEquip.getItem().equals(feetEquip.getItem())) {
-                if ((lastFeetEquip.getItem() instanceof ArmorMetaItem<?>) && ((ArmorMetaItem<?>) lastFeetEquip.getItem()).getItem(lastFeetEquip).getArmorLogic() instanceof IStepAssist)
-                    event.player.stepHeight = 0.6f;
+                if (lastFeetEquip.getItem() instanceof ArmorMetaItem<?>) {
+                    ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) lastFeetEquip.getItem()).getItem(lastFeetEquip);
+                    if (valueItem != null && valueItem.getArmorLogic() instanceof IStepAssist) {
+                        event.player.stepHeight = 0.6f;
+                    }
+                }
 
                 lastFeetEquip = feetEquip.copy();
             }

--- a/src/main/java/gregtech/common/metatileentities/primitive/MetaTileEntityCharcoalPileIgniter.java
+++ b/src/main/java/gregtech/common/metatileentities/primitive/MetaTileEntityCharcoalPileIgniter.java
@@ -199,7 +199,7 @@ public class MetaTileEntityCharcoalPileIgniter extends MultiblockControllerBase 
         // slice is finished after center, so we can re-use it a bit more
         slice[slice.length - 1] = wallBuilder.toString();
 
-            return FactoryBlockPattern.start()
+        return FactoryBlockPattern.start()
                 .aisle(wall)
                 .aisle(slice).setRepeatable(0, 4)
                 .aisle(center)
@@ -513,10 +513,9 @@ public class MetaTileEntityCharcoalPileIgniter extends MultiblockControllerBase 
                 } else if (stack.getItem() instanceof MetaItem) {
                     // lighters
                     MetaItem<?>.MetaValueItem valueItem = ((MetaItem<?>) stack.getItem()).getItem(stack);
-                    for (IItemBehaviour behaviour : valueItem.getBehaviours()) {
-                        if (behaviour instanceof LighterBehaviour) {
-                            if (((LighterBehaviour) behaviour).consumeFuel(event.getEntityPlayer(), stack)) {
-
+                    if (valueItem != null) {
+                        for (IItemBehaviour behaviour : valueItem.getBehaviours()) {
+                            if (behaviour instanceof LighterBehaviour && ((LighterBehaviour) behaviour).consumeFuel(event.getEntityPlayer(), stack)) {
                                 // lighter sound does not get played when handled like this
                                 event.getWorld().playSound(null, event.getPos(), SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.PLAYERS, 1.0F, 1.0F);
 

--- a/src/main/java/gregtech/common/terminal/app/guide/ItemGuideApp.java
+++ b/src/main/java/gregtech/common/terminal/app/guide/ItemGuideApp.java
@@ -25,7 +25,8 @@ public class ItemGuideApp extends GuideApp<ItemGuideApp.GuideItem> {
     @Override
     protected String rawItemName(GuideItem item) {
         if (item.stack.getItem() instanceof MetaItem) {
-            return ((MetaItem<?>) item.stack.getItem()).getItem((short) item.stack.getMetadata()).unlocalizedName;
+            MetaItem<?>.MetaValueItem metaValueItem = ((MetaItem<?>) item.stack.getItem()).getItem((short) item.stack.getMetadata());
+            if (metaValueItem != null) return metaValueItem.unlocalizedName;
         }
         return item.stack.getTranslationKey();
     }


### PR DESCRIPTION
## What
This PR fixes a possible crash by NPE from accessing nonexistent `MetaValueItem`.

## Implementation Details
All three overloaded variations of `MetaItem#getItem` can return `null` on invalid state, thus the result should be handled accordingly. Although a majority of usages already contained null-checking, some portion of them lacked proper null checks, and posed a risk of crashing the game. One instance, `ClientEventHandler#renderHUDMetaItem`, accessed MetaValueItem under mouse cursor each frame with no null checking, so this created client side crash if a player hovered their mouse over invalid metaitem.

This PR addresses the issue by (1) annotating `getItem` method as `@Nullable`, and (2) inserting null check on each `getItem` usages.
