### PR TITLE
Implement High Tier API

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -145,11 +145,6 @@ public class GTValues {
      */
     public static final int FALLBACK = -1;
 
-    /**
-     * Used to tell if any high-tier machine (UHV+) was registered.
-     */
-    public static boolean HT = false;
-
     public static Supplier<Boolean> FOOLS = () -> {
         String[] yearMonthDay = LocalDate.now().toString().split("-");
         return yearMonthDay[1].equals("04") && yearMonthDay[2].equals("01");

--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -53,6 +53,8 @@ public class GregTechAPI {
     public static IAdvancementManager advancementManager;
     /** Will be available at the Pre-Initialization stage */
     public static ISoundManager soundManager;
+    /** Will be available at the Pre-Initialization stage */
+    public static boolean highTier;
 
     public static final GTControlledRegistry<ResourceLocation, MetaTileEntity> MTE_REGISTRY = new GTControlledRegistry<>(Short.MAX_VALUE);
     public static final GTControlledRegistry<ResourceLocation, UIFactory> UI_FACTORY_REGISTRY = new GTControlledRegistry<>(Short.MAX_VALUE);

--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -7,6 +7,7 @@ import gregtech.api.block.IHeatingCoilBlockStats;
 import gregtech.api.block.machines.BlockMachine;
 import gregtech.api.command.ICommandManager;
 import gregtech.api.cover.CoverDefinition;
+import gregtech.api.event.HighTierEvent;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.modules.IModuleManager;
@@ -21,6 +22,7 @@ import gregtech.api.util.BaseCreativeTab;
 import gregtech.api.util.GTControlledRegistry;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.IBlockOre;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockWarningSign;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.items.MetaItems;
@@ -29,6 +31,7 @@ import gregtech.common.metatileentities.MetaTileEntities;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.GenericEvent;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -54,7 +57,8 @@ public class GregTechAPI {
     /** Will be available at the Pre-Initialization stage */
     public static ISoundManager soundManager;
     /** Will be available at the Pre-Initialization stage */
-    public static boolean highTier;
+    private static boolean highTier;
+    private static boolean highTierInitialized;
 
     public static final GTControlledRegistry<ResourceLocation, MetaTileEntity> MTE_REGISTRY = new GTControlledRegistry<>(Short.MAX_VALUE);
     public static final GTControlledRegistry<ResourceLocation, UIFactory> UI_FACTORY_REGISTRY = new GTControlledRegistry<>(Short.MAX_VALUE);
@@ -81,6 +85,26 @@ public class GregTechAPI {
             new BaseCreativeTab(GTValues.MODID + ".ores", () -> OreDictUnifier.get(OrePrefix.ore, Materials.Aluminium), true);
     public static final BaseCreativeTab TAB_GREGTECH_DECORATIONS =
             new BaseCreativeTab(GTValues.MODID + ".decorations", () -> MetaBlocks.WARNING_SIGN.getItemVariant(BlockWarningSign.SignType.YELLOW_STRIPES), true);
+
+    /** Will be available at the Pre-Initialization stage */
+    public static boolean isHighTier() {
+        return highTier;
+    }
+
+    /**
+     * Initializes High-Tier. Internal use only, do not attempt to call this.
+     */
+    static void initializeHighTier() {
+        if (highTierInitialized) throw new IllegalStateException("High-Tier is already initialized.");
+        HighTierEvent highTierEvent = new HighTierEvent();
+        MinecraftForge.EVENT_BUS.post(highTierEvent);
+
+        highTier = ConfigHolder.machines.highTierContent || highTierEvent.isHighTier();
+        highTierInitialized = true;
+
+        if (GregTechAPI.isHighTier()) GTLog.logger.info("High-Tier is Enabled.");
+        else GTLog.logger.info("High-Tier is Disabled.");
+    }
 
     public static class RegisterEvent<V> extends GenericEvent<V> {
 

--- a/src/main/java/gregtech/api/GregTechAPIInternal.java
+++ b/src/main/java/gregtech/api/GregTechAPIInternal.java
@@ -1,0 +1,14 @@
+package gregtech.api;
+
+/**
+ * If you're an addon looking in here, you're probably in the wrong place.
+ * @see GregTechAPI
+ */
+public final class GregTechAPIInternal {
+
+    private GregTechAPIInternal() {/**/}
+
+    public static void preInit() {
+        GregTechAPI.initializeHighTier();
+    }
+}

--- a/src/main/java/gregtech/api/event/HighTierEvent.java
+++ b/src/main/java/gregtech/api/event/HighTierEvent.java
@@ -1,0 +1,25 @@
+package gregtech.api.event;
+
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class HighTierEvent extends Event {
+
+    private boolean isHighTier = false;
+
+    /**
+     * @return if High-Tier will be enabled by this event.
+     */
+    public boolean isHighTier() {
+        return this.isHighTier;
+    }
+
+    /**
+     * Used to enable High-Tier. This overrides the config for High-Tier.
+     * <p>
+     * High-Tier cannot be disabled, once enabled through this event.
+     */
+    @SuppressWarnings("unused")
+    public void enableHighTier() {
+        this.isHighTier = true;
+    }
+}

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -116,6 +116,18 @@ public class ConfigHolder {
 
         @Config.Comment({"Block to replace mined ores with in the miner and multiblock miner.", "Default: minecraft:cobblestone"})
         public String replaceMinedBlocksWith = "minecraft:cobblestone";
+
+        /**
+         * <strong>Addons mods should not reference this config directly.</strong>
+         * Use {@link gregtech.api.GregTechAPI#highTier} instead.
+         */
+        @Config.Comment({"If High Tier (>UV-tier) GT content should be registered.",
+                "Items and Machines enabled with this config will have missing recipes by default.",
+                "This is intended for modpack developers only, and is not playable without custom tweaks or addons.",
+                "Other mods can override this to true, regardless of the config file.",
+                "Default: false"})
+        @Config.RequiresMcRestart
+        public boolean highTierContent = false;
     }
 
     public static class WorldGenOptions {

--- a/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
@@ -39,7 +39,7 @@ public class BlockMachineCasing extends VariantBlock<BlockMachineCasing.MachineC
     @Override
     public void getSubBlocks(CreativeTabs tab, NonNullList<ItemStack> list) {
         for (MachineCasingType variant : VALUES) {
-            if (variant.ordinal() <= MachineCasingType.UHV.ordinal() || GregTechAPI.highTier) {
+            if (variant.ordinal() <= MachineCasingType.UHV.ordinal() || GregTechAPI.isHighTier()) {
                 list.add(getItemVariant(variant));
             }
         }

--- a/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.SoundType;
@@ -38,7 +39,7 @@ public class BlockMachineCasing extends VariantBlock<BlockMachineCasing.MachineC
     @Override
     public void getSubBlocks(CreativeTabs tab, NonNullList<ItemStack> list) {
         for (MachineCasingType variant : VALUES) {
-            if (variant.ordinal() <= MachineCasingType.UHV.ordinal() || GTValues.HT) {
+            if (variant.ordinal() <= MachineCasingType.UHV.ordinal() || GregTechAPI.highTier) {
                 list.add(getItemVariant(variant));
             }
         }

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -206,11 +206,11 @@ public class MetaItem1 extends StandardMetaItem {
         ELECTRIC_MOTOR_LuV = addItem(132, "electric.motor.luv");
         ELECTRIC_MOTOR_ZPM = addItem(133, "electric.motor.zpm");
         ELECTRIC_MOTOR_UV = addItem(134, "electric.motor.uv");
-        ELECTRIC_MOTOR_UHV = addItem(135, "electric.motor.uhv").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_MOTOR_UEV = addItem(136, "electric.motor.uev").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_MOTOR_UIV = addItem(137, "electric.motor.uiv").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_MOTOR_UXV = addItem(138, "electric.motor.uxv").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_MOTOR_OpV = addItem(139, "electric.motor.opv").setInvisibleIf(!GTValues.HT);
+        ELECTRIC_MOTOR_UHV = addItem(135, "electric.motor.uhv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_MOTOR_UEV = addItem(136, "electric.motor.uev").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_MOTOR_UIV = addItem(137, "electric.motor.uiv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_MOTOR_UXV = addItem(138, "electric.motor.uxv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_MOTOR_OpV = addItem(139, "electric.motor.opv").setInvisibleIf(!GregTechAPI.highTier);
 
         // Pumps: ID 141-155
         ELECTRIC_PUMP_LV = addItem(142, "electric.pump.lv").addComponents(new TooltipBehavior(lines -> {
@@ -248,23 +248,23 @@ public class MetaItem1 extends StandardMetaItem {
         ELECTRIC_PUMP_UHV = addItem(150, "electric.pump.uhv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ELECTRIC_PUMP_UEV = addItem(151, "electric.pump.uev").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ELECTRIC_PUMP_UIV = addItem(152, "electric.pump.uiv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ELECTRIC_PUMP_UXV = addItem(153, "electric.pump.uxv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ELECTRIC_PUMP_OpV = addItem(154, "electric.pump.opv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
 
         // Conveyors: ID 156-170
         CONVEYOR_MODULE_LV = addItem(157, "conveyor.module.lv").addComponents(new TooltipBehavior(lines -> {
@@ -302,23 +302,23 @@ public class MetaItem1 extends StandardMetaItem {
         CONVEYOR_MODULE_UHV = addItem(165, "conveyor.module.uhv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         CONVEYOR_MODULE_UEV = addItem(166, "conveyor.module.uev").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         CONVEYOR_MODULE_UIV = addItem(167, "conveyor.module.uiv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         CONVEYOR_MODULE_UXV = addItem(168, "conveyor.module.uxv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         CONVEYOR_MODULE_OpV = addItem(169, "conveyor.module.opv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
 
         // Pistons: ID 171-185
         ELECTRIC_PISTON_LV = addItem(172, "electric.piston.lv");
@@ -329,11 +329,11 @@ public class MetaItem1 extends StandardMetaItem {
         ELECTRIC_PISTON_LUV = addItem(177, "electric.piston.luv");
         ELECTRIC_PISTON_ZPM = addItem(178, "electric.piston.zpm");
         ELECTRIC_PISTON_UV = addItem(179, "electric.piston.uv");
-        ELECTRIC_PISTON_UHV = addItem(180, "electric.piston.uhv").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_PISTON_UEV = addItem(181, "electric.piston.uev").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_PISTON_UIV = addItem(182, "electric.piston.uiv").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_PISTON_UXV = addItem(183, "electric.piston.uxv").setInvisibleIf(!GTValues.HT);
-        ELECTRIC_PISTON_OpV = addItem(184, "electric.piston.opv").setInvisibleIf(!GTValues.HT);
+        ELECTRIC_PISTON_UHV = addItem(180, "electric.piston.uhv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_PISTON_UEV = addItem(181, "electric.piston.uev").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_PISTON_UIV = addItem(182, "electric.piston.uiv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_PISTON_UXV = addItem(183, "electric.piston.uxv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_PISTON_OpV = addItem(184, "electric.piston.opv").setInvisibleIf(!GregTechAPI.highTier);
 
         // Robot Arms: ID 186-200
         ROBOT_ARM_LV = addItem(187, "robot.arm.lv").addComponents(new TooltipBehavior(lines -> {
@@ -371,23 +371,23 @@ public class MetaItem1 extends StandardMetaItem {
         ROBOT_ARM_UHV = addItem(195, "robot.arm.uhv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ROBOT_ARM_UEV = addItem(196, "robot.arm.uev").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ROBOT_ARM_UIV = addItem(197, "robot.arm.uiv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ROBOT_ARM_UXV = addItem(198, "robot.arm.uxv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
         ROBOT_ARM_OpV = addItem(199, "robot.arm.opv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GTValues.HT);
+        })).setInvisibleIf(!GregTechAPI.highTier);
 
         // Field Generators: ID 201-215
         FIELD_GENERATOR_LV = addItem(202, "field.generator.lv");
@@ -398,11 +398,11 @@ public class MetaItem1 extends StandardMetaItem {
         FIELD_GENERATOR_LuV = addItem(207, "field.generator.luv");
         FIELD_GENERATOR_ZPM = addItem(208, "field.generator.zpm");
         FIELD_GENERATOR_UV = addItem(209, "field.generator.uv");
-        FIELD_GENERATOR_UHV = addItem(210, "field.generator.uhv").setInvisibleIf(!GTValues.HT);
-        FIELD_GENERATOR_UEV = addItem(211, "field.generator.uev").setInvisibleIf(!GTValues.HT);
-        FIELD_GENERATOR_UIV = addItem(212, "field.generator.uiv").setInvisibleIf(!GTValues.HT);
-        FIELD_GENERATOR_UXV = addItem(213, "field.generator.uxv").setInvisibleIf(!GTValues.HT);
-        FIELD_GENERATOR_OpV = addItem(214, "field.generator.opv").setInvisibleIf(!GTValues.HT);
+        FIELD_GENERATOR_UHV = addItem(210, "field.generator.uhv").setInvisibleIf(!GregTechAPI.highTier);
+        FIELD_GENERATOR_UEV = addItem(211, "field.generator.uev").setInvisibleIf(!GregTechAPI.highTier);
+        FIELD_GENERATOR_UIV = addItem(212, "field.generator.uiv").setInvisibleIf(!GregTechAPI.highTier);
+        FIELD_GENERATOR_UXV = addItem(213, "field.generator.uxv").setInvisibleIf(!GregTechAPI.highTier);
+        FIELD_GENERATOR_OpV = addItem(214, "field.generator.opv").setInvisibleIf(!GregTechAPI.highTier);
 
         // Emitters: ID 216-230
         EMITTER_LV = addItem(217, "emitter.lv");
@@ -413,11 +413,11 @@ public class MetaItem1 extends StandardMetaItem {
         EMITTER_LuV = addItem(222, "emitter.luv");
         EMITTER_ZPM = addItem(223, "emitter.zpm");
         EMITTER_UV = addItem(224, "emitter.uv");
-        EMITTER_UHV = addItem(225, "emitter.uhv").setInvisibleIf(!GTValues.HT);
-        EMITTER_UEV = addItem(226, "emitter.uev").setInvisibleIf(!GTValues.HT);
-        EMITTER_UIV = addItem(227, "emitter.uiv").setInvisibleIf(!GTValues.HT);
-        EMITTER_UXV = addItem(228, "emitter.uxv").setInvisibleIf(!GTValues.HT);
-        EMITTER_OpV = addItem(229, "emitter.opv").setInvisibleIf(!GTValues.HT);
+        EMITTER_UHV = addItem(225, "emitter.uhv").setInvisibleIf(!GregTechAPI.highTier);
+        EMITTER_UEV = addItem(226, "emitter.uev").setInvisibleIf(!GregTechAPI.highTier);
+        EMITTER_UIV = addItem(227, "emitter.uiv").setInvisibleIf(!GregTechAPI.highTier);
+        EMITTER_UXV = addItem(228, "emitter.uxv").setInvisibleIf(!GregTechAPI.highTier);
+        EMITTER_OpV = addItem(229, "emitter.opv").setInvisibleIf(!GregTechAPI.highTier);
 
         // Sensors: ID 231-245
         SENSOR_LV = addItem(232, "sensor.lv");
@@ -428,11 +428,11 @@ public class MetaItem1 extends StandardMetaItem {
         SENSOR_LuV = addItem(237, "sensor.luv");
         SENSOR_ZPM = addItem(238, "sensor.zpm");
         SENSOR_UV = addItem(239, "sensor.uv");
-        SENSOR_UHV = addItem(240, "sensor.uhv").setInvisibleIf(!GTValues.HT);
-        SENSOR_UEV = addItem(241, "sensor.uev").setInvisibleIf(!GTValues.HT);
-        SENSOR_UIV = addItem(242, "sensor.uiv").setInvisibleIf(!GTValues.HT);
-        SENSOR_UXV = addItem(243, "sensor.uxv").setInvisibleIf(!GTValues.HT);
-        SENSOR_OpV = addItem(244, "sensor.opv").setInvisibleIf(!GTValues.HT);
+        SENSOR_UHV = addItem(240, "sensor.uhv").setInvisibleIf(!GregTechAPI.highTier);
+        SENSOR_UEV = addItem(241, "sensor.uev").setInvisibleIf(!GregTechAPI.highTier);
+        SENSOR_UIV = addItem(242, "sensor.uiv").setInvisibleIf(!GregTechAPI.highTier);
+        SENSOR_UXV = addItem(243, "sensor.uxv").setInvisibleIf(!GregTechAPI.highTier);
+        SENSOR_OpV = addItem(244, "sensor.opv").setInvisibleIf(!GregTechAPI.highTier);
 
         // Fluid Regulators: ID 246-260
         FLUID_REGULATOR_LV = addItem(247, "fluid.regulator.lv").addComponents(new TooltipBehavior(lines -> {

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -206,11 +206,11 @@ public class MetaItem1 extends StandardMetaItem {
         ELECTRIC_MOTOR_LuV = addItem(132, "electric.motor.luv");
         ELECTRIC_MOTOR_ZPM = addItem(133, "electric.motor.zpm");
         ELECTRIC_MOTOR_UV = addItem(134, "electric.motor.uv");
-        ELECTRIC_MOTOR_UHV = addItem(135, "electric.motor.uhv").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_MOTOR_UEV = addItem(136, "electric.motor.uev").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_MOTOR_UIV = addItem(137, "electric.motor.uiv").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_MOTOR_UXV = addItem(138, "electric.motor.uxv").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_MOTOR_OpV = addItem(139, "electric.motor.opv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_MOTOR_UHV = addItem(135, "electric.motor.uhv").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_MOTOR_UEV = addItem(136, "electric.motor.uev").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_MOTOR_UIV = addItem(137, "electric.motor.uiv").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_MOTOR_UXV = addItem(138, "electric.motor.uxv").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_MOTOR_OpV = addItem(139, "electric.motor.opv").setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Pumps: ID 141-155
         ELECTRIC_PUMP_LV = addItem(142, "electric.pump.lv").addComponents(new TooltipBehavior(lines -> {
@@ -248,23 +248,23 @@ public class MetaItem1 extends StandardMetaItem {
         ELECTRIC_PUMP_UHV = addItem(150, "electric.pump.uhv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ELECTRIC_PUMP_UEV = addItem(151, "electric.pump.uev").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ELECTRIC_PUMP_UIV = addItem(152, "electric.pump.uiv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ELECTRIC_PUMP_UXV = addItem(153, "electric.pump.uxv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ELECTRIC_PUMP_OpV = addItem(154, "electric.pump.opv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.electric.pump.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.fluid_transfer_rate", 1280 * 64 * 64 * 4 / 20));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Conveyors: ID 156-170
         CONVEYOR_MODULE_LV = addItem(157, "conveyor.module.lv").addComponents(new TooltipBehavior(lines -> {
@@ -302,23 +302,23 @@ public class MetaItem1 extends StandardMetaItem {
         CONVEYOR_MODULE_UHV = addItem(165, "conveyor.module.uhv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         CONVEYOR_MODULE_UEV = addItem(166, "conveyor.module.uev").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         CONVEYOR_MODULE_UIV = addItem(167, "conveyor.module.uiv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         CONVEYOR_MODULE_UXV = addItem(168, "conveyor.module.uxv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         CONVEYOR_MODULE_OpV = addItem(169, "conveyor.module.opv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.conveyor.module.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Pistons: ID 171-185
         ELECTRIC_PISTON_LV = addItem(172, "electric.piston.lv");
@@ -329,11 +329,11 @@ public class MetaItem1 extends StandardMetaItem {
         ELECTRIC_PISTON_LUV = addItem(177, "electric.piston.luv");
         ELECTRIC_PISTON_ZPM = addItem(178, "electric.piston.zpm");
         ELECTRIC_PISTON_UV = addItem(179, "electric.piston.uv");
-        ELECTRIC_PISTON_UHV = addItem(180, "electric.piston.uhv").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_PISTON_UEV = addItem(181, "electric.piston.uev").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_PISTON_UIV = addItem(182, "electric.piston.uiv").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_PISTON_UXV = addItem(183, "electric.piston.uxv").setInvisibleIf(!GregTechAPI.highTier);
-        ELECTRIC_PISTON_OpV = addItem(184, "electric.piston.opv").setInvisibleIf(!GregTechAPI.highTier);
+        ELECTRIC_PISTON_UHV = addItem(180, "electric.piston.uhv").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_PISTON_UEV = addItem(181, "electric.piston.uev").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_PISTON_UIV = addItem(182, "electric.piston.uiv").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_PISTON_UXV = addItem(183, "electric.piston.uxv").setInvisibleIf(!GregTechAPI.isHighTier());
+        ELECTRIC_PISTON_OpV = addItem(184, "electric.piston.opv").setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Robot Arms: ID 186-200
         ROBOT_ARM_LV = addItem(187, "robot.arm.lv").addComponents(new TooltipBehavior(lines -> {
@@ -371,23 +371,23 @@ public class MetaItem1 extends StandardMetaItem {
         ROBOT_ARM_UHV = addItem(195, "robot.arm.uhv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ROBOT_ARM_UEV = addItem(196, "robot.arm.uev").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ROBOT_ARM_UIV = addItem(197, "robot.arm.uiv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ROBOT_ARM_UXV = addItem(198, "robot.arm.uxv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
         ROBOT_ARM_OpV = addItem(199, "robot.arm.opv").addComponents(new TooltipBehavior(lines -> {
             lines.add(I18n.format("metaitem.robot.arm.tooltip"));
             lines.add(I18n.format("gregtech.universal.tooltip.item_transfer_rate_stacks", 16));
-        })).setInvisibleIf(!GregTechAPI.highTier);
+        })).setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Field Generators: ID 201-215
         FIELD_GENERATOR_LV = addItem(202, "field.generator.lv");
@@ -398,11 +398,11 @@ public class MetaItem1 extends StandardMetaItem {
         FIELD_GENERATOR_LuV = addItem(207, "field.generator.luv");
         FIELD_GENERATOR_ZPM = addItem(208, "field.generator.zpm");
         FIELD_GENERATOR_UV = addItem(209, "field.generator.uv");
-        FIELD_GENERATOR_UHV = addItem(210, "field.generator.uhv").setInvisibleIf(!GregTechAPI.highTier);
-        FIELD_GENERATOR_UEV = addItem(211, "field.generator.uev").setInvisibleIf(!GregTechAPI.highTier);
-        FIELD_GENERATOR_UIV = addItem(212, "field.generator.uiv").setInvisibleIf(!GregTechAPI.highTier);
-        FIELD_GENERATOR_UXV = addItem(213, "field.generator.uxv").setInvisibleIf(!GregTechAPI.highTier);
-        FIELD_GENERATOR_OpV = addItem(214, "field.generator.opv").setInvisibleIf(!GregTechAPI.highTier);
+        FIELD_GENERATOR_UHV = addItem(210, "field.generator.uhv").setInvisibleIf(!GregTechAPI.isHighTier());
+        FIELD_GENERATOR_UEV = addItem(211, "field.generator.uev").setInvisibleIf(!GregTechAPI.isHighTier());
+        FIELD_GENERATOR_UIV = addItem(212, "field.generator.uiv").setInvisibleIf(!GregTechAPI.isHighTier());
+        FIELD_GENERATOR_UXV = addItem(213, "field.generator.uxv").setInvisibleIf(!GregTechAPI.isHighTier());
+        FIELD_GENERATOR_OpV = addItem(214, "field.generator.opv").setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Emitters: ID 216-230
         EMITTER_LV = addItem(217, "emitter.lv");
@@ -413,11 +413,11 @@ public class MetaItem1 extends StandardMetaItem {
         EMITTER_LuV = addItem(222, "emitter.luv");
         EMITTER_ZPM = addItem(223, "emitter.zpm");
         EMITTER_UV = addItem(224, "emitter.uv");
-        EMITTER_UHV = addItem(225, "emitter.uhv").setInvisibleIf(!GregTechAPI.highTier);
-        EMITTER_UEV = addItem(226, "emitter.uev").setInvisibleIf(!GregTechAPI.highTier);
-        EMITTER_UIV = addItem(227, "emitter.uiv").setInvisibleIf(!GregTechAPI.highTier);
-        EMITTER_UXV = addItem(228, "emitter.uxv").setInvisibleIf(!GregTechAPI.highTier);
-        EMITTER_OpV = addItem(229, "emitter.opv").setInvisibleIf(!GregTechAPI.highTier);
+        EMITTER_UHV = addItem(225, "emitter.uhv").setInvisibleIf(!GregTechAPI.isHighTier());
+        EMITTER_UEV = addItem(226, "emitter.uev").setInvisibleIf(!GregTechAPI.isHighTier());
+        EMITTER_UIV = addItem(227, "emitter.uiv").setInvisibleIf(!GregTechAPI.isHighTier());
+        EMITTER_UXV = addItem(228, "emitter.uxv").setInvisibleIf(!GregTechAPI.isHighTier());
+        EMITTER_OpV = addItem(229, "emitter.opv").setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Sensors: ID 231-245
         SENSOR_LV = addItem(232, "sensor.lv");
@@ -428,11 +428,11 @@ public class MetaItem1 extends StandardMetaItem {
         SENSOR_LuV = addItem(237, "sensor.luv");
         SENSOR_ZPM = addItem(238, "sensor.zpm");
         SENSOR_UV = addItem(239, "sensor.uv");
-        SENSOR_UHV = addItem(240, "sensor.uhv").setInvisibleIf(!GregTechAPI.highTier);
-        SENSOR_UEV = addItem(241, "sensor.uev").setInvisibleIf(!GregTechAPI.highTier);
-        SENSOR_UIV = addItem(242, "sensor.uiv").setInvisibleIf(!GregTechAPI.highTier);
-        SENSOR_UXV = addItem(243, "sensor.uxv").setInvisibleIf(!GregTechAPI.highTier);
-        SENSOR_OpV = addItem(244, "sensor.opv").setInvisibleIf(!GregTechAPI.highTier);
+        SENSOR_UHV = addItem(240, "sensor.uhv").setInvisibleIf(!GregTechAPI.isHighTier());
+        SENSOR_UEV = addItem(241, "sensor.uev").setInvisibleIf(!GregTechAPI.isHighTier());
+        SENSOR_UIV = addItem(242, "sensor.uiv").setInvisibleIf(!GregTechAPI.isHighTier());
+        SENSOR_UXV = addItem(243, "sensor.uxv").setInvisibleIf(!GregTechAPI.isHighTier());
+        SENSOR_OpV = addItem(244, "sensor.opv").setInvisibleIf(!GregTechAPI.isHighTier());
 
         // Fluid Regulators: ID 246-260
         FLUID_REGULATOR_LV = addItem(247, "fluid.regulator.lv").addComponents(new TooltipBehavior(lines -> {

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -459,7 +459,7 @@ public class MetaTileEntities {
         MAGIC_ENERGY_ABSORBER = registerMetaTileEntity(984, new MetaTileEntityMagicEnergyAbsorber(gregtechId("magic_energy_absorber")));
 
         // Hulls, IDs 985-999
-        int endPos = GTValues.HT ? HULL.length : Math.min(HULL.length - 1, GTValues.UV + 2);
+        int endPos = GregTechAPI.highTier ? HULL.length : Math.min(HULL.length - 1, GTValues.UV + 2);
         for (int i = 0; i < endPos; i++) {
             HULL[i] = new MetaTileEntityHull(gregtechId("hull." + GTValues.VN[i].toLowerCase()), i);
             registerMetaTileEntity(985 + i, HULL[i]);
@@ -539,7 +539,7 @@ public class MetaTileEntities {
         MULTI_FLUID_EXPORT_HATCH[1] = registerMetaTileEntity(1206, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_9x"), 3, true));
 
         // Energy Input/Output Hatches, IDs 1210-1269
-        endPos = GTValues.HT ? ENERGY_INPUT_HATCH.length - 1 : Math.min(ENERGY_INPUT_HATCH.length - 1, GTValues.UV + 2);
+        endPos = GregTechAPI.highTier ? ENERGY_INPUT_HATCH.length - 1 : Math.min(ENERGY_INPUT_HATCH.length - 1, GTValues.UV + 2);
         for (int i = 0; i < endPos; i++) {
             String voltageName = GTValues.VN[i].toLowerCase();
             ENERGY_INPUT_HATCH[i] = registerMetaTileEntity(1210 + i, new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.input." + voltageName), i, 2, false));
@@ -557,7 +557,7 @@ public class MetaTileEntities {
 
 
         // Transformer, IDs 1270-1299
-        endPos = GTValues.HT ? TRANSFORMER.length - 1 : Math.min(TRANSFORMER.length - 1, GTValues.UV);
+        endPos = GregTechAPI.highTier ? TRANSFORMER.length - 1 : Math.min(TRANSFORMER.length - 1, GTValues.UV);
         for (int i = 0; i <= endPos; i++) {
             MetaTileEntityTransformer transformer = new MetaTileEntityTransformer(gregtechId("transformer." + GTValues.VN[i].toLowerCase()), i);
             TRANSFORMER[i] = registerMetaTileEntity(1270 + (i), transformer);
@@ -566,7 +566,7 @@ public class MetaTileEntities {
         }
 
         // Diode, IDs 1300-1314
-        endPos = GTValues.HT ? DIODES.length - 1 : Math.min(DIODES.length - 1, GTValues.UV + 2);
+        endPos = GregTechAPI.highTier ? DIODES.length - 1 : Math.min(DIODES.length - 1, GTValues.UV + 2);
         for (int i = 0; i < endPos; i++) {
             String diodeId = "diode." + GTValues.VN[i].toLowerCase();
             MetaTileEntityDiode diode = new MetaTileEntityDiode(gregtechId(diodeId), i);
@@ -574,7 +574,7 @@ public class MetaTileEntities {
         }
 
         // Battery Buffer, IDs 1315-1360
-        endPos = GTValues.HT ? BATTERY_BUFFER[0].length - 1 : Math.min(BATTERY_BUFFER[0].length - 1, GTValues.UHV + 1);
+        endPos = GregTechAPI.highTier ? BATTERY_BUFFER[0].length - 1 : Math.min(BATTERY_BUFFER[0].length - 1, GTValues.UHV + 1);
         int[] batteryBufferSlots = new int[]{4, 8, 16};
         for (int slot = 0; slot < batteryBufferSlots.length; slot++) {
             BATTERY_BUFFER[slot] = new MetaTileEntityBatteryBuffer[endPos];
@@ -586,7 +586,7 @@ public class MetaTileEntities {
         }
 
         // Charger, IDs 1375-1389
-        endPos = GTValues.HT ? CHARGER.length - 1 : Math.min(CHARGER.length - 1, GTValues.UHV + 1);
+        endPos = GregTechAPI.highTier ? CHARGER.length - 1 : Math.min(CHARGER.length - 1, GTValues.UHV + 1);
         for (int i = 0; i < endPos; i++) {
             String chargerId = "charger." + GTValues.VN[i].toLowerCase();
             MetaTileEntityCharger charger = new MetaTileEntityCharger(gregtechId(chargerId), i, 4);
@@ -734,7 +734,7 @@ public class MetaTileEntities {
         CREATIVE_TANK = registerMetaTileEntity(1669, new MetaTileEntityCreativeTank(gregtechId("creative_tank")));
 
         // Energy Converter, IDs 1670-1729
-        endPos = GTValues.HT ? ENERGY_CONVERTER[0].length - 1 : Math.min(ENERGY_CONVERTER[0].length - 1, GTValues.UHV + 1);
+        endPos = GregTechAPI.highTier ? ENERGY_CONVERTER[0].length - 1 : Math.min(ENERGY_CONVERTER[0].length - 1, GTValues.UHV + 1);
         int[] amps = {1, 4, 8, 16};
         for(int i = 0; i < endPos; i++) {
             for(int j = 0; j < 4; j++) {
@@ -830,7 +830,7 @@ public class MetaTileEntities {
     @SuppressWarnings("unused")
     public static void setHighTier(String key, boolean enabled) {
         HIGH_TIER.put(key, enabled);
-        GTValues.HT = enabled || HIGH_TIER.containsValue(true);
+        GregTechAPI.highTier = enabled || HIGH_TIER.containsValue(true);
     }
 
     public static boolean getMidTier(String key) {
@@ -838,6 +838,6 @@ public class MetaTileEntities {
     }
 
     public static boolean getHighTier(String key) {
-        return HIGH_TIER.getOrDefault(key, GTValues.HT);
+        return HIGH_TIER.getOrDefault(key, GregTechAPI.highTier);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -459,7 +459,7 @@ public class MetaTileEntities {
         MAGIC_ENERGY_ABSORBER = registerMetaTileEntity(984, new MetaTileEntityMagicEnergyAbsorber(gregtechId("magic_energy_absorber")));
 
         // Hulls, IDs 985-999
-        int endPos = GregTechAPI.highTier ? HULL.length : Math.min(HULL.length - 1, GTValues.UV + 2);
+        int endPos = GregTechAPI.isHighTier() ? HULL.length : Math.min(HULL.length - 1, GTValues.UV + 2);
         for (int i = 0; i < endPos; i++) {
             HULL[i] = new MetaTileEntityHull(gregtechId("hull." + GTValues.VN[i].toLowerCase()), i);
             registerMetaTileEntity(985 + i, HULL[i]);
@@ -539,7 +539,7 @@ public class MetaTileEntities {
         MULTI_FLUID_EXPORT_HATCH[1] = registerMetaTileEntity(1206, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_9x"), 3, true));
 
         // Energy Input/Output Hatches, IDs 1210-1269
-        endPos = GregTechAPI.highTier ? ENERGY_INPUT_HATCH.length - 1 : Math.min(ENERGY_INPUT_HATCH.length - 1, GTValues.UV + 2);
+        endPos = GregTechAPI.isHighTier() ? ENERGY_INPUT_HATCH.length - 1 : Math.min(ENERGY_INPUT_HATCH.length - 1, GTValues.UV + 2);
         for (int i = 0; i < endPos; i++) {
             String voltageName = GTValues.VN[i].toLowerCase();
             ENERGY_INPUT_HATCH[i] = registerMetaTileEntity(1210 + i, new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.input." + voltageName), i, 2, false));
@@ -557,7 +557,7 @@ public class MetaTileEntities {
 
 
         // Transformer, IDs 1270-1299
-        endPos = GregTechAPI.highTier ? TRANSFORMER.length - 1 : Math.min(TRANSFORMER.length - 1, GTValues.UV);
+        endPos = GregTechAPI.isHighTier() ? TRANSFORMER.length - 1 : Math.min(TRANSFORMER.length - 1, GTValues.UV);
         for (int i = 0; i <= endPos; i++) {
             MetaTileEntityTransformer transformer = new MetaTileEntityTransformer(gregtechId("transformer." + GTValues.VN[i].toLowerCase()), i);
             TRANSFORMER[i] = registerMetaTileEntity(1270 + (i), transformer);
@@ -566,7 +566,7 @@ public class MetaTileEntities {
         }
 
         // Diode, IDs 1300-1314
-        endPos = GregTechAPI.highTier ? DIODES.length - 1 : Math.min(DIODES.length - 1, GTValues.UV + 2);
+        endPos = GregTechAPI.isHighTier() ? DIODES.length - 1 : Math.min(DIODES.length - 1, GTValues.UV + 2);
         for (int i = 0; i < endPos; i++) {
             String diodeId = "diode." + GTValues.VN[i].toLowerCase();
             MetaTileEntityDiode diode = new MetaTileEntityDiode(gregtechId(diodeId), i);
@@ -574,7 +574,7 @@ public class MetaTileEntities {
         }
 
         // Battery Buffer, IDs 1315-1360
-        endPos = GregTechAPI.highTier ? BATTERY_BUFFER[0].length - 1 : Math.min(BATTERY_BUFFER[0].length - 1, GTValues.UHV + 1);
+        endPos = GregTechAPI.isHighTier() ? BATTERY_BUFFER[0].length - 1 : Math.min(BATTERY_BUFFER[0].length - 1, GTValues.UHV + 1);
         int[] batteryBufferSlots = new int[]{4, 8, 16};
         for (int slot = 0; slot < batteryBufferSlots.length; slot++) {
             BATTERY_BUFFER[slot] = new MetaTileEntityBatteryBuffer[endPos];
@@ -586,7 +586,7 @@ public class MetaTileEntities {
         }
 
         // Charger, IDs 1375-1389
-        endPos = GregTechAPI.highTier ? CHARGER.length - 1 : Math.min(CHARGER.length - 1, GTValues.UHV + 1);
+        endPos = GregTechAPI.isHighTier() ? CHARGER.length - 1 : Math.min(CHARGER.length - 1, GTValues.UHV + 1);
         for (int i = 0; i < endPos; i++) {
             String chargerId = "charger." + GTValues.VN[i].toLowerCase();
             MetaTileEntityCharger charger = new MetaTileEntityCharger(gregtechId(chargerId), i, 4);
@@ -734,7 +734,7 @@ public class MetaTileEntities {
         CREATIVE_TANK = registerMetaTileEntity(1669, new MetaTileEntityCreativeTank(gregtechId("creative_tank")));
 
         // Energy Converter, IDs 1670-1729
-        endPos = GregTechAPI.highTier ? ENERGY_CONVERTER[0].length - 1 : Math.min(ENERGY_CONVERTER[0].length - 1, GTValues.UHV + 1);
+        endPos = GregTechAPI.isHighTier() ? ENERGY_CONVERTER[0].length - 1 : Math.min(ENERGY_CONVERTER[0].length - 1, GTValues.UHV + 1);
         int[] amps = {1, 4, 8, 16};
         for(int i = 0; i < endPos; i++) {
             for(int j = 0; j < 4; j++) {
@@ -830,7 +830,9 @@ public class MetaTileEntities {
     @SuppressWarnings("unused")
     public static void setHighTier(String key, boolean enabled) {
         HIGH_TIER.put(key, enabled);
-        GregTechAPI.highTier = enabled || HIGH_TIER.containsValue(true);
+        if (!GregTechAPI.isHighTier()) {
+            throw new IllegalArgumentException("Cannot set High-Tier machine without high tier being enabled in GregTechAPI.");
+        }
     }
 
     public static boolean getMidTier(String key) {
@@ -838,6 +840,6 @@ public class MetaTileEntities {
     }
 
     public static boolean getHighTier(String key) {
-        return HIGH_TIER.getOrDefault(key, GregTechAPI.highTier);
+        return HIGH_TIER.getOrDefault(key, GregTechAPI.isHighTier());
     }
 }

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -3,11 +3,11 @@ package gregtech.core;
 import crafttweaker.CraftTweakerAPI;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
+import gregtech.api.GregTechAPIInternal;
 import gregtech.api.block.IHeatingCoilBlockStats;
 import gregtech.api.capability.SimpleCapabilityManager;
 import gregtech.api.cover.CoverBehaviorUIFactory;
 import gregtech.api.cover.CoverDefinition;
-import gregtech.api.event.HighTierEvent;
 import gregtech.api.fluids.MetaFluids;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.items.gui.PlayerInventoryUIFactory;
@@ -92,11 +92,7 @@ public class CoreModule implements IGregTechModule {
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {
-        HighTierEvent highTierEvent = new HighTierEvent();
-        MinecraftForge.EVENT_BUS.post(highTierEvent);
-        GregTechAPI.highTier = ConfigHolder.machines.highTierContent || highTierEvent.isHighTier();
-        if (GregTechAPI.highTier) logger.info("High-Tier is Enabled");
-
+        GregTechAPIInternal.preInit();
         GregTechAPI.advancementManager = AdvancementManager.getInstance();
         AdvancementTriggers.register();
 

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -7,6 +7,7 @@ import gregtech.api.block.IHeatingCoilBlockStats;
 import gregtech.api.capability.SimpleCapabilityManager;
 import gregtech.api.cover.CoverBehaviorUIFactory;
 import gregtech.api.cover.CoverDefinition;
+import gregtech.api.event.HighTierEvent;
 import gregtech.api.fluids.MetaFluids;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.items.gui.PlayerInventoryUIFactory;
@@ -91,6 +92,11 @@ public class CoreModule implements IGregTechModule {
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {
+        HighTierEvent highTierEvent = new HighTierEvent();
+        MinecraftForge.EVENT_BUS.post(highTierEvent);
+        GregTechAPI.highTier = ConfigHolder.machines.highTierContent || highTierEvent.isHighTier();
+        if (GregTechAPI.highTier) logger.info("High-Tier is Enabled");
+
         GregTechAPI.advancementManager = AdvancementManager.getInstance();
         AdvancementTriggers.register();
 

--- a/src/main/java/gregtech/loaders/recipe/CraftingComponent.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingComponent.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.MarkerMaterials.Tier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.BlastProperty;
@@ -134,7 +135,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             PUMP.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ELECTRIC_PUMP_UHV.getStackForm()},
                     {10, MetaItems.ELECTRIC_PUMP_UEV.getStackForm()},
@@ -290,7 +291,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             HULL.appendIngredients(Stream.of(new Object[][]{
                     {10, MetaTileEntities.HULL[10].getStackForm()},
                     {11, MetaTileEntities.HULL[11].getStackForm()},
@@ -315,7 +316,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             CASING.appendIngredients(Stream.of(new Object[][]{
                     {10, MetaBlocks.MACHINE_CASING.getItemVariant(BlockMachineCasing.MachineCasingType.UEV)},
                     {11, MetaBlocks.MACHINE_CASING.getItemVariant(BlockMachineCasing.MachineCasingType.UIV)},
@@ -441,7 +442,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             MOTOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ELECTRIC_MOTOR_UHV.getStackForm()},
                     {10, MetaItems.ELECTRIC_MOTOR_UEV.getStackForm()},
@@ -478,7 +479,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             SENSOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.SENSOR_UHV.getStackForm()},
                     {10, MetaItems.SENSOR_UEV.getStackForm()},
@@ -534,7 +535,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             PISTON.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ELECTRIC_PISTON_UHV.getStackForm()},
                     {10, MetaItems.ELECTRIC_PISTON_UEV.getStackForm()},
@@ -557,7 +558,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             EMITTER.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.EMITTER_UHV.getStackForm()},
                     {10, MetaItems.EMITTER_UEV.getStackForm()},
@@ -580,7 +581,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             CONVEYOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.CONVEYOR_MODULE_UHV.getStackForm()},
                     {10, MetaItems.CONVEYOR_MODULE_UEV.getStackForm()},
@@ -603,7 +604,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             ROBOT_ARM.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ROBOT_ARM_UHV.getStackForm()},
                     {10, MetaItems.ROBOT_ARM_UEV.getStackForm()},
@@ -698,7 +699,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GTValues.HT) {
+        if (GregTechAPI.highTier) {
             FIELD_GENERATOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.FIELD_GENERATOR_UHV.getStackForm()},
                     {10, MetaItems.FIELD_GENERATOR_UEV.getStackForm()},

--- a/src/main/java/gregtech/loaders/recipe/CraftingComponent.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingComponent.java
@@ -135,7 +135,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             PUMP.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ELECTRIC_PUMP_UHV.getStackForm()},
                     {10, MetaItems.ELECTRIC_PUMP_UEV.getStackForm()},
@@ -291,7 +291,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             HULL.appendIngredients(Stream.of(new Object[][]{
                     {10, MetaTileEntities.HULL[10].getStackForm()},
                     {11, MetaTileEntities.HULL[11].getStackForm()},
@@ -316,7 +316,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             CASING.appendIngredients(Stream.of(new Object[][]{
                     {10, MetaBlocks.MACHINE_CASING.getItemVariant(BlockMachineCasing.MachineCasingType.UEV)},
                     {11, MetaBlocks.MACHINE_CASING.getItemVariant(BlockMachineCasing.MachineCasingType.UIV)},
@@ -442,7 +442,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             MOTOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ELECTRIC_MOTOR_UHV.getStackForm()},
                     {10, MetaItems.ELECTRIC_MOTOR_UEV.getStackForm()},
@@ -479,7 +479,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             SENSOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.SENSOR_UHV.getStackForm()},
                     {10, MetaItems.SENSOR_UEV.getStackForm()},
@@ -535,7 +535,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             PISTON.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ELECTRIC_PISTON_UHV.getStackForm()},
                     {10, MetaItems.ELECTRIC_PISTON_UEV.getStackForm()},
@@ -558,7 +558,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             EMITTER.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.EMITTER_UHV.getStackForm()},
                     {10, MetaItems.EMITTER_UEV.getStackForm()},
@@ -581,7 +581,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             CONVEYOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.CONVEYOR_MODULE_UHV.getStackForm()},
                     {10, MetaItems.CONVEYOR_MODULE_UEV.getStackForm()},
@@ -604,7 +604,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             ROBOT_ARM.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.ROBOT_ARM_UHV.getStackForm()},
                     {10, MetaItems.ROBOT_ARM_UEV.getStackForm()},
@@ -699,7 +699,7 @@ public class CraftingComponent {
 
         }).collect(Collectors.toMap(data -> (Integer) data[0], data -> data[1])));
 
-        if (GregTechAPI.highTier) {
+        if (GregTechAPI.isHighTier()) {
             FIELD_GENERATOR.appendIngredients(Stream.of(new Object[][]{
                     {9, MetaItems.FIELD_GENERATOR_UHV.getStackForm()},
                     {10, MetaItems.FIELD_GENERATOR_UEV.getStackForm()},


### PR DESCRIPTION
## What
This PR completes the API implementation of GT's "High Tier" setting. It allows modpacks and for addons to enable this setting. Disabling HT is not possible / intended. Additionally, addons can force-enable HT, regardless of the config, in order to ensure their functionality works correctly at all times.

Closes #885 
Closes #1436

## Outcome
Completes High Tier API implementation.

## Potential Compatibility Issues
This PR removes `GTValues.HT` and replaces it in favor of `GregTechAPI.highTier`. This is a breaking change for all mods utilizing it, while also being simple to fix.
