### PR TITLE
Take the Ceiling of the entire EU value

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -29,7 +29,7 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
     public void applyParallelBonus(@Nonnull RecipeBuilder<?> builder) {
         int currentRecipeEU = builder.getEUt();
         int currentRecipeDuration = builder.getDuration() / getParallelLimit();
-        builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU) * 1.33))
+        builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU * 1.33)))
                 .duration((int) (currentRecipeDuration * 1.5));
     }
 }


### PR DESCRIPTION
## What
For steam multiblock parallels, the EU cost should be the ceiling of the entire (eu * 1.33) value, not just the ceiling of the integer EU value, because that does not make sense.


## Outcome
Slight EU adjustment for steam parallel
