### PR TITLE
Fix lighting bug on quantum storages

### DIFF
--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -32,9 +32,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.EnumMap;
 
-import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
-import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
-
 public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     private static final Cuboid6 glassBox = new Cuboid6(1 / 16.0, 1 / 16.0, 1 / 16.0, 15 / 16.0, 15 / 16.0, 15 / 16.0);
 
@@ -99,11 +96,11 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     }
 
     public static void renderTankFluid(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline,
-                                       FluidTank tank, IBlockAccess world, BlockPos pos) {
+                                       FluidTank tank, IBlockAccess world, BlockPos pos, EnumFacing frontFacing) {
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         if (world != null) {
-            setLightingCorrectly(world, pos);
+            renderState.setBrightness(world, pos);
         }
         FluidStack stack = tank.getFluid();
         if (stack == null || stack.amount == 0)
@@ -118,22 +115,18 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
             partialFluidBox.max.y = Math.min((11.875 * fillFraction) + 2.0625, 14.0) / 16.0;
         }
 
-        GlStateManager.enableBlend();
-        GlStateManager.blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         renderState.setFluidColour(stack);
         ResourceLocation fluidStill = stack.getFluid().getStill(stack);
         TextureAtlasSprite fluidStillSprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(fluidStill.toString());
         for (EnumFacing facing : EnumFacing.VALUES) {
             Textures.renderFace(renderState, translation, pipeline, facing, partialFluidBox, fluidStillSprite, BlockRenderLayer.CUTOUT_MIPPED);
         }
-        GlStateManager.disableBlend();
         GlStateManager.resetColor();
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
     }
 
-    public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing,
-                                        IBlockAccess world, BlockPos pos, long amount) {
+    public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing, long amount) {
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
@@ -167,8 +160,8 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         // Evil bit hackery from net.minecraft.client.renderer.ItemRenderer to actually get the right light coords
         // This makes about as much sense as the fast inverse square root algorithm
         int actualLight = world.getCombinedLight(pos, 0);
-        float lightmapXCoord = (actualLight & 65535);
-        float lightmapYCoord = (actualLight >> 16);
+        float lightmapXCoord = actualLight & 65535;
+        float lightmapYCoord = actualLight >> 16;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lightmapXCoord, lightmapYCoord);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -57,13 +57,13 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
                 Textures.FLUID_OUTPUT_OVERLAY.renderSided(this.getOutputFacing(), renderState, translation, pipeline);
             }
         }
-        QuantumStorageRenderer.renderTankFluid(renderState, translation, pipeline, this.fluidTank, getWorld(), getPos());
+        QuantumStorageRenderer.renderTankFluid(renderState, translation, pipeline, this.fluidTank, getWorld(), getPos(), getFrontFacing());
     }
 
     @Override
     public void renderMetaTileEntity(double x, double y, double z, float partialTicks) {
         if (this.getWorld() != null && this.fluidTank.getFluid() != null && this.fluidTank.getFluid().amount > 0)
-            QuantumStorageRenderer.renderTankAmount(x, y, z, frontFacing, this.getWorld(), this.getPos(), 69);
+            QuantumStorageRenderer.renderTankAmount(x, y, z, frontFacing, 69);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -596,4 +596,9 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     public boolean isOpaqueCube() {
         return false;
     }
+
+    @Override
+    public int getLightOpacity() {
+        return 0;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -236,14 +236,14 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
                 Textures.FLUID_OUTPUT_OVERLAY.renderSided(outputFacing, renderState, translation, pipeline);
             }
         }
-        QuantumStorageRenderer.renderTankFluid(renderState, translation, pipeline, fluidTank, getWorld(), getPos());
+        QuantumStorageRenderer.renderTankFluid(renderState, translation, pipeline, fluidTank, getWorld(), getPos(), getFrontFacing());
     }
 
     @Override
     public void renderMetaTileEntity(double x, double y, double z, float partialTicks) {
         if (this.fluidTank.getFluid() == null || this.fluidTank.getFluid().amount == 0)
             return;
-        QuantumStorageRenderer.renderTankAmount(x, y, z, this.getFrontFacing(), this.getWorld(), this.getPos(), this.fluidTank.getFluid().amount);
+        QuantumStorageRenderer.renderTankAmount(x, y, z, this.getFrontFacing(), this.fluidTank.getFluid().amount);
     }
 
     @Override
@@ -547,5 +547,10 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     @Override
     public boolean isOpaqueCube() {
         return false;
+    }
+
+    @Override
+    public int getLightOpacity() {
+        return 0;
     }
 }


### PR DESCRIPTION
## What
Whenever a quantum storage was surrounded by blocks, Minecraft dies inside, and made the internal block level 0, as the quantum storage was not marked as having no light opacity.

## Outcome
Fix extra lighting bug on quantum storages

## Additional Information
It looks OK now.
![image](https://user-images.githubusercontent.com/80226372/227820954-00e7bd3d-fed7-4ee0-82ff-2d35d46e99c4.png)