### PR TITLE
Re-add Concrete movement speed bonuses

### DIFF
--- a/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
+++ b/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
@@ -1,0 +1,14 @@
+package gregtech.api.block;
+
+import net.minecraft.block.state.IBlockState;
+
+public interface IWalkingSpeedBonus {
+
+    default double getWalkingSpeedBonus() {
+        return 1.0D;
+    }
+
+    default boolean checkApplicableBlocks(IBlockState state) {
+        return false;
+    }
+}

--- a/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
+++ b/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
@@ -1,6 +1,7 @@
 package gregtech.api.block;
 
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 
 public interface IWalkingSpeedBonus {
 
@@ -10,5 +11,9 @@ public interface IWalkingSpeedBonus {
 
     default boolean checkApplicableBlocks(IBlockState state) {
         return false;
+    }
+
+    default boolean bonusSpeedCondition(Entity walkingEntity) {
+        return !walkingEntity.isInWater();
     }
 }

--- a/src/main/java/gregtech/api/block/VariantBlock.java
+++ b/src/main/java/gregtech/api/block/VariantBlock.java
@@ -10,9 +10,11 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -22,7 +24,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
-public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block {
+public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block implements IWalkingSpeedBonus {
 
     protected PropertyEnum<T> VARIANT;
     protected T[] VALUES;
@@ -103,6 +105,18 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
     @Override
     public int getMetaFromState(IBlockState state) {
         return state.getValue(VARIANT).ordinal();
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (checkApplicableBlocks(below)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= getWalkingSpeedBonus();
+                entityIn.motionZ *= getWalkingSpeedBonus();
+            }
+        }
     }
 
 }

--- a/src/main/java/gregtech/api/block/VariantBlock.java
+++ b/src/main/java/gregtech/api/block/VariantBlock.java
@@ -108,7 +108,11 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Entity entityIn) {
+        // Short circuit if there is no bonus speed
+        if (getWalkingSpeedBonus() == 1.0D) {
+            return;
+        }
 
         IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
         if (checkApplicableBlocks(below)) {

--- a/src/main/java/gregtech/api/block/VariantBlock.java
+++ b/src/main/java/gregtech/api/block/VariantBlock.java
@@ -112,7 +112,7 @@ public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block
 
         IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
         if (checkApplicableBlocks(below)) {
-            if (!entityIn.isInWater()) {
+            if (bonusSpeedCondition(entityIn)) {
                 entityIn.motionX *= getWalkingSpeedBonus();
                 entityIn.motionZ *= getWalkingSpeedBonus();
             }

--- a/src/main/java/gregtech/common/blocks/BlockAsphalt.java
+++ b/src/main/java/gregtech/common/blocks/BlockAsphalt.java
@@ -9,7 +9,6 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -30,11 +29,18 @@ public class BlockAsphalt extends VariantBlock<BlockAsphalt.BlockType> {
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
-        if ((entityIn.motionX != 0 || entityIn.motionZ != 0) && !entityIn.isInWater() && !entityIn.isSneaking()) {
-            entityIn.motionX *= 1.3;
-            entityIn.motionZ *= 1.3;
-        }
+    public double getWalkingSpeedBonus() {
+        return 1.3D;
+    }
+
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockType.ASPHALT);
+    }
+
+    @Override
+    public boolean bonusSpeedCondition(Entity walkingEntity) {
+        return super.bonusSpeedCondition(walkingEntity) && !walkingEntity.isSneaking();
     }
 
     public enum BlockType implements IStringSerializable, IStateHarvestLevel {

--- a/src/main/java/gregtech/common/blocks/BlockAsphalt.java
+++ b/src/main/java/gregtech/common/blocks/BlockAsphalt.java
@@ -30,7 +30,7 @@ public class BlockAsphalt extends VariantBlock<BlockAsphalt.BlockType> {
 
     @Override
     public double getWalkingSpeedBonus() {
-        return 1.3D;
+        return 1.6D;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricks.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricks.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneBricks extends VariantBlock<BlockStoneBricks.BlockType> {
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockType.CONCRETE_DARK) || below == getState(BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricks.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricks.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneBricks extends VariantBlock<BlockStoneBricks.BlockType> {
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockType.CONCRETE_DARK) || below == getState(BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockType.CONCRETE_DARK) || state == getState(BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksCracked.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksCracked.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneBricksCracked extends VariantBlock<BlockStoneBricksCracke
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneBricksCracked.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksCracked.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneBricksCracked.BlockType.CONCRETE_DARK) || state == getState(BlockStoneBricksCracked.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksCracked.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksCracked.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneBricksCracked extends VariantBlock<BlockStoneBricksCracke
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneBricksCracked.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksCracked.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksMossy.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksMossy.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneBricksMossy extends VariantBlock<BlockStoneBricksMossy.Bl
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneBricksMossy.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksMossy.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksMossy.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksMossy.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneBricksMossy extends VariantBlock<BlockStoneBricksMossy.Bl
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneBricksMossy.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksMossy.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneBricksMossy.BlockType.CONCRETE_DARK) || state == getState(BlockStoneBricksMossy.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksSmall.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksSmall.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneBricksSmall extends VariantBlock<BlockStoneBricksSmall.Bl
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneBricksSmall.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksSmall.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksSmall.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksSmall.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneBricksSmall extends VariantBlock<BlockStoneBricksSmall.Bl
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneBricksSmall.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksSmall.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneBricksSmall.BlockType.CONCRETE_DARK) || state == getState(BlockStoneBricksSmall.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksSquare.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksSquare.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneBricksSquare extends VariantBlock<BlockStoneBricksSquare.
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneBricksSquare.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksSquare.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneBricksSquare.BlockType.CONCRETE_DARK) || state == getState(BlockStoneBricksSquare.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneBricksSquare.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneBricksSquare.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneBricksSquare extends VariantBlock<BlockStoneBricksSquare.
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneBricksSquare.BlockType.CONCRETE_DARK) || below == getState(BlockStoneBricksSquare.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneChiseled.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneChiseled.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneChiseled extends VariantBlock<BlockStoneChiseled.BlockTyp
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneChiseled.BlockType.CONCRETE_DARK) || below == getState(BlockStoneChiseled.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneChiseled.BlockType.CONCRETE_DARK) || state == getState(BlockStoneChiseled.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneChiseled.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneChiseled.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneChiseled extends VariantBlock<BlockStoneChiseled.BlockTyp
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneChiseled.BlockType.CONCRETE_DARK) || below == getState(BlockStoneChiseled.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneCobble.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneCobble.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneCobble extends VariantBlock<BlockStoneCobble.BlockType> {
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneCobble.BlockType.CONCRETE_DARK) || below == getState(BlockStoneCobble.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneCobble.BlockType.CONCRETE_DARK) || state == getState(BlockStoneCobble.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneCobble.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneCobble.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneCobble extends VariantBlock<BlockStoneCobble.BlockType> {
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneCobble.BlockType.CONCRETE_DARK) || below == getState(BlockStoneCobble.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneCobbleMossy.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneCobbleMossy.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneCobbleMossy extends VariantBlock<BlockStoneCobbleMossy.Bl
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneCobbleMossy.BlockType.CONCRETE_DARK) || below == getState(BlockStoneCobbleMossy.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneCobbleMossy.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneCobbleMossy.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneCobbleMossy extends VariantBlock<BlockStoneCobbleMossy.Bl
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneCobbleMossy.BlockType.CONCRETE_DARK) || below == getState(BlockStoneCobbleMossy.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneCobbleMossy.BlockType.CONCRETE_DARK) || state == getState(BlockStoneCobbleMossy.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStonePolished.java
+++ b/src/main/java/gregtech/common/blocks/BlockStonePolished.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStonePolished extends VariantBlock<BlockStonePolished.BlockTyp
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStonePolished.BlockType.CONCRETE_DARK) || below == getState(BlockStonePolished.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStonePolished.java
+++ b/src/main/java/gregtech/common/blocks/BlockStonePolished.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStonePolished extends VariantBlock<BlockStonePolished.BlockTyp
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStonePolished.BlockType.CONCRETE_DARK) || below == getState(BlockStonePolished.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStonePolished.BlockType.CONCRETE_DARK) || state == getState(BlockStonePolished.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneSmooth.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneSmooth.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneSmooth extends VariantBlock<BlockStoneSmooth.BlockType> {
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneSmooth.BlockType.CONCRETE_DARK) || below == getState(BlockStoneSmooth.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public BlockStoneSmooth.BlockType getVariant(IBlockState blockState) {

--- a/src/main/java/gregtech/common/blocks/BlockStoneSmooth.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneSmooth.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneSmooth extends VariantBlock<BlockStoneSmooth.BlockType> {
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneSmooth.BlockType.CONCRETE_DARK) || below == getState(BlockStoneSmooth.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneSmooth.BlockType.CONCRETE_DARK) || state == getState(BlockStoneSmooth.BlockType.CONCRETE_LIGHT);
     }
 
     public BlockStoneSmooth.BlockType getVariant(IBlockState blockState) {

--- a/src/main/java/gregtech/common/blocks/BlockStoneTiled.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneTiled.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneTiled extends VariantBlock<BlockStoneTiled.BlockType> {
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneTiled.BlockType.CONCRETE_DARK) || below == getState(BlockStoneTiled.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneTiled.BlockType.CONCRETE_DARK) || state == getState(BlockStoneTiled.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneTiled.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneTiled.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneTiled extends VariantBlock<BlockStoneTiled.BlockType> {
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneTiled.BlockType.CONCRETE_DARK) || below == getState(BlockStoneTiled.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneTiledSmall.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneTiledSmall.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneTiledSmall extends VariantBlock<BlockStoneTiledSmall.Bloc
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneTiledSmall.BlockType.CONCRETE_DARK) || below == getState(BlockStoneTiledSmall.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneTiledSmall.BlockType.CONCRETE_DARK) || state == getState(BlockStoneTiledSmall.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneTiledSmall.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneTiledSmall.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneTiledSmall extends VariantBlock<BlockStoneTiledSmall.Bloc
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneTiledSmall.BlockType.CONCRETE_DARK) || below == getState(BlockStoneTiledSmall.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneWindmillA.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneWindmillA.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneWindmillA extends VariantBlock<BlockStoneWindmillA.BlockT
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneWindmillA.BlockType.CONCRETE_DARK) || below == getState(BlockStoneWindmillA.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneWindmillA.BlockType.CONCRETE_DARK) || state == getState(BlockStoneWindmillA.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneWindmillA.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneWindmillA.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneWindmillA extends VariantBlock<BlockStoneWindmillA.BlockT
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneWindmillA.BlockType.CONCRETE_DARK) || below == getState(BlockStoneWindmillA.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneWindmillB.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneWindmillB.java
@@ -4,12 +4,10 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +29,13 @@ public class BlockStoneWindmillB extends VariantBlock<BlockStoneWindmillB.BlockT
     }
 
     @Override
-    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+    public double getWalkingSpeedBonus() {
+        return 1.6D;
+    }
 
-        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
-        if (below == getState(BlockStoneWindmillB.BlockType.CONCRETE_DARK) || below == getState(BlockStoneWindmillB.BlockType.CONCRETE_LIGHT)) {
-            if (!entityIn.isInWater()) {
-                entityIn.motionX *= 1.6;
-                entityIn.motionZ *= 1.6;
-            }
-        }
+    @Override
+    public boolean checkApplicableBlocks(IBlockState state) {
+        return state == getState(BlockStoneWindmillB.BlockType.CONCRETE_DARK) || state == getState(BlockStoneWindmillB.BlockType.CONCRETE_LIGHT);
     }
 
     public enum BlockType implements IStringSerializable {

--- a/src/main/java/gregtech/common/blocks/BlockStoneWindmillB.java
+++ b/src/main/java/gregtech/common/blocks/BlockStoneWindmillB.java
@@ -4,10 +4,12 @@ import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 
@@ -26,6 +28,18 @@ public class BlockStoneWindmillB extends VariantBlock<BlockStoneWindmillB.BlockT
     @Override
     public boolean canCreatureSpawn(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EntityLiving.SpawnPlacementType type) {
         return false;
+    }
+
+    @Override
+    public void onEntityWalk(@Nonnull World worldIn, @Nonnull BlockPos pos, Entity entityIn) {
+
+        IBlockState below = entityIn.getEntityWorld().getBlockState(new BlockPos(entityIn.posX, entityIn.posY - (1 / 16D), entityIn.posZ));
+        if (below == getState(BlockStoneWindmillB.BlockType.CONCRETE_DARK) || below == getState(BlockStoneWindmillB.BlockType.CONCRETE_LIGHT)) {
+            if (!entityIn.isInWater()) {
+                entityIn.motionX *= 1.6;
+                entityIn.motionZ *= 1.6;
+            }
+        }
     }
 
     public enum BlockType implements IStringSerializable {


### PR DESCRIPTION
## What
Adds back the movement speed bonuses for concrete. These were removed in #419 (I think accidentally), when Tech divided up the concrete block class


## Outcome
Once again move faster on concrete
