### PR TITLE
Fix recycling edge case

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -176,8 +176,7 @@ public class RecyclingRecipes {
         // Null check the Item before adding it to the Builder.
         // - Try to output an Ingot, otherwise output a Dust.
         if (itemMs != null) {
-            OrePrefix outputPrefix = itemMs.material.hasProperty(PropertyKey.INGOT) ? OrePrefix.ingot : OrePrefix.dust;
-            extractorBuilder.output(outputPrefix, itemMs.material, (int) (itemMs.amount / M));
+            extractorBuilder.outputs(OreDictUnifier.getIngotOrDust(itemMs));
         }
 
         cleanInputNBT(input, extractorBuilder);


### PR DESCRIPTION
## What
This PR fixes an error with recyling 1x cables with dust properties. Since a 1x cable has `M / 2` for its material amount, materials with only dust, such as Graphene, will output an empty ItemStack for a full dust. This PR fixes this, and the behavior will now output two small dust. 

## Outcome
Fixes recycling edge case.
