### PR TITLE
Fix the weird seam visible in button widgets

### DIFF
--- a/src/main/java/gregtech/api/gui/resources/SizedTextureArea.java
+++ b/src/main/java/gregtech/api/gui/resources/SizedTextureArea.java
@@ -39,14 +39,15 @@ public class SizedTextureArea extends TextureArea {
 
     public void drawHorizontalCutSubArea(int x, int y, int width, int height, double drawnV, double drawnHeight) {
         double drawnWidth = width / 2.0 / pixelImageWidth;
-        drawSubArea(x, y, width / 2, height, 0.0, drawnV, drawnWidth, drawnHeight);
-        drawSubArea(x + width / 2F, y, width / 2, height, 1.0 - drawnWidth, drawnV, drawnWidth, drawnHeight);
+        int half = width / 2;
+        drawSubArea(x, y, half, height, 0.0, drawnV, drawnWidth, drawnHeight);
+        drawSubArea(x + half, y, width - half, height, 1.0 - drawnWidth, drawnV, drawnWidth, drawnHeight);
     }
 
     public void drawVerticalCutSubArea(int x, int y, int width, int height, double drawnU, double drawnWidth) {
         double drawnHeight = height / 2.0 / pixelImageHeight;
-        drawSubArea(x, y, width, height / 2, drawnU, 0.0, drawnWidth, drawnHeight);
-        drawSubArea(x, y + height / 2F, width, height / 2, drawnU, 1.0 - drawnHeight, drawnWidth, drawnHeight);
+        int half = height / 2;
+        drawSubArea(x, y, width, half, drawnU, 0.0, drawnWidth, drawnHeight);
+        drawSubArea(x, y + half, width, height - half, drawnU, 1.0 - drawnHeight, drawnWidth, drawnHeight);
     }
-
 }

--- a/src/main/java/gregtech/api/gui/resources/SizedTextureArea.java
+++ b/src/main/java/gregtech/api/gui/resources/SizedTextureArea.java
@@ -38,15 +38,15 @@ public class SizedTextureArea extends TextureArea {
     }
 
     public void drawHorizontalCutSubArea(int x, int y, int width, int height, double drawnV, double drawnHeight) {
-        double drawnWidth = width / 2.0 / pixelImageWidth;
         int half = width / 2;
+        double drawnWidth = half / pixelImageWidth;
         drawSubArea(x, y, half, height, 0.0, drawnV, drawnWidth, drawnHeight);
         drawSubArea(x + half, y, width - half, height, 1.0 - drawnWidth, drawnV, drawnWidth, drawnHeight);
     }
 
     public void drawVerticalCutSubArea(int x, int y, int width, int height, double drawnU, double drawnWidth) {
-        double drawnHeight = height / 2.0 / pixelImageHeight;
         int half = height / 2;
+        double drawnHeight = half / pixelImageHeight;
         drawSubArea(x, y, width, half, drawnU, 0.0, drawnWidth, drawnHeight);
         drawSubArea(x, y + half, width, height - half, drawnU, 1.0 - drawnHeight, drawnWidth, drawnHeight);
     }


### PR DESCRIPTION
## What
This PR fixes the weird seam visible in middle of button widgets.

## Implementation Details
The issue is caused by providing subpixel position to `drawSubArea` function, likely because of the IntelliJ IDEA overanalyzing the code as always and subsequently freaking out saying dropping decimal points is major sin.

I've changed the implementation to correctly draw the image without seams, while making IDEA shut the fuck up about reporting nonexistent errors.

## Outcome
World peace