### PR TITLE
Allow any charge lapotron battery to be used in recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
@@ -311,7 +311,7 @@ public class BatteryRecipes {
 
         // Lapotronic Energy Orb
         LASER_ENGRAVER_RECIPES.recipeBuilder()
-                .input(LAPOTRON_CRYSTAL)
+                .inputNBT(LAPOTRON_CRYSTAL, NBTMatcher.ANY, NBTCondition.ANY)
                 .notConsumable(craftingLens, Color.Blue)
                 .output(ENGRAVED_LAPOTRON_CHIP, 3)
                 .cleanroom(CleanroomType.CLEANROOM)


### PR DESCRIPTION
## What
Allows any charge lapotron crystal to be used in the lapotron chip recipe. Closes #1438 

There was some discussion on if there should be charge limits, like the recipe only working when the charge is less than 25%, but this was generally thought to be confusing for the player. The general consensus was allow any charge to be used.

## Outcome
Fix Lapotron Crystal Chip recipe.
