### PR TITLE
Fix TOP displaying two fluid bars for Multiblock tank

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
@@ -5,7 +5,6 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.impl.FilteredFluidHandler;
-import gregtech.api.capability.impl.FluidHandlerProxy;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -35,7 +34,6 @@ import net.minecraftforge.fluids.FluidTank;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
 public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
@@ -47,22 +45,20 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
         super(metaTileEntityId);
         this.isMetal = isMetal;
         this.capacity = capacity;
-        initializeAbilities();
+        initializeInventory();
     }
 
-    protected void initializeAbilities() {
-        this.importFluids = new FluidTankList(true, makeFluidTanks());
-        this.exportFluids = importFluids;
-        this.fluidInventory = new FluidHandlerProxy(this.importFluids, this.exportFluids);
-    }
+    @Override
+    protected void initializeInventory() {
+        super.initializeInventory();
 
-    @Nonnull
-    private List<FluidTank> makeFluidTanks() {
-        List<FluidTank> fluidTankList = new ArrayList<>(1);
-        fluidTankList.add(new FilteredFluidHandler(capacity).setFillPredicate(
-                fluidStack -> isMetal || (!fluidStack.getFluid().isGaseous() && fluidStack.getFluid().getTemperature() <= 325)
-        ));
-        return fluidTankList;
+        FluidTank tank = new FilteredFluidHandler(capacity).setFillPredicate(
+                fluidStack -> isMetal || (!fluidStack.getFluid().isGaseous() && fluidStack.getFluid().getTemperature() <= 325));
+        FluidTankList tankList = new FluidTankList(true, tank);
+
+        this.importFluids = tankList;
+        this.exportFluids = tankList;
+        this.fluidInventory = tank;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
@@ -72,6 +72,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
     }
 
     @Override
+    @Nonnull
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
                 .aisle("XXX", "XXX", "XXX")
@@ -97,6 +98,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
     }
 
     @Override
+    @Nonnull
     public ICubeRenderer getBaseTexture(IMultiblockPart sourcePart) {
         if (isMetal)
             return Textures.SOLID_STEEL_CASING;
@@ -138,7 +140,7 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("gregtech.multiblock.tank.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.tooltip.fluid_storage_capacity", capacity));

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
@@ -132,7 +132,7 @@ public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
+    public void addInformation(ItemStack stack, @Nullable World player, @Nonnull List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("gregtech.tank_valve.tooltip"));
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
@@ -1,6 +1,5 @@
 package gregtech.common.metatileentities.multi;
 
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
@@ -21,7 +20,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -81,41 +79,26 @@ public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implem
     @Override
     protected void initializeInventory() {
         super.initializeInventory();
-        this.fluidInventory = new FluidHandlerProxy(new FluidTankList(false), new FluidTankList(false));
+        initializeDummyInventory();
     }
 
-    @Override
-    public boolean onWrenchClick(EntityPlayer playerIn, EnumHand hand, EnumFacing wrenchSide, CuboidRayTraceResult hitResult) {
-        boolean wasRotated = super.onWrenchClick(playerIn, hand, wrenchSide, hitResult);
-        if (wasRotated && !getWorld().isRemote) {
-            reinitializeFluidInventory(getFrontFacing());
-        }
-        return wasRotated;
+    /**
+     * When this block is not connected to any multiblock it uses dummy inventory to prevent problems with capability checks
+     */
+    private void initializeDummyInventory() {
+        this.fluidInventory = new FluidHandlerProxy(new FluidTankList(false), new FluidTankList(false));
     }
 
     @Override
     public void addToMultiBlock(MultiblockControllerBase controllerBase) {
         super.addToMultiBlock(controllerBase);
-        if (getFrontFacing() == EnumFacing.DOWN) {
-            this.fluidInventory = new FluidHandlerProxy(new FluidTankList(false), controllerBase.getImportFluids());
-        } else {
-            this.fluidInventory = new FluidHandlerProxy(new FluidTankList(false, controllerBase.getImportFluids()), controllerBase.getImportFluids());
-        }
-    }
-
-    private void reinitializeFluidInventory(EnumFacing facing) {
-        FluidHandlerProxy proxy = (FluidHandlerProxy) fluidInventory;
-        if (facing == EnumFacing.DOWN) {
-            proxy.reinitializeHandler(new FluidTankList(false), proxy.output);
-        } else {
-            proxy.reinitializeHandler(proxy.output, proxy.output);
-        }
+        this.fluidInventory = controllerBase.getFluidInventory(); //directly use controllers fluid inventory as there is no reason to proxy it
     }
 
     @Override
     public void removeFromMultiBlock(MultiblockControllerBase controllerBase) {
         super.removeFromMultiBlock(controllerBase);
-        this.fluidInventory = new FluidHandlerProxy(new FluidTankList(false), new FluidTankList(false));
+        initializeDummyInventory();
     }
 
     @Override


### PR DESCRIPTION
## What
Fix TOP displaying two fluid bars for Multiblock tank (both controller and valves)

## Implementation Details
Implementation now correctly constructs fluid inventory with one tank.

## Outcome
TOP displays only one fluid bar for Multiblock tank (both controller and valves)

## Additional Information
Before:
![2023-03-29_08 43 05](https://user-images.githubusercontent.com/3093101/228403006-60b692b6-1118-4845-9243-5f10a4931782.png)

After:
![2023-03-29_09 23 17](https://user-images.githubusercontent.com/3093101/228403028-0571bb18-1543-4453-a78c-61760188e6ba.png)

## Potential Compatibility Issues
None