### PR TITLE
Make EBF voltage tier heat bonuses predictable

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -76,7 +76,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
             this.blastFurnaceTemperature = CoilType.CUPRONICKEL.getCoilTemperature();
         }
 
-        this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getTierByVoltage(getEnergyContainer().getInputVoltage()) - GTValues.MV);
+        this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getFloorTierByVoltage(getEnergyContainer().getInputVoltage()) - 1);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -76,7 +76,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
             this.blastFurnaceTemperature = CoilType.CUPRONICKEL.getCoilTemperature();
         }
 
-        this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getFloorTierByVoltage(getEnergyContainer().getInputVoltage()) - 1);
+        this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getFloorTierByVoltage(getEnergyContainer().getInputVoltage()) - GTValues.LV);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -76,7 +76,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
             this.blastFurnaceTemperature = CoilType.CUPRONICKEL.getCoilTemperature();
         }
         //the subtracted tier gives the starting level (exclusive) of the +100K heat bonus
-        this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getFloorTierByVoltage(getEnergyContainer().getInputVoltage()) - GTValues.LV);
+        this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getFloorTierByVoltage(getEnergyContainer().getInputVoltage()) - GTValues.MV);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -75,7 +75,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
         } else {
             this.blastFurnaceTemperature = CoilType.CUPRONICKEL.getCoilTemperature();
         }
-
+        //the subtracted tier gives the starting level (exclusive) of the +100K heat bonus
         this.blastFurnaceTemperature += 100 * Math.max(0, GTUtility.getFloorTierByVoltage(getEnergyContainer().getInputVoltage()) - GTValues.LV);
     }
 


### PR DESCRIPTION
## What
Addresses #1611 by making sure that the heat bonuses get applied when going up a voltage tier

## Outcome
Fixes: #1611 
