### PR TITLE
Fix pipes not updating their redstone signals

### DIFF
--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -188,9 +188,10 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
     @Override
     public void neighborChanged(@Nonnull IBlockState state, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Block blockIn, @Nonnull BlockPos fromPos) {
         if (worldIn.isRemote) return;
-        if (!ConfigHolder.machines.gt6StylePipesCables) {
-            IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
-            if (pipeTile != null) {
+        IPipeTile<PipeType, NodeDataType> pipeTile = getPipeTileEntity(worldIn, pos);
+        if (pipeTile != null) {
+            pipeTile.getCoverableImplementation().updateInputRedstoneSignals();
+            if (!ConfigHolder.machines.gt6StylePipesCables) {
                 EnumFacing facing = null;
                 for (EnumFacing facing1 : EnumFacing.values()) {
                     if (GTUtility.arePosEqual(fromPos, pos.offset(facing1))) {
@@ -209,10 +210,8 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                 if (open && !canConnect)
                     pipeTile.setConnection(facing, false, false);
                 updateActiveNodeStatus(worldIn, pos, pipeTile);
-                pipeTile.getCoverableImplementation().updateInputRedstoneSignals();
             }
         }
-
     }
 
     @Override


### PR DESCRIPTION
## What
This PR fixes a bug where pipes would not have their redstone input signals updated, if the GT6 Pipes config was enabled.

## Implementation Details
The redstone signal update was moved to the beginning of the method, instead of at the end, to stay consistent with `BlockMachine`.

## Outcome
Fixes #1525.
