### PR TITLE
Allow ICoverable to determine if the machine grid should render

### DIFF
--- a/src/main/java/gregtech/api/cover/ICoverable.java
+++ b/src/main/java/gregtech/api/cover/ICoverable.java
@@ -24,6 +24,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -217,7 +218,12 @@ public interface ICoverable {
         return false;
     }
 
-    default boolean canRenderMachineGrid() {
+    /**
+     * @param mainHandStack the itemstack held in the player's main hand
+     * @param offHandStack the itemstack held in the player's off-hand
+     * @return if the machine grid should be rendered
+     */
+    default boolean canRenderMachineGrid(@Nonnull ItemStack mainHandStack, @Nonnull ItemStack offHandStack) {
         return true;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -26,6 +26,7 @@ import gregtech.api.cover.CoverIO;
 import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.items.toolitem.ToolClasses;
+import gregtech.api.items.toolitem.ToolHelper;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTLog;
@@ -1472,6 +1473,13 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
 
     public boolean doTickProfileMessage() {
         return true;
+    }
+
+    @Override
+    public boolean canRenderMachineGrid(@Nonnull ItemStack mainHandStack, @Nonnull ItemStack offHandStack) {
+        final String[] tools = {ToolClasses.WRENCH, ToolClasses.SCREWDRIVER};
+        return ToolHelper.isTool(mainHandStack, tools) ||
+                ToolHelper.isTool(offHandStack, tools);
     }
 
     @Override

--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -289,11 +289,8 @@ public class ToolEventHandlers {
 
         if (tile instanceof IGregTechTileEntity) {
             MetaTileEntity mte = ((IGregTechTileEntity) tile).getMetaTileEntity();
-            if (mte != null && mte.canRenderMachineGrid()) {
-                if (ToolHelper.isTool(mainHand, ToolClasses.WRENCH, ToolClasses.SCREWDRIVER) ||
-                        ToolHelper.isTool(offHand, ToolClasses.WRENCH, ToolClasses.SCREWDRIVER)) {
-                    return true;
-                }
+            if (mte != null && mte.canRenderMachineGrid(mainHand, offHand)) {
+                return true;
             }
         }
         ICoverable coverable = tile.getCapability(GregtechTileCapabilities.CAPABILITY_COVERABLE, null);

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -52,6 +52,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
@@ -474,7 +475,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     }
 
     @Override
-    public boolean canRenderMachineGrid() {
+    public boolean canRenderMachineGrid(@Nonnull ItemStack mainHandStack, @Nonnull ItemStack offHandStack) {
         return false;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
@@ -18,11 +18,11 @@ import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.IFastRenderMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.ingredients.GTRecipeItemInput;
 import gregtech.api.recipes.ingredients.GTRecipeOreInput;
-import gregtech.api.recipes.ingredients.GTRecipeInput;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.util.GTUtility;
+import gregtech.client.renderer.texture.Textures;
 import gregtech.common.worldgen.LootTableHelper;
 import gregtech.loaders.recipe.CraftingComponent;
 import gregtech.loaders.recipe.CraftingComponent.Component;
@@ -408,7 +408,7 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
     }
 
     @Override
-    public boolean canRenderMachineGrid() {
+    public boolean canRenderMachineGrid(@Nonnull ItemStack mainHandStack, @Nonnull ItemStack offHandStack) {
         return false;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -41,6 +41,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
@@ -240,7 +241,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
     }
 
     @Override
-    public boolean canRenderMachineGrid() {
+    public boolean canRenderMachineGrid(@Nonnull ItemStack mainHandStack, @Nonnull ItemStack offHandStack) {
         return false;
     }
 


### PR DESCRIPTION
## What
Allows `ICoverable` to determine if the machine grid should be rendered. This allows MTEs, for example, to render the machine grid when a specific item is held, instead of only displaying when a wrench/screwdriver is held, or if a crowbar is held and a cover is attached.

## Outcome
Allows `ICoverable` to determine if the machine grid should render

## Potential Compatibility Issues
This changes a method signature in `ICoverable`, which will break mods utilizing this method, until they update.
