### PR TITLE
Only draw armor hud for chestplates

### DIFF
--- a/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
+++ b/src/main/java/gregtech/api/items/armor/ArmorLogicSuite.java
@@ -119,6 +119,12 @@ public abstract class ArmorLogicSuite implements ISpecialArmorLogic, IItemHUDPro
         hud.newString(I18n.format("metaarmor.hud.energy_lvl", String.format("%.1f", energyMultiplier) + "%"));
     }
 
+    @SideOnly(Side.CLIENT)
+    @Override
+    public boolean shouldDrawHUD() {
+        return this.SLOT == EntityEquipmentSlot.CHEST;
+    }
+
     public int getEnergyPerUse() {
         return this.energyPerUse;
     }

--- a/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
+++ b/src/main/java/gregtech/common/items/armor/NightvisionGoggles.java
@@ -15,8 +15,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -97,11 +95,5 @@ public class NightvisionGoggles extends ArmorLogicSuite {
                 lines.add(I18n.format("metaarmor.message.nightvision.disabled"));
             }
         }
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
-    public boolean shouldDrawHUD() {
-        return false;
     }
 }


### PR DESCRIPTION
## What
This PR changes the armors' HUDs to only be drawn for the chestplate. This will prevent them from overlapping, and also mimics the original IC2/GraviSuite mod's behavior (from which our own are inspired). 

There is currently not a robust enough system to combine the armor's information into one display, so this is a work-around for the present. In the future, a refactor of the armor would better allow for this.

## Outcome
Fixes armor HUDs overlapping. Closes #1560.
