### PR TITLE
OverlayedFluidHandler refactor

### DIFF
--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -74,18 +74,7 @@ public class OverlayedFluidHandler {
             // if the fluid key matches the tank, insert the fluid
             OverlayedTank overlayedTank = this.overlayedTanks[i];
             if (toInsert.equals(overlayedTank.getFluidKey())) {
-                if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
-                    if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
-                        NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
-                        if (!(uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert))) {
-                            continue;
-                        }
-                    } else {
-                        if (!(uniqueFluidMap.get(overlayed).add(toInsert))) {
-                            continue;
-                        }
-                    }
-                }
+                if (!handleUniqueFluid(toInsert, i)) continue;
                 int spaceInTank = overlayedTank.getCapacity() - overlayedTank.getFluidAmount();
                 int canInsertUpTo = Math.min(spaceInTank, amountToInsert);
                 if (canInsertUpTo > 0) {
@@ -106,19 +95,7 @@ public class OverlayedFluidHandler {
                 OverlayedTank overlayedTank = this.overlayedTanks[i];
                 // if the tank is empty
                 if (overlayedTank.getFluidKey() == null) {
-                    if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
-                        IMultipleTankHandler mth = overlayed;
-                        if (mth.getTankAt(i) instanceof NotifiableFluidTankFromList) {
-                            NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) mth.getTankAt(i);
-                            if (!(uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert))) {
-                                continue;
-                            }
-                        } else {
-                            if (!(uniqueFluidMap.get(mth).add(toInsert))) {
-                                continue;
-                            }
-                        }
-                    }
+                    if (!handleUniqueFluid(toInsert, i)) continue;
                     //check if this tanks accepts the fluid we're simulating
                     if (overlayed.getTankProperties()[i].canFillFluidType(new FluidStack(toInsert.getFluid(), amountToInsert))) {
                         int canInsertUpTo = Math.min(overlayedTank.getCapacity(), amountToInsert);
@@ -137,6 +114,25 @@ public class OverlayedFluidHandler {
         }
         // return the amount of fluid that was inserted
         return insertedAmount;
+    }
+
+    /**
+     * If the overlayed handler does not allow the same fluid in multiple storages, adds a fluid to the uniqueFluidMap
+     *
+     * @param toInsert the fluid to insert
+     * @param i the index of the tank
+     * @return if the fluid is unique in this handler's maps
+     */
+    private boolean handleUniqueFluid(@Nonnull FluidKey toInsert, int i) {
+        if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
+            if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
+                NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
+                return uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert);
+            } else if (!this.allowSameFluidFill) {
+                return uniqueFluidMap.get(overlayed).add(toInsert);
+            }
+        }
+        return false;
     }
 
     private static class OverlayedTank {

--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -10,6 +10,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public class OverlayedFluidHandler {
@@ -17,7 +18,7 @@ public class OverlayedFluidHandler {
     private final OverlayedTank[] overlayedTanks;
     private final OverlayedTank[] originalTanks;
     private final IMultipleTankHandler overlayed;
-    private boolean allowSameFluidFill = true;
+
     private final ObjectOpenCustomHashSet<IFluidTankProperties> tankDeniesSameFluidFill = new ObjectOpenCustomHashSet<>(IFluidTankPropertiesHashStrategy.create());
     private final Map<IMultipleTankHandler, ObjectOpenHashSet<FluidKey>> uniqueFluidMap = new Object2ObjectOpenHashMap<>();
 
@@ -31,7 +32,6 @@ public class OverlayedFluidHandler {
      * Resets the {slots} array to the state when the handler was
      * first mirrored
      */
-
     public void reset() {
         for (int i = 0; i < this.originalTanks.length; i++) {
             if (this.originalTanks[i] != null) {
@@ -51,61 +51,51 @@ public class OverlayedFluidHandler {
             this.originalTanks[tank] = new OverlayedTank(fluidTankProperties);
             this.overlayedTanks[tank] = new OverlayedTank(fluidTankProperties);
 
-            if (!overlayed.allowSameFluidFill()) {
-                this.allowSameFluidFill = false;
-            }
             if (overlayed.getTankAt(tank) instanceof NotifiableFluidTankFromList) {
                 NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(tank);
                 if (!nftfl.getFluidTankList().get().allowSameFluidFill()) {
                     this.tankDeniesSameFluidFill.add(overlayed.getTankProperties()[tank]);
-                    uniqueFluidMap.computeIfAbsent(nftfl.getFluidTankList().get(), list -> new ObjectOpenHashSet<>());
                 }
-            } else if (!this.allowSameFluidFill) {
-                uniqueFluidMap.computeIfAbsent(overlayed, list -> new ObjectOpenHashSet<>());
             }
         }
     }
 
     public int insertStackedFluidKey(@Nonnull FluidKey toInsert, int amountToInsert) {
+        if (amountToInsert <= 0) {
+            return 0;
+        }
         int insertedAmount = 0;
+        // search for tanks with same fluid type first
         for (int i = 0; i < this.overlayedTanks.length; i++) {
+            // initialize the tanks if they are not already populated
             initTank(i);
-            // populate the tanks if they are not already populated
-            // if the fluid key matches the tank, insert the fluid
             OverlayedTank overlayedTank = this.overlayedTanks[i];
-            if (toInsert.equals(overlayedTank.getFluidKey())) {
-                if (!handleUniqueFluid(toInsert, i)) continue;
-                int spaceInTank = overlayedTank.getCapacity() - overlayedTank.getFluidAmount();
-                int canInsertUpTo = Math.min(spaceInTank, amountToInsert);
+            // if the fluid key matches the tank, insert the fluid
+            if (toInsert.equals(overlayedTank.fluidKey)) {
+                if (!markFluidAsUnique(toInsert, i)) continue;
+                int canInsertUpTo = overlayedTank.tryInsert(toInsert, amountToInsert);
                 if (canInsertUpTo > 0) {
                     insertedAmount += canInsertUpTo;
-                    overlayedTank.setFluidKey(toInsert);
-                    overlayedTank.setFluidAmount(overlayedTank.getFluidAmount() + canInsertUpTo);
                     amountToInsert -= canInsertUpTo;
-                }
-                if (amountToInsert == 0) {
-                    return insertedAmount;
+                    if (amountToInsert <= 0) {
+                        return insertedAmount;
+                    }
                 }
             }
         }
-        // if we still have fluid to insert, insert it into the first tank that can accept it
-        if (amountToInsert > 0) {
-            // loop through the tanks until we find one that can accept the fluid
-            for (int i = 0, tanksLength = this.overlayedTanks.length; i < tanksLength; i++) {
-                OverlayedTank overlayedTank = this.overlayedTanks[i];
-                // if the tank is empty
-                if (overlayedTank.getFluidKey() == null) {
-                    if (!handleUniqueFluid(toInsert, i)) continue;
-                    //check if this tanks accepts the fluid we're simulating
-                    if (overlayed.getTankProperties()[i].canFillFluidType(new FluidStack(toInsert.getFluid(), amountToInsert))) {
-                        int canInsertUpTo = Math.min(overlayedTank.getCapacity(), amountToInsert);
-                        if (canInsertUpTo > 0) {
-                            insertedAmount += canInsertUpTo;
-                            overlayedTank.setFluidKey(toInsert);
-                            overlayedTank.setFluidAmount(canInsertUpTo);
-                            amountToInsert -= canInsertUpTo;
-                        }
-                        if (amountToInsert == 0) {
+        // if we still have fluid to insert, loop through empty tanks until we find one that can accept the fluid
+        for (int i = 0; i < this.overlayedTanks.length; i++) {
+            OverlayedTank overlayedTank = this.overlayedTanks[i];
+            // if the tank is empty
+            if (overlayedTank.fluidKey == null) {
+                if (!markFluidAsUnique(toInsert, i)) continue;
+                //check if this tanks accepts the fluid we're simulating
+                if (overlayed.getTankProperties()[i].canFillFluidType(new FluidStack(toInsert.getFluid(), amountToInsert))) {
+                    int inserted = overlayedTank.tryInsert(toInsert, amountToInsert);
+                    if (inserted > 0) {
+                        insertedAmount += inserted;
+                        amountToInsert -= inserted;
+                        if (amountToInsert <= 0) {
                             return insertedAmount;
                         }
                     }
@@ -117,28 +107,43 @@ public class OverlayedFluidHandler {
     }
 
     /**
-     * If the overlayed handler does not allow the same fluid in multiple storages, adds a fluid to the uniqueFluidMap
+     * Marks the fluid as unique, to prevent further insertions in other tank slots.
+     * If the fluid is already marked as unique in previous calls to this method,
+     * this method fails and returns {@code false}.
+     * <p>
+     * If {@link IMultipleTankHandler#allowSameFluidFill()} is {@code false} for
+     * {@link #overlayed} field or tank provider returned by {@link
+     * NotifiableFluidTankFromList#getFluidTankList()}, this method gets bypassed
+     * and {@code true} is returned without modifying any state.
      *
-     * @param toInsert the fluid to insert
-     * @param i the index of the tank
-     * @return if the fluid is unique in this handler's maps
+     * @param fluid     the fluid to mark
+     * @param tankIndex the index of the tank
+     * @return {@code true} if the fluid is not marked as unique in previous calls,
+     * or the tank allows same fluids to be filled in multiple slots
      */
-    private boolean handleUniqueFluid(@Nonnull FluidKey toInsert, int i) {
-        if ((!this.allowSameFluidFill || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[i]))) {
-            if (overlayed.getTankAt(i) instanceof NotifiableFluidTankFromList) {
-                NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(i);
-                return uniqueFluidMap.get(nftfl.getFluidTankList().get()).add(toInsert);
-            } else if (!this.allowSameFluidFill) {
-                return uniqueFluidMap.get(overlayed).add(toInsert);
+    private boolean markFluidAsUnique(@Nonnull FluidKey fluid, int tankIndex) {
+        if (overlayed.getTankAt(tankIndex) instanceof NotifiableFluidTankFromList) {
+            if (!overlayed.allowSameFluidFill() || tankDeniesSameFluidFill.contains(overlayed.getTankProperties()[tankIndex])) {
+                NotifiableFluidTankFromList nftfl = (NotifiableFluidTankFromList) overlayed.getTankAt(tankIndex);
+                return this.uniqueFluidMap
+                        .computeIfAbsent(nftfl.getFluidTankList().get(), t -> new ObjectOpenHashSet<>())
+                        .add(fluid);
             }
+        } else if (!overlayed.allowSameFluidFill()) {
+            return this.uniqueFluidMap
+                    .computeIfAbsent(overlayed, t -> new ObjectOpenHashSet<>())
+                    .add(fluid);
         }
         return true;
     }
 
     private static class OverlayedTank {
+
+        private final int capacity;
+
+        @Nullable
         private FluidKey fluidKey = null;
         private int fluidAmount = 0;
-        private int capacity = 0;
 
         OverlayedTank(IFluidTankProperties property) {
             FluidStack stackToMirror = property.getContents();
@@ -149,30 +154,28 @@ public class OverlayedFluidHandler {
             this.capacity = property.getCapacity();
         }
 
-        OverlayedTank(FluidKey fluidKey, int fluidAmount, int capacity) {
+        OverlayedTank(@Nullable FluidKey fluidKey, int fluidAmount, int capacity) {
             this.fluidKey = fluidKey;
             this.fluidAmount = fluidAmount;
             this.capacity = capacity;
         }
 
-        public int getCapacity() {
-            return capacity;
-        }
-
-        public int getFluidAmount() {
-            return fluidAmount;
-        }
-
-        public FluidKey getFluidKey() {
-            return fluidKey;
-        }
-
-        public void setFluidKey(FluidKey fluidKey) {
-            this.fluidKey = fluidKey;
-        }
-
-        public void setFluidAmount(int fluidAmount) {
-            this.fluidAmount = fluidAmount;
+        /**
+         * Tries to insert set amount of fluid into this tank. If operation succeeds,
+         * the fluid key of this tank will be set to {@code fluid} and the {@code
+         * fluidAmount} will be changed to reflect the state after insertion.
+         *
+         * @param fluid          Fluid key
+         * @param amountToInsert Amount of the fluid to insert
+         * @return Amount of fluid inserted into this tank
+         */
+        public int tryInsert(@Nonnull FluidKey fluid, int amountToInsert) {
+            int maxInsert = Math.min(this.capacity - this.fluidAmount, amountToInsert);
+            if (maxInsert > 0) {
+                this.fluidKey = fluid;
+                this.fluidAmount += maxInsert;
+                return maxInsert;
+            } else return 0;
         }
 
         public OverlayedTank copy() {

--- a/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedFluidHandler.java
@@ -132,7 +132,7 @@ public class OverlayedFluidHandler {
                 return uniqueFluidMap.get(overlayed).add(toInsert);
             }
         }
-        return false;
+        return true;
     }
 
     private static class OverlayedTank {


### PR DESCRIPTION
## What
This PR refactors OverlayedFluidHandler. Supersedes #1682.

## Implementation Details
In addition to the bugfix provided by aforementioned PR, this PR adds a few things.
* Initialization of `uniqueFluidMap` cache was moved from `initTank` to usage.
* Separated two insertion logic used to its own method.
* `allowSameFluidFill` cache is replaced with direct access to `overlayed.allowSameFluidFill()` method.
* Minor code edits (removing unnecessary getter/setters, docs and stuff)

## Potential Compatibility Issues
None
