### PR TITLE
Lighting fix for glass casings

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
@@ -28,6 +28,7 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
         setSoundType(SoundType.GLASS);
         setHarvestLevel(ToolClasses.PICKAXE, 1);
         setDefaultState(getState(CasingType.TEMPERED_GLASS));
+        this.useNeighborBrightness = true;
     }
 
     @Override
@@ -47,7 +48,6 @@ public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.Casing
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     @SuppressWarnings("deprecation")
     public boolean isOpaqueCube(IBlockState state) {
         return false;


### PR DESCRIPTION
## What
This PR fixes lighting issue observable on glass casings.

## Implementation Details
This PR fixes two issues in previous implementation of `BlockGlassCasing`.

Firstly, the `SideOnly` annotation on `isOpaqueCube` is removed. The side checking made result of `isOpaqueCube` to fallback to default implementation of returning `true` in dedicated server, which made lights to be calculated as if the glass casings were fully opaque on multiplayer world hosted by dedicated server.

Secondly, the `useNeighborBrightness` flag has been set to `true` to prevent light not being able to pass through glass casings and creating visually awkward shade.

## Potential Compatibility Issues
None
