### PR TITLE
Hide MetaItem on search tab if it's hidden

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -1016,7 +1016,8 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         }
 
         public boolean isInCreativeTab(CreativeTabs tab) {
-            return tab == CreativeTabs.SEARCH || ArrayUtils.contains(creativeTabsOverride != null ? creativeTabsOverride : MetaItem.this.defaultCreativeTabs, tab);
+            CreativeTabs[] tabs = this.creativeTabsOverride != null ? this.creativeTabsOverride : MetaItem.this.defaultCreativeTabs;
+            return tabs.length > 0 && (tab == CreativeTabs.SEARCH || ArrayUtils.contains(tabs, tab));
         }
 
         @Override


### PR DESCRIPTION
## What
This PR fixes an unintended behavior with hidden metaitem variants introduced in #1527.

## Implementation Details
Previously, the metaitem were added to search tab regardless of the tab overrides, which made hidden items visible in JEI.

This PR addresses the issue by excluding search tab from the check if the tabs for the metaitem is empty.

## Outcome
Hidden items are actually hidden.

## Potential Compatibility Issues
None
