### PR TITLE
Make sure to call the Cover Behavior Right click

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -430,7 +430,10 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
             }
             EnumActionResult result = coverBehavior.onRightClick(playerIn, hand, hitResult);
 
-            if (result != EnumActionResult.SUCCESS && playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
+            if (result == EnumActionResult.SUCCESS) {
+                return true;
+            }
+            else if (playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
                 result = coverBehavior.onScrewdriverClick(playerIn, hand, hitResult);
 
                 return result == EnumActionResult.SUCCESS;

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -15,7 +15,9 @@ import com.google.common.base.Preconditions;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.block.machines.BlockMachine;
-import gregtech.api.capability.*;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IControllable;
+import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.*;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.CoverDefinition;
@@ -420,16 +422,21 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
                 MetaTileEntityUIFactory.INSTANCE.openUI(getHolder(), (EntityPlayerMP) playerIn);
             }
             return true;
-        } else if (playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
+        } else {
             EnumFacing hitFacing = hitResult.sideHit;
-
             CoverBehavior coverBehavior = hitFacing == null ? null : getCoverAtSide(hitFacing);
+            if (coverBehavior == null) {
+                return false;
+            }
+            EnumActionResult result = coverBehavior.onRightClick(playerIn, hand, hitResult);
 
-            EnumActionResult coverResult = coverBehavior == null ? EnumActionResult.PASS :
-                    coverBehavior.onScrewdriverClick(playerIn, hand, hitResult);
+            if (result != EnumActionResult.SUCCESS && playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
+                result = coverBehavior.onScrewdriverClick(playerIn, hand, hitResult);
 
-            return coverResult == EnumActionResult.SUCCESS;
+                return result == EnumActionResult.SUCCESS;
+            }
         }
+
         return false;
     }
 


### PR DESCRIPTION
## What
This PR makes sure that `CoverBehavior#onRightClick` is called when the cover is placed on an MTE. Currently, this is only called when placed on a pipe. 

Not calling this on MTEs can mess with covers like the digital interface cover


## Outcome
Make sure to call the cover behavior right click method from mtes
