### PR TITLE
Fix issues with breaking ice

### DIFF
--- a/src/main/java/gregtech/api/util/function/Task.java
+++ b/src/main/java/gregtech/api/util/function/Task.java
@@ -3,6 +3,11 @@ package gregtech.api.util.function;
 @FunctionalInterface
 public interface Task {
 
+    /**
+     * Run the actions of this Task. Will be infinitely run each world tick until false is returned.
+     *
+     * @return {@code true} if the task should be run again, otherwise {@code false}
+     */
     boolean run();
 
 }

--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -103,7 +103,7 @@ public class ToolEventHandlers {
         EntityPlayer player = event.getHarvester();
         if (player != null) {
             ItemStack stack = player.getHeldItemMainhand();
-            if (!stack.hasTagCompound() || !(stack.getItem() instanceof IGTTool)) {
+            if (stack.isEmpty() || !stack.hasTagCompound() || !(stack.getItem() instanceof IGTTool)) {
                 return;
             }
             if (!event.isSilkTouching()) {
@@ -121,6 +121,8 @@ public class ToolEventHandlers {
                         IBlockState flowingState = world.getBlockState(icePos);
                         if (flowingState == Blocks.FLOWING_WATER.getDefaultState()) {
                             world.setBlockToAir(icePos);
+                            // end immediately so the task doesn't remove other water that comes into this block-space
+                            return false;
                         }
                         return true;
                     });

--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -121,10 +121,9 @@ public class ToolEventHandlers {
                         IBlockState flowingState = world.getBlockState(icePos);
                         if (flowingState == Blocks.FLOWING_WATER.getDefaultState()) {
                             world.setBlockToAir(icePos);
-                            // end immediately so the task doesn't remove other water that comes into this block-space
-                            return false;
                         }
-                        return true;
+                        // only try once, so future water placement does not get eaten too
+                        return false;
                     });
                 }
             }


### PR DESCRIPTION
## What
This PR fixes two issues with breaking ice.

First, it checks if the tool ItemStack is empty. Doing so prevents the ice breaking code from applying when mining with things other than tools. This previously caused ice to never create water when broken with an empty hand, for example.

Second, it fixes the "looping water" bug, where flowing water moving into the blockspace would get repeatedly deleted, after the initial ice block's water was removed.

## Outcome
Fixes bugs with breaking ice.
