### PR TITLE
Fix classloading crash with ASM

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -122,7 +122,8 @@ public class GTValues {
             MODID_COFH = "cofhcore",
             MODID_APPENG = "appliedenergistics2",
             MODID_JEI = "jei",
-            MODID_GROOVYSCRIPT = "groovyscript";
+            MODID_GROOVYSCRIPT = "groovyscript",
+            MODID_NC = "nuclearcraft";
 
     private static Boolean isClient;
 


### PR DESCRIPTION
## What
This PR fixes a crash related to classloading issues when checking `Loader#isModLoaded` during ASM transformation. `Loader` is unable to determine if a mod is loaded properly, and may crash in attempting to do so, this early in loading. For mods that run server side, an alternative means of checking is used, like NuclearCraft is checked presently. For client side only mods, a class from the target mod must be checked if present instead.

## Outcome
Fixes classloading crash with ASM Transformers. Closes #1415.
