### PR TITLE
Make overclockResults protected instead of private

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -48,7 +48,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     private boolean allowOverclocking = true;
     protected int parallelRecipesPerformed;
     private long overclockVoltage = 0;
-    private int[] overclockResults;
+    protected int[] overclockResults;
 
     protected boolean canRecipeProgress = true;
 


### PR DESCRIPTION
## What
Makes AbstractRecipeLogic.overclockResults protected so children can set and get it easily.

## Implementation Details
I changed the word

## Outcome
Makes it so I don't have to use reflections to override setupAndConsumeRecipe() 

## Additional Information
I like your haircut

## Potential Compatibility Issues
I don't think this even breaks if you were using reflections.
