### PR TITLE
Fix issue with GTTransferUtils#insertItem

### DIFF
--- a/src/main/java/gregtech/api/util/GTTransferUtils.java
+++ b/src/main/java/gregtech/api/util/GTTransferUtils.java
@@ -181,7 +181,7 @@ public class GTTransferUtils {
             if (slotStack.isEmpty()) {
                 emptySlots.add(i);
             }
-            if (ItemHandlerHelper.canItemStacksStackRelaxed(stack, slotStack)) {
+            if (ItemHandlerHelper.canItemStacksStack(stack, slotStack)) {
                 stack = handler.insertItem(i, stack, simulate);
                 if (stack.isEmpty()) {
                     return ItemStack.EMPTY;


### PR DESCRIPTION
## What
`GTTransferUtils#insertItem` used `ItemHandlerHelper.canItemStacksStackRelaxed` previously. This method would condense items of the same metadata if they did not have sub-types. This behavior is undesirable in our use-case, as according to the javadoc it is intended for when players pick up items, and may cause issues with specific items from other mods. It also had measurably worse performance according to a received Spark Report.

Switching to `ItemHandlerHelper.canItemStacksStack` resolves this.

## Outcome
Fixes an issue with `GTTransferUtils#insertItem`.
