### PR TITLE
Expose RecipeMap#removeAll to CT

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeUtils.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeUtils.java
@@ -4,6 +4,7 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
+import gregtech.api.recipes.GTRecipeHandler;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTLog;
@@ -77,5 +78,10 @@ public class CTRecipeUtils {
         for (Recipe recipe : recipesToRemove) {
             recipeMap.removeRecipe(recipe);
         }
+    }
+
+    @ZenMethod("clear")
+    public static void removeAll(RecipeMap<?> recipeMap) {
+        GTRecipeHandler.removeAllRecipes(recipeMap);
     }
 }


### PR DESCRIPTION
## What
Exposes `RecipeMap#removeAll` to CT. I found this useful when attempting to test specific bugs, and it may be useful to modpack developers as well.

It can be used like such:

```zenscript
import mods.gregtech.recipe.helpers;

helpers.clear(<recipemap:assembler>);
```

## Outcome
Exposes `RecipeMap#removeAll` to CT.
