### PR TITLE
Refactor MTETrait

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -130,4 +130,12 @@ public class GregtechDataCodes {
     // From MetaTileEntityHolder
     public static final String CUSTOM_NAME = "CustomName";
 
+    // MTE Trait Names
+
+    public static final String ABSTRACT_WORKABLE_TRAIT = "RecipeMapWorkable";
+    public static final String ENERGY_CONTAINER_TRAIT = "EnergyContainer";
+    public static final String ENERGY_CONVERTER_TRAIT = "EnergyConvertTrait";
+    public static final String FUSION_REACTOR_ENERGY_CONTAINER_TRAIT = "EnergyContainerInternal";
+    public static final String BATTERY_BUFFER_ENERGY_CONTAINER_TRAIT = "BatteryEnergyContainer";
+
 }

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -38,9 +38,10 @@ import static gregtech.api.recipes.logic.OverclockingLogic.*;
 
 public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable, IParallelableRecipeLogic {
 
+    public static final String MTE_TRAIT_NAME = "RecipeMapWorkable";
+
     private static final String ALLOW_OVERCLOCKING = "AllowOverclocking";
     private static final String OVERCLOCK_VOLTAGE = "OverclockVoltage";
-
 
     private final RecipeMap<?> recipeMap;
 
@@ -152,12 +153,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     @Nonnull
     @Override
     public final String getName() {
-        return "RecipeMapWorkable";
-    }
-
-    @Override
-    public final int getNetworkID() {
-        return TraitNetworkIds.TRAIT_ID_WORKABLE;
+        // this is final so machines are not accidentally given multiple workable instances
+        return MTE_TRAIT_NAME;
     }
 
     @Override
@@ -934,7 +931,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     @Override
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
+    public void receiveCustomData(int dataId, @Nonnull PacketBuffer buf) {
         if (dataId == GregtechDataCodes.WORKABLE_ACTIVE) {
             this.isActive = buf.readBoolean();
             getMetaTileEntity().scheduleRenderUpdate();
@@ -956,6 +953,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.workingEnabled = buf.readBoolean();
     }
 
+    @Nonnull
     @Override
     public NBTTagCompound serializeNBT() {
         NBTTagCompound compound = new NBTTagCompound();

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -38,8 +38,6 @@ import static gregtech.api.recipes.logic.OverclockingLogic.*;
 
 public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable, IParallelableRecipeLogic {
 
-    public static final String MTE_TRAIT_NAME = "RecipeMapWorkable";
-
     private static final String ALLOW_OVERCLOCKING = "AllowOverclocking";
     private static final String OVERCLOCK_VOLTAGE = "OverclockVoltage";
 
@@ -154,7 +152,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     @Override
     public final String getName() {
         // this is final so machines are not accidentally given multiple workable instances
-        return MTE_TRAIT_NAME;
+        return GregtechDataCodes.ABSTRACT_WORKABLE_TRAIT;
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -219,11 +219,13 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
         wasActiveAndNeedsUpdate = true;
     }
 
+    @Nonnull
     @Override
     public MetaTileEntityLargeBoiler getMetaTileEntity() {
         return (MetaTileEntityLargeBoiler) super.getMetaTileEntity();
     }
 
+    @Nonnull
     @Override
     public NBTTagCompound serializeNBT() {
         NBTTagCompound compound = super.serializeNBT();
@@ -258,7 +260,7 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
+    public void receiveCustomData(int dataId, @Nonnull PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
         if (dataId == BOILER_HEAT) {
             this.currentHeat = buf.readVarInt();

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryBuffer.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryBuffer.java
@@ -1,10 +1,7 @@
 package gregtech.api.capability.impl;
 
 import gregtech.api.GTValues;
-import gregtech.api.capability.FeCompat;
-import gregtech.api.capability.GregtechCapabilities;
-import gregtech.api.capability.IElectricItem;
-import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.*;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
@@ -21,7 +18,6 @@ import java.util.List;
 
 public class EnergyContainerBatteryBuffer extends EnergyContainerHandler {
 
-    public static final String MTE_TRAIT_NAME = "BatteryEnergyContainer";
     public static final long AMPS_PER_BATTERY = 2L;
 
     private final int tier;
@@ -237,8 +233,8 @@ public class EnergyContainerBatteryBuffer extends EnergyContainerHandler {
 
     @Nonnull
     @Override
-    public String getName() {
-        return MTE_TRAIT_NAME;
+    public final String getName() {
+        return GregtechDataCodes.BATTERY_BUFFER_ENERGY_CONTAINER_TRAIT;
     }
 
     protected IItemHandlerModifiable getInventory() {

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryBuffer.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerBatteryBuffer.java
@@ -15,11 +15,13 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
 public class EnergyContainerBatteryBuffer extends EnergyContainerHandler {
 
+    public static final String MTE_TRAIT_NAME = "BatteryEnergyContainer";
     public static final long AMPS_PER_BATTERY = 2L;
 
     private final int tier;
@@ -233,9 +235,10 @@ public class EnergyContainerBatteryBuffer extends EnergyContainerHandler {
         return !inputsEnergy(side);
     }
 
+    @Nonnull
     @Override
     public String getName() {
-        return "BatteryEnergyContainer";
+        return MTE_TRAIT_NAME;
     }
 
     protected IItemHandlerModifiable getInventory() {

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
@@ -18,9 +18,12 @@ import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 
 public class EnergyContainerHandler extends MTETrait implements IEnergyContainer {
+
+    public static final String MTE_TRAIT_NAME = "EnergyContainer";
 
     protected final long maxCapacity;
     protected long energyStored;
@@ -76,14 +79,10 @@ public class EnergyContainerHandler extends MTETrait implements IEnergyContainer
         return lastEnergyOutputPerSec;
     }
 
+    @Nonnull
     @Override
     public String getName() {
-        return "EnergyContainer";
-    }
-
-    @Override
-    public int getNetworkID() {
-        return TraitNetworkIds.TRAIT_ID_ENERGY_CONTAINER;
+        return MTE_TRAIT_NAME;
     }
 
     @Override
@@ -94,6 +93,7 @@ public class EnergyContainerHandler extends MTETrait implements IEnergyContainer
         return null;
     }
 
+    @Nonnull
     @Override
     public NBTTagCompound serializeNBT() {
         NBTTagCompound compound = new NBTTagCompound();
@@ -102,7 +102,7 @@ public class EnergyContainerHandler extends MTETrait implements IEnergyContainer
     }
 
     @Override
-    public void deserializeNBT(NBTTagCompound compound) {
+    public void deserializeNBT(@Nonnull NBTTagCompound compound) {
         this.energyStored = compound.getLong("EnergyStored");
         notifyEnergyListener(true);
     }

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
@@ -1,10 +1,7 @@
 package gregtech.api.capability.impl;
 
 import gregtech.api.GTValues;
-import gregtech.api.capability.FeCompat;
-import gregtech.api.capability.GregtechCapabilities;
-import gregtech.api.capability.IElectricItem;
-import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.*;
 import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.util.GTUtility;
@@ -22,8 +19,6 @@ import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 
 public class EnergyContainerHandler extends MTETrait implements IEnergyContainer {
-
-    public static final String MTE_TRAIT_NAME = "EnergyContainer";
 
     protected final long maxCapacity;
     protected long energyStored;
@@ -82,7 +77,7 @@ public class EnergyContainerHandler extends MTETrait implements IEnergyContainer
     @Nonnull
     @Override
     public String getName() {
-        return MTE_TRAIT_NAME;
+        return GregtechDataCodes.ENERGY_CONTAINER_TRAIT;
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -94,7 +94,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
+    public void receiveCustomData(int dataId, @Nonnull PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
         if (dataId == GregtechDataCodes.NEEDS_VENTING) {
             this.needsVenting = buf.readBoolean();
@@ -224,6 +224,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
         return GTValues.V[GTValues.LV];
     }
 
+    @Nonnull
     @Override
     public NBTTagCompound serializeNBT() {
         NBTTagCompound compound = super.serializeNBT();

--- a/src/main/java/gregtech/api/metatileentity/MTETrait.java
+++ b/src/main/java/gregtech/api/metatileentity/MTETrait.java
@@ -1,28 +1,57 @@
 package gregtech.api.metatileentity;
 
+import it.unimi.dsi.fastutil.objects.Object2IntFunction;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 
+import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
 public abstract class MTETrait {
 
-    protected final MetaTileEntity metaTileEntity;
+    private static final Object2IntFunction<String> traitIds = new Object2IntOpenHashMap<>();
+    private static int rollingNetworkId = 0;
 
-    public MTETrait(MetaTileEntity metaTileEntity) {
+    protected final MetaTileEntity metaTileEntity;
+    private final int networkId;
+
+    /**
+     * Create a new MTE trait.
+     *
+     * @param metaTileEntity the MTE to reference, and add the trait to
+     */
+    public MTETrait(@Nonnull MetaTileEntity metaTileEntity) {
         this.metaTileEntity = metaTileEntity;
         metaTileEntity.addMetaTileEntityTrait(this);
+
+        final String traitName = getName();
+        if (!traitIds.containsKey(traitName)) {
+           this.networkId = traitIds.put(traitName, rollingNetworkId++);
+        } else {
+            this.networkId = traitIds.getInt(traitName);
+        }
     }
 
+    @Nonnull
     public MetaTileEntity getMetaTileEntity() {
         return metaTileEntity;
     }
 
+    /**
+     * @return the name of the MTE Trait
+     */
+    @Nonnull
     public abstract String getName();
 
-    public abstract int getNetworkID();
+    /**
+     * @return the network ID of the MTE Trait
+     */
+    public final int getNetworkID() {
+        return this.networkId;
+    }
 
     public abstract <T> T getCapability(Capability<T> capability);
 
@@ -32,29 +61,24 @@ public abstract class MTETrait {
     public void update() {
     }
 
+    @Nonnull
     public NBTTagCompound serializeNBT() {
         return new NBTTagCompound();
     }
 
-    public void deserializeNBT(NBTTagCompound compound) {
+    public void deserializeNBT(@Nonnull NBTTagCompound compound) {
     }
 
-    public void writeInitialData(PacketBuffer buffer) {
+    public void writeInitialData(@Nonnull PacketBuffer buffer) {
     }
 
-    public void receiveInitialData(PacketBuffer buffer) {
+    public void receiveInitialData(@Nonnull PacketBuffer buffer) {
     }
 
-    public void receiveCustomData(int id, PacketBuffer buffer) {
+    public void receiveCustomData(int id, @Nonnull PacketBuffer buffer) {
     }
 
-    public final void writeCustomData(int id, Consumer<PacketBuffer> writer) {
+    public final void writeCustomData(int id, @Nonnull Consumer<PacketBuffer> writer) {
         metaTileEntity.writeTraitData(this, id, writer);
     }
-
-    protected static final class TraitNetworkIds {
-        public static final int TRAIT_ID_ENERGY_CONTAINER = 1;
-        public static final int TRAIT_ID_WORKABLE = 2;
-    }
-
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -17,6 +17,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
 import gregtech.api.metatileentity.WorkableTieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.recipes.RecipeMap;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
@@ -924,8 +925,10 @@ public class GTUtility {
         }
 
         MetaTileEntity machine = getMetaTileEntity(machineStack);
-        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity))
-            return !findMachineInBlacklist(machine.getRecipeMap().getUnlocalizedName(), recipeMapBlacklist);
+        if (machine instanceof WorkableTieredMetaTileEntity && !(machine instanceof SimpleGeneratorMetaTileEntity)) {
+            RecipeMap<?> recipeMap = machine.getRecipeMap();
+            return recipeMap != null && !findMachineInBlacklist(recipeMap.getUnlocalizedName(), recipeMapBlacklist);
+        }
 
         return false;
     }

--- a/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.converter;
 import gregtech.api.GTValues;
 import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.util.GTUtility;
@@ -17,8 +18,6 @@ import net.minecraftforge.energy.IEnergyStorage;
 import javax.annotation.Nonnull;
 
 public class ConverterTrait extends MTETrait {
-
-    public static final String MTE_TRAIT_NAME = "EnergyConvertTrait";
 
     private final int amps;
     private final long voltage;
@@ -75,7 +74,7 @@ public class ConverterTrait extends MTETrait {
     @Nonnull
     @Override
     public String getName() {
-        return MTE_TRAIT_NAME;
+        return GregtechDataCodes.ENERGY_CONVERTER_TRAIT;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/ConverterTrait.java
@@ -14,7 +14,11 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 
+import javax.annotation.Nonnull;
+
 public class ConverterTrait extends MTETrait {
+
+    public static final String MTE_TRAIT_NAME = "EnergyConvertTrait";
 
     private final int amps;
     private final long voltage;
@@ -68,14 +72,10 @@ public class ConverterTrait extends MTETrait {
         return voltage;
     }
 
+    @Nonnull
     @Override
     public String getName() {
-        return "EnergyConvertTrait";
-    }
-
-    @Override
-    public int getNetworkID() {
-        return 1;
+        return MTE_TRAIT_NAME;
     }
 
     @Override
@@ -90,6 +90,7 @@ public class ConverterTrait extends MTETrait {
         return change;
     }
 
+    @Nonnull
     @Override
     public NBTTagCompound serializeNBT() {
         NBTTagCompound nbt = new NBTTagCompound();
@@ -99,7 +100,7 @@ public class ConverterTrait extends MTETrait {
     }
 
     @Override
-    public void deserializeNBT(NBTTagCompound nbt) {
+    public void deserializeNBT(@Nonnull NBTTagCompound nbt) {
         this.storedEU = nbt.getLong("StoredEU");
         this.feToEu = nbt.getBoolean("feToEu");
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -75,7 +75,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
             @Nonnull
             @Override
             public String getName() {
-                return "EnergyContainerInternal";
+                return GregtechDataCodes.FUSION_REACTOR_ENERGY_CONTAINER_TRAIT;
             }
         };
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -72,6 +72,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         this.recipeMapWorkable = new FusionRecipeLogic(this);
         this.tier = tier;
         this.energyContainer = new EnergyContainerHandler(this, Integer.MAX_VALUE, 0, 0, 0, 0) {
+            @Nonnull
             @Override
             public String getName() {
                 return "EnergyContainerInternal";
@@ -205,6 +206,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         this.inputEnergyContainers = new EnergyContainerList(energyInputs);
         long euCapacity = calculateEnergyStorageFactor(energyInputs.size());
         this.energyContainer = new EnergyContainerHandler(this, euCapacity, GTValues.V[tier], 0, 0, 0) {
+            @Nonnull
             @Override
             public String getName() {
                 return "EnergyContainerInternal";
@@ -351,6 +353,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
             return true;
         }
 
+        @Nonnull
         @Override
         public NBTTagCompound serializeNBT() {
             NBTTagCompound tag = super.serializeNBT();

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -209,7 +209,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
             @Nonnull
             @Override
             public String getName() {
-                return "EnergyContainerInternal";
+                return GregtechDataCodes.FUSION_REACTOR_ENERGY_CONTAINER_TRAIT;
             }
         };
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -4,7 +4,10 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
-import gregtech.api.metatileentity.*;
+import gregtech.api.metatileentity.IMachineHatchMultiblock;
+import gregtech.api.metatileentity.ITieredMetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
@@ -263,21 +266,10 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
         @Override
         public boolean checkRecipe(@Nonnull Recipe recipe) {
+            if (mte == null) return false;
 
-            if (mte == null) {
-                return false;
-            }
-
-            AbstractRecipeLogic arl = null;
-            for (MTETrait trait : mte.mteTraits) {
-                if (trait.getName().equals("RecipeMapWorkable")) {
-                    arl = ((AbstractRecipeLogic) trait);
-                }
-            }
-
-            if (arl == null) {
-                return false;
-            }
+            AbstractRecipeLogic arl = mte.getRecipeLogic();
+            if (arl == null) return false;
 
             return arl.checkRecipe(recipe) && super.checkRecipe(recipe);
         }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -158,12 +158,12 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
         super.update();
         if (!getWorld().isRemote) {
             if (recipeLogic != null) {
-                getRecipeLogic().update();
+                getCraftingRecipeLogic().update();
             }
         }
     }
 
-    private CraftingRecipeLogic getRecipeLogic() {
+    private CraftingRecipeLogic getCraftingRecipeLogic() {
         Preconditions.checkState(getWorld() != null, "getRecipeResolver called too early");
         return recipeLogic;
     }
@@ -179,7 +179,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
         WidgetGroup widgetGroup = new WidgetGroup();
         widgetGroup.addWidget(new LabelWidget(5, 20, "gregtech.machine.workbench.storage_note_1"));
         widgetGroup.addWidget(new LabelWidget(5, 30, "gregtech.machine.workbench.storage_note_2"));
-        CraftingRecipeLogic recipeResolver = getRecipeLogic();
+        CraftingRecipeLogic recipeResolver = getCraftingRecipeLogic();
         IItemList itemList = recipeResolver == null ? null : recipeResolver.getItemSourceList();
         widgetGroup.addWidget(new ItemListGridWidget(11, 45, 8, 5, itemList));
         return widgetGroup;

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -536,6 +536,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
                 return 32;
             }
 
+            @Nonnull
             @Override
             public MetaTileEntity getMetaTileEntity() {
                 return EBF;
@@ -613,6 +614,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
                 return 32;
             }
 
+            @Nonnull
             @Override
             public MetaTileEntity getMetaTileEntity() {
                 return EBF;
@@ -679,6 +681,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
                 return 32;
             }
 
+            @Nonnull
             @Override
             public MetaTileEntity getMetaTileEntity() {
                 return EBF;
@@ -748,6 +751,7 @@ public class IParallelableRecipeLogicTest implements IParallelableRecipeLogic {
                 return 32;
             }
 
+            @Nonnull
             @Override
             public MetaTileEntity getMetaTileEntity() {
                 return EBF;


### PR DESCRIPTION
## What
This PR refactors `MTETrait` to no longer depend on hard-coded network ids. Additionally, it provides a superior method of retrieving MTETraits from a given `MetaTileEntity`.

## Outcome
Refactors MTE trait.

## Potential Compatibility Issues
No compatibility issues are expected, but addons using the same name for different traits will run into problems, just as the previous behavior has also done.
