### PR TITLE
Fix jar configuration not applying to deobfJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,12 +176,15 @@ fancyGradle {
     }
 }
 
+processJarTask jar
+
 if (project.build_deobfJar.toBoolean()) {
     // Create deobf dev jars
     tasks.register('deobfJar', Jar) {
         archiveClassifier.set 'deobf'
         from sourceSets.main.output
     }
+    processJarTask deobfJar
 }
 
 if (project.build_apiJar.toBoolean()) {
@@ -235,33 +238,6 @@ sourceSets {
     main.output.setResourcesDir(main.java.classesDirectory)
 }
 
-jar {
-    manifest {
-        // noinspection GroovyAssignabilityCheck
-        def attribute_map = [:]
-        if (project.use_coremod.toBoolean()) {
-            attribute_map['FMLCorePlugin'] = project.coremod_plugin_class_name
-            if (project.include_mod.toBoolean()) {
-                attribute_map['FMLCorePluginContainsFMLMod'] = true
-                attribute_map['ForceLoadAsMod'] = project.gradle.startParameter.taskNames[0] == 'build'
-            }
-        }
-        if (project.use_mixins.toBoolean()) {
-            attribute_map['TweakClass'] = 'org.spongepowered.asm.launch.MixinTweaker'
-        }
-        if (project.has_access_transformer.toBoolean()) {
-            attribute_map['FMLAT'] = 'gregtech_at.cfg'
-        }
-        attributes(attribute_map)
-    }
-
-    // exclude all files in src/api from being shipped in the jar
-    // this prevents crashes in obfuscated environments
-    file('src/api/').eachDirRecurse { dir ->
-        exclude dir.name
-    }
-}
-
 artifacts {
     if (project.build_deobfJar.toBoolean()) {
         archives deobfJar
@@ -313,6 +289,42 @@ test {
     useJUnitPlatform()
 }
 
+/**
+ * Applies required processing to jar tasks
+ * @param task the task to process
+ */
+private void processJarTask(task) {
+    task.configure {
+        manifest {
+            // noinspection GroovyAssignabilityCheck
+            def attribute_map = [:]
+            if (project.use_coremod.toBoolean()) {
+                attribute_map['FMLCorePlugin'] = project.coremod_plugin_class_name
+                if (project.include_mod.toBoolean()) {
+                    attribute_map['FMLCorePluginContainsFMLMod'] = true
+                    attribute_map['ForceLoadAsMod'] = project.gradle.startParameter.taskNames[0] == 'build'
+                }
+            }
+            if (project.use_mixins.toBoolean()) {
+                attribute_map['TweakClass'] = 'org.spongepowered.asm.launch.MixinTweaker'
+            }
+            if (project.has_access_transformer.toBoolean()) {
+                attribute_map['FMLAT'] = 'gregtech_at.cfg'
+            }
+            attributes(attribute_map)
+        }
+
+        // exclude all files in src/api from being shipped in the jar
+        // this prevents crashes in obfuscated environments
+        file('src/api/').eachDirRecurse { dir ->
+            exclude dir.name
+        }
+    }
+}
+
+/**
+ * @return the current project version, parsed from the version file
+ */
 @SuppressWarnings('GroovyAssignabilityCheck')
 private String getVersionFromJava() {
     def major = '0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,15 +8,15 @@ minecraft_version = 1.12.2
 maven_group = gregtech
 archives_base_name = gregtech
 
-# This will downlaod sourses and Javadoc for the dependencies (for example mixins), set which ide you use
-# You can look up dependencies and their available sources and Javadoc in intellij by going to File ProjectStructure Libaries
+# This will download sources and Javadoc for the dependencies (for example mixins), set which ide you use
+# You can look up dependencies and their available sources and Javadoc in intellij by going to File ProjectStructure Libraries
 use_intellij_idea = true
 use_eclipse = false
 
-# Optionial Jar compiling
-build_deobfJar = false
+# Optional Jar compiling
+build_deobfJar = true
 build_apiJar = false
-build_sourceJar = false
+build_sourceJar = true
 
 # If any properties change below this line, refresh gradle again to ensure everything is working correctly.
 
@@ -42,22 +42,27 @@ mcp_mappings_channel = stable
 mcp_mappings_version = 39-1.12
 
 ## Hard Dependencies
+### CCL 3.2.3.358
 ccl_pid = 242818
 ccl_fid = 2779848
 
 ## Soft Dependencies
 jei_version = 4.16.1.302
 crt_version = 4.1.20.684
+### TOP 1.4.28
 top_pid = 245211
 top_fid = 2667280
+### CTM 1.0.2.31
 ctm_pid = 267602
 ctm_fid = 2915363
+### GRS 0.3.0
 grs_pid = 687577
 grs_fid = 4399621
+### AE2 0.55.6
 ae2_pid = 570458
 ae2_fid = 4402048
 
-## Mixin Depdencies
+## Mixin Dependencies
 mixingradle_version = 0.7-SNAPSHOT
 mixinbooter_version = 7.0
 mixin_annotations_version = 0.8.5


### PR DESCRIPTION
## What
This fixes a problem where the `deobfJar` did not contain all the required information in its `MANIFEST.MF` file. This would cause forge to not load Access Transformers, and potentially also CoreMods and Mixins. This leads to run-time crashes when attempting to use the deobf jar as a dependency.

## Outcome
Fixes jar configuration not applying to deobfJar.
