### PR TITLE
Allow Advanced Quarktech to use any charge input

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -1,10 +1,13 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTCondition;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTMatcher;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterials;
 import gregtech.api.unification.material.MarkerMaterials.Color;
@@ -226,7 +229,7 @@ public class MiscRecipeLoader {
                 .buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(1000).EUt(GTValues.VA[GTValues.LuV])
-                .inputs(QUANTUM_CHESTPLATE.getStackForm())
+                .inputNBT(((ArmorMetaItem<?>) QUANTUM_CHESTPLATE.getStackForm().getItem()).getItem(QUANTUM_CHESTPLATE.getStackForm()), NBTMatcher.ANY, NBTCondition.ANY)
                 .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(2))
                 .input(wireFine, NiobiumTitanium, 64)
                 .input(wireGtQuadruple, Osmium, 6)


### PR DESCRIPTION
## What
Allows the Advanced Quarktech suite assembler recipe to use any charge quarktech suit input. Also, armor meta items are cursed.


## Outcome
Allows the Advanced Quarktech suite assembler recipe to use any charge quarktech suit input
