### PR TITLE
Correct ResourceLocation cache in recurseIconsetPath

### DIFF
--- a/src/main/java/gregtech/api/gui/resources/ResourceHelper.java
+++ b/src/main/java/gregtech/api/gui/resources/ResourceHelper.java
@@ -87,19 +87,14 @@ public final class ResourceHelper {
      */
     @SideOnly(Side.CLIENT)
     public static boolean doResourcepacksHaveResource(@Nonnull ResourceLocation resource) {
-        // check minecraft for null for CI environments
-        //noinspection ConstantValue
-        if (Minecraft.getMinecraft() != null) {
-            IResourceManager manager = Minecraft.getMinecraft().getResourceManager();
-            try {
-                // check if the texture file exists
-                manager.getResource(resource);
-                return true;
-            } catch (IOException ignored) {
-                return false;
-            }
+        IResourceManager manager = Minecraft.getMinecraft().getResourceManager();
+        try {
+            // check if the texture file exists
+            manager.getResource(resource);
+            return true;
+        } catch (IOException ignored) {
+            return false;
         }
-        return false;
     }
 
     /**

--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
@@ -7,12 +7,18 @@ import com.google.common.collect.Table;
 import gregtech.api.GTValues;
 import gregtech.api.gui.resources.ResourceHelper;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 
+@EventBusSubscriber(modid = GTValues.MODID, value = Side.CLIENT)
 public class MaterialIconType {
 
     public static final Map<String, MaterialIconType> ICON_TYPES = new HashMap<>();
@@ -127,40 +133,43 @@ public class MaterialIconType {
     /**
      * Find the location of the asset associated with the iconset or its parents as a fallback
      *
-     * @param materialIconSet the starting IconSet to get the location for
-     * @param cache           the cache to store the value in
-     * @param fullPath        the full path to the asset with formatting (%s) for IconSet and IconType names
-     * @param path            the abbreviated path to the asset with formatting (%s) for IconSet and IconType names
+     * @param iconSet  the starting IconSet to get the location for
+     * @param cache    the cache to store the value in
+     * @param fullPath the full path to the asset with formatting (%s) for IconSet and IconType names
+     * @param path     the abbreviated path to the asset with formatting (%s) for IconSet and IconType names
      * @return the location of the asset
      */
     @Nonnull
-    public ResourceLocation recurseIconsetPath(@Nonnull MaterialIconSet materialIconSet,
+    public ResourceLocation recurseIconsetPath(@Nonnull MaterialIconSet iconSet,
                                                @Nonnull Table<MaterialIconType, MaterialIconSet, ResourceLocation> cache,
                                                @Nonnull String fullPath, @Nonnull String path) {
-        if (cache.contains(this, materialIconSet)) {
-            return cache.get(this, materialIconSet);
+        if (cache.contains(this, iconSet)) {
+            return cache.get(this, iconSet);
         }
 
-        MaterialIconSet iconSet = materialIconSet;
-        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getEffectiveSide().isClient()) {
-            while (!iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format(fullPath, iconSet.name, this.name));
-                if (ResourceHelper.doResourcepacksHaveResource(location)) {
-                    break;
-                } else {
-                    iconSet = iconSet.parentIconset;
-                }
+        if (FMLCommonHandler.instance().getSide().isClient()) {
+            ResourceLocation fullLocation = new ResourceLocation(GTValues.MODID, String.format(fullPath, iconSet.name, this.name));
+            if (!iconSet.isRootIconset && !ResourceHelper.doResourcepacksHaveResource(fullLocation)) {
+                ResourceLocation iconSetPath = recurseIconsetPath(iconSet.parentIconset, cache, fullPath, path);
+                cache.put(this, iconSet, iconSetPath);
+                return iconSetPath;
             }
         }
 
-        ResourceLocation location = new ResourceLocation(GTValues.MODID, String.format(path, iconSet.name, this.name));
-        cache.put(this, iconSet, location);
-
-        return location;
+        ResourceLocation iconSetPath = new ResourceLocation(GTValues.MODID, String.format(path, iconSet.name, this.name));
+        cache.put(this, iconSet, iconSetPath);
+        return iconSetPath;
     }
 
     @Override
     public String toString() {
         return this.name;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public static void onModelBake(ModelBakeEvent event) {
+        ITEM_MODEL_CACHE.clear();
+        BLOCK_TEXTURE_CACHE.clear();
     }
 }

--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
@@ -147,9 +147,9 @@ public class MaterialIconType {
             return cache.get(this, iconSet);
         }
 
-        if (FMLCommonHandler.instance().getSide().isClient()) {
+        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getSide().isClient()) {
             ResourceLocation fullLocation = new ResourceLocation(GTValues.MODID, String.format(fullPath, iconSet.name, this.name));
-            if (!iconSet.isRootIconset && !ResourceHelper.doResourcepacksHaveResource(fullLocation)) {
+            if (!ResourceHelper.doResourcepacksHaveResource(fullLocation)) {
                 ResourceLocation iconSetPath = recurseIconsetPath(iconSet.parentIconset, cache, fullPath, path);
                 cache.put(this, iconSet, iconSetPath);
                 return iconSetPath;

--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconType.java
@@ -147,7 +147,9 @@ public class MaterialIconType {
             return cache.get(this, iconSet);
         }
 
-        if (!iconSet.isRootIconset && FMLCommonHandler.instance().getSide().isClient()) {
+        if (!iconSet.isRootIconset &&
+                FMLCommonHandler.instance().getSidedDelegate() != null && // Test environment check
+                FMLCommonHandler.instance().getSide().isClient()) {
             ResourceLocation fullLocation = new ResourceLocation(GTValues.MODID, String.format(fullPath, iconSet.name, this.name));
             if (!ResourceHelper.doResourcepacksHaveResource(fullLocation)) {
                 ResourceLocation iconSetPath = recurseIconsetPath(iconSet.parentIconset, cache, fullPath, path);


### PR DESCRIPTION
## What
This PR corrects an insufficient caching strategy used in `MaterialIconType#recurseIconsetPath()` to account for its sub iconsets.

## Implementation Details
Previous implementation of `recurseIconsetPath` only updated cache for its final iconset, so the cache made was inaccessible from its child iconsets. This implementation made constantly re-evaluate iconset path each call, which made the game check resource directory very frequently, especially during render call.

To fix this, `recurseIconsetPath` is rewritten using recursion. Additionally, the cache is cleared when reloading resources, which should solve potential problems with outdated cache.

## Outcome
Fixes #1576.

## Potential Compatibility Issues
None
