### PR TITLE
Fix stone types dropping the wrong variant

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/StoneType.java
+++ b/src/main/java/gregtech/api/unification/ore/StoneType.java
@@ -96,4 +96,31 @@ public class StoneType implements Comparable<StoneType> {
         return null;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StoneType stoneType = (StoneType) o;
+
+        if (shouldBeDroppedAsItem != stoneType.shouldBeDroppedAsItem) return false;
+        if (!name.equals(stoneType.name)) return false;
+        if (!processingPrefix.equals(stoneType.processingPrefix)) return false;
+        if (!stoneMaterial.equals(stoneType.stoneMaterial)) return false;
+        if (!stone.equals(stoneType.stone)) return false;
+        if (!soundType.equals(stoneType.soundType)) return false;
+        return predicate.equals(stoneType.predicate);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + processingPrefix.hashCode();
+        result = 31 * result + stoneMaterial.hashCode();
+        result = 31 * result + stone.hashCode();
+        result = 31 * result + soundType.hashCode();
+        result = 31 * result + predicate.hashCode();
+        result = 31 * result + (shouldBeDroppedAsItem ? 1 : 0);
+        return result;
+    }
 }

--- a/src/main/java/gregtech/api/worldgen/config/OreConfigUtils.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreConfigUtils.java
@@ -17,6 +17,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,11 +55,12 @@ public class OreConfigUtils {
         return getOreForMaterial(material);
     }
 
+    @Nonnull
     public static Map<StoneType, IBlockState> getOreForMaterial(Material material) {
         List<BlockOre> oreBlocks = MetaBlocks.ORES.stream()
                 .filter(ore -> ore.material == material)
                 .collect(Collectors.toList());
-        HashMap<StoneType, IBlockState> stoneTypeMap = new HashMap<>();
+        Map<StoneType, IBlockState> stoneTypeMap = new HashMap<>();
         for (BlockOre blockOre : oreBlocks) {
             for (StoneType stoneType : blockOre.STONE_TYPE.getAllowedValues()) {
                 IBlockState blockState = blockOre.getOreBlock(stoneType);

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -6,8 +6,10 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.StoneType;
+import gregtech.api.unification.ore.StoneTypes;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.IBlockOre;
+import gregtech.api.worldgen.config.OreConfigUtils;
 import gregtech.client.model.OreBakedModel;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.common.blocks.properties.PropertyStoneType;
@@ -33,6 +35,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 public class BlockOre extends Block implements IBlockOre {
@@ -72,6 +75,23 @@ public class BlockOre extends Block implements IBlockOre {
         BlockStateContainer stateContainer = createStateContainer();
         this.blockState = stateContainer;
         setDefaultState(stateContainer.getBaseState());
+    }
+
+    @Nonnull
+    @Override
+    public Item getItemDropped(@Nonnull IBlockState state, @Nonnull Random rand, int fortune) {
+        StoneType stoneType = state.getValue(STONE_TYPE);
+        // if the stone type should be dropped as an item, or if it is within the first 16 block states
+        // don't do any special handling
+        if (stoneType.shouldBeDroppedAsItem || StoneType.STONE_TYPE_REGISTRY.getIDForObject(stoneType) < 16) {
+            return super.getItemDropped(state, rand, fortune);
+        }
+
+        // always drop StoneTypes.STONE as the default
+        // this prevents stone types of id>15 from dropping the meta=0 variant of the block,
+        // which might not be the block with the vanilla stone type
+        IBlockState stoneOre = OreConfigUtils.getOreForMaterial(this.material).get(StoneTypes.STONE);
+        return Item.getItemFromBlock(stoneOre.getBlock());
     }
 
     @Override


### PR DESCRIPTION
## What
This PR fixes a bug where stone types will drop the wrong item. If the `ConfigHolder.worldgen.allUniqueStoneTypes` config is enabled, there is an edge case where the wrong variant is dropped. When the stone type ids go past 15, 31, 47, etc, a new block (ore_material_2, _3, etc) is created. When mining these blocks, it is expected that the `StoneTypes.STONE` variant would drop, but instead it would drop the ItemBlock corresponding to the `_ore_material_N` block with meta=0. This means that the additional "_N" blocks will drop their first variant, instead of the expected `StoneTypes.STONE` variant. This PR fixes this behavior to always drop the `StoneTypes.STONE` variant when the scenario is present.

## Outcome
Fixes stone types dropping the wrong variant.
