### PR TITLE
Synchronize access to VariantActiveBlock#ACTIVE_BLOCKS

### DIFF
--- a/src/main/java/gregtech/api/block/VariantActiveBlock.java
+++ b/src/main/java/gregtech/api/block/VariantActiveBlock.java
@@ -6,7 +6,8 @@ import gregtech.client.model.IModelSupplier;
 import gregtech.client.model.modelfactories.ActiveVariantBlockBakedModel;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.common.ConfigHolder;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import net.minecraft.block.material.Material;
@@ -40,9 +41,31 @@ import java.util.stream.Collectors;
 
 public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends VariantBlock<T> implements IModelSupplier {
 
-    public static final Object2ObjectOpenHashMap<Integer, ObjectSet<BlockPos>> ACTIVE_BLOCKS = new Object2ObjectOpenHashMap<>();
+    private static final Int2ObjectMap<ObjectSet<BlockPos>> ACTIVE_BLOCKS = new Int2ObjectOpenHashMap<>();
+
     public static final PropertyBool ACTIVE_DEPRECATED = PropertyBool.create("active");
     public static final UnlistedBooleanProperty ACTIVE = new UnlistedBooleanProperty("active");
+
+    public static boolean isBlockActive(int dimension, BlockPos pos) {
+        synchronized (ACTIVE_BLOCKS) {
+            ObjectSet<BlockPos> set = ACTIVE_BLOCKS.get(dimension);
+            return set != null && set.contains(pos);
+        }
+    }
+
+    public static void setBlockActive(int dimension, BlockPos pos, boolean active) {
+        synchronized (ACTIVE_BLOCKS) {
+            ObjectSet<BlockPos> set = ACTIVE_BLOCKS.get(dimension);
+            if (active) {
+                if (set == null) {
+                    ACTIVE_BLOCKS.put(dimension, set = new ObjectOpenHashSet<>());
+                }
+                set.add(pos);
+            } else {
+                if (set != null) set.remove(pos);
+            }
+        }
+    }
 
     public VariantActiveBlock(Material materialIn) {
         super(materialIn);
@@ -96,13 +119,10 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
 
     @Override
     public IExtendedBlockState getExtendedState(IBlockState state, IBlockAccess world, BlockPos pos) {
-        IExtendedBlockState ext = (IExtendedBlockState) state;
-        if (Minecraft.getMinecraft().world == null) {
-            ext = ext.withProperty(ACTIVE, false);
-        } else {
-            ACTIVE_BLOCKS.putIfAbsent(Minecraft.getMinecraft().world.provider.getDimension(), new ObjectOpenHashSet<>());
-            ext = ext.withProperty(ACTIVE, ACTIVE_BLOCKS.get(Minecraft.getMinecraft().world.provider.getDimension()).contains(pos));
-        }
+        IExtendedBlockState ext = ((IExtendedBlockState) state)
+                .withProperty(ACTIVE, Minecraft.getMinecraft().world != null &&
+                        isBlockActive(Minecraft.getMinecraft().world.provider.getDimension(), pos));
+
         if (Loader.isModLoaded(GTValues.MODID_CTM)) {
             //if the Connected Textures Mod is loaded we wrap our IExtendedBlockState with their wrapper,
             //so that the CTM renderer can render the block properly.


### PR DESCRIPTION
## What
This PR fixes a presumed concurrency error by synchronizing all usage of `VariantActiveBlock#ACTIVE_BLOCKS`.

## Implementation Details
Although the crash report on aforementioned issue does not directly say CME, it is most likely an issue caused by concurrency. Because `VariantActiveBlock#ACTIVE_BLOCKS` is accessed during both rendering and server world ticking, it has a possibility of crashing with each other in singleplayer environment.

To prevent such scenario, the `VariantActiveBlock#ACTIVE_BLOCKS` has been made private and all query/insertion/removal operation is redirected to newly created static methods.

Additionally I've changed the type of collection to `Int2ObjectOpenHashMap`. Since the collection never used null key in the first place, it shouldn't affect anything.

## Outcome
Probably fixes #1566.

## Potential Compatibility Issues
Any addons directly accessing `VariantActiveBlock#ACTIVE_BLOCKS` will break. Since VAB is declared in API layer, this PR is a breaking change.
