### PR TITLE
Fix issues with electric tools

### DIFF
--- a/src/main/java/gregtech/common/crafting/ShapedOreEnergyTransferRecipe.java
+++ b/src/main/java/gregtech/common/crafting/ShapedOreEnergyTransferRecipe.java
@@ -56,6 +56,7 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
     public static void chargeStackFromComponents(ItemStack toolStack, IInventory ingredients, Predicate<ItemStack> chargePredicate, boolean transferMaxCharge) {
         IElectricItem electricItem = toolStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
         long totalMaxCharge = 0L;
+        long toCharge = 0L;
         if (electricItem != null && electricItem.getMaxCharge() > 0L) {
             for (int slotIndex = 0; slotIndex < ingredients.getSizeInventory(); slotIndex++) {
                 ItemStack stackInSlot = ingredients.getStackInSlot(slotIndex);
@@ -67,12 +68,13 @@ public class ShapedOreEnergyTransferRecipe extends ShapedOreRecipe {
                     continue;
                 }
                 totalMaxCharge += batteryItem.getMaxCharge();
-                long discharged = batteryItem.discharge(Long.MAX_VALUE, Integer.MAX_VALUE, true, true, true);
-                electricItem.charge(discharged, Integer.MAX_VALUE, true, false);
+                toCharge += batteryItem.discharge(Long.MAX_VALUE, Integer.MAX_VALUE, true, true, true);
             }
         }
         if (electricItem instanceof ElectricItem && transferMaxCharge) {
             ((ElectricItem) electricItem).setMaxChargeOverride(totalMaxCharge);
         }
+        //noinspection DataFlowIssue
+        electricItem.charge(toCharge, Integer.MAX_VALUE, true, false);
     }
 }


### PR DESCRIPTION
## What
This PR fixes two issues with electric tools. 

First, it fixes issues found in `ShapedOreEnergyTransferRecipe`. It previously attempted to charge the output item before overriding its max charge. In cases where there was only one item to transfer charge from, it would be transferred before setting the maximum charge. This can be seen when crafting tools using power units with higher maximum charges than the default power unit. This PR fixes this bug.

The second issue fixed is related to electric tools breaking. When electric tools broke, the power unit stack dropped would have the default maximum charge. This PR fixes this by overriding the maximum charge to be the same as the tool's.

## Outcome
Fixes issues with electric tools. Closes #1484.
