### PR TITLE
Fix null itemInventory in Maintenance Hatch

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -57,8 +57,8 @@ import static gregtech.api.capability.GregtechDataCodes.*;
 
 public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IMaintenanceHatch>, IMaintenanceHatch {
 
-    private final ItemStackHandler itemStackHandler = new TapeItemStackHandler(1);
     private final boolean isConfigurable;
+    private ItemStackHandler itemStackHandler;
     private boolean isTaped;
 
     // Used to store state temporarily if the Controller is broken
@@ -101,6 +101,7 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     @Override
     protected void initializeInventory() {
         super.initializeInventory();
+        this.itemStackHandler = new TapeItemStackHandler(1);
         this.itemInventory = itemStackHandler;
     }
 


### PR DESCRIPTION
## What
This PR fixes `itemInventory` being null in the maintenance hatch. This was caused by `initializeInventory()` being called in the super constructor before the maintenance hatch's `itemStackHandler` was initialized, which happens after the super ctor call in Java when set in the instance variable declaration.

## Outcome
Fixes #1687.
