### PR TITLE
Fix some issues with tape and maintenance hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -39,7 +39,6 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.event.HoverEvent;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
@@ -59,7 +58,7 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
 
     private final boolean isConfigurable;
     private boolean isTaped;
-    private ItemStackHandler itemStackHandler;
+    private final ItemStackHandler itemStackHandler = new TapeItemStackHandler(1);;
 
     // Used to store state temporarily if the Controller is broken
     private byte maintenanceProblems = -1;
@@ -99,14 +98,14 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     }
 
     @Override
-    protected IItemHandlerModifiable createImportItemHandler() {
-        return new TapeItemStackHandler(1);
+    protected void initializeInventory() {
+        super.initializeInventory();
+        this.itemInventory = itemStackHandler;
     }
 
     @Override
-    protected void initializeInventory() {
-        super.initializeInventory();
-        this.itemInventory = itemStackHandler = new ItemStackHandler(1);
+    public void clearMachineInventory(NonNullList<ItemStack> itemBuffer) {
+        clearInventory(itemBuffer, itemStackHandler);
     }
 
     /**
@@ -429,6 +428,7 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
         // Legacy Inventory Handler Support
         if (data.hasKey("ImportInventory")) {
             GTUtility.readItems(itemStackHandler, "ImportInventory", data);
+            data.removeTag("ImportInventory");
         }
     }
 


### PR DESCRIPTION
## What
This PR fixes some existing issues with tape and maintenance hatches mentioned in #1657 

Closes #1657 

## Implementation Details
The import handler override was removed as it was constantly creating a value in `importItems`, which would then write the contents to NBT, triggering the legacy NBT conversion, which was the cause of the tape duping on world load.

## Outcome
Fix some issues with tape and maintenance hatches
