### PR TITLE
Remove RecipeMap Minimums and add setters for Maximums

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
@@ -90,37 +90,25 @@ public abstract class MultiMapMultiblockController extends RecipeMapMultiblockCo
 
         for (RecipeMap<?> recipeMap : getAvailableRecipeMaps()) {
             if (!checkedItemIn && checkItemIn) {
-                if (recipeMap.getMinInputs() > 0) {
-                    checkedItemIn = true;
-                    predicate = predicate.or(abilities(MultiblockAbility.IMPORT_ITEMS).setMinGlobalLimited(1).setPreviewCount(1));
-                } else if (recipeMap.getMaxInputs() > 0) {
+                if (recipeMap.getMaxInputs() > 0) {
                     checkedItemIn = true;
                     predicate = predicate.or(abilities(MultiblockAbility.IMPORT_ITEMS).setPreviewCount(1));
                 }
             }
             if (!checkedItemOut && checkItemOut) {
-                if (recipeMap.getMinOutputs() > 0) {
-                    checkedItemOut = true;
-                    predicate = predicate.or(abilities(MultiblockAbility.EXPORT_ITEMS).setMinGlobalLimited(1).setPreviewCount(1));
-                } else if (recipeMap.getMaxOutputs() > 0) {
+                if (recipeMap.getMaxOutputs() > 0) {
                     checkedItemOut = true;
                     predicate = predicate.or(abilities(MultiblockAbility.EXPORT_ITEMS).setPreviewCount(1));
                 }
             }
             if (!checkedFluidIn && checkFluidIn) {
-                if (recipeMap.getMinFluidInputs() > 0) {
-                    checkedFluidIn = true;
-                    predicate = predicate.or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1).setPreviewCount(recipeMap.getMinFluidInputs()));
-                } else if (recipeMap.getMaxFluidInputs() > 0) {
+                if (recipeMap.getMaxFluidInputs() > 0) {
                     checkedFluidIn = true;
                     predicate = predicate.or(abilities(MultiblockAbility.IMPORT_FLUIDS).setPreviewCount(1));
                 }
             }
             if (!checkedFluidOut && checkFluidOut) {
-                if (recipeMap.getMinFluidOutputs() > 0) {
-                    checkedFluidOut = true;
-                    predicate = predicate.or(abilities(MultiblockAbility.EXPORT_FLUIDS).setMinGlobalLimited(1).setPreviewCount(recipeMap.getMinFluidOutputs()));
-                } else if (recipeMap.getMaxFluidOutputs() > 0) {
+                if (recipeMap.getMaxFluidOutputs() > 0) {
                     checkedFluidOut = true;
                     predicate = predicate.or(abilities(MultiblockAbility.EXPORT_FLUIDS).setPreviewCount(1));
                 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -207,30 +207,22 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 .or(checkEnergyIn ? abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3).setPreviewCount(1) : new TraceabilityPredicate());
 
         if (checkItemIn) {
-            if (recipeMap.getMinInputs() > 0) {
-                predicate = predicate.or(abilities(MultiblockAbility.IMPORT_ITEMS).setMinGlobalLimited(1).setPreviewCount(1));
-            } else if (recipeMap.getMaxInputs() > 0) {
+            if (recipeMap.getMaxInputs() > 0) {
                 predicate = predicate.or(abilities(MultiblockAbility.IMPORT_ITEMS).setPreviewCount(1));
             }
         }
         if (checkItemOut) {
-            if (recipeMap.getMinOutputs() > 0) {
-                predicate = predicate.or(abilities(MultiblockAbility.EXPORT_ITEMS).setMinGlobalLimited(1).setPreviewCount(1));
-            } else if (recipeMap.getMaxOutputs() > 0) {
+            if (recipeMap.getMaxOutputs() > 0) {
                 predicate = predicate.or(abilities(MultiblockAbility.EXPORT_ITEMS).setPreviewCount(1));
             }
         }
         if (checkFluidIn) {
-            if (recipeMap.getMinFluidInputs() > 0) {
-                predicate = predicate.or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1).setPreviewCount(recipeMap.getMinFluidInputs()));
-            } else if (recipeMap.getMaxFluidInputs() > 0) {
+            if (recipeMap.getMaxFluidInputs() > 0) {
                 predicate = predicate.or(abilities(MultiblockAbility.IMPORT_FLUIDS).setPreviewCount(1));
             }
         }
         if (checkFluidOut) {
-            if (recipeMap.getMinFluidOutputs() > 0) {
-                predicate = predicate.or(abilities(MultiblockAbility.EXPORT_FLUIDS).setMinGlobalLimited(1).setPreviewCount(recipeMap.getMinFluidOutputs()));
-            } else if (recipeMap.getMaxFluidOutputs() > 0) {
+            if (recipeMap.getMaxFluidOutputs() > 0) {
                 predicate = predicate.or(abilities(MultiblockAbility.EXPORT_FLUIDS).setPreviewCount(1));
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
@@ -139,18 +139,12 @@ public abstract class RecipeMapSteamMultiblockController extends MultiblockWithD
         TraceabilityPredicate predicate = super.autoAbilities(checkMaintainer, checkMuffler)
                 .or(checkSteam ? abilities(MultiblockAbility.STEAM).setMinGlobalLimited(1).setPreviewCount(1) : new TraceabilityPredicate());
         if (checkItemIn) {
-            if (recipeMap.getMinInputs() > 0) {
-                predicate = predicate.or(abilities(MultiblockAbility.STEAM_IMPORT_ITEMS).setMinGlobalLimited(1).setPreviewCount(1));
-            }
-            else if (recipeMap.getMaxInputs() > 0) {
+            if (recipeMap.getMaxInputs() > 0) {
                 predicate = predicate.or(abilities(MultiblockAbility.STEAM_IMPORT_ITEMS).setPreviewCount(1));
             }
         }
         if (checkItemOut) {
-            if (recipeMap.getMinOutputs() > 0) {
-                predicate = predicate.or(abilities(MultiblockAbility.STEAM_EXPORT_ITEMS).setMinGlobalLimited(1).setPreviewCount(1));
-            }
-            else if (recipeMap.getMaxOutputs() > 0) {
+            if (recipeMap.getMaxOutputs() > 0) {
                 predicate =  predicate.or(abilities(MultiblockAbility.STEAM_EXPORT_ITEMS).setPreviewCount(1));
             }
         }

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -771,27 +771,26 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     protected void validateGroovy(GroovyLog.Msg errorMsg) {
         errorMsg.add(EUt == 0, () -> "EU/t must not be to 0");
         errorMsg.add(duration <= 0, () -> "Duration must not be less or equal to 0");
-        int minInput = recipeMap.getMinInputs(), maxInput = recipeMap.getMaxInputs(), minOutput = recipeMap.getMinOutputs(), maxOutput = recipeMap.getMaxOutputs();
-        int minFluidInput = recipeMap.getMinFluidInputs(), maxFluidInput = recipeMap.getMaxFluidInputs(), minFluidOutput = recipeMap.getMinFluidOutputs(), maxFluidOutput = recipeMap.getMaxFluidOutputs();
-        errorMsg.add(inputs.size() < minInput || inputs.size() > maxInput, () -> getRequiredString(minInput, maxInput, " item input") + ", but found " + inputs.size());
-        errorMsg.add(outputs.size() < minOutput || outputs.size() > maxOutput, () -> getRequiredString(minOutput, maxOutput, "item output") + ", but found " + outputs.size());
-        errorMsg.add(fluidInputs.size() < minFluidInput || fluidInputs.size() > maxFluidInput, () -> getRequiredString(minFluidInput, maxFluidInput, "fluid input") + ", but found " + fluidInputs.size());
-        errorMsg.add(fluidOutputs.size() < minFluidOutput || fluidOutputs.size() > maxFluidOutput, () -> getRequiredString(minFluidOutput, maxFluidOutput, "fluid output") + ", but found " + fluidOutputs.size());
+        int maxInput = recipeMap.getMaxInputs();
+        int maxOutput = recipeMap.getMaxOutputs();
+        int maxFluidInput = recipeMap.getMaxFluidInputs();
+        int maxFluidOutput = recipeMap.getMaxFluidOutputs();
+        errorMsg.add(inputs.size() > maxInput, () -> getRequiredString(maxInput, inputs.size(), "item input"));
+        errorMsg.add(outputs.size() > maxOutput, () -> getRequiredString(maxOutput, outputs.size(), "item output"));
+        errorMsg.add(fluidInputs.size() > maxFluidInput, () -> getRequiredString(maxFluidInput, fluidInputs.size(), "fluid input"));
+        errorMsg.add(fluidOutputs.size() > maxFluidOutput, () -> getRequiredString(maxFluidOutput, fluidOutputs.size(), "fluid output"));
     }
 
-    protected static String getRequiredString(int min, int max, String type) {
+    @Nonnull
+    protected static String getRequiredString(int max, int actual, @Nonnull String type) {
         if (max <= 0) {
-            return "No " + type + "s allowed";
+            return "No " + type + "s allowed, but found " + actual;
         }
-        String out = "Must have ";
-        if (min == max) {
-            out += "exactly " + min + " " + type;
-        } else {
-            out += min + " - " + max + " " + type;
-        }
+        String out = "Must have at most " + max + " " + type;
         if (max != 1) {
             out += "s";
         }
+        out += ", but found " + actual;
         return out;
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -78,6 +78,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private int maxOutputs;
     private int maxFluidInputs;
     private int maxFluidOutputs;
+    private final boolean modifyItemInputs, modifyItemOutputs, modifyFluidInputs, modifyFluidOutputs;
     protected final TByteObjectMap<TextureArea> slotOverlays;
     protected TextureArea specialTexture;
     protected int[] specialTexturePosition;
@@ -130,6 +131,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         this.maxOutputs = maxOutputs;
         this.maxFluidOutputs = maxFluidOutputs;
 
+        this.modifyItemInputs = true;
+        this.modifyItemOutputs = true;
+        this.modifyFluidInputs = true;
+        this.modifyFluidOutputs = true;
+
         this.isHidden = isHidden;
         defaultRecipeBuilder.setRecipeMap(this);
         this.recipeBuilderSample = defaultRecipeBuilder;
@@ -137,6 +143,47 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
         this.virtualizedRecipeMap = GroovyScriptCompat.isLoaded() ? new VirtualizedRecipeMap(this) : null;
     }
+
+    /**
+     * @param unlocalizedName the unlocalized name for the RecipeMap
+     * @param maxInputs the maximum item inputs
+     * @param modifyItemInputs If the Maximum Item Inputs should be modified
+     * @param maxOutputs the maximum item outputs
+     * @param modifyItemOutputs If the Maximum Item Outputs should be modified
+     * @param maxFluidInputs the maximum fluid inputs
+     * @param modifyFluidInputs If the Maximum Fluid Inputs should be modified
+     * @param maxFluidOutputs the maximum fluid outputs
+     * @param modifyFluidOutputs If the Maximum Fluid Outputs should be modified
+     * @param defaultRecipeBuilder the default RecipeBuilder for the RecipeMap
+     * @param isHidden if the RecipeMap should have a category in JEI
+     */
+    public RecipeMap(@Nonnull String unlocalizedName, @Nonnegative int maxInputs, boolean modifyItemInputs, @Nonnegative int maxOutputs,
+                     boolean modifyItemOutputs, @Nonnegative int maxFluidInputs, boolean modifyFluidInputs,
+                     @Nonnegative int maxFluidOutputs, boolean modifyFluidOutputs, @Nonnull R defaultRecipeBuilder,
+                     boolean isHidden) {
+        this.unlocalizedName = unlocalizedName;
+        this.slotOverlays = new TByteObjectHashMap<>();
+        this.progressBarTexture = GuiTextures.PROGRESS_BAR_ARROW;
+        this.moveType = MoveType.HORIZONTAL;
+
+        this.maxInputs = maxInputs;
+        this.maxFluidInputs = maxFluidInputs;
+        this.maxOutputs = maxOutputs;
+        this.maxFluidOutputs = maxFluidOutputs;
+
+        this.modifyItemInputs = modifyItemInputs;
+        this.modifyItemOutputs = modifyItemOutputs;
+        this.modifyFluidInputs = modifyFluidInputs;
+        this.modifyFluidOutputs = modifyFluidOutputs;
+
+        this.isHidden = isHidden;
+        defaultRecipeBuilder.setRecipeMap(this);
+        this.recipeBuilderSample = defaultRecipeBuilder;
+        RECIPE_MAP_REGISTRY.put(unlocalizedName, this);
+
+        this.virtualizedRecipeMap = GroovyScriptCompat.isLoaded() ? new VirtualizedRecipeMap(this) : null;
+    }
+
 
     @ZenMethod
     public static List<RecipeMap<?>> getRecipeMaps() {
@@ -1055,7 +1102,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     @ZenSetter("maxInputs")
     public void setMaxInputs(@Nonnegative int maxInputs) {
-        this.maxInputs = Math.max(this.maxInputs, maxInputs);
+        if (modifyItemInputs) {
+            this.maxInputs = Math.max(this.maxInputs, maxInputs);
+        }
     }
 
     /**
@@ -1074,7 +1123,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     @ZenSetter("maxOutputs")
     public void setMaxOutputs(@Nonnegative int maxOutputs) {
-        this.maxOutputs = Math.max(this.maxOutputs, maxOutputs);
+        if (modifyItemOutputs) {
+            this.maxOutputs = Math.max(this.maxOutputs, maxOutputs);
+        }
     }
 
     /**
@@ -1093,7 +1144,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     @ZenSetter("maxFluidInputs")
     public void setMaxFluidInputs(@Nonnegative int maxFluidInputs) {
-        this.maxFluidInputs = Math.max(this.maxFluidInputs, maxFluidInputs);
+        if (modifyFluidInputs) {
+            this.maxFluidInputs = Math.max(this.maxFluidInputs, maxFluidInputs);
+        }
     }
 
     /**
@@ -1112,7 +1165,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     @ZenSetter("maxFluidOutputs")
     public void setMaxFluidOutputs(@Nonnegative int maxFluidOutputs) {
-        this.maxFluidOutputs = Math.max(this.maxFluidOutputs, maxFluidOutputs);
+        if (modifyFluidOutputs) {
+            this.maxFluidOutputs = Math.max(this.maxFluidOutputs, maxFluidOutputs);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -252,9 +252,6 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         if (recipe.isGroovyRecipe()) {
             return validationResult;
         }
-        if (recipe.getInputs().size() + recipe.getFluidInputs().size() == 0) {
-            GTLog.logger.error("Invalid amount of recipe inputs");
-        }
 
         boolean emptyInputs = recipe.getInputs().isEmpty() && recipe.getFluidInputs().isEmpty();
         if (emptyInputs) {
@@ -264,6 +261,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 CraftTweakerAPI.logError("Invalid amount of recipe inputs. Recipe inputs are empty.");
                 CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
             }
+            recipeStatus = EnumValidationResult.INVALID;
         }
         boolean emptyOutputs = recipe.getOutputs().isEmpty() && recipe.getFluidOutputs().isEmpty() && recipe.getChancedOutputs().isEmpty();
         if (recipe.getEUt() > 0 && emptyOutputs) {
@@ -273,6 +271,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 CraftTweakerAPI.logError("Invalid amount of outputs inputs. Recipe outputs are empty.");
                 CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
             }
+            recipeStatus = EnumValidationResult.INVALID;
         }
         if (emptyInputs && emptyOutputs) {
             GTLog.logger.error("Invalid recipe. Inputs and Outputs are empty.");

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -1104,6 +1104,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public void setMaxInputs(@Nonnegative int maxInputs) {
         if (modifyItemInputs) {
             this.maxInputs = Math.max(this.maxInputs, maxInputs);
+        } else {
+            throw new UnsupportedOperationException("Cannot change max item input amount for " + getUnlocalizedName());
         }
     }
 
@@ -1125,6 +1127,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public void setMaxOutputs(@Nonnegative int maxOutputs) {
         if (modifyItemOutputs) {
             this.maxOutputs = Math.max(this.maxOutputs, maxOutputs);
+        } else {
+            throw new UnsupportedOperationException("Cannot change max item output amount for " + getUnlocalizedName());
         }
     }
 
@@ -1146,6 +1150,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public void setMaxFluidInputs(@Nonnegative int maxFluidInputs) {
         if (modifyFluidInputs) {
             this.maxFluidInputs = Math.max(this.maxFluidInputs, maxFluidInputs);
+        } else {
+            throw new UnsupportedOperationException("Cannot change max fluid input amount for " + getUnlocalizedName());
         }
     }
 
@@ -1167,6 +1173,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public void setMaxFluidOutputs(@Nonnegative int maxFluidOutputs) {
         if (modifyFluidOutputs) {
             this.maxFluidOutputs = Math.max(this.maxFluidOutputs, maxFluidOutputs);
+        } else {
+            throw new UnsupportedOperationException("Cannot change max fluid output amount for " + getUnlocalizedName());
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -40,9 +40,7 @@ import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.oredict.OreDictionary;
 import stanhebben.zenscript.annotations.Optional;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenMethod;
+import stanhebben.zenscript.annotations.*;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -254,6 +252,37 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         if (recipe.isGroovyRecipe()) {
             return validationResult;
         }
+        if (recipe.getInputs().size() + recipe.getFluidInputs().size() == 0) {
+            GTLog.logger.error("Invalid amount of recipe inputs");
+        }
+
+        boolean emptyInputs = recipe.getInputs().isEmpty() && recipe.getFluidInputs().isEmpty();
+        if (emptyInputs) {
+            GTLog.logger.error("Invalid amount of recipe inputs. Recipe inputs are empty.");
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+            if (recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError("Invalid amount of recipe inputs. Recipe inputs are empty.");
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+            }
+        }
+        boolean emptyOutputs = recipe.getOutputs().isEmpty() && recipe.getFluidOutputs().isEmpty() && recipe.getChancedOutputs().isEmpty();
+        if (recipe.getEUt() > 0 && emptyOutputs) {
+            GTLog.logger.error("Invalid amount of recipe outputs. Recipe outputs are empty.");
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+            if (recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError("Invalid amount of outputs inputs. Recipe outputs are empty.");
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+            }
+        }
+        if (emptyInputs && emptyOutputs) {
+            GTLog.logger.error("Invalid recipe. Inputs and Outputs are empty.");
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Recipe is empty"));
+            if (recipe.getIsCTRecipe()) {
+                CraftTweakerAPI.logError("Invalid recipe. Inputs and Outputs are empty.");
+                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Recipe is empty"));
+            }
+        }
+
         int amount = recipe.getInputs().size();
         if (amount > getMaxInputs()) {
             GTLog.logger.error("Invalid amount of recipe inputs. Actual: {}. Should be at most {}.", amount, getMaxInputs());
@@ -1025,6 +1054,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return maxInputs;
     }
 
+    @ZenSetter("maxInputs")
     public void setMaxInputs(@Nonnegative int maxInputs) {
         this.maxInputs = Math.max(this.maxInputs, maxInputs);
     }
@@ -1043,6 +1073,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return maxOutputs;
     }
 
+    @ZenSetter("maxOutputs")
     public void setMaxOutputs(@Nonnegative int maxOutputs) {
         this.maxOutputs = Math.max(this.maxOutputs, maxOutputs);
     }
@@ -1061,6 +1092,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return maxFluidInputs;
     }
 
+    @ZenSetter("maxFluidInputs")
     public void setMaxFluidInputs(@Nonnegative int maxFluidInputs) {
         this.maxFluidInputs = Math.max(this.maxFluidInputs, maxFluidInputs);
     }
@@ -1079,6 +1111,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return maxFluidOutputs;
     }
 
+    @ZenSetter("maxFluidOutputs")
     public void setMaxFluidOutputs(@Nonnegative int maxFluidOutputs) {
         this.maxFluidOutputs = Math.max(this.maxFluidOutputs, maxFluidOutputs);
     }

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -131,7 +131,7 @@ public class RecipeMaps {
      * The Assembly Line Recipe Builder has no special properties/build actions yet, but will in the future
      */
     @ZenProperty
-    public static final RecipeMapAssemblyLine<SimpleRecipeBuilder> ASSEMBLY_LINE_RECIPES = (RecipeMapAssemblyLine<SimpleRecipeBuilder>) new RecipeMapAssemblyLine<>("assembly_line", 16, 1, 4, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMapAssemblyLine<SimpleRecipeBuilder> ASSEMBLY_LINE_RECIPES = (RecipeMapAssemblyLine<SimpleRecipeBuilder>) new RecipeMapAssemblyLine<>("assembly_line", 16, false, 1, false,  4, false,  0, false, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ASSEMBLER);
 
@@ -393,7 +393,7 @@ public class RecipeMaps {
      * As a Primitive Machine, the Coke Oven does not need an <B>EUt</B> parameter specified for the Recipe Builder.
      */
     @ZenProperty
-    public static final RecipeMap<PrimitiveRecipeBuilder> COKE_OVEN_RECIPES = new RecipeMapCokeOven<>("coke_oven", 1, 1, 0, 1, new PrimitiveRecipeBuilder(), false)
+    public static final RecipeMap<PrimitiveRecipeBuilder> COKE_OVEN_RECIPES = new RecipeMapCokeOven<>("coke_oven", 1, false, 1, false, 0, false, 1, false, new PrimitiveRecipeBuilder(), false)
             .setSound(GTSoundEvents.FIRE);
 
     /**
@@ -430,7 +430,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CRACKING_RECIPES = new RecipeMapCrackerUnit<>("cracker", 1, 0, 2, 2, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CRACKING_RECIPES = new RecipeMapCrackerUnit<>("cracker", 1, false, 0, true, 2, false, 2, true, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, true, GuiTextures.CRACKING_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.CRACKING_OVERLAY_2)
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)
@@ -512,7 +512,7 @@ public class RecipeMaps {
      *  This behavior can be disabled by adding a <B>.disableDistilleryRecipes()</B> onto the recipe builder.
      */
     @ZenProperty
-    public static final RecipeMap<UniversalDistillationRecipeBuilder> DISTILLATION_RECIPES = new RecipeMapDistillationTower("distillation_tower", 0, 1, 1, 12, new UniversalDistillationRecipeBuilder(), false)
+    public static final RecipeMap<UniversalDistillationRecipeBuilder> DISTILLATION_RECIPES = new RecipeMapDistillationTower("distillation_tower", 0, true, 1, true, 1, true, 12, false, new UniversalDistillationRecipeBuilder(), false)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
 
     /**

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -993,7 +993,7 @@ public class RecipeMaps {
      * As a Primitive Machine, the Primitive Blast Furnace does not need an <B>EUt</B> parameter specified for the Recipe Builder.
      */
     @ZenProperty
-    public static final RecipeMap<PrimitiveRecipeBuilder> PRIMITIVE_BLAST_FURNACE_RECIPES = new RecipeMap<>("primitive_blast_furnace", 3, 3, 0, 0, new PrimitiveRecipeBuilder(), false)
+    public static final RecipeMap<PrimitiveRecipeBuilder> PRIMITIVE_BLAST_FURNACE_RECIPES = new RecipeMap<>("primitive_blast_furnace", 3, false, 3, false, 0, false, 0, false, new PrimitiveRecipeBuilder(), false)
             .setSound(GTSoundEvents.FIRE);
 
     /**

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -46,7 +46,7 @@ public class RecipeMaps {
      * Note that the use of <B>OrePrefix</B> ensures that OreDictionary Entries are used for the recipe.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> ALLOY_SMELTER_RECIPES = new RecipeMap<>("alloy_smelter", 1, 2, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> ALLOY_SMELTER_RECIPES = new RecipeMap<>("alloy_smelter", 2, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.FURNACE_OVERLAY_1)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.FURNACE);
@@ -77,7 +77,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> ARC_FURNACE_RECIPES = new RecipeMap<>("arc_furnace", 1, 1, 1, 4, 1, 1, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> ARC_FURNACE_RECIPES = new RecipeMap<>("arc_furnace", 1, 4, 1, 1, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARC_FURNACE, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ARC)
             .onRecipeBuild(recipeBuilder -> {
@@ -99,7 +99,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<AssemblerRecipeBuilder> ASSEMBLER_RECIPES = new RecipeMap<>("assembler", 1, 9, 1, 1, 0, 1, 0, 0, new AssemblerRecipeBuilder(), false)
+    public static final RecipeMap<AssemblerRecipeBuilder> ASSEMBLER_RECIPES = new RecipeMap<>("assembler", 9, 1, 1, 0, new AssemblerRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_CIRCUIT, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ASSEMBLER)
@@ -131,7 +131,7 @@ public class RecipeMaps {
      * The Assembly Line Recipe Builder has no special properties/build actions yet, but will in the future
      */
     @ZenProperty
-    public static final RecipeMapAssemblyLine<SimpleRecipeBuilder> ASSEMBLY_LINE_RECIPES = (RecipeMapAssemblyLine<SimpleRecipeBuilder>) new RecipeMapAssemblyLine<>("assembly_line", 4, 16, 1, 1, 0, 4, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMapAssemblyLine<SimpleRecipeBuilder> ASSEMBLY_LINE_RECIPES = (RecipeMapAssemblyLine<SimpleRecipeBuilder>) new RecipeMapAssemblyLine<>("assembly_line", 16, 1, 4, 0, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ASSEMBLER);
 
@@ -148,7 +148,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> AUTOCLAVE_RECIPES = new RecipeMap<>("autoclave", 1, 2, 1, 2, 1, 1, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> AUTOCLAVE_RECIPES = new RecipeMap<>("autoclave", 2, 2, 1, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.DUST_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.CRYSTAL_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_CRYSTALLIZATION, MoveType.HORIZONTAL)
@@ -169,7 +169,7 @@ public class RecipeMaps {
      * Just like other SimpleRecipeBuilder RecipeMaps, <B>circuit</B> can be used to easily set a circuit
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> BENDER_RECIPES = new RecipeMap<>("bender", 2, 2, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> BENDER_RECIPES = new RecipeMap<>("bender", 2, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, false, GuiTextures.BENDER_OVERLAY)
             .setSlotOverlay(false, false, true, GuiTextures.INT_CIRCUIT_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_BENDING, MoveType.HORIZONTAL)
@@ -196,7 +196,7 @@ public class RecipeMaps {
      * cooling recipe.
      */
     @ZenProperty
-    public static final RecipeMap<BlastRecipeBuilder> BLAST_RECIPES = new RecipeMap<>("electric_blast_furnace", 1, 3, 0, 3, 0, 1, 0, 1, new BlastRecipeBuilder(), false)
+    public static final RecipeMap<BlastRecipeBuilder> BLAST_RECIPES = new RecipeMap<>("electric_blast_furnace", 3, 3, 1, 1, new BlastRecipeBuilder(), false)
             .setSound(GTSoundEvents.FURNACE);
 
     /**
@@ -214,7 +214,7 @@ public class RecipeMaps {
      * Any Recipe added to the Brewery not specifying an <B>EUt</B> value will default 4.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> BREWING_RECIPES = new RecipeMap<>("brewery", 1, 1, 0, 0, 1, 1, 1, 1, new SimpleRecipeBuilder().duration(128).EUt(4), false)
+    public static final RecipeMap<SimpleRecipeBuilder> BREWING_RECIPES = new RecipeMap<>("brewery", 1, 0, 1, 1, new SimpleRecipeBuilder().duration(128).EUt(4), false)
             .setSlotOverlay(false, false, GuiTextures.BREWER_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
@@ -236,7 +236,7 @@ public class RecipeMaps {
      * It will empty or fill any fluid handler, so there is no need to add explicit recipes for the fluid handlers.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CANNER_RECIPES = new RecipeMapFluidCanner("canner", 1, 2, 1, 2, 0, 1, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CANNER_RECIPES = new RecipeMapFluidCanner("canner", 2, 2, 1, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, false, GuiTextures.CANNER_OVERLAY)
             .setSlotOverlay(false, false, true, GuiTextures.CANISTER_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.CANISTER_OVERLAY)
@@ -264,7 +264,7 @@ public class RecipeMaps {
      * Any Centrifuge recipe not specifying an <B>EUt</B> value will have the value default to 5.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CENTRIFUGE_RECIPES = new RecipeMap<>("centrifuge", 0, 2, 0, 6, 0, 1, 0, 6, new SimpleRecipeBuilder().EUt(5), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CENTRIFUGE_RECIPES = new RecipeMap<>("centrifuge", 2, 6, 1, 6, new SimpleRecipeBuilder().EUt(5), false)
             .setSlotOverlay(false, false, false, GuiTextures.EXTRACTOR_OVERLAY)
             .setSlotOverlay(false, false, true, GuiTextures.CANISTER_OVERLAY)
             .setSlotOverlay(false, true, true, GuiTextures.CENTRIFUGE_OVERLAY)
@@ -283,7 +283,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CHEMICAL_BATH_RECIPES = new RecipeMap<>("chemical_bath", 1, 1, 1, 6, 1, 1, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CHEMICAL_BATH_RECIPES = new RecipeMap<>("chemical_bath", 1, 6, 1, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, true, GuiTextures.BREWER_OVERLAY)
             .setSlotOverlay(true, false, false, GuiTextures.DUST_OVERLAY)
             .setSlotOverlay(true, false, true, GuiTextures.DUST_OVERLAY)
@@ -313,7 +313,7 @@ public class RecipeMaps {
      * Any recipe added to the Chemical Reactor not specifying an <B>EUt</B> value will default to 30.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CHEMICAL_RECIPES = new RecipeMap<>("chemical_reactor", 0, 2, 0, 2, 0, 3, 0, 2, new SimpleRecipeBuilder().EUt(VA[LV]), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CHEMICAL_RECIPES = new RecipeMap<>("chemical_reactor", 2, 2, 3, 2, new SimpleRecipeBuilder().EUt(VA[LV]), false)
             .setSlotOverlay(false, false, false, GuiTextures.MOLECULAR_OVERLAY_1)
             .setSlotOverlay(false, false, true, GuiTextures.MOLECULAR_OVERLAY_2)
             .setSlotOverlay(false, true, false, GuiTextures.MOLECULAR_OVERLAY_3)
@@ -362,8 +362,7 @@ public class RecipeMaps {
      * This action can be negated by simply specifying a fluid input in the recipe.
      */
     @ZenProperty
-    public static final RecipeMap<CircuitAssemblerRecipeBuilder> CIRCUIT_ASSEMBLER_RECIPES = new RecipeMap<>("circuit_assembler",
-            1, 6, 1, 1, 0, 1, 0, 0, new CircuitAssemblerRecipeBuilder(), false)
+    public static final RecipeMap<CircuitAssemblerRecipeBuilder> CIRCUIT_ASSEMBLER_RECIPES = new RecipeMap<>("circuit_assembler", 6, 1, 1, 0, new CircuitAssemblerRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_CIRCUIT_ASSEMBLER, ProgressWidget.MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ASSEMBLER)
@@ -394,7 +393,7 @@ public class RecipeMaps {
      * As a Primitive Machine, the Coke Oven does not need an <B>EUt</B> parameter specified for the Recipe Builder.
      */
     @ZenProperty
-    public static final RecipeMap<PrimitiveRecipeBuilder> COKE_OVEN_RECIPES = new RecipeMapCokeOven<>("coke_oven", 1, 1, 0, 1, 0, 0, 0, 1, new PrimitiveRecipeBuilder(), false)
+    public static final RecipeMap<PrimitiveRecipeBuilder> COKE_OVEN_RECIPES = new RecipeMapCokeOven<>("coke_oven", 1, 1, 0, 1, new PrimitiveRecipeBuilder(), false)
             .setSound(GTSoundEvents.FIRE);
 
     /**
@@ -412,7 +411,7 @@ public class RecipeMaps {
      * Any Recipe added to the Compressor not specifying a <B>duration</B> value will default to 200.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> COMPRESSOR_RECIPES = new RecipeMap<>("compressor", 1, 1, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(200).EUt(2), false)
+    public static final RecipeMap<SimpleRecipeBuilder> COMPRESSOR_RECIPES = new RecipeMap<>("compressor", 1, 1, 0, 0, new SimpleRecipeBuilder().duration(200).EUt(2), false)
             .setSlotOverlay(false, false, GuiTextures.COMPRESSOR_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_COMPRESS, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.COMPRESSOR);
@@ -431,7 +430,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CRACKING_RECIPES = new RecipeMapCrackerUnit<>("cracker", 0, 1, 0, 0, 2, 2, 0, 2, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CRACKING_RECIPES = new RecipeMapCrackerUnit<>("cracker", 1, 0, 2, 2, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, true, GuiTextures.CRACKING_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.CRACKING_OVERLAY_2)
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)
@@ -459,7 +458,7 @@ public class RecipeMaps {
      */
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CUTTER_RECIPES = new RecipeMap<>("cutter", 1, 1, 1, 2, 0, 1, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CUTTER_RECIPES = new RecipeMap<>("cutter", 1, 2, 1, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.SAWBLADE_OVERLAY)
             .setSlotOverlay(true, false, false, GuiTextures.CUTTER_OVERLAY)
             .setSlotOverlay(true, false, true, GuiTextures.DUST_OVERLAY)
@@ -513,7 +512,7 @@ public class RecipeMaps {
      *  This behavior can be disabled by adding a <B>.disableDistilleryRecipes()</B> onto the recipe builder.
      */
     @ZenProperty
-    public static final RecipeMap<UniversalDistillationRecipeBuilder> DISTILLATION_RECIPES = new RecipeMapDistillationTower("distillation_tower", 0, 0, 0, 1, 1, 1, 1, 12, new UniversalDistillationRecipeBuilder(), false)
+    public static final RecipeMap<UniversalDistillationRecipeBuilder> DISTILLATION_RECIPES = new RecipeMapDistillationTower("distillation_tower", 0, 1, 1, 12, new UniversalDistillationRecipeBuilder(), false)
             .setSound(GTSoundEvents.CHEMICAL_REACTOR);
 
     /**
@@ -529,7 +528,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> DISTILLERY_RECIPES = new RecipeMap<>("distillery", 1, 1, 0, 1, 1, 1, 1, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> DISTILLERY_RECIPES = new RecipeMap<>("distillery", 1, 1, 1, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, true, GuiTextures.BEAKER_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.BEAKER_OVERLAY_4)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
@@ -551,7 +550,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> ELECTROLYZER_RECIPES = new RecipeMap<>("electrolyzer", 0, 2, 0, 6, 0, 1, 0, 6, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> ELECTROLYZER_RECIPES = new RecipeMap<>("electrolyzer", 2, 6, 1, 6, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, false, GuiTextures.LIGHTNING_OVERLAY_1)
             .setSlotOverlay(false, false, true, GuiTextures.CANISTER_OVERLAY)
             .setSlotOverlay(false, true, true, GuiTextures.LIGHTNING_OVERLAY_2)
@@ -572,7 +571,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> ELECTROMAGNETIC_SEPARATOR_RECIPES = new RecipeMap<>("electromagnetic_separator", 1, 1, 1, 3, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> ELECTROMAGNETIC_SEPARATOR_RECIPES = new RecipeMap<>("electromagnetic_separator", 1, 3, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MAGNET, MoveType.HORIZONTAL)
@@ -592,7 +591,7 @@ public class RecipeMaps {
      * Any Recipe added to the Extractor not specifying an <B>duration</B> value will default to 400.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> EXTRACTOR_RECIPES = new RecipeMap<>("extractor", 0, 1, 0, 1, 0, 0, 0, 1, new SimpleRecipeBuilder().duration(400).EUt(2), false)
+    public static final RecipeMap<SimpleRecipeBuilder> EXTRACTOR_RECIPES = new RecipeMap<>("extractor", 1, 1, 0, 1, new SimpleRecipeBuilder().duration(400).EUt(2), false)
             .setSlotOverlay(false, false, GuiTextures.EXTRACTOR_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_EXTRACT, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.COMPRESSOR);
@@ -610,7 +609,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> EXTRUDER_RECIPES = new RecipeMap<>("extruder", 2, 2, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> EXTRUDER_RECIPES = new RecipeMap<>("extruder", 2, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, true, GuiTextures.MOLD_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_EXTRUDER, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ARC);
@@ -628,7 +627,7 @@ public class RecipeMaps {
      * Any Recipe added to the Fermenter not specifying an <B>EUt</B> value will default to 2.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> FERMENTING_RECIPES = new RecipeMap<>("fermenter", 0, 1, 0, 1, 1, 1, 1, 1, new SimpleRecipeBuilder().EUt(2), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FERMENTING_RECIPES = new RecipeMap<>("fermenter", 1, 1, 1, 1, new SimpleRecipeBuilder().EUt(2), false)
             .setSlotOverlay(false, false, true, GuiTextures.DUST_OVERLAY)
             .setSlotOverlay(true, false, true, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
@@ -647,7 +646,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> FLUID_HEATER_RECIPES = new RecipeMap<>("fluid_heater", 1, 1, 0, 0, 1, 1, 1, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FLUID_HEATER_RECIPES = new RecipeMap<>("fluid_heater", 1, 0, 1, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, true, GuiTextures.HEATING_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.HEATING_OVERLAY_2)
             .setSlotOverlay(false, false, GuiTextures.INT_CIRCUIT_OVERLAY)
@@ -667,7 +666,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> FLUID_SOLIDFICATION_RECIPES = new RecipeMap<>("fluid_solidifier", 1, 1, 1, 1, 1, 1, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FLUID_SOLIDFICATION_RECIPES = new RecipeMap<>("fluid_solidifier", 1, 1, 1, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.SOLIDIFIER_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.COOLING);
@@ -684,7 +683,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> FORGE_HAMMER_RECIPES = new RecipeMap<>("forge_hammer", 1, 1, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FORGE_HAMMER_RECIPES = new RecipeMap<>("forge_hammer", 1, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.HAMMER_OVERLAY)
             .setSpecialTexture(78, 42, 20, 6, GuiTextures.PROGRESS_BAR_HAMMER_BASE)
             .setProgressBar(GuiTextures.PROGRESS_BAR_HAMMER, MoveType.VERTICAL_DOWNWARDS)
@@ -702,7 +701,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> FORMING_PRESS_RECIPES = new RecipeMapFormingPress("forming_press", 2, 6, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FORMING_PRESS_RECIPES = new RecipeMapFormingPress("forming_press", 6, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_COMPRESS, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.COMPRESSOR);
 
@@ -726,7 +725,7 @@ public class RecipeMaps {
      * Recipe List, so any recipes added will be exclusive to the GTCEu Furnaces.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> FURNACE_RECIPES = new RecipeMapFurnace("electric_furnace", 1, 1, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> FURNACE_RECIPES = new RecipeMapFurnace("electric_furnace", 1, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.FURNACE_OVERLAY_1)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.FURNACE);
@@ -752,12 +751,12 @@ public class RecipeMaps {
      * MK3: 320MEU - 640MEU
      */
     @ZenProperty
-    public static final RecipeMap<FusionRecipeBuilder> FUSION_RECIPES = new RecipeMap<>("fusion_reactor", 0, 0, 0, 0, 2, 2, 0, 1, new FusionRecipeBuilder(), false)
+    public static final RecipeMap<FusionRecipeBuilder> FUSION_RECIPES = new RecipeMap<>("fusion_reactor", 0, 0, 2, 1, new FusionRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_FUSION, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ARC);
 
     @ZenProperty
-    public static final RecipeMap<GasCollectorRecipeBuilder> GAS_COLLECTOR_RECIPES = new RecipeMap<>("gas_collector", 1, 1, 0, 0, 0, 0, 1, 1, new GasCollectorRecipeBuilder(), false)
+    public static final RecipeMap<GasCollectorRecipeBuilder> GAS_COLLECTOR_RECIPES = new RecipeMap<>("gas_collector", 1, 0, 0, 1, new GasCollectorRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.INT_CIRCUIT_OVERLAY)
             .setSlotOverlay(true, true, GuiTextures.CENTRIFUGE_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
@@ -794,7 +793,7 @@ public class RecipeMaps {
      * Note that the count must be between 1 and 64 inclusive
      */
     @ZenProperty
-    public static final RecipeMap<ImplosionRecipeBuilder> IMPLOSION_RECIPES = new RecipeMap<>("implosion_compressor", 2, 3, 0, 2, 0, 0, 0, 0, new ImplosionRecipeBuilder().duration(20).EUt(VA[LV]), false)
+    public static final RecipeMap<ImplosionRecipeBuilder> IMPLOSION_RECIPES = new RecipeMap<>("implosion_compressor", 3, 2, 0, 0, new ImplosionRecipeBuilder().duration(20).EUt(VA[LV]), false)
             .setSlotOverlay(false, false, true, GuiTextures.IMPLOSION_OVERLAY_1)
             .setSlotOverlay(false, false, false, GuiTextures.IMPLOSION_OVERLAY_2)
             .setSlotOverlay(true, false, true, GuiTextures.DUST_OVERLAY)
@@ -819,7 +818,7 @@ public class RecipeMaps {
      * Any Recipe added to the Large Chemical Reactor not specifying an <B>EUt</B> value will default to 30.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> LARGE_CHEMICAL_RECIPES = new RecipeMap<>("large_chemical_reactor", 0, 3, 0, 3, 0, 5, 0, 4, new SimpleRecipeBuilder().EUt(VA[LV]), false)
+    public static final RecipeMap<SimpleRecipeBuilder> LARGE_CHEMICAL_RECIPES = new RecipeMap<>("large_chemical_reactor", 3, 3, 5, 4, new SimpleRecipeBuilder().EUt(VA[LV]), false)
             .setSlotOverlay(false, false, false, GuiTextures.MOLECULAR_OVERLAY_1)
             .setSlotOverlay(false, false, true, GuiTextures.MOLECULAR_OVERLAY_2)
             .setSlotOverlay(false, true, false, GuiTextures.MOLECULAR_OVERLAY_3)
@@ -843,7 +842,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> LASER_ENGRAVER_RECIPES = new RecipeMap<>("laser_engraver", 2, 2, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> LASER_ENGRAVER_RECIPES = new RecipeMap<>("laser_engraver", 2, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, true, GuiTextures.LENS_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ELECTROLYZER);
@@ -860,7 +859,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> LATHE_RECIPES = new RecipeMap<>("lathe", 1, 1, 1, 2, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> LATHE_RECIPES = new RecipeMap<>("lathe", 1, 2, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.PIPE_OVERLAY_1)
             .setSlotOverlay(true, false, false, GuiTextures.PIPE_OVERLAY_2)
             .setSlotOverlay(true, false, true, GuiTextures.DUST_OVERLAY)
@@ -882,7 +881,7 @@ public class RecipeMaps {
      * Any Recipe added to the Macerator not specifying a <B>duration</B> value will default to 150.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> MACERATOR_RECIPES = new RecipeMap<>("macerator", 1, 1, 1, 4, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(150).EUt(2), false)
+    public static final RecipeMap<SimpleRecipeBuilder> MACERATOR_RECIPES = new RecipeMap<>("macerator", 1, 4, 0, 0, new SimpleRecipeBuilder().duration(150).EUt(2), false)
             .setSlotOverlay(false, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MACERATE, MoveType.HORIZONTAL)
@@ -894,7 +893,7 @@ public class RecipeMaps {
      */
     @ZenProperty
     @SuppressWarnings("unused")
-    public static final RecipeMap<SimpleRecipeBuilder> MASS_FABRICATOR_RECIPES = new RecipeMap<>("mass_fabricator", 0, 1, 0, 0, 0, 1, 1, 2, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> MASS_FABRICATOR_RECIPES = new RecipeMap<>("mass_fabricator", 1, 0, 1, 2, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.ATOMIC_OVERLAY_1)
             .setSlotOverlay(false, true, GuiTextures.ATOMIC_OVERLAY_2)
             .setSlotOverlay(true, true, GuiTextures.POSITIVE_MATTER_OVERLAY)
@@ -915,7 +914,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> MIXER_RECIPES = new RecipeMap<>("mixer", 0, 6, 0, 1, 0, 2, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> MIXER_RECIPES = new RecipeMap<>("mixer", 6, 1, 2, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.DUST_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MIXER, MoveType.CIRCULAR)
@@ -936,7 +935,7 @@ public class RecipeMaps {
      * Any Recipe added to the Ore Washer not specifying a <B>duration</B> value will default to 400.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> ORE_WASHER_RECIPES = new RecipeMap<>("ore_washer", 1, 2, 1, 3, 0, 1, 0, 0, new SimpleRecipeBuilder().duration(400).EUt(16), false)
+    public static final RecipeMap<SimpleRecipeBuilder> ORE_WASHER_RECIPES = new RecipeMap<>("ore_washer", 2, 3, 1, 0, new SimpleRecipeBuilder().duration(400).EUt(16), false)
             .setSlotOverlay(false, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_BATH, MoveType.CIRCULAR)
@@ -957,7 +956,7 @@ public class RecipeMaps {
      * Any Recipe added to the Packer not specifying a <B>duration</B> value will default to 10.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> PACKER_RECIPES = new RecipeMap<>("packer", 1, 2, 1, 2, 0, 0, 0, 0, new SimpleRecipeBuilder().EUt(12).duration(10), false)
+    public static final RecipeMap<SimpleRecipeBuilder> PACKER_RECIPES = new RecipeMap<>("packer", 2, 2, 0, 0, new SimpleRecipeBuilder().EUt(12).duration(10), false)
             .setSlotOverlay(false, false, true, GuiTextures.BOX_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.BOXED_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_UNPACKER, MoveType.HORIZONTAL)
@@ -975,7 +974,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> POLARIZER_RECIPES = new RecipeMap<>("polarizer", 1, 1, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> POLARIZER_RECIPES = new RecipeMap<>("polarizer", 1, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MAGNET, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.ARC);
 
@@ -994,7 +993,7 @@ public class RecipeMaps {
      * As a Primitive Machine, the Primitive Blast Furnace does not need an <B>EUt</B> parameter specified for the Recipe Builder.
      */
     @ZenProperty
-    public static final RecipeMap<PrimitiveRecipeBuilder> PRIMITIVE_BLAST_FURNACE_RECIPES = new RecipeMap<>("primitive_blast_furnace", 2, 3, 0, 3, 0, 0, 0, 0, new PrimitiveRecipeBuilder(), false)
+    public static final RecipeMap<PrimitiveRecipeBuilder> PRIMITIVE_BLAST_FURNACE_RECIPES = new RecipeMap<>("primitive_blast_furnace", 3, 3, 0, 0, new PrimitiveRecipeBuilder(), false)
             .setSound(GTSoundEvents.FIRE);
 
     /**
@@ -1012,14 +1011,14 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> PYROLYSE_RECIPES = new RecipeMap<>("pyrolyse_oven", 2, 2, 0, 1, 0, 1, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> PYROLYSE_RECIPES = new RecipeMap<>("pyrolyse_oven", 2, 1, 1, 1, new SimpleRecipeBuilder(), false)
             .setSound(GTSoundEvents.FIRE);
 
     /**
      * Currently unused
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> REPLICATOR_RECIPES = new RecipeMap<>("replicator", 1, 1, 0, 1, 1, 2, 0, 1, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> REPLICATOR_RECIPES = new RecipeMap<>("replicator", 1, 1, 2, 1, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.DATA_ORB_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.ATOMIC_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.ATOMIC_OVERLAY_2)
@@ -1029,7 +1028,7 @@ public class RecipeMaps {
             .setSound(GTSoundEvents.REPLICATOR);
 
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> ROCK_BREAKER_RECIPES = new RecipeMap<>("rock_breaker", 1, 1, 1, 4, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> ROCK_BREAKER_RECIPES = new RecipeMap<>("rock_breaker", 1, 4, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.DUST_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_MACERATE, MoveType.HORIZONTAL)
@@ -1040,7 +1039,7 @@ public class RecipeMaps {
      */
     @ZenProperty
     @SuppressWarnings("unused")
-    public static final RecipeMap<SimpleRecipeBuilder> SCANNER_RECIPES = new RecipeMap<>("scanner", 0, 2, 1, 1, 0, 1, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> SCANNER_RECIPES = new RecipeMap<>("scanner", 2, 1, 1, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.DATA_ORB_OVERLAY)
             .setSlotOverlay(false, false, true, GuiTextures.SCANNER_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
@@ -1062,7 +1061,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> SIFTER_RECIPES = new RecipeMap<>("sifter", 1, 1, 0, 6, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> SIFTER_RECIPES = new RecipeMap<>("sifter", 1, 6, 0, 0, new SimpleRecipeBuilder(), false)
             .setProgressBar(GuiTextures.PROGRESS_BAR_SIFT, MoveType.VERTICAL_DOWNWARDS)
             .setSound(SoundEvents.BLOCK_SAND_PLACE);
 
@@ -1081,7 +1080,7 @@ public class RecipeMaps {
      * Any Recipe added to the Thermal Centrifuge not specifying a <B>duration</B> value will default to 400.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> THERMAL_CENTRIFUGE_RECIPES = new RecipeMap<>("thermal_centrifuge", 1, 1, 1, 3, 0, 0, 0, 0, new SimpleRecipeBuilder().duration(400).EUt(30), false)
+    public static final RecipeMap<SimpleRecipeBuilder> THERMAL_CENTRIFUGE_RECIPES = new RecipeMap<>("thermal_centrifuge", 1, 3, 0, 0, new SimpleRecipeBuilder().duration(400).EUt(30), false)
             .setSlotOverlay(false, false, GuiTextures.CRUSHED_ORE_OVERLAY)
             .setSlotOverlay(true, false, GuiTextures.DUST_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, MoveType.HORIZONTAL)
@@ -1100,7 +1099,7 @@ public class RecipeMaps {
      * Any Recipe added to the Thermal Centrifuge not specifying an <B>EUt</B> value will default to 120.
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> VACUUM_RECIPES = new RecipeMap<>("vacuum_freezer", 0, 1, 0, 1, 0, 2, 0, 1, new SimpleRecipeBuilder().EUt(VA[MV]), false)
+    public static final RecipeMap<SimpleRecipeBuilder> VACUUM_RECIPES = new RecipeMap<>("vacuum_freezer", 1, 1, 2, 1, new SimpleRecipeBuilder().EUt(VA[MV]), false)
             .setSound(GTSoundEvents.COOLING);
 
     /**
@@ -1115,7 +1114,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> WIREMILL_RECIPES = new RecipeMap<>("wiremill", 1, 1, 1, 1, 0, 0, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> WIREMILL_RECIPES = new RecipeMap<>("wiremill", 1, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.WIREMILL_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_WIREMILL, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.MOTOR);
@@ -1126,31 +1125,31 @@ public class RecipeMaps {
     //////////////////////////////////////
 
     @ZenProperty
-    public static final RecipeMap<FuelRecipeBuilder> COMBUSTION_GENERATOR_FUELS = new RecipeMap<>("combustion_generator", 0, 0, 0, 0, 1, 1, 0, 0, new FuelRecipeBuilder(), false)
+    public static final RecipeMap<FuelRecipeBuilder> COMBUSTION_GENERATOR_FUELS = new RecipeMap<>("combustion_generator", 0, 0, 1, 0, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.FURNACE_OVERLAY_2)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.COMBUSTION);
 
     @ZenProperty
-    public static final RecipeMap<FuelRecipeBuilder> GAS_TURBINE_FUELS = new RecipeMap<>("gas_turbine", 0, 0, 0, 0, 1, 1, 0, 0, new FuelRecipeBuilder(), false)
+    public static final RecipeMap<FuelRecipeBuilder> GAS_TURBINE_FUELS = new RecipeMap<>("gas_turbine", 0, 0, 1, 0, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.DARK_CANISTER_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.TURBINE);
 
     @ZenProperty
-    public static final RecipeMap<FuelRecipeBuilder> STEAM_TURBINE_FUELS = new RecipeMap<>("steam_turbine", 0, 0, 0, 0, 1, 1, 0, 1, new FuelRecipeBuilder(), false)
+    public static final RecipeMap<FuelRecipeBuilder> STEAM_TURBINE_FUELS = new RecipeMap<>("steam_turbine", 0, 0, 1, 1, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.CENTRIFUGE_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.TURBINE);
 
     @ZenProperty
-    public static final RecipeMap<FuelRecipeBuilder> SEMI_FLUID_GENERATOR_FUELS = new RecipeMap<>("semi_fluid_generator", 0, 0, 0, 0, 1, 1, 0, 0, new FuelRecipeBuilder(), false)
+    public static final RecipeMap<FuelRecipeBuilder> SEMI_FLUID_GENERATOR_FUELS = new RecipeMap<>("semi_fluid_generator", 0, 0, 1, 0, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.FURNACE_OVERLAY_2)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.COMBUSTION);
 
     @ZenProperty
-    public static final RecipeMap<FuelRecipeBuilder> PLASMA_GENERATOR_FUELS = new RecipeMap<>("plasma_generator", 0, 0, 0, 0, 1, 1, 0, 1, new FuelRecipeBuilder(), false)
+    public static final RecipeMap<FuelRecipeBuilder> PLASMA_GENERATOR_FUELS = new RecipeMap<>("plasma_generator", 0, 0, 1, 1, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.CENTRIFUGE_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.TURBINE);

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -71,11 +71,11 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
 
     @Override
     public void setMaxInputs(int maxInputs) {
-        throw new UnsupportedOperationException("Cannot change output amount for Assembly Line.");
+        throw new UnsupportedOperationException("Cannot change item input amount for Assembly Line.");
     }
 
     @Override
     public void setMaxFluidInputs(int maxFluidInputs) {
-        throw new UnsupportedOperationException("Cannot change fluid output amount for Assembly Line.");
+        throw new UnsupportedOperationException("Cannot change fluid input amount for Assembly Line.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -68,4 +68,14 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
             addSlot(builder, startInputsX + 18 * 4, 1, 0/*18*/, itemHandler, fluidHandler, invertFluids, true); // Output Slot - 18 for data slot
         }
     }
+
+    @Override
+    public void setMaxInputs(int maxInputs) {
+        throw new UnsupportedOperationException("Cannot change output amount for Assembly Line.");
+    }
+
+    @Override
+    public void setMaxFluidInputs(int maxFluidInputs) {
+        throw new UnsupportedOperationException("Cannot change fluid output amount for Assembly Line.");
+    }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -13,11 +13,9 @@ import javax.annotation.Nonnull;
 
 public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
-    public RecipeMapAssemblyLine(String unlocalizedName,
-                                 int minInputs, int maxInputs, int minOutputs, int maxOutputs,
-                                 int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs,
-                                 R defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapAssemblyLine(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs,
+                                 int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -13,9 +13,9 @@ import javax.annotation.Nonnull;
 
 public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
-    public RecipeMapAssemblyLine(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs,
-                                 int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapAssemblyLine(String unlocalizedName, int maxInputs, boolean modifyItemInputs, int maxOutputs, boolean modifyItemOutputs,
+                                 int maxFluidInputs, boolean modifyFluidInputs, int maxFluidOutputs, boolean modifyFluidOutputs, R defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, modifyItemInputs, maxOutputs, modifyItemOutputs, maxFluidInputs, modifyFluidInputs, maxFluidOutputs, modifyFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override
@@ -67,25 +67,5 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
         } else {
             addSlot(builder, startInputsX + 18 * 4, 1, 0/*18*/, itemHandler, fluidHandler, invertFluids, true); // Output Slot - 18 for data slot
         }
-    }
-
-    @Override
-    public void setMaxInputs(int maxInputs) {
-        throw new UnsupportedOperationException("Cannot change item input amount for Assembly Line.");
-    }
-
-    @Override
-    public void setMaxOutputs(int maxOutputs) {
-        throw new UnsupportedOperationException("Cannot change item output amount for Assembly Line.");
-    }
-
-    @Override
-    public void setMaxFluidInputs(int maxFluidInputs) {
-        throw new UnsupportedOperationException("Cannot change fluid input amount for Assembly Line.");
-    }
-
-    @Override
-    public void setMaxFluidOutputs(int maxFluidInputs) {
-        throw new UnsupportedOperationException("Cannot change fluid output amount for Assembly Line.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -75,7 +75,17 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
     }
 
     @Override
+    public void setMaxOutputs(int maxOutputs) {
+        throw new UnsupportedOperationException("Cannot change item output amount for Assembly Line.");
+    }
+
+    @Override
     public void setMaxFluidInputs(int maxFluidInputs) {
         throw new UnsupportedOperationException("Cannot change fluid input amount for Assembly Line.");
+    }
+
+    @Override
+    public void setMaxFluidOutputs(int maxFluidInputs) {
+        throw new UnsupportedOperationException("Cannot change fluid output amount for Assembly Line.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
@@ -23,4 +23,24 @@ public class RecipeMapCokeOven<R extends RecipeBuilder<R>> extends RecipeMap<R> 
         addSlot(builder, 106, 28, 0, null, exportFluids, true, true);
         return builder;
     }
+
+    @Override
+    public void setMaxInputs(int maxInputs) {
+        throw new UnsupportedOperationException("Cannot change item input amount for Coke Oven.");
+    }
+
+    @Override
+    public void setMaxOutputs(int maxOutputs) {
+        throw new UnsupportedOperationException("Cannot change item output amount for Coke Oven.");
+    }
+
+    @Override
+    public void setMaxFluidInputs(int maxFluidInputs) {
+        throw new UnsupportedOperationException("Cannot change fluid input amount for Coke Oven.");
+    }
+
+    @Override
+    public void setMaxFluidOutputs(int maxFluidOutputs) {
+        throw new UnsupportedOperationException("Cannot change fluid output amount for Coke Oven.");
+    }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
@@ -10,11 +10,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class RecipeMapCokeOven<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
-    public RecipeMapCokeOven(String unlocalizedName,
-                             int minInputs, int maxInputs, int minOutputs, int maxOutputs,
-                             int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs,
-                             R defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapCokeOven(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
@@ -10,8 +10,9 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class RecipeMapCokeOven<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
-    public RecipeMapCokeOven(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapCokeOven(String unlocalizedName, int maxInputs, boolean modifyItemInputs, int maxOutputs, boolean modifyItemOutputs,
+                                 int maxFluidInputs, boolean modifyFluidInputs, int maxFluidOutputs, boolean modifyFluidOutputs, R defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, modifyItemInputs, maxOutputs, modifyItemOutputs, maxFluidInputs, modifyFluidInputs, maxFluidOutputs, modifyFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override
@@ -22,25 +23,5 @@ public class RecipeMapCokeOven<R extends RecipeBuilder<R>> extends RecipeMap<R> 
         addSlot(builder, 106, 10, 0, exportItems, null, false, true);
         addSlot(builder, 106, 28, 0, null, exportFluids, true, true);
         return builder;
-    }
-
-    @Override
-    public void setMaxInputs(int maxInputs) {
-        throw new UnsupportedOperationException("Cannot change item input amount for Coke Oven.");
-    }
-
-    @Override
-    public void setMaxOutputs(int maxOutputs) {
-        throw new UnsupportedOperationException("Cannot change item output amount for Coke Oven.");
-    }
-
-    @Override
-    public void setMaxFluidInputs(int maxFluidInputs) {
-        throw new UnsupportedOperationException("Cannot change fluid input amount for Coke Oven.");
-    }
-
-    @Override
-    public void setMaxFluidOutputs(int maxFluidOutputs) {
-        throw new UnsupportedOperationException("Cannot change fluid output amount for Coke Oven.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
@@ -15,8 +15,9 @@ import java.util.function.DoubleSupplier;
 
 public class RecipeMapCrackerUnit<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
-    public RecipeMapCrackerUnit(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapCrackerUnit(String unlocalizedName, int maxInputs, boolean modifyItemInputs, int maxOutputs, boolean modifyItemOutputs,
+                                 int maxFluidInputs, boolean modifyFluidInputs, int maxFluidOutputs, boolean modifyFluidOutputs, R defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, modifyItemInputs, maxOutputs, modifyItemOutputs, maxFluidInputs, modifyFluidInputs, maxFluidOutputs, modifyFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override
@@ -45,15 +46,5 @@ public class RecipeMapCrackerUnit<R extends RecipeBuilder<R>> extends RecipeMap<
         };
         DoubleSupplier supplier2 = () -> tracker.get() >= 0.5 ? (tracker.get() - 0.5) * 2 : 0;
         return Pair.of(supplier1, supplier2);
-    }
-
-    @Override
-    public void setMaxInputs(int maxInputs) {
-        throw new UnsupportedOperationException("Cannot change item input amount for Cracking Unit.");
-    }
-
-    @Override
-    public void setMaxFluidInputs(int maxFluidInputs) {
-        throw new UnsupportedOperationException("Cannot change fluid input amount for Cracking Unit.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
@@ -46,4 +46,14 @@ public class RecipeMapCrackerUnit<R extends RecipeBuilder<R>> extends RecipeMap<
         DoubleSupplier supplier2 = () -> tracker.get() >= 0.5 ? (tracker.get() - 0.5) * 2 : 0;
         return Pair.of(supplier1, supplier2);
     }
+
+    @Override
+    public void setMaxInputs(int maxInputs) {
+        throw new UnsupportedOperationException("Cannot change item input amount for Cracking Unit.");
+    }
+
+    @Override
+    public void setMaxFluidInputs(int maxFluidInputs) {
+        throw new UnsupportedOperationException("Cannot change fluid input amount for Cracking Unit.");
+    }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
@@ -15,8 +15,8 @@ import java.util.function.DoubleSupplier;
 
 public class RecipeMapCrackerUnit<R extends RecipeBuilder<R>> extends RecipeMap<R> {
 
-    public RecipeMapCrackerUnit(String unlocalizedName, int minInputs, int maxInputs, int minOutputs, int maxOutputs, int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapCrackerUnit(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, R defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
@@ -104,6 +104,6 @@ public class RecipeMapDistillationTower extends RecipeMap<UniversalDistillationR
 
     @Override
     public void setMaxFluidOutputs(int maxFluidOutputs) {
-        throw new UnsupportedOperationException("Cannot change output amount for Distillation Tower.");
+        throw new UnsupportedOperationException("Cannot change fluid output amount for Distillation Tower.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
@@ -13,8 +13,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class RecipeMapDistillationTower extends RecipeMap<UniversalDistillationRecipeBuilder> {
 
-    public RecipeMapDistillationTower(String unlocalizedName, int minInputs, int maxInputs, int minOutputs, int maxOutputs, int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs, UniversalDistillationRecipeBuilder defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapDistillationTower(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, UniversalDistillationRecipeBuilder defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
@@ -13,8 +13,9 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class RecipeMapDistillationTower extends RecipeMap<UniversalDistillationRecipeBuilder> {
 
-    public RecipeMapDistillationTower(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, UniversalDistillationRecipeBuilder defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapDistillationTower(String unlocalizedName, int maxInputs, boolean modifyItemInputs, int maxOutputs, boolean modifyItemOutputs,
+                                 int maxFluidInputs, boolean modifyFluidInputs, int maxFluidOutputs, boolean modifyFluidOutputs, UniversalDistillationRecipeBuilder defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, modifyItemInputs, maxOutputs, modifyItemOutputs, maxFluidInputs, modifyFluidInputs, maxFluidOutputs, modifyFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override
@@ -100,10 +101,5 @@ public class RecipeMapDistillationTower extends RecipeMap<UniversalDistillationR
                 addSlot(builder, x, y, i, itemHandler, fluidHandler, true, true);
             }
         }
-    }
-
-    @Override
-    public void setMaxFluidOutputs(int maxFluidOutputs) {
-        throw new UnsupportedOperationException("Cannot change fluid output amount for Distillation Tower.");
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapDistillationTower.java
@@ -101,4 +101,9 @@ public class RecipeMapDistillationTower extends RecipeMap<UniversalDistillationR
             }
         }
     }
+
+    @Override
+    public void setMaxFluidOutputs(int maxFluidOutputs) {
+        throw new UnsupportedOperationException("Cannot change output amount for Distillation Tower.");
+    }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFluidCanner.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFluidCanner.java
@@ -14,8 +14,8 @@ import java.util.List;
 
 public class RecipeMapFluidCanner extends RecipeMap<SimpleRecipeBuilder> {
 
-    public RecipeMapFluidCanner(String unlocalizedName, int minInputs, int maxInputs, int minOutputs, int maxOutputs, int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs, SimpleRecipeBuilder defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapFluidCanner(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, SimpleRecipeBuilder defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFormingPress.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFormingPress.java
@@ -23,8 +23,8 @@ public class RecipeMapFormingPress extends RecipeMap<SimpleRecipeBuilder> {
 
     private static ItemStack NAME_MOLD = ItemStack.EMPTY;
 
-    public RecipeMapFormingPress(String unlocalizedName, int minInputs, int maxInputs, int minOutputs, int maxOutputs, int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs, SimpleRecipeBuilder defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapFormingPress(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, SimpleRecipeBuilder defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapFurnace.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 public class RecipeMapFurnace extends RecipeMap<SimpleRecipeBuilder> {
 
-    public RecipeMapFurnace(String unlocalizedName, int minInputs, int maxInputs, int minOutputs, int maxOutputs, int minFluidInputs, int maxFluidInputs, int minFluidOutputs, int maxFluidOutputs, SimpleRecipeBuilder defaultRecipe, boolean isHidden) {
-        super(unlocalizedName, minInputs, maxInputs, minOutputs, maxOutputs, minFluidInputs, maxFluidInputs, minFluidOutputs, maxFluidOutputs, defaultRecipe, isHidden);
+    public RecipeMapFurnace(String unlocalizedName, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs, SimpleRecipeBuilder defaultRecipe, boolean isHidden) {
+        super(unlocalizedName, maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs, defaultRecipe, isHidden);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -112,7 +112,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
                 .where('K', states(getCoilState()))
                 .where('O', states(getCasingState()).or(abilities(MultiblockAbility.EXPORT_FLUIDS)))
                 .where('A', air())
-                .where('I', states(getCasingState()).or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1)))
+                .where('I', states(getCasingState()).or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(2)))
                 .where('#', any())
                 .build();
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -112,7 +112,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
                 .where('K', states(getCoilState()))
                 .where('O', states(getCasingState()).or(abilities(MultiblockAbility.EXPORT_FLUIDS)))
                 .where('A', air())
-                .where('I', states(getCasingState()).or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(recipeMap.getMinFluidInputs())))
+                .where('I', states(getCasingState()).or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1)))
                 .where('#', any())
                 .build();
     }


### PR DESCRIPTION
## What
This PR removes RecipeMap minimums. This means a RecipeMap will no longer require a certain amount of inputs/outputs, which should allow more freedom for recipes being added going forwards.

Additionally, it adds setters for recipemap maximum's, allowing other addons/scripts to change them. They do not allow reducing the minimum in any way, to prevent incompatibility.

## Outcome
Remove RecipeMap Minimums and adds setters for Maximums.
