### PR TITLE
Allow Crafting Table covers to be opened with screwdriver or hand

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverCraftingTable.java
+++ b/src/main/java/gregtech/common/covers/CoverCraftingTable.java
@@ -75,16 +75,11 @@ public class CoverCraftingTable extends CoverBehavior implements CoverWithUI, IT
     }
 
     @Override
-    public EnumActionResult onRightClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
+    public EnumActionResult onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
         if (!playerIn.world.isRemote) {
             this.openUI((EntityPlayerMP) playerIn);
         }
         return EnumActionResult.SUCCESS;
-    }
-
-    @Override
-    public EnumActionResult onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
-        return EnumActionResult.FAIL;
     }
 
     @Override


### PR DESCRIPTION
## What
Allows the Crafting Table cover to be opened with either the screwdriver or an empty hand (when shift clicking)

This bring it inline with all the other covers

## Outcome
Allow the Crafting Table cover to be opened with either the screwdriver or an empty hand
