### PR TITLE
Fix recipe lookup failure for some recipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/map/MapItemStackIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapItemStackIngredient.java
@@ -48,7 +48,7 @@ public class MapItemStackIngredient extends AbstractMapIngredient {
             }
             if (this.gtRecipeInput != null) {
                 if (other.gtRecipeInput != null) {
-                    return gtRecipeInput.equals(other.gtRecipeInput);
+                    return gtRecipeInput.equalIgnoreAmount(other.gtRecipeInput);
                 }
             } else if (other.gtRecipeInput != null) {
                 return other.gtRecipeInput.acceptsStack(this.stack);

--- a/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
+++ b/src/main/java/gregtech/api/recipes/map/MapItemStackNBTIngredient.java
@@ -49,7 +49,7 @@ public class MapItemStackNBTIngredient extends MapItemStackIngredient {
             }
             if (this.gtRecipeInput != null) {
                 if (other.gtRecipeInput != null) {
-                    return gtRecipeInput.equals(other.gtRecipeInput);
+                    return gtRecipeInput.equalIgnoreAmount(other.gtRecipeInput);
                 }
             } else if (other.gtRecipeInput != null) {
                 return other.gtRecipeInput.acceptsStack(this.stack);

--- a/src/test/java/gregtech/api/recipes/RecipeMapTest.java
+++ b/src/test/java/gregtech/api/recipes/RecipeMapTest.java
@@ -2,11 +2,18 @@ package gregtech.api.recipes;
 
 import gregtech.Bootstrap;
 import gregtech.api.recipes.builders.SimpleRecipeBuilder;
+import gregtech.api.recipes.ingredients.GTRecipeInput;
+import gregtech.api.recipes.ingredients.GTRecipeItemInput;
+import gregtech.api.recipes.map.MapFluidIngredient;
+import gregtech.api.recipes.map.MapItemStackIngredient;
+import gregtech.api.recipes.map.MapOreDictIngredient;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsNot;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static gregtech.api.items.OreDictNames.cobblestone;
 import static gregtech.api.unification.material.Materials.*;
 import static org.hamcrest.CoreMatchers.*;
 
@@ -118,4 +126,85 @@ public class RecipeMapTest {
                 64000), nullValue());
         MatcherAssert.assertThat(map.getRecipeList().size(), is(2));
     }
+
+    @Test
+    public void recipeLookupIgnoresStackAmount() {
+        MapItemStackIngredient ingFromStack = new MapItemStackIngredient(
+                new ItemStack(Blocks.COBBLESTONE), 0, null
+        );
+
+        RecipeBuilder r = new RecipeBuilder()
+                .inputs(new ItemStack(Blocks.COBBLESTONE))
+                .inputs(new ItemStack(Blocks.COBBLESTONE, 2))
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(1).duration(1);
+        Recipe rec = (Recipe) r.build().getResult();
+
+        MapItemStackIngredient ing0FromGTRecipeInput = new MapItemStackIngredient(rec.getInputs().get(0).getInputStacks()[0], rec.getInputs().get(0));
+        MapItemStackIngredient ing1FromGTRecipeInput = new MapItemStackIngredient(rec.getInputs().get(1).getInputStacks()[0], rec.getInputs().get(1));
+
+        MatcherAssert.assertThat(ingFromStack, equalTo(ing0FromGTRecipeInput));
+        MatcherAssert.assertThat(ingFromStack, equalTo(ing1FromGTRecipeInput));
+
+        MatcherAssert.assertThat(ing0FromGTRecipeInput, equalTo(ing1FromGTRecipeInput));
+    }
+
+    @Test
+    public void recipeLookupIgnoresFluidStackAmount() {
+        MapFluidIngredient ingFromStack = new MapFluidIngredient(
+                new FluidStack(FluidRegistry.getFluid("water"), 1000)
+        );
+
+        RecipeBuilder r = new RecipeBuilder()
+                .fluidInputs(new FluidStack(FluidRegistry.getFluid("water"), 1000))
+                .fluidInputs(new FluidStack(FluidRegistry.getFluid("water"), 1001))
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(1).duration(1);
+        Recipe rec = (Recipe) r.build().getResult();
+
+        MapFluidIngredient ing0FromGTRecipeInput = new MapFluidIngredient(rec.getFluidInputs().get(0));
+        MapFluidIngredient ing1FromGTRecipeInput = new MapFluidIngredient(rec.getFluidInputs().get(1));
+
+        MatcherAssert.assertThat(ingFromStack, equalTo(ing0FromGTRecipeInput));
+        MatcherAssert.assertThat(ingFromStack, equalTo(ing1FromGTRecipeInput));
+
+        MatcherAssert.assertThat(ing0FromGTRecipeInput, equalTo(ing1FromGTRecipeInput));
+    }
+
+    @Test
+    public void GTRecipeInputEquals() {
+        RecipeBuilder r = new RecipeBuilder()
+                .inputs(new ItemStack(Blocks.COBBLESTONE))
+                .inputs(new ItemStack(Blocks.COBBLESTONE, 2))
+                .input("cobblestone", 2)
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(1).duration(1);
+
+        MatcherAssert.assertThat(r.inputs.get(0), new IsNot(equalTo(r.inputs.get(1))));
+        MatcherAssert.assertThat(r.inputs.get(1), new IsNot(equalTo(r.inputs.get(2))));
+    }
+
+    @Test
+    public void MapIngredientEquals() {
+        RecipeBuilder r = new RecipeBuilder()
+                .inputs(new ItemStack(Blocks.COBBLESTONE))
+                .inputs(new ItemStack(Blocks.COBBLESTONE, 2))
+                .input("cobblestone", 2)
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(1).duration(1);
+        Recipe rec = (Recipe) r.build().getResult();
+
+        MapItemStackIngredient ing0FromGTRecipeInput = new MapItemStackIngredient(rec.getInputs().get(0).getInputStacks()[0], rec.getInputs().get(0));
+        MapOreDictIngredient ing1FromGTRecipeInput = new MapOreDictIngredient(OreDictionary.getOreID("cobblestone"));
+
+        MatcherAssert.assertThat(ing0FromGTRecipeInput, new IsNot(equalTo(ing1FromGTRecipeInput)));
+        MatcherAssert.assertThat(ing1FromGTRecipeInput, new IsNot(equalTo(ing0FromGTRecipeInput)));
+
+        MatcherAssert.assertThat(rec.getInputs().get(0).acceptsStack(new ItemStack(Blocks.COBBLESTONE)), is(true));
+        MatcherAssert.assertThat(rec.getInputs().get(1).acceptsStack(new ItemStack(Blocks.COBBLESTONE)), is(true));
+
+
+    }
+
+
 }


### PR DESCRIPTION
Fix amount of ingredient on the recipe changing the key thats placed on the recipe lookup. (these keys would have the same hashcode(the hashcode already ignored the amount properly) but different equals)

Outcome: CT actually finds the "Multi-layer Fiber-Reinforced Circuit Board" Recipe to remove.