### PR TITLE
Remove Lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,8 +143,6 @@ dependencies {
     testImplementation("org.hamcrest:hamcrest:${hamcrest_version}")
 
     // Compile-Time Dependencies
-    compileOnly "org.projectlombok:lombok:${lombok_version}"
-    annotationProcessor "org.projectlombok:lombok:${lombok_version}"
 
     // GroovyScript dependency
     implementation "zone.rong:mixinbooter:${mixinbooter_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -75,7 +75,6 @@ junit_version = 5.9.1
 hamcrest_version = 2.2
 
 ## Compile-Time Dependencies
-lombok_version = 1.18.16
 
 # Deployment
 deployment_debug = false

--- a/src/main/java/gregtech/api/network/IPacket.java
+++ b/src/main/java/gregtech/api/network/IPacket.java
@@ -13,7 +13,7 @@ import net.minecraft.network.PacketBuffer;
  * <p>
  * - If this Packet is to be received on the CLIENT, implement {@link IClientExecutor}.<br><br>
  * <p>
- * Lastly, add the {@link lombok.NoArgsConstructor} annotation to your Packet class.
+ * Lastly, add a no-args constructor to your Packet class.
  */
 public interface IPacket {
 

--- a/src/main/java/gregtech/core/network/packets/PacketBlockParticle.java
+++ b/src/main/java/gregtech/core/network/packets/PacketBlockParticle.java
@@ -4,7 +4,6 @@ import codechicken.lib.vec.Vector3;
 import gregtech.api.block.ICustomParticleBlock;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
-import lombok.NoArgsConstructor;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.network.NetHandlerPlayClient;
@@ -15,12 +14,14 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@NoArgsConstructor
 public class PacketBlockParticle implements IPacket, IClientExecutor {
 
     private BlockPos blockPos;
     private Vector3 entityPos;
     private int particlesAmount;
+
+    @SuppressWarnings("unused")
+    public PacketBlockParticle() {/**/}
 
     public PacketBlockParticle(BlockPos blockPos, Vector3 entityPos, int particlesAmount) {
         this.blockPos = blockPos;

--- a/src/main/java/gregtech/core/network/packets/PacketBlockParticle.java
+++ b/src/main/java/gregtech/core/network/packets/PacketBlockParticle.java
@@ -21,7 +21,7 @@ public class PacketBlockParticle implements IPacket, IClientExecutor {
     private int particlesAmount;
 
     @SuppressWarnings("unused")
-    public PacketBlockParticle() {/**/}
+    public PacketBlockParticle() {}
 
     public PacketBlockParticle(BlockPos blockPos, Vector3 entityPos, int particlesAmount) {
         this.blockPos = blockPos;

--- a/src/main/java/gregtech/core/network/packets/PacketClipboard.java
+++ b/src/main/java/gregtech/core/network/packets/PacketClipboard.java
@@ -13,7 +13,7 @@ public class PacketClipboard implements IPacket, IClientExecutor {
     private String text;
 
     @SuppressWarnings("unused")
-    public PacketClipboard() {/**/}
+    public PacketClipboard() {}
 
     public PacketClipboard(final String text) {
         this.text = text;

--- a/src/main/java/gregtech/core/network/packets/PacketClipboard.java
+++ b/src/main/java/gregtech/core/network/packets/PacketClipboard.java
@@ -3,16 +3,17 @@ package gregtech.core.network.packets;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
 import gregtech.api.util.ClipboardUtil;
-import lombok.NoArgsConstructor;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@NoArgsConstructor
 public class PacketClipboard implements IPacket, IClientExecutor {
 
     private String text;
+
+    @SuppressWarnings("unused")
+    public PacketClipboard() {/**/}
 
     public PacketClipboard(final String text) {
         this.text = text;

--- a/src/main/java/gregtech/core/network/packets/PacketClipboardNBTUpdate.java
+++ b/src/main/java/gregtech/core/network/packets/PacketClipboardNBTUpdate.java
@@ -5,18 +5,19 @@ import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
 import gregtech.common.metatileentities.MetaTileEntityClipboard;
 import gregtech.core.network.NetworkUtils;
-import lombok.NoArgsConstructor;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 
-@NoArgsConstructor
 public class PacketClipboardNBTUpdate implements IPacket, IServerExecutor {
     private int dimension;
     private BlockPos pos;
     private int id;
     private PacketBuffer updateData;
+
+    @SuppressWarnings("unused")
+    public PacketClipboardNBTUpdate() {/**/}
 
     public PacketClipboardNBTUpdate(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketClipboardNBTUpdate.java
+++ b/src/main/java/gregtech/core/network/packets/PacketClipboardNBTUpdate.java
@@ -17,7 +17,7 @@ public class PacketClipboardNBTUpdate implements IPacket, IServerExecutor {
     private PacketBuffer updateData;
 
     @SuppressWarnings("unused")
-    public PacketClipboardNBTUpdate() {/**/}
+    public PacketClipboardNBTUpdate() {}
 
     public PacketClipboardNBTUpdate(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketClipboardUIWidgetUpdate.java
+++ b/src/main/java/gregtech/core/network/packets/PacketClipboardUIWidgetUpdate.java
@@ -5,19 +5,20 @@ import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
 import gregtech.common.metatileentities.MetaTileEntityClipboard;
 import gregtech.core.network.NetworkUtils;
-import lombok.NoArgsConstructor;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 
-@NoArgsConstructor
 public class PacketClipboardUIWidgetUpdate implements IPacket, IServerExecutor {
 
     private int dimension;
     private BlockPos pos;
     private int id;
     private PacketBuffer updateData;
+
+    @SuppressWarnings("unused")
+    public PacketClipboardUIWidgetUpdate() {/**/}
 
     public PacketClipboardUIWidgetUpdate(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketClipboardUIWidgetUpdate.java
+++ b/src/main/java/gregtech/core/network/packets/PacketClipboardUIWidgetUpdate.java
@@ -18,7 +18,7 @@ public class PacketClipboardUIWidgetUpdate implements IPacket, IServerExecutor {
     private PacketBuffer updateData;
 
     @SuppressWarnings("unused")
-    public PacketClipboardUIWidgetUpdate() {/**/}
+    public PacketClipboardUIWidgetUpdate() {}
 
     public PacketClipboardUIWidgetUpdate(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketFluidVeinList.java
+++ b/src/main/java/gregtech/core/network/packets/PacketFluidVeinList.java
@@ -3,7 +3,6 @@ package gregtech.core.network.packets;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
 import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinHandler;
-import lombok.NoArgsConstructor;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
@@ -14,10 +13,12 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import java.util.HashMap;
 import java.util.Map;
 
-@NoArgsConstructor
 public class PacketFluidVeinList implements IPacket, IClientExecutor {
 
     private Map<BedrockFluidVeinHandler.FluidVeinWorldEntry, Integer> map;
+
+    @SuppressWarnings("unused")
+    public PacketFluidVeinList() {/**/}
 
     public PacketFluidVeinList(HashMap<BedrockFluidVeinHandler.FluidVeinWorldEntry, Integer> map) {
         this.map = map;

--- a/src/main/java/gregtech/core/network/packets/PacketFluidVeinList.java
+++ b/src/main/java/gregtech/core/network/packets/PacketFluidVeinList.java
@@ -18,7 +18,7 @@ public class PacketFluidVeinList implements IPacket, IClientExecutor {
     private Map<BedrockFluidVeinHandler.FluidVeinWorldEntry, Integer> map;
 
     @SuppressWarnings("unused")
-    public PacketFluidVeinList() {/**/}
+    public PacketFluidVeinList() {}
 
     public PacketFluidVeinList(HashMap<BedrockFluidVeinHandler.FluidVeinWorldEntry, Integer> map) {
         this.map = map;

--- a/src/main/java/gregtech/core/network/packets/PacketKeysPressed.java
+++ b/src/main/java/gregtech/core/network/packets/PacketKeysPressed.java
@@ -3,17 +3,18 @@ package gregtech.core.network.packets;
 import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
 import gregtech.api.util.input.KeyBind;
-import lombok.NoArgsConstructor;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.PacketBuffer;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 
-@NoArgsConstructor
 public class PacketKeysPressed implements IPacket, IServerExecutor {
 
     private Object updateKeys;
+
+    @SuppressWarnings("unused")
+    public PacketKeysPressed() {/**/}
 
     public PacketKeysPressed(List<KeyBind> updateKeys) {
         this.updateKeys = updateKeys;

--- a/src/main/java/gregtech/core/network/packets/PacketKeysPressed.java
+++ b/src/main/java/gregtech/core/network/packets/PacketKeysPressed.java
@@ -14,7 +14,7 @@ public class PacketKeysPressed implements IPacket, IServerExecutor {
     private Object updateKeys;
 
     @SuppressWarnings("unused")
-    public PacketKeysPressed() {/**/}
+    public PacketKeysPressed() {}
 
     public PacketKeysPressed(List<KeyBind> updateKeys) {
         this.updateKeys = updateKeys;

--- a/src/main/java/gregtech/core/network/packets/PacketNotifyCapeChange.java
+++ b/src/main/java/gregtech/core/network/packets/PacketNotifyCapeChange.java
@@ -3,18 +3,19 @@ package gregtech.core.network.packets;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
 import gregtech.api.util.CapesRegistry;
-import lombok.NoArgsConstructor;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.UUID;
 
-@NoArgsConstructor
 public class PacketNotifyCapeChange implements IPacket, IClientExecutor {
 
     public ResourceLocation cape;
     public UUID uuid;
+
+    @SuppressWarnings("unused")
+    public PacketNotifyCapeChange() {/**/}
 
     public PacketNotifyCapeChange(UUID uuid, ResourceLocation cape) {
         this.uuid = uuid;

--- a/src/main/java/gregtech/core/network/packets/PacketNotifyCapeChange.java
+++ b/src/main/java/gregtech/core/network/packets/PacketNotifyCapeChange.java
@@ -15,7 +15,7 @@ public class PacketNotifyCapeChange implements IPacket, IClientExecutor {
     public UUID uuid;
 
     @SuppressWarnings("unused")
-    public PacketNotifyCapeChange() {/**/}
+    public PacketNotifyCapeChange() {}
 
     public PacketNotifyCapeChange(UUID uuid, ResourceLocation cape) {
         this.uuid = uuid;

--- a/src/main/java/gregtech/core/network/packets/PacketPluginSynced.java
+++ b/src/main/java/gregtech/core/network/packets/PacketPluginSynced.java
@@ -19,7 +19,7 @@ public class PacketPluginSynced implements IPacket, IServerExecutor {
     private PacketBuffer updateData;
 
     @SuppressWarnings("unused")
-    public PacketPluginSynced() {/**/}
+    public PacketPluginSynced() {}
 
     public PacketPluginSynced(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketPluginSynced.java
+++ b/src/main/java/gregtech/core/network/packets/PacketPluginSynced.java
@@ -6,19 +6,20 @@ import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityMonitorScreen;
 import gregtech.core.network.NetworkUtils;
-import lombok.NoArgsConstructor;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 
-@NoArgsConstructor
 public class PacketPluginSynced implements IPacket, IServerExecutor {
 
     private int dimension;
     private BlockPos pos;
     private int id;
     private PacketBuffer updateData;
+
+    @SuppressWarnings("unused")
+    public PacketPluginSynced() {/**/}
 
     public PacketPluginSynced(int dimension, BlockPos pos, int id, PacketBuffer updateData) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketProspecting.java
+++ b/src/main/java/gregtech/core/network/packets/PacketProspecting.java
@@ -1,7 +1,6 @@
 package gregtech.core.network.packets;
 
 import io.netty.buffer.Unpooled;
-import lombok.NoArgsConstructor;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 
@@ -9,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-@NoArgsConstructor
 public class PacketProspecting {
     public int chunkX;
     public int chunkZ;
@@ -18,6 +16,9 @@ public class PacketProspecting {
     public int mode;
     public HashMap<Byte, String>[][] map;
     public Set<String> ores;
+
+    @SuppressWarnings("unused")
+    public PacketProspecting() {/**/}
 
     public PacketProspecting(int chunkX, int chunkZ, int posX, int posZ, int mode) {
         this.chunkX = chunkX;

--- a/src/main/java/gregtech/core/network/packets/PacketProspecting.java
+++ b/src/main/java/gregtech/core/network/packets/PacketProspecting.java
@@ -18,7 +18,7 @@ public class PacketProspecting {
     public Set<String> ores;
 
     @SuppressWarnings("unused")
-    public PacketProspecting() {/**/}
+    public PacketProspecting() {}
 
     public PacketProspecting(int chunkX, int chunkZ, int posX, int posZ, int mode) {
         this.chunkX = chunkX;

--- a/src/main/java/gregtech/core/network/packets/PacketRecoverMTE.java
+++ b/src/main/java/gregtech/core/network/packets/PacketRecoverMTE.java
@@ -21,7 +21,7 @@ public class PacketRecoverMTE implements IPacket, IServerExecutor {
     private BlockPos pos;
 
     @SuppressWarnings("unused")
-    public PacketRecoverMTE() {/**/}
+    public PacketRecoverMTE() {}
 
     public PacketRecoverMTE(int dimension, BlockPos pos) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketRecoverMTE.java
+++ b/src/main/java/gregtech/core/network/packets/PacketRecoverMTE.java
@@ -5,7 +5,6 @@ import gregtech.api.block.machines.BlockMachine;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
-import lombok.NoArgsConstructor;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SPacketBlockChange;
@@ -16,11 +15,13 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import static gregtech.api.capability.GregtechDataCodes.INITIALIZE_MTE;
 
-@NoArgsConstructor
 public class PacketRecoverMTE implements IPacket, IServerExecutor {
 
     private int dimension;
     private BlockPos pos;
+
+    @SuppressWarnings("unused")
+    public PacketRecoverMTE() {/**/}
 
     public PacketRecoverMTE(int dimension, BlockPos pos) {
         this.dimension = dimension;

--- a/src/main/java/gregtech/core/network/packets/PacketReloadShaders.java
+++ b/src/main/java/gregtech/core/network/packets/PacketReloadShaders.java
@@ -10,7 +10,7 @@ import net.minecraft.network.PacketBuffer;
 public class PacketReloadShaders implements IPacket, IClientExecutor {
 
     @SuppressWarnings("unused")
-    public PacketReloadShaders() {/**/}
+    public PacketReloadShaders() {}
 
     @Override
     public void encode(PacketBuffer buf) {

--- a/src/main/java/gregtech/core/network/packets/PacketReloadShaders.java
+++ b/src/main/java/gregtech/core/network/packets/PacketReloadShaders.java
@@ -4,12 +4,13 @@ import gregtech.api.gui.resources.ShaderTexture;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
 import gregtech.client.shader.Shaders;
-import lombok.NoArgsConstructor;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.PacketBuffer;
 
-@NoArgsConstructor
 public class PacketReloadShaders implements IPacket, IClientExecutor {
+
+    @SuppressWarnings("unused")
+    public PacketReloadShaders() {/**/}
 
     @Override
     public void encode(PacketBuffer buf) {

--- a/src/main/java/gregtech/core/network/packets/PacketUIClientAction.java
+++ b/src/main/java/gregtech/core/network/packets/PacketUIClientAction.java
@@ -5,17 +5,18 @@ import gregtech.api.gui.impl.ModularUIContainer;
 import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
 import gregtech.core.network.NetworkUtils;
-import lombok.NoArgsConstructor;
 import net.minecraft.inventory.Container;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.PacketBuffer;
 
-@NoArgsConstructor
 public class PacketUIClientAction implements IPacket, IServerExecutor {
 
     private int windowId;
     private int widgetId;
     private PacketBuffer updateData;
+
+    @SuppressWarnings("unused")
+    public PacketUIClientAction() {/**/}
 
     public PacketUIClientAction(int windowId, int widgetId, PacketBuffer updateData) {
         this.windowId = windowId;

--- a/src/main/java/gregtech/core/network/packets/PacketUIClientAction.java
+++ b/src/main/java/gregtech/core/network/packets/PacketUIClientAction.java
@@ -16,7 +16,7 @@ public class PacketUIClientAction implements IPacket, IServerExecutor {
     private PacketBuffer updateData;
 
     @SuppressWarnings("unused")
-    public PacketUIClientAction() {/**/}
+    public PacketUIClientAction() {}
 
     public PacketUIClientAction(int windowId, int widgetId, PacketBuffer updateData) {
         this.windowId = windowId;

--- a/src/main/java/gregtech/core/network/packets/PacketUIOpen.java
+++ b/src/main/java/gregtech/core/network/packets/PacketUIOpen.java
@@ -6,7 +6,6 @@ import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
 import gregtech.api.util.GTLog;
 import gregtech.core.network.NetworkUtils;
-import lombok.NoArgsConstructor;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.relauncher.Side;
@@ -15,13 +14,15 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import java.util.ArrayList;
 import java.util.List;
 
-@NoArgsConstructor
 public class PacketUIOpen implements IPacket, IClientExecutor {
 
     private int uiFactoryId;
     private PacketBuffer serializedHolder;
     private int windowId;
     private List<PacketUIWidgetUpdate> initialWidgetUpdates;
+
+    @SuppressWarnings("unused")
+    public PacketUIOpen() {/**/}
 
     public PacketUIOpen(int uiFactoryId, PacketBuffer serializedHolder, int windowId, List<PacketUIWidgetUpdate> initialWidgetUpdates) {
         this.uiFactoryId = uiFactoryId;

--- a/src/main/java/gregtech/core/network/packets/PacketUIOpen.java
+++ b/src/main/java/gregtech/core/network/packets/PacketUIOpen.java
@@ -22,7 +22,7 @@ public class PacketUIOpen implements IPacket, IClientExecutor {
     private List<PacketUIWidgetUpdate> initialWidgetUpdates;
 
     @SuppressWarnings("unused")
-    public PacketUIOpen() {/**/}
+    public PacketUIOpen() {}
 
     public PacketUIOpen(int uiFactoryId, PacketBuffer serializedHolder, int windowId, List<PacketUIWidgetUpdate> initialWidgetUpdates) {
         this.uiFactoryId = uiFactoryId;

--- a/src/main/java/gregtech/core/network/packets/PacketUIWidgetUpdate.java
+++ b/src/main/java/gregtech/core/network/packets/PacketUIWidgetUpdate.java
@@ -18,7 +18,7 @@ public class PacketUIWidgetUpdate implements IPacket, IClientExecutor {
     public PacketBuffer updateData;
 
     @SuppressWarnings("unused")
-    public PacketUIWidgetUpdate() {/**/}
+    public PacketUIWidgetUpdate() {}
 
     public PacketUIWidgetUpdate(int windowId, int widgetId, PacketBuffer updateData) {
         this.windowId = windowId;

--- a/src/main/java/gregtech/core/network/packets/PacketUIWidgetUpdate.java
+++ b/src/main/java/gregtech/core/network/packets/PacketUIWidgetUpdate.java
@@ -4,7 +4,6 @@ import gregtech.api.gui.impl.ModularUIGui;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.IPacket;
 import gregtech.core.network.NetworkUtils;
-import lombok.NoArgsConstructor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.network.NetHandlerPlayClient;
@@ -12,12 +11,14 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@NoArgsConstructor
 public class PacketUIWidgetUpdate implements IPacket, IClientExecutor {
 
     public int windowId;
     public int widgetId;
     public PacketBuffer updateData;
+
+    @SuppressWarnings("unused")
+    public PacketUIWidgetUpdate() {/**/}
 
     public PacketUIWidgetUpdate(int windowId, int widgetId, PacketBuffer updateData) {
         this.windowId = windowId;


### PR DESCRIPTION
## What
This PR removes Lombok from the project. Lombok is currently only used for the `@NoArgsConstructor` annotation in packets. Given this use-case is so simple, and so easy to replace with manual empty constructors, it is best to remove the extra dependency. 

## Outcome
Removes Lombok.

## Potential Compatibility Issues
Removal of Lombok will not cause compatability problems. Addons utilizing it still have to pull the dependency themselves, just as before, and their code will compile and run without any needed changes.
