### PR TITLE
TaskScheduler cleanup

### DIFF
--- a/src/main/java/gregtech/api/util/TaskScheduler.java
+++ b/src/main/java/gregtech/api/util/TaskScheduler.java
@@ -9,7 +9,10 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @EventBusSubscriber(modid = GTValues.MODID)
 public class TaskScheduler {
@@ -48,17 +51,13 @@ public class TaskScheduler {
     @SubscribeEvent
     public static void onWorldUnload(WorldEvent.Unload event) {
         if (!event.getWorld().isRemote) {
-            TaskScheduler scheduler = tasksPerWorld.get(event.getWorld());
-            if (scheduler != null) {
-                scheduler.unload();
-                tasksPerWorld.remove(event.getWorld());
-            }
+            tasksPerWorld.remove(event.getWorld());
         }
     }
 
     @SubscribeEvent
     public static void onWorldTick(TickEvent.WorldTickEvent event) {
-        if (!event.world.isRemote) {
+        if (!event.world.isRemote && event.phase == TickEvent.Phase.START) {
             TaskScheduler scheduler = get(event.world);
             if (scheduler != null) {
                 if (!scheduler.scheduledTasks.isEmpty()) {


### PR DESCRIPTION
## What
This PR addresses minor points in TaskScheduler class.

## Implementation Details
This PR changes two things.
1. Tasks only run at phase of `START`. Previously, all tasks ran twice each tick, once at `START` and once at `END`.
2. Removed `clear` calls in `onWorldUnload`. In theory the only situation where the `clear` call would matter is when any of the task maintains a strong reference to `TaskScheduler` instance while simultaneously being referenced by somewhere else, which is unlikely.

## Potential Compatibility Issues
Technically the tasks not being run at `END` might change the behavior. In the base mod there are only two places TaskScheduler is used, namely the ice sawing and updating cable heat. During my testing I did not observe any significant changes on these instances.