### PR TITLE
feat: computercraft integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ dependencies {
     implementation files("libs/groovyscript-0.4.0.jar")
     //implementation fg.deobf("curse.maven:groovyscript-${grs_pid}:${grs_fid}")
     implementation fg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
+    implementation fg.deobf("curse.maven:cc-tweaked-${cc_pid}:${cc_fid}")
 
     // Tests
     testImplementation("org.junit.jupiter:junit-jupiter:${junit_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -64,6 +64,9 @@ grs_fid = 4426112
 ### AE2 0.55.6
 ae2_pid = 570458
 ae2_fid = 4402048
+### CC 1.83.0
+cc_pid = 282001
+cc_fid = 2718128
 
 ## Mixin Dependencies
 mixingradle_version = 0.7-SNAPSHOT

--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.modules.ModuleContainerRegistryEvent;
 import gregtech.client.utils.BloomEffectUtil;
+import gregtech.integration.cc.ComputerCraft;
 import gregtech.integration.groovy.GroovyScriptCompat;
 import gregtech.modules.GregTechModules;
 import gregtech.modules.ModuleManager;
@@ -58,6 +59,7 @@ public class GregTechMod {
     @EventHandler
     public void init(FMLInitializationEvent event) {
         moduleManager.onInit(event);
+        ComputerCraft.init();
     }
 
     @EventHandler

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -123,7 +123,8 @@ public class GTValues {
             MODID_APPENG = "appliedenergistics2",
             MODID_JEI = "jei",
             MODID_GROOVYSCRIPT = "groovyscript",
-            MODID_NC = "nuclearcraft";
+            MODID_NC = "nuclearcraft",
+            MODID_COMPUTERCRAFT = "computercraft";
 
     private static Boolean isClient;
 

--- a/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
@@ -119,4 +119,61 @@ public abstract class TieredMetaTileEntity extends MetaTileEntity implements IEn
         return false;
     }
 
+
+    /**
+     * Gets the average input eu/t
+     */
+    public long getAverageInput() {
+        return energyContainer.getInputPerSec() / 20;
+    }
+
+    /**
+     * Gets the average output eu/t
+     */
+    public long getAverageOutput() {
+        return energyContainer.getOutputPerSec() / 20;
+    }
+
+    /**
+     * Gets the current stored eu
+     */
+    public long getEnergyStored() {
+        return energyContainer.getEnergyStored();
+    }
+
+    /**
+     * Gets the max stored eu
+     */
+    public long getEnergyCapacity() {
+        return energyContainer.getEnergyCapacity();
+    }
+
+    /**
+     * Gets the max input voltage
+     */
+    public long getInputVoltage() {
+        return energyContainer.getInputVoltage();
+    }
+
+    /**
+     * Gets the output voltage
+     */
+    public long getOutputVoltage() {
+        return energyContainer.getOutputVoltage();
+    }
+
+    /**
+     * Gets the max input amperage
+     */
+    public long getInputAmperage() {
+        return energyContainer.getInputAmperage();
+    }
+
+    /**
+     * Gets the max output amperage
+     */
+    public long getOutputAmperage() {
+        return energyContainer.getOutputAmperage();
+    }
+
 }

--- a/src/main/java/gregtech/common/covers/CoverScreen.java
+++ b/src/main/java/gregtech/common/covers/CoverScreen.java
@@ -4,13 +4,26 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import gregtech.api.GTValues;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.ICoverable;
+import gregtech.api.metatileentity.TieredMetaTileEntity;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.integration.cc.IPeripheralWrapper;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.common.Optional;
 
-public class CoverScreen extends CoverBehavior {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CoverScreen extends CoverBehavior implements IPeripheralWrapper {
 
     public CoverScreen(ICoverable coverHolder, EnumFacing attachedSide) {
         super(coverHolder, attachedSide);
@@ -29,5 +42,53 @@ public class CoverScreen extends CoverBehavior {
     @Override
     public boolean shouldAutoConnect() {
         return false;
+    }
+
+    @Optional.Method(modid = GTValues.MODID_COMPUTERCRAFT)
+    public IPeripheral getPeripheral() {
+        return new CoverScreenPeripheral(this);
+    }
+
+    public class CoverScreenPeripheral implements IPeripheral {
+        public CoverScreen coverScreen;
+
+        public CoverScreenPeripheral(CoverScreen coverScreen) {
+            this.coverScreen = coverScreen;
+        }
+
+        @Nonnull
+        public String getType() {
+            return "gregtech_cover_screen";
+        }
+
+        @Nonnull
+        public String[] getMethodNames() {
+            return new String[]{"getEnergy", "getTier"};
+        }
+
+        @Nullable
+        public Object[] callMethod(@Nonnull IComputerAccess iComputerAccess, @Nonnull ILuaContext iLuaContext, int i, @Nonnull Object[] objects) throws LuaException, InterruptedException {
+            if (i == 0 && coverScreen.coverHolder instanceof TieredMetaTileEntity) {
+                TieredMetaTileEntity tieredMetaTileEntity = (TieredMetaTileEntity) coverScreen.coverHolder;
+                Map<String, Object> data = new HashMap<>();
+                data.put("stored", tieredMetaTileEntity.getEnergyStored());
+                data.put("capacity", tieredMetaTileEntity.getEnergyCapacity());
+                data.put("average_input", tieredMetaTileEntity.getAverageInput());
+                data.put("average_output", tieredMetaTileEntity.getAverageOutput());
+                data.put("input_voltage", tieredMetaTileEntity.getInputVoltage());
+                data.put("output_voltage", tieredMetaTileEntity.getOutputVoltage());
+                data.put("input_amperage", tieredMetaTileEntity.getInputAmperage());
+                data.put("output_amperage", tieredMetaTileEntity.getOutputAmperage());
+                return new Object[]{data};
+            } else if (i == 1 && coverScreen.coverHolder instanceof TieredMetaTileEntity) {
+                TieredMetaTileEntity tieredMetaTileEntity = (TieredMetaTileEntity) coverScreen.coverHolder;
+                return new Object[]{tieredMetaTileEntity.getTier()};
+            }
+            return null;
+        }
+
+        public boolean equals(@Nullable IPeripheral iPeripheral) {
+            return iPeripheral == this;
+        }
     }
 }

--- a/src/main/java/gregtech/integration/cc/ComputerCraft.java
+++ b/src/main/java/gregtech/integration/cc/ComputerCraft.java
@@ -1,0 +1,49 @@
+package gregtech.integration.cc;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import gregtech.api.GTValues;
+import gregtech.api.cover.CoverBehavior;
+import gregtech.api.cover.ICoverable;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.util.GTUtility;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ComputerCraft {
+    public static void init() {
+        if (!Loader.isModLoaded(GTValues.MODID_COMPUTERCRAFT)) return;
+
+        ComputerCraftAPI.registerPeripheralProvider(new IPeripheralProvider() {
+            @Nullable
+            @Override
+            public IPeripheral getPeripheral(@Nonnull World world, @Nonnull BlockPos blockPos, @Nonnull EnumFacing enumFacing) {
+                MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(world, blockPos);
+
+                if (metaTileEntity != null) {
+                    CoverBehavior cover = ((ICoverable) metaTileEntity).getCoverAtSide(enumFacing);
+                    if (cover instanceof IPeripheralWrapper) {
+                        IPeripheral peripheral = ((IPeripheralWrapper) cover).getPeripheral();
+                        if (peripheral != null) {
+                            return peripheral;
+                        }
+                    }
+                    if (metaTileEntity instanceof IPeripheralWrapper) {
+                        IPeripheral peripheral = ((IPeripheralWrapper) metaTileEntity).getPeripheral();
+                        if (peripheral != null) {
+                            return peripheral;
+                        }
+                    }
+                }
+                return null;
+            }
+        });
+    }
+
+}

--- a/src/main/java/gregtech/integration/cc/IPeripheralWrapper.java
+++ b/src/main/java/gregtech/integration/cc/IPeripheralWrapper.java
@@ -1,0 +1,10 @@
+package gregtech.integration.cc;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import gregtech.api.GTValues;
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(modid = GTValues.MODID_COMPUTERCRAFT, iface = "dan200.computercraft.api.peripheral")
+public interface IPeripheralWrapper {
+    IPeripheral getPeripheral();
+}


### PR DESCRIPTION
## What
- added functionality to the computer cover
  - if placed on a block computercraft can use it
    - `getEnergy` to read energy information about a machine
    - `getTier` to read the machines tier

## Implementation Details
Implemented using a `IPeripheralWrapper` interface allowing for easily adding integration to other blocks covers.

## Outcome
![image](https://user-images.githubusercontent.com/1949038/227730946-91227b4c-dec1-4560-86d4-cc6c60a255b0.png)
![image](https://user-images.githubusercontent.com/1949038/227730948-ecb4616e-e2b3-4895-a75e-9bc0dc19cc84.png)

## Potential Compatibility Issues
Needs testing if it breaks, without computercraft installed
