### PR TITLE
Fix Fluid Pipes not working with Fluid Filters

### DIFF
--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -126,6 +126,7 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
             IFluidHandler pipeTank = tank;
             CoverBehavior cover = getCoverableImplementation().getCoverAtSide(facing);
 
+            // pipeTank should only be determined by the cover attached to the actual pipe
             if (cover != null){
                 IFluidHandler capability = cover.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, pipeTank);
                 // Shutter covers return null capability when active, so check here to prevent NPE
@@ -133,10 +134,9 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
                     continue;
                 }
                 pipeTank = capability;
-            }
-
-            if (cover == null)
+            } else {
                 cover = getOtherCoverAt(facing, oppositeSide);
+            }
 
             if (cover instanceof CoverPump) {
 

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/tile/TileEntityFluidPipeTickable.java
@@ -126,9 +126,6 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
             IFluidHandler pipeTank = tank;
             CoverBehavior cover = getCoverableImplementation().getCoverAtSide(facing);
 
-            if (cover == null)
-                cover = getOtherCoverAt(facing, oppositeSide);
-
             if (cover != null){
                 IFluidHandler capability = cover.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, pipeTank);
                 // Shutter covers return null capability when active, so check here to prevent NPE
@@ -137,6 +134,9 @@ public class TileEntityFluidPipeTickable extends TileEntityFluidPipe implements 
                 }
                 pipeTank = capability;
             }
+
+            if (cover == null)
+                cover = getOtherCoverAt(facing, oppositeSide);
 
             if (cover instanceof CoverPump) {
 


### PR DESCRIPTION
## What
Fixes issue with fluid pipes not working with fluid filters if the filter was on the block the pipe was inserting into. Fixes #1572.

## Implementation Details
Moved the `cover == null` check below the `cover != null` check

## Outcome
People's chemistry setups are saved

## Potential Compatibility Issues
Shouldn't be any issues
