### PR TITLE
Fix vanilla ore disabling

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -3,6 +3,7 @@ package gregtech;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.modules.ModuleContainerRegistryEvent;
+import gregtech.api.worldgen.generator.WorldGeneratorImpl;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.modules.GregTechModules;
 import gregtech.modules.ModuleManager;
@@ -43,6 +44,7 @@ public class GregTechMod {
         GregTechAPI.moduleManager = moduleManager;
         moduleManager.registerContainer(new GregTechModules());
         MinecraftForge.EVENT_BUS.post(new ModuleContainerRegistryEvent());
+        MinecraftForge.ORE_GEN_BUS.register(WorldGeneratorImpl.INSTANCE);
     }
 
     @EventHandler

--- a/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
+++ b/src/main/java/gregtech/api/worldgen/generator/WorldGeneratorImpl.java
@@ -34,7 +34,7 @@ public class WorldGeneratorImpl implements IWorldGenerator {
     private WorldGeneratorImpl() { }
 
     @SubscribeEvent(priority = EventPriority.HIGH)
-    public static void onOreGenerate(OreGenEvent.GenerateMinable event) {
+    public void onOreGenerate(OreGenEvent.GenerateMinable event) {
         EventType eventType = event.getType();
         if (ConfigHolder.worldgen.disableVanillaOres && ORE_EVENT_TYPES.contains(eventType)) {
             event.setResult(Result.DENY);


### PR DESCRIPTION
## What
The disableVanillaOres config is broken because someone forgot to register event properly

## Implementation Details
Registers it in construction event to ore gen bus.

## Outcome
A broken config no one asked why it's broken or not been fixed
