### PR TITLE
Fix more duplicate recipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -108,9 +108,7 @@ public class RecipeMaps {
                 if (recipeBuilder.fluidInputs.size() == 1 && recipeBuilder.fluidInputs.get(0).getInputFluidStack().getFluid() == Materials.SolderingAlloy.getFluid()) {
                     int amount = recipeBuilder.fluidInputs.get(0).getInputFluidStack().amount;
 
-                    recipeBuilder.copy().clearFluidInputs().fluidInputs(Materials.Lead.getFluid(amount * 2)).buildAndRegister();
-
-                    recipeBuilder.copy().clearFluidInputs().fluidInputs(Materials.Tin.getFluid((int) (amount * 1.5))).buildAndRegister();
+                    recipeBuilder.copy().clearFluidInputs().fluidInputs(Materials.Tin.getFluid(amount * 2)).buildAndRegister();
                 }
             });
 

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -102,7 +102,17 @@ public class RecipeMaps {
     public static final RecipeMap<AssemblerRecipeBuilder> ASSEMBLER_RECIPES = new RecipeMap<>("assembler", 1, 9, 1, 1, 0, 1, 0, 0, new AssemblerRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_CIRCUIT, MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.ASSEMBLER);
+            .setSound(GTSoundEvents.ASSEMBLER)
+            .onRecipeBuild(recipeBuilder -> {
+                recipeBuilder.invalidateOnBuildAction();
+                if (recipeBuilder.fluidInputs.size() == 1 && recipeBuilder.fluidInputs.get(0).getInputFluidStack().getFluid() == Materials.SolderingAlloy.getFluid()) {
+                    int amount = recipeBuilder.fluidInputs.get(0).getInputFluidStack().amount;
+
+                    recipeBuilder.copy().clearFluidInputs().fluidInputs(Materials.Lead.getFluid(amount * 2)).buildAndRegister();
+
+                    recipeBuilder.copy().clearFluidInputs().fluidInputs(Materials.Tin.getFluid((int) (amount * 1.5))).buildAndRegister();
+                }
+            });
 
     /**
      * Example:

--- a/src/main/java/gregtech/api/recipes/builders/AssemblerRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/AssemblerRecipeBuilder.java
@@ -3,12 +3,12 @@ package gregtech.api.recipes.builders;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.unification.material.Materials;
 
 public class AssemblerRecipeBuilder extends RecipeBuilder<AssemblerRecipeBuilder> {
 
     public AssemblerRecipeBuilder() {/**/}
 
+    @SuppressWarnings("unused")
     public AssemblerRecipeBuilder(Recipe recipe, RecipeMap<AssemblerRecipeBuilder> recipeMap) {
         super(recipe, recipeMap);
     }
@@ -20,18 +20,5 @@ public class AssemblerRecipeBuilder extends RecipeBuilder<AssemblerRecipeBuilder
     @Override
     public AssemblerRecipeBuilder copy() {
         return new AssemblerRecipeBuilder(this);
-    }
-
-    @Override
-    public void buildAndRegister() {
-        if (fluidInputs.size() == 1 && fluidInputs.get(0).getInputFluidStack().getFluid() == Materials.SolderingAlloy.getFluid()) {
-            int amount = fluidInputs.get(0).getAmount();
-            fluidInputs.clear();
-            recipeMap.addRecipe(this.copy().fluidInputs(Materials.SolderingAlloy.getFluid(amount)).build());
-            recipeMap.addRecipe(this.copy().fluidInputs(Materials.Tin.getFluid((int) (amount * 1.5))).build());
-            recipeMap.addRecipe(this.copy().fluidInputs(Materials.Lead.getFluid(amount * 2)).build());
-        } else {
-            recipeMap.addRecipe(build());
-        }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -418,72 +418,73 @@ public class MachineRecipeLoader {
                 .EUt(16).duration(100)
                 .buildAndRegister();
 
-        for (FluidStack solder : new FluidStack[]{Tin.getFluid(L), SolderingAlloy.getFluid(L / 2)}) {
-            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                    .inputs(new ItemStack(Blocks.LEVER))
-                    .input(OrePrefix.plate, material)
-                    .fluidInputs(solder)
-                    .outputs(MetaItems.COVER_MACHINE_CONTROLLER.getStackForm(1))
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        FluidStack solder = SolderingAlloy.getFluid(L / 2);
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .input(cableGtSingle, Copper, 4)
-                    .input(circuit, MarkerMaterials.Tier.LV)
-                    .input(plate, material)
-                    .fluidInputs(solder)
-                    .outputs(COVER_ENERGY_DETECTOR.getStackForm())
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.LEVER))
+                .input(OrePrefix.plate, material)
+                .fluidInputs(solder)
+                .outputs(MetaItems.COVER_MACHINE_CONTROLLER.getStackForm(1))
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .input(COVER_ENERGY_DETECTOR)
-                    .input(SENSOR_HV)
-                    .fluidInputs(solder)
-                    .output(COVER_ENERGY_DETECTOR_ADVANCED)
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(cableGtSingle, Copper, 4)
+                .input(circuit, MarkerMaterials.Tier.LV)
+                .input(plate, material)
+                .fluidInputs(solder)
+                .outputs(COVER_ENERGY_DETECTOR.getStackForm())
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .inputs(new ItemStack(Blocks.REDSTONE_TORCH))
-                    .input(plate, material)
-                    .fluidInputs(solder)
-                    .outputs(COVER_ACTIVITY_DETECTOR.getStackForm())
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(COVER_ENERGY_DETECTOR)
+                .input(SENSOR_HV)
+                .fluidInputs(solder)
+                .output(COVER_ENERGY_DETECTOR_ADVANCED)
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .input(wireFine, Gold, 4)
-                    .input(circuit, MarkerMaterials.Tier.HV)
-                    .input(plate, Aluminium)
-                    .fluidInputs(solder)
-                    .outputs(COVER_ACTIVITY_DETECTOR_ADVANCED.getStackForm())
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.REDSTONE_TORCH))
+                .input(plate, material)
+                .fluidInputs(solder)
+                .outputs(COVER_ACTIVITY_DETECTOR.getStackForm())
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .inputs(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE))
-                    .input(plate, material)
-                    .fluidInputs(solder)
-                    .outputs(COVER_FLUID_DETECTOR.getStackForm())
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(wireFine, Gold, 4)
+                .input(circuit, MarkerMaterials.Tier.HV)
+                .input(plate, Aluminium)
+                .fluidInputs(solder)
+                .outputs(COVER_ACTIVITY_DETECTOR_ADVANCED.getStackForm())
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .inputs(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE))
-                    .input(plate, material)
-                    .fluidInputs(solder)
-                    .outputs(COVER_ITEM_DETECTOR.getStackForm())
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE))
+                .input(plate, material)
+                .fluidInputs(solder)
+                .outputs(COVER_FLUID_DETECTOR.getStackForm())
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
-            ASSEMBLER_RECIPES.recipeBuilder()
-                    .input(COVER_FLUID_DETECTOR)
-                    .input(SENSOR_HV)
-                    .fluidInputs(solder)
-                    .outputs(COVER_FLUID_DETECTOR_ADVANCED.getStackForm())
-                    .EUt(16).duration(100)
-                    .buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE))
+                .input(plate, material)
+                .fluidInputs(solder)
+                .outputs(COVER_ITEM_DETECTOR.getStackForm())
+                .EUt(16).duration(100)
+                .buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(COVER_FLUID_DETECTOR)
+                .input(SENSOR_HV)
+                .fluidInputs(solder)
+                .outputs(COVER_FLUID_DETECTOR_ADVANCED.getStackForm())
+                .EUt(16).duration(100)
+                .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder()
                     .input(COVER_ITEM_DETECTOR)
@@ -492,7 +493,6 @@ public class MachineRecipeLoader {
                     .outputs(COVER_ITEM_DETECTOR_ADVANCED.getStackForm())
                     .EUt(16).duration(100)
                     .buildAndRegister();
-        }
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(plate, Glass)


### PR DESCRIPTION
## What
Removes some more attempts to register duplicate recipes, and moves the Assembler's custom fluid input logic from a `buildAndRegister` override to an `onBuildAction`

## Implementation Details
The block of code in `MachineRecipeLoader` was going through Tin and Soldering Alloy as fluids inputs for recipes, despite the fact that tin recipes would already be registered when soldering alloy recipes were created, thus duplicate recipes.

## Outcome
Fix more duplicate recipes that were found in the log
