### PR TITLE
Allow tools to have default enchantments

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -35,6 +35,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.utils.ToolChargeBarRenderer;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.common.ConfigHolder;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.resources.I18n;
@@ -171,8 +172,10 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             stackCompound.setBoolean(UNBREAKABLE_KEY, true);
         }
 
-        // Set material enchantments
-        toolProperty.getEnchantments().forEach((enchantment, level) -> {
+        // Set tool and material enchantments
+        Object2IntMap<Enchantment> enchantments = toolProperty.getEnchantments();
+        enchantments.putAll(toolStats.getDefaultEnchantments(stack));
+        enchantments.forEach((enchantment, level) -> {
             if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
                 stack.addEnchantment(enchantment, level);
             }

--- a/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
@@ -2,6 +2,7 @@ package gregtech.api.items.toolitem;
 
 import gregtech.api.items.toolitem.aoe.AoESymmetrical;
 import gregtech.api.items.toolitem.behavior.IToolBehavior;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
@@ -91,6 +92,8 @@ public interface IGTToolDefinition {
     }
 
     boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment);
+
+    Object2IntMap<Enchantment> getDefaultEnchantments(ItemStack stack);
 
     /**
      * Misc

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -3,6 +3,8 @@ package gregtech.api.items.toolitem;
 import com.google.common.collect.ImmutableList;
 import gregtech.api.items.toolitem.aoe.AoESymmetrical;
 import gregtech.api.items.toolitem.behavior.IToolBehavior;
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -42,6 +44,7 @@ public class ToolDefinitionBuilder {
     private final Set<Block> effectiveBlocks = new ObjectOpenHashSet<>();
     private final Set<Material> effectiveMaterials = new ObjectOpenHashSet<>();
     private Predicate<IBlockState> effectiveStates;
+    private Object2IntMap<Enchantment> defaultEnchantments = new Object2IntArrayMap<>();
 
     public ToolDefinitionBuilder behaviors(IToolBehavior... behaviours) {
         Collections.addAll(this.behaviours, behaviours);
@@ -180,6 +183,11 @@ public class ToolDefinitionBuilder {
         return this;
     }
 
+    public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, int level) {
+        this.defaultEnchantments.put(enchantment, level);
+        return this;
+    }
+
     public IGTToolDefinition build() {
         return new IGTToolDefinition() {
 
@@ -202,6 +210,8 @@ public class ToolDefinitionBuilder {
             private final Supplier<ItemStack> brokenStack = ToolDefinitionBuilder.this.brokenStack;
             private final AoESymmetrical aoeSymmetrical = ToolDefinitionBuilder.this.aoeSymmetrical;
             private final Predicate<IBlockState> effectiveStatePredicate;
+            private final Object2IntMap<Enchantment> defaultEnchantments = ToolDefinitionBuilder.this.defaultEnchantments;
+
 
             {
                 Set<Block> effectiveBlocks = ToolDefinitionBuilder.this.effectiveBlocks;
@@ -295,6 +305,11 @@ public class ToolDefinitionBuilder {
             @Override
             public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
                 return canApplyEnchantment.test(stack, enchantment);
+            }
+
+            @Override
+            public Object2IntMap<Enchantment> getDefaultEnchantments(ItemStack stack) {
+                return this.defaultEnchantments;
             }
 
             @Override

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.entity.monster.EntityGolem;
 import net.minecraft.entity.monster.EntitySpider;
+import net.minecraft.init.Enchantments;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
@@ -190,7 +191,7 @@ public final class ToolItems {
                 .toolClasses(ToolClasses.KNIFE, ToolClasses.SWORD));
         BUTCHERY_KNIFE = register(ItemGTSword.Builder.of(GTValues.MODID, "butchery_knife")
                 .toolStats(b -> b.crafting().attacking()
-                        .attackDamage(1.5F).attackSpeed(-1.3F))
+                        .attackDamage(1.5F).attackSpeed(-1.3F).defaultEnchantment(Enchantments.LOOTING, 3))
                 .oreDict(ToolOreDict.toolButcheryKnife)
                 .secondaryOreDicts("craftingToolButcheryKnife")
                 .toolClasses(ToolClasses.BUTCHERY_KNIFE));


### PR DESCRIPTION
## What
Since the major tool refactor, the butchery knife has been severely nerfed, due to it losing its looting III enchantment. This PR serves to fix that by adding in methods to add default enchantments.

## Implementation Details
I would like to know if I should actually be putting the default enchantments in IGTToolDefinition, or if I should put it in IGTTool. Furthermore, I do wonder if the use of `putAll` in IGTTool is preferable to just repeating the code for adding enchantments to the stack for `toolStats.getDefaultEnchantments()`.

## Outcome
Gives butchery knifes the looting III enchantment again.

## Potential Compatibility Issues
Technically, if someone had made separate implementations for IGTToolDefinition in an addon, it would break, although it seems rather unlikely.