### PR TITLE
Fix LT visitor incompatibility with recent ASM version

### DIFF
--- a/src/api/java/com/creativemd/creativecore/client/mods/optifine/OptifineHelper.java
+++ b/src/api/java/com/creativemd/creativecore/client/mods/optifine/OptifineHelper.java
@@ -1,7 +1,7 @@
 package com.creativemd.creativecore.client.mods.optifine;
 
-public interface OptifineHelper {
-    static boolean isActive() {
+public class OptifineHelper {
+    public static boolean isActive() {
         return false;
     }
 }


### PR DESCRIPTION
This fixes the LittleTiles ASM visitor generating an InterfaceMethodRef instead of a MethodRef, which causes error with more recent versions of ASM, which are more strict.