### PR TITLE
fix crash with OverlayedFluidHandler

### DIFF
--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -74,18 +74,7 @@ public class OverlayedFluidHandler {
             // if the fluid key matches the tank, insert the fluid
             OverlayedTank overlayedTank = this.overlayedTanks[i];
             if (toInsert.equals(overlayedTank.getFluidKey())) {
-                if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
-                    if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
-                        NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
-                        if (!(uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert))) {
-                            continue;
-                        }
-                    } else {
-                        if (!(uniqueFluidMap.get(overlayed).add(toInsert))) {
-                            continue;
-                        }
-                    }
-                }
+                if (!handleUniqueFluid(toInsert, i)) continue;
                 int spaceInTank = overlayedTank.getCapacity() - overlayedTank.getFluidAmount();
                 int canInsertUpTo = Math.min(spaceInTank, amountToInsert);
                 if (canInsertUpTo > 0) {
@@ -106,19 +95,7 @@ public class OverlayedFluidHandler {
                 OverlayedTank overlayedTank = this.overlayedTanks[i];
                 // if the tank is empty
                 if (overlayedTank.getFluidKey() == null) {
-                    if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
-                        IMultipleTankHandler mth = overlayed;
-                        if (mth.getTankAt(i) instanceof NotifiableFluidTankFromList) {
-                            NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) mth.getTankAt(i);
-                            if (!(uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert))) {
-                                continue;
-                            }
-                        } else {
-                            if (!(uniqueFluidMap.get(mth).add(toInsert))) {
-                                continue;
-                            }
-                        }
-                    }
+                    if (!handleUniqueFluid(toInsert, i)) continue;
                     //check if this tanks accepts the fluid we're simulating
                     if (overlayed.getTankProperties()[i].canFillFluidType(new FluidStack(toInsert.getFluid(), amountToInsert))) {
                         int canInsertUpTo = Math.min(overlayedTank.getCapacity(), amountToInsert);
@@ -137,6 +114,25 @@ public class OverlayedFluidHandler {
         }
         // return the amount of fluid that was inserted
         return insertedAmount;
+    }
+
+    /**
+     * If the overlayed handler does not allow the same fluid in multiple storages, adds a fluid to the uniqueFluidMap
+     *
+     * @param toInsert the fluid to insert
+     * @param i the index of the tank
+     * @return if the fluid is unique in this handler's maps
+     */
+    private boolean handleUniqueFluid(@Nonnull FluidKey toInsert, int i) {
+        if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
+            if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
+                NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
+                return uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert);
+            } else if (!this.allowSameFluidFill) {
+                return uniqueFluidMap.get(overlayed).add(toInsert);
+            }
+        }
+        return false;
     }
 
     private static class OverlayedTank {

--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -31,7 +31,6 @@ public class OverlayedFluidHandler {
      * Resets the {slots} array to the state when the handler was
      * first mirrored
      */
-
     public void reset() {
         for (int i = 0; i < this.originalTanks.length; i++) {
             if (this.originalTanks[i] != null) {
@@ -74,7 +73,7 @@ public class OverlayedFluidHandler {
             // if the fluid key matches the tank, insert the fluid
             OverlayedTank overlayedTank = this.overlayedTanks[i];
             if (toInsert.equals(overlayedTank.getFluidKey())) {
-                if (!handleUniqueFluid(toInsert, i)) continue;
+                if (!markUniqueFluid(toInsert, i)) continue;
                 int spaceInTank = overlayedTank.getCapacity() - overlayedTank.getFluidAmount();
                 int canInsertUpTo = Math.min(spaceInTank, amountToInsert);
                 if (canInsertUpTo > 0) {
@@ -95,7 +94,7 @@ public class OverlayedFluidHandler {
                 OverlayedTank overlayedTank = this.overlayedTanks[i];
                 // if the tank is empty
                 if (overlayedTank.getFluidKey() == null) {
-                    if (!handleUniqueFluid(toInsert, i)) continue;
+                    if (!markUniqueFluid(toInsert, i)) continue;
                     //check if this tanks accepts the fluid we're simulating
                     if (overlayed.getTankProperties()[i].canFillFluidType(new FluidStack(toInsert.getFluid(), amountToInsert))) {
                         int canInsertUpTo = Math.min(overlayedTank.getCapacity(), amountToInsert);
@@ -123,14 +122,14 @@ public class OverlayedFluidHandler {
      * @param i the index of the tank
      * @return if the fluid is unique in this handler's maps
      */
-    private boolean handleUniqueFluid(@Nonnull FluidKey toInsert, int i) {
-        if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
-            if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
+    private boolean markUniqueFluid(@Nonnull FluidKey toInsert, int i) {
+        if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
+            if (!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i])) {
                 NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
                 return uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert);
-            } else if (!this.allowSameFluidFill) {
-                return uniqueFluidMap.get(overlayed).add(toInsert);
             }
+        } else if (!this.allowSameFluidFill) {
+            return uniqueFluidMap.get(overlayed).add(toInsert);
         }
         return true;
     }

--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -132,7 +132,7 @@ public class OverlayedFluidHandler {
                 return uniqueFluidMap.get(overlayed).add(toInsert);
             }
         }
-        return false;
+        return true;
     }
 
     private static class OverlayedTank {


### PR DESCRIPTION
## What
This PR fixes a crash with OverlayedFluidHandler, where the retrieved set from `uniqueFluidMap` was null using some fluid tank configurations. This occurred in a multiblock with a quad fluid output hatch and a regular fluid output hatch, for example.

## Outcome
Fixes a crash with OverlayedFluidHandler.
