### PR TITLE
Make stone types always show in TOP

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -25,7 +25,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
@@ -77,7 +76,12 @@ public class BlockOre extends Block implements IBlockOre {
 
     @Override
     public int damageDropped(@Nonnull IBlockState state) {
-        return getMetaFromState(state);
+        StoneType stoneType = state.getValue(STONE_TYPE);
+        if (stoneType.shouldBeDroppedAsItem) {
+            return getMetaFromState(state);
+        } else {
+            return 0;
+        }
     }
 
     @Nonnull
@@ -120,41 +124,10 @@ public class BlockOre extends Block implements IBlockOre {
     }
 
     @Override
-    public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
-        StoneType stoneType = state.getValue(STONE_TYPE);
-        if (stoneType.shouldBeDroppedAsItem) {
-            super.getDrops(drops, world, pos, state, fortune);
-        } else {
-            super.getDrops(drops, world, pos, this.getDefaultState(), fortune);
-        }
-    }
-
-    @Override
-    @Nonnull
-    @SuppressWarnings("deprecation")
-    public ItemStack getItem(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
-        StoneType stoneType = state.getValue(STONE_TYPE);
-        if (stoneType.shouldBeDroppedAsItem) {
-            return super.getItem(worldIn, pos, state);
-        }
-        return new ItemStack(this, 1, 0);
-    }
-
-    @Override
     @SuppressWarnings("deprecation")
     public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
         // Still get correct block even if shouldBeDroppedAsItem is false
-        return super.getItem(world, pos, state);
-    }
-
-    @Override
-    @Nonnull
-    protected ItemStack getSilkTouchDrop(IBlockState state) {
-        StoneType stoneType = state.getValue(STONE_TYPE);
-        if (stoneType.shouldBeDroppedAsItem) {
-            return super.getSilkTouchDrop(state);
-        }
-        return super.getSilkTouchDrop(this.getDefaultState());
+        return BlockOre.getItem(state);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -17,12 +17,14 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
@@ -136,6 +138,13 @@ public class BlockOre extends Block implements IBlockOre {
             return super.getItem(worldIn, pos, state);
         }
         return new ItemStack(this, 1, 0);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+        // Still get correct block even if shouldBeDroppedAsItem is false
+        return super.getItem(world, pos, state);
     }
 
     @Override

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeCompatibility.java
@@ -22,5 +22,6 @@ public class TheOneProbeCompatibility {
         oneProbe.registerProvider(new RecipeLogicInfoProvider());
         oneProbe.registerProvider(new PrimitivePumpInfoProvider());
         oneProbe.registerProvider(new CoverProvider());
+        oneProbe.registerProvider(new BlockOreProvider());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/BlockOreProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/BlockOreProvider.java
@@ -1,0 +1,31 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.unification.ore.StoneType;
+import gregtech.common.blocks.BlockOre;
+import mcjty.theoneprobe.api.*;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class BlockOreProvider implements IProbeInfoProvider {
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":ore_block_provider";
+    }
+
+    @Override
+    public void addProbeInfo(ProbeMode probeMode, IProbeInfo probeInfo, EntityPlayer entityPlayer, World world, IBlockState blockState, IProbeHitData probeHitData) {
+        if (blockState.getBlock() instanceof BlockOre) {
+            StoneType stoneType = blockState.getValue(((BlockOre) blockState.getBlock()).STONE_TYPE);
+            if (entityPlayer.isSneaking() && !stoneType.shouldBeDroppedAsItem) {
+                probeInfo.text(TextStyleClass.INFO + "Drops:");
+                ItemStack itemDropped = blockState.getBlock().getItem(world, probeHitData.getPos(), blockState);
+                IProbeInfo horizontalInfo = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+                horizontalInfo.item(itemDropped);
+                horizontalInfo.itemLabel(itemDropped);
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/BlockOreProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/BlockOreProvider.java
@@ -20,7 +20,7 @@ public class BlockOreProvider implements IProbeInfoProvider {
         if (blockState.getBlock() instanceof BlockOre) {
             StoneType stoneType = blockState.getValue(((BlockOre) blockState.getBlock()).STONE_TYPE);
             if (entityPlayer.isSneaking() && !stoneType.shouldBeDroppedAsItem) {
-                probeInfo.text(TextStyleClass.INFO + "Drops:");
+                probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.block_drops*}:");
                 ItemStack itemDropped = blockState.getBlock().getItem(world, probeHitData.getPos(), blockState);
                 IProbeInfo horizontalInfo = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
                 horizontalInfo.item(itemDropped);

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -94,6 +94,8 @@ gregtech.top.unit.items=Items
 gregtech.top.unit.fluid_milibuckets=L
 gregtech.top.unit.fluid_buckets=kL
 
+gregtech.top.block_drops=Drops
+
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.
 gregtech.multiblock.coke_oven.description=The Coke Oven is a multiblock structure used for getting coke and creosote in the early game. It doesn't require fuel and has an internal tank of 32 buckets for creosote. Its inventory can be accessed via its Coke Oven Hatch.


### PR DESCRIPTION
## What
Previously, when TOP tried to get the item for an ore block with a stone type that was meant to drop as the default stone type when mined, it would use the default `getPickBlock` method which called the `getItem` method, which prevented it from seeing its true stonetype. This was fixed by simply overriding `getPickBlock`.

## Implementation Details
I just use the method that `getItem()` used, which was its superclass's implementation, which I hope makes sense. Also, do I need the comment?

## Outcome
Always makes the correct stone type appear in TOP.

## Additional Information
![image](https://user-images.githubusercontent.com/80226372/229311730-4acaea9b-c214-469b-9cb4-a84523f83adc.png)

## Potential Compatibility Issues
For any mods that add new stone types that are supposed to show the default stone type in TOP, this would prevent that, although I don't see why that would be intended.
