### PR TITLE
Produce any wire type in the wiremill

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -1114,8 +1114,9 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> WIREMILL_RECIPES = new RecipeMap<>("wiremill", 1, 1, 0, 0, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> WIREMILL_RECIPES = new RecipeMap<>("wiremill", 2, 1, 0, 0, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, false, GuiTextures.WIREMILL_OVERLAY)
+            .setSlotOverlay(false, false, true, GuiTextures.INT_CIRCUIT_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_WIREMILL, MoveType.HORIZONTAL)
             .setSound(GTSoundEvents.MOTOR);
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -137,27 +137,28 @@ public class PartsRecipeHandler {
     }
 
     public static void processFineWire(OrePrefix fineWirePrefix, Material material, IngotProperty property) {
-        ItemStack fineWireStack = OreDictUnifier.get(fineWirePrefix, material);
-
         if (!OreDictUnifier.get(foil, material).isEmpty())
             ModHandler.addShapelessRecipe(String.format("fine_wire_%s", material.toString()),
-                    fineWireStack, 'x', new UnificationEntry(OrePrefix.foil, material));
+                    OreDictUnifier.get(fineWirePrefix, material),
+                    'x', new UnificationEntry(OrePrefix.foil, material));
 
         if (material.hasProperty(PropertyKey.WIRE)) {
             RecipeMaps.WIREMILL_RECIPES.recipeBuilder()
                     .input(OrePrefix.wireGtSingle, material)
-                    .outputs(OreDictUnifier.get(OrePrefix.wireFine, material, 4))
+                    .circuitMeta(1)
+                    .output(fineWirePrefix, material, 4)
                     .duration((int) material.getMass() * 3 / 2)
                     .EUt(VA[ULV])
                     .buildAndRegister();
-        } else {
-            RecipeMaps.WIREMILL_RECIPES.recipeBuilder()
-                    .input(OrePrefix.ingot, material)
-                    .outputs(OreDictUnifier.get(OrePrefix.wireFine, material, 8))
-                    .duration((int) material.getMass() * 3)
-                    .EUt(VA[ULV])
-                    .buildAndRegister();
         }
+
+        RecipeMaps.WIREMILL_RECIPES.recipeBuilder()
+                .input(OrePrefix.ingot, material)
+                .circuitMeta(3)
+                .output(fineWirePrefix, material, 8)
+                .duration((int) material.getMass() * 3)
+                .EUt(VA[ULV])
+                .buildAndRegister();
     }
 
     public static void processGear(OrePrefix gearPrefix, Material material, DustProperty property) {

--- a/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
@@ -63,6 +63,7 @@ public class WireRecipeHandler {
     }
 
 
+    private static final OrePrefix[] wireSizes = {wireGtDouble, wireGtQuadruple, wireGtOctal, wireGtHex};
     public static void processWireSingle(OrePrefix wirePrefix, Material material, WireProperties property) {
         OrePrefix prefix = material.hasProperty(PropertyKey.INGOT) ? ingot : material.hasProperty(PropertyKey.GEM) ? gem : dust;
 
@@ -76,10 +77,22 @@ public class WireRecipeHandler {
 
         WIREMILL_RECIPES.recipeBuilder()
                 .input(prefix, material)
+                .circuitMeta(1)
                 .output(wireGtSingle, material, 2)
                 .duration((int) material.getMass())
                 .EUt(getVoltageMultiplier(material))
                 .buildAndRegister();
+
+        for (OrePrefix wireSize : wireSizes) {
+            final int multiplier = (int) (wireSize.getMaterialAmount(material) / GTValues.M);
+            WIREMILL_RECIPES.recipeBuilder()
+                    .input(prefix, material, multiplier)
+                    .circuitMeta(multiplier * 2)
+                    .output(wireSize, material)
+                    .duration((int) (material.getMass() * multiplier * 2))
+                    .EUt(getVoltageMultiplier(material))
+                    .buildAndRegister();
+        }
 
         if (!material.hasFlag(NO_WORKING) && material.hasFlag(GENERATE_PLATE)) {
             ModHandler.addShapedRecipe(String.format("%s_wire_single", material),


### PR DESCRIPTION
## What
Allows the wiremill to produce any type/size of wire. This is made possible/feasible by the ghost circuit slot PR.

## Outcome
Allows the wiremill to produce any type/size of wire. 

## Potential Compatibility Issues
This will break existing automation/autocrafting setups, which utilize wiremills to produce wires.
