### PR TITLE
Replace usage of WildcardAwareHashMap with plain maps

### DIFF
--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -168,14 +168,14 @@ public class OreDictUnifier {
     public static Set<String> getOreDictionaryNames(ItemStack itemStack) {
         if (itemStack.isEmpty()) return Collections.emptySet();
         ItemAndMetadata key = new ItemAndMetadata(itemStack);
-        Set<String> t1 = stackOreDictName.get(key);
-        Set<String> t2 = key.isWildcard() ? null : stackOreDictName.get(key.toWildcard());
-        if (t1 == null) {
-            return t2 == null ? Collections.emptySet() : Collections.unmodifiableSet(t2);
-        } else if (t2 == null) {
-            return Collections.unmodifiableSet(t1);
+        Set<String> names = stackOreDictName.get(key);
+        Set<String> wildcardNames = key.isWildcard() ? null : stackOreDictName.get(key.toWildcard());
+        if (names == null) {
+            return wildcardNames == null ? Collections.emptySet() : Collections.unmodifiableSet(wildcardNames);
+        } else if (wildcardNames == null) {
+            return Collections.unmodifiableSet(names);
         } else {
-            return Sets.union(t1, t2);
+            return Sets.union(names, wildcardNames);
         }
     }
 

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -1,12 +1,16 @@
 package gregtech.api.unification;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
 import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.MarkerMaterial;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.*;
+import gregtech.api.unification.stack.ItemAndMetadata;
+import gregtech.api.unification.stack.ItemMaterialInfo;
+import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.CustomModPriorityComparator;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
@@ -19,6 +23,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.OreDictionary.OreRegisterEvent;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.*;
@@ -30,15 +35,14 @@ import static gregtech.api.GTValues.M;
 
 public class OreDictUnifier {
 
-    private OreDictUnifier() {
-    }
+    private OreDictUnifier() {}
 
     //simple version of material registry for marker materials
     private static final Map<String, MarkerMaterial> markerMaterialRegistry = new Object2ObjectOpenHashMap<>();
-    private static final Map<ItemAndMetadata, ItemMaterialInfo> materialUnificationInfo = new WildcardAwareHashMap<>();
-    private static final Map<ItemAndMetadata, UnificationEntry> stackUnificationInfo = new WildcardAwareHashMap<>();
+    private static final Map<ItemAndMetadata, ItemMaterialInfo> materialUnificationInfo = new Object2ObjectOpenHashMap<>();
+    private static final Map<ItemAndMetadata, UnificationEntry> stackUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<UnificationEntry, ArrayList<ItemAndMetadata>> stackUnificationItems = new Object2ObjectOpenHashMap<>();
-    private static final Map<ItemAndMetadata, Set<String>> stackOreDictName = new WildcardAwareHashMap<>();
+    private static final Map<ItemAndMetadata, Set<String>> stackOreDictName = new Object2ObjectOpenHashMap<>();
     private static final Map<String, List<ItemStack>> oreDictNameStacks = new Object2ObjectOpenHashMap<>();
 
     @Nullable
@@ -101,10 +105,10 @@ public class OreDictUnifier {
 
     @SubscribeEvent
     public static void onItemRegistration(OreRegisterEvent event) {
-        ItemAndMetadata simpleItemStack = new ItemAndMetadata(event.getOre());
+        ItemAndMetadata key = new ItemAndMetadata(event.getOre());
         String oreName = event.getName();
         //cache this registration by name
-        stackOreDictName.computeIfAbsent(simpleItemStack, k -> new HashSet<>()).add(oreName);
+        stackOreDictName.computeIfAbsent(key, k -> new HashSet<>()).add(oreName);
         List<ItemStack> itemStackListForOreDictName = oreDictNameStacks.computeIfAbsent(oreName, k -> new ArrayList<>());
         addAndSort(itemStackListForOreDictName, event.getOre().copy(), getItemStackComparator());
 
@@ -152,10 +156,10 @@ public class OreDictUnifier {
         if (orePrefix != null && (material != null || orePrefix.isSelfReferencing)) {
             UnificationEntry unificationEntry = new UnificationEntry(orePrefix, material);
             ArrayList<ItemAndMetadata> itemListForUnifiedEntry = stackUnificationItems.computeIfAbsent(unificationEntry, p -> new ArrayList<>());
-            addAndSort(itemListForUnifiedEntry, simpleItemStack, getSimpleItemStackComparator());
+            addAndSort(itemListForUnifiedEntry, key, getSimpleItemStackComparator());
 
             if (!unificationEntry.orePrefix.isMarkerPrefix()) {
-                stackUnificationInfo.put(simpleItemStack, unificationEntry);
+                stackUnificationInfo.put(key, unificationEntry);
             }
             orePrefix.processOreRegistration(material);
         }
@@ -163,10 +167,16 @@ public class OreDictUnifier {
 
     public static Set<String> getOreDictionaryNames(ItemStack itemStack) {
         if (itemStack.isEmpty()) return Collections.emptySet();
-        ItemAndMetadata simpleItemStack = new ItemAndMetadata(itemStack);
-        if (stackOreDictName.containsKey(simpleItemStack))
-            return Collections.unmodifiableSet(stackOreDictName.get(simpleItemStack));
-        return Collections.emptySet();
+        ItemAndMetadata key = new ItemAndMetadata(itemStack);
+        Set<String> t1 = stackOreDictName.get(key);
+        Set<String> t2 = key.isWildcard() ? null : stackOreDictName.get(key.toWildcard());
+        if (t1 == null) {
+            return t2 == null ? Collections.emptySet() : Collections.unmodifiableSet(t2);
+        } else if (t2 == null) {
+            return Collections.unmodifiableSet(t1);
+        } else {
+            return Sets.union(t1, t2);
+        }
     }
 
     public static List<ItemStack> getAllWithOreDictionaryName(String oreDictionaryName) {
@@ -178,8 +188,8 @@ public class OreDictUnifier {
     @Nullable
     public static MaterialStack getMaterial(ItemStack itemStack) {
         if (itemStack.isEmpty()) return null;
-        ItemAndMetadata simpleItemStack = new ItemAndMetadata(itemStack);
-        UnificationEntry entry = stackUnificationInfo.get(simpleItemStack);
+        ItemAndMetadata key = new ItemAndMetadata(itemStack);
+        UnificationEntry entry = getOrWildcard(stackUnificationInfo, key);
         if (entry != null) {
             Material entryMaterial = entry.material;
             if (entryMaterial == null) {
@@ -189,24 +199,21 @@ public class OreDictUnifier {
                 return new MaterialStack(entryMaterial, entry.orePrefix.getMaterialAmount(entryMaterial));
             }
         }
-        ItemMaterialInfo info = materialUnificationInfo.get(simpleItemStack);
+        ItemMaterialInfo info = getOrWildcard(materialUnificationInfo, key);
         return info == null ? null : info.getMaterial().copy();
     }
 
     @Nullable
     public static ItemMaterialInfo getMaterialInfo(ItemStack itemStack) {
         if (itemStack.isEmpty()) return null;
-        ItemAndMetadata simpleItemStack = new ItemAndMetadata(itemStack);
-        return materialUnificationInfo.get(simpleItemStack);
+        return getOrWildcard(materialUnificationInfo, new ItemAndMetadata(itemStack));
     }
 
     @Nullable
     public static OrePrefix getPrefix(ItemStack itemStack) {
         if (itemStack.isEmpty()) return null;
-        ItemAndMetadata simpleItemStack = new ItemAndMetadata(itemStack);
-        UnificationEntry entry = stackUnificationInfo.get(simpleItemStack);
-        if (entry != null) return entry.orePrefix;
-        return null;
+        UnificationEntry entry = getOrWildcard(stackUnificationInfo, new ItemAndMetadata(itemStack));
+        return entry != null ? entry.orePrefix : null;
     }
 
     public static OrePrefix getPrefix(Block block) {
@@ -216,7 +223,7 @@ public class OreDictUnifier {
     @Nullable
     public static UnificationEntry getUnificationEntry(ItemStack itemStack) {
         if (itemStack.isEmpty()) return null;
-        return stackUnificationInfo.get(new ItemAndMetadata(itemStack));
+        return getOrWildcard(stackUnificationInfo, new ItemAndMetadata(itemStack));
     }
 
     public static ItemStack getUnificated(ItemStack itemStack) {
@@ -323,5 +330,21 @@ public class OreDictUnifier {
 
         if (list.size() > 1)
             list.sort(comparator);
+    }
+
+    /**
+     * Get the value corresponding to given key or its wildcard counterpart.
+     *
+     * @param map Map
+     * @param key Key
+     * @return value corresponding to given key or its wildcard counterpart
+     */
+    @Nullable
+    private static <T> T getOrWildcard(@Nonnull Map<ItemAndMetadata, T> map,
+                                       @Nonnull ItemAndMetadata key) {
+        T t = map.get(key);
+        if (t != null) return t;
+        if (key.isWildcard()) return null;
+        return map.get(key.toWildcard());
     }
 }

--- a/src/main/java/gregtech/api/unification/stack/ItemAndMetadata.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemAndMetadata.java
@@ -1,30 +1,45 @@
 package gregtech.api.unification.stack;
 
+import gregtech.api.GTValues;
 import gregtech.api.util.GTUtility;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
+
 public final class ItemAndMetadata {
 
+    @Nonnull
     public final Item item;
     public final int itemDamage;
 
-    public ItemAndMetadata(Item item, int itemDamage) {
+    public ItemAndMetadata(@Nonnull Item item, int itemDamage) {
         this.item = item;
         this.itemDamage = itemDamage;
     }
 
-    public ItemAndMetadata(ItemStack itemStack) {
+    public ItemAndMetadata(@Nonnull ItemStack itemStack) {
         this.item = itemStack.getItem();
         this.itemDamage = GTUtility.getActualItemDamageFromStack(itemStack);
     }
 
+    @Nonnull
     public ItemStack toItemStack() {
         return new ItemStack(item, 1, itemDamage);
     }
 
+    @Nonnull
     public ItemStack toItemStack(int stackSize) {
         return new ItemStack(item, stackSize, itemDamage);
+    }
+
+    public boolean isWildcard() {
+        return this.itemDamage == GTValues.W;
+    }
+
+    @Nonnull
+    public ItemAndMetadata toWildcard() {
+        return this.isWildcard() ? this : new ItemAndMetadata(item, GTValues.W);
     }
 
     @Override
@@ -49,5 +64,4 @@ public final class ItemAndMetadata {
     public String toString() {
         return this.item.getTranslationKey(toItemStack());
     }
-
 }

--- a/src/main/java/gregtech/api/unification/stack/WildcardAwareHashMap.java
+++ b/src/main/java/gregtech/api/unification/stack/WildcardAwareHashMap.java
@@ -4,13 +4,21 @@ import gregtech.api.GTValues;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * HashMap-based implementation of map with key type {@link ItemAndMetadata}
  * This map automatically takes care of wildcard item stacks as keys
  *
  * @param <V> value type
+ * @deprecated Faulty implementation. If wildcard entry is inserted, all read access
+ * will be redirected to wildcard entry. This behavior breaks some functions such as
+ * {@link Map#computeIfAbsent(Object, Function)}. Not to mention this implementation
+ * violates the contract of {@link Map} class.
+ * <p>
+ * Any usage of this class should be replaced by plain maps.
  */
+@Deprecated
 public class WildcardAwareHashMap<V> extends Object2ObjectOpenHashMap<ItemAndMetadata, V> {
 
     public WildcardAwareHashMap(int initialCapacity, float loadFactor) {


### PR DESCRIPTION
## What
This PR deprecates `WildcardAwareHashMap` and replaces its usage with plain hashmaps.

## Implementation Details
The implementation of `WildcardAwareHashMap` essentially treats wildcard meta as a fallback on read access. While this approach worked in other use cases, usage of the class in `stackOreDictName` produces erroneous result, due to `computeIfAbsent` methods not creating new entry for non-wildcard keys when the map already contains wildcard entry.

I figured the class is unnecessary, and decided to write a small static method to provide identical behavior without using custom hashmap implementation. `getOreDictionaryNames` received a correct implementation that should fix the previous issue.

## Outcome
Fixes `getOreDictionaryNames` reporting weird values of certain items depending on registration order.

## Additional Information
I decided to leave `WildcardAwareHashMap` unchanged, as it is currently exposed as an API. But considering the niche application of the class, which it doesn't serve anymore, it could be possible to remove the class entirely without worrying too much about compat break.

## Potential Compatibility Issues
None
