### PR TITLE
Improve default enchantment API

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/EnchantmentLevel.java
+++ b/src/main/java/gregtech/api/items/toolitem/EnchantmentLevel.java
@@ -1,0 +1,15 @@
+package gregtech.api.items.toolitem;
+
+public class EnchantmentLevel {
+    private double level;
+    private double levelGrowth;
+
+    public EnchantmentLevel(double level, double levelGrowth) {
+        this.level = level;
+        this.levelGrowth = levelGrowth;
+    }
+
+    public int getLevel(int harvestTier) {
+        return (int) Math.min(Byte.MAX_VALUE, Math.floor(this.level + this.levelGrowth * harvestTier));
+    }
+}

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -179,7 +179,9 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         enchantments.putAll(toolStats.getDefaultEnchantments(stack));
         enchantments.forEach((enchantment, level) -> {
             if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
-                stack.addEnchantment(enchantment, level);
+                int levelIncrease = toolStats.getDefaultEnchantmentLevelIncrease(stack).getOrDefault(enchantment, 0)
+                        * toolProperty.getToolHarvestLevel();
+                stack.addEnchantment(enchantment, level + levelIncrease);
             }
         });
 

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -175,13 +175,11 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
 
         // Set tool and material enchantments
         Object2IntMap<Enchantment> enchantments = new Object2IntOpenHashMap<>();
-        enchantments.putAll(toolProperty.getEnchantments());
-        enchantments.putAll(toolStats.getDefaultEnchantments(stack));
+        toolProperty.getEnchantments().forEach((enchantment, level) -> enchantments.put(enchantment, level.getLevel(toolProperty.getToolHarvestLevel())));
+        toolStats.getDefaultEnchantments(stack).forEach((enchantment, level) -> enchantments.put(enchantment, level.getLevel(toolProperty.getToolHarvestLevel())));
         enchantments.forEach((enchantment, level) -> {
             if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
-                int levelIncrease = toolStats.getDefaultEnchantmentLevelIncrease(stack).getOrDefault(enchantment, 0)
-                        * toolProperty.getToolHarvestLevel();
-                stack.addEnchantment(enchantment, level + levelIncrease);
+                stack.addEnchantment(enchantment, level);
             }
         });
 

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -36,6 +36,7 @@ import gregtech.client.utils.ToolChargeBarRenderer;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.resources.I18n;
@@ -173,7 +174,8 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         }
 
         // Set tool and material enchantments
-        Object2IntMap<Enchantment> enchantments = toolProperty.getEnchantments();
+        Object2IntMap<Enchantment> enchantments = new Object2IntOpenHashMap<>();
+        enchantments.putAll(toolProperty.getEnchantments());
         enchantments.putAll(toolStats.getDefaultEnchantments(stack));
         enchantments.forEach((enchantment, level) -> {
             if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {

--- a/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
@@ -95,6 +95,8 @@ public interface IGTToolDefinition {
 
     Object2IntMap<Enchantment> getDefaultEnchantments(ItemStack stack);
 
+    Object2IntMap<Enchantment> getDefaultEnchantmentLevelIncrease(ItemStack stack);
+
     /**
      * Misc
      */

--- a/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTToolDefinition.java
@@ -2,7 +2,7 @@ package gregtech.api.items.toolitem;
 
 import gregtech.api.items.toolitem.aoe.AoESymmetrical;
 import gregtech.api.items.toolitem.behavior.IToolBehavior;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
@@ -93,9 +93,7 @@ public interface IGTToolDefinition {
 
     boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment);
 
-    Object2IntMap<Enchantment> getDefaultEnchantments(ItemStack stack);
-
-    Object2IntMap<Enchantment> getDefaultEnchantmentLevelIncrease(ItemStack stack);
+    Object2ObjectMap<Enchantment, EnchantmentLevel> getDefaultEnchantments(ItemStack stack);
 
     /**
      * Misc

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -46,6 +46,8 @@ public class ToolDefinitionBuilder {
     private Predicate<IBlockState> effectiveStates;
     private Object2IntMap<Enchantment> defaultEnchantments = new Object2IntArrayMap<>();
 
+    private Object2IntMap<Enchantment> defaultEnchantmentLevelIncreases = new Object2IntArrayMap<>();
+
     public ToolDefinitionBuilder behaviors(IToolBehavior... behaviours) {
         Collections.addAll(this.behaviours, behaviours);
         return this;
@@ -188,6 +190,11 @@ public class ToolDefinitionBuilder {
         return this;
     }
 
+    public ToolDefinitionBuilder defaultEnchantmentLevelIncrease(Enchantment enchantment, int increase) {
+        this.defaultEnchantmentLevelIncreases.put(enchantment, increase);
+        return this;
+    }
+
     public IGTToolDefinition build() {
         return new IGTToolDefinition() {
 
@@ -211,6 +218,7 @@ public class ToolDefinitionBuilder {
             private final AoESymmetrical aoeSymmetrical = ToolDefinitionBuilder.this.aoeSymmetrical;
             private final Predicate<IBlockState> effectiveStatePredicate;
             private final Object2IntMap<Enchantment> defaultEnchantments = ToolDefinitionBuilder.this.defaultEnchantments;
+            private final Object2IntMap<Enchantment> defaultEnchantmentLevelIncreases = ToolDefinitionBuilder.this.defaultEnchantmentLevelIncreases;
 
 
             {
@@ -310,6 +318,11 @@ public class ToolDefinitionBuilder {
             @Override
             public Object2IntMap<Enchantment> getDefaultEnchantments(ItemStack stack) {
                 return this.defaultEnchantments;
+            }
+
+            @Override
+            public Object2IntMap<Enchantment> getDefaultEnchantmentLevelIncrease(ItemStack stack) {
+                return this.defaultEnchantmentLevelIncreases;
             }
 
             @Override

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -182,7 +182,7 @@ public class ToolDefinitionBuilder {
     }
 
     public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, int level) {
-        return this.defaultEnchantment(enchantment, (double) level, 0);
+        return this.defaultEnchantment(enchantment, level, 0);
     }
 
     public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, double level, double growth) {

--- a/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolDefinitionBuilder.java
@@ -3,9 +3,7 @@ package gregtech.api.items.toolitem;
 import com.google.common.collect.ImmutableList;
 import gregtech.api.items.toolitem.aoe.AoESymmetrical;
 import gregtech.api.items.toolitem.behavior.IToolBehavior;
-import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.*;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -44,9 +42,7 @@ public class ToolDefinitionBuilder {
     private final Set<Block> effectiveBlocks = new ObjectOpenHashSet<>();
     private final Set<Material> effectiveMaterials = new ObjectOpenHashSet<>();
     private Predicate<IBlockState> effectiveStates;
-    private Object2IntMap<Enchantment> defaultEnchantments = new Object2IntArrayMap<>();
-
-    private Object2IntMap<Enchantment> defaultEnchantmentLevelIncreases = new Object2IntArrayMap<>();
+    private Object2ObjectMap<Enchantment, EnchantmentLevel> defaultEnchantments = new Object2ObjectArrayMap<>();
 
     public ToolDefinitionBuilder behaviors(IToolBehavior... behaviours) {
         Collections.addAll(this.behaviours, behaviours);
@@ -186,14 +182,14 @@ public class ToolDefinitionBuilder {
     }
 
     public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, int level) {
-        this.defaultEnchantments.put(enchantment, level);
+        return this.defaultEnchantment(enchantment, (double) level, 0);
+    }
+
+    public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, double level, double growth) {
+        this.defaultEnchantments.put(enchantment, new EnchantmentLevel(level, growth));
         return this;
     }
 
-    public ToolDefinitionBuilder defaultEnchantmentLevelIncrease(Enchantment enchantment, int increase) {
-        this.defaultEnchantmentLevelIncreases.put(enchantment, increase);
-        return this;
-    }
 
     public IGTToolDefinition build() {
         return new IGTToolDefinition() {
@@ -217,9 +213,7 @@ public class ToolDefinitionBuilder {
             private final Supplier<ItemStack> brokenStack = ToolDefinitionBuilder.this.brokenStack;
             private final AoESymmetrical aoeSymmetrical = ToolDefinitionBuilder.this.aoeSymmetrical;
             private final Predicate<IBlockState> effectiveStatePredicate;
-            private final Object2IntMap<Enchantment> defaultEnchantments = ToolDefinitionBuilder.this.defaultEnchantments;
-            private final Object2IntMap<Enchantment> defaultEnchantmentLevelIncreases = ToolDefinitionBuilder.this.defaultEnchantmentLevelIncreases;
-
+            private final Object2ObjectMap<Enchantment, EnchantmentLevel> defaultEnchantments = ToolDefinitionBuilder.this.defaultEnchantments;
 
             {
                 Set<Block> effectiveBlocks = ToolDefinitionBuilder.this.effectiveBlocks;
@@ -316,13 +310,8 @@ public class ToolDefinitionBuilder {
             }
 
             @Override
-            public Object2IntMap<Enchantment> getDefaultEnchantments(ItemStack stack) {
-                return this.defaultEnchantments;
-            }
-
-            @Override
-            public Object2IntMap<Enchantment> getDefaultEnchantmentLevelIncrease(ItemStack stack) {
-                return this.defaultEnchantmentLevelIncreases;
+            public Object2ObjectMap<Enchantment, EnchantmentLevel> getDefaultEnchantments(ItemStack stack) {
+                return Object2ObjectMaps.unmodifiable(this.defaultEnchantments);
             }
 
             @Override

--- a/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
@@ -186,7 +186,7 @@ public final class ToolHelper {
         if (toolProperty != null) {
             toolProperty.getEnchantments().forEach((enchantment, level) -> {
                 if (stack.getItem().canApplyAtEnchantingTable(stack, enchantment)) {
-                    stack.addEnchantment(enchantment, level);
+                    stack.addEnchantment(enchantment, level.getLevel(toolProperty.getToolHarvestLevel()));
                 }
             });
         }

--- a/src/main/java/gregtech/api/unification/crafttweaker/MaterialExpansion.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/MaterialExpansion.java
@@ -196,11 +196,17 @@ public class MaterialExpansion {
     @ZenMethod
     @net.minecraftforge.fml.common.Optional.Method(modid = GTValues.MODID_CT)
     public static void addToolEnchantment(Material m, IEnchantment enchantment) {
+        addScaledToolEnchantment(m, enchantment, 0);
+    }
+
+    @ZenMethod
+    @net.minecraftforge.fml.common.Optional.Method(modid = GTValues.MODID_CT)
+    public static void addScaledToolEnchantment(Material m, IEnchantment enchantment, double levelGrowth) {
         if (checkFrozen("add tool enchantment")) return;
         ToolProperty prop = m.getProperty(PropertyKey.TOOL);
         if (prop != null) {
             Enchantment enchantmentType = (Enchantment) enchantment.getDefinition().getInternal();
-            prop.addEnchantmentForTools(enchantmentType, enchantment.getLevel());
+            prop.addEnchantmentForTools(enchantmentType, enchantment.getLevel(), levelGrowth);
         } else logError(m, "change tool enchantments", "Tool");
     }
 

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -1,7 +1,8 @@
 package gregtech.api.unification.material.properties;
 
-import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import gregtech.api.items.toolitem.EnchantmentLevel;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import net.minecraft.enchantment.Enchantment;
 
 public class ToolProperty implements IMaterialProperty<ToolProperty> {
@@ -73,7 +74,7 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     /**
      * Enchantment to be applied to tools made from this Material.
      */
-    private final Object2IntMap<Enchantment> enchantments = new Object2IntArrayMap<>();
+    private final Object2ObjectMap<Enchantment, EnchantmentLevel> enchantments = new Object2ObjectArrayMap();
 
     public ToolProperty(float harvestSpeed, float attackDamage, int durability, int harvestLevel) {
         this.harvestSpeed = harvestSpeed;
@@ -150,7 +151,7 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
         this.isUnbreakable = isUnbreakable;
     }
 
-    public Object2IntMap<Enchantment> getEnchantments() {
+    public Object2ObjectMap<Enchantment, EnchantmentLevel> getEnchantments() {
         return enchantments;
     }
 
@@ -176,7 +177,11 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     }
 
     public void addEnchantmentForTools(Enchantment enchantment, int level) {
-        enchantments.put(enchantment, level);
+        this.addEnchantmentForTools(enchantment, level, 0);
+    }
+
+    public void addEnchantmentForTools(Enchantment enchantment, double level, double levelGrowth) {
+        enchantments.put(enchantment, new EnchantmentLevel(level, levelGrowth));
     }
 
     public static class Builder {

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -74,7 +74,7 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     /**
      * Enchantment to be applied to tools made from this Material.
      */
-    private final Object2ObjectMap<Enchantment, EnchantmentLevel> enchantments = new Object2ObjectArrayMap();
+    private final Object2ObjectMap<Enchantment, EnchantmentLevel> enchantments = new Object2ObjectArrayMap<>();
 
     public ToolProperty(float harvestSpeed, float attackDamage, int durability, int harvestLevel) {
         this.harvestSpeed = harvestSpeed;


### PR DESCRIPTION
## What
This PR is intended to fix an issue with tools being applied default enchantments from other tool types, as well as to expand the API slightly in the process, by adding functionality for letting default enchantment levels increase as the material level increases. The first issue had been made apparent by other sword items taking on the butchery knife's looting III.

## Implementation Details
There is probably a better way to implement the default enchantment level increase, as well as a better way to name it in the code.

## Outcome
Fixes other GT swords having Looting III unnecessarily

## Potential Compatibility Issues
The new method added to IGTToolDefinition will require any other implementations of it to error, and anything reliant on the current oddity of GT default enchantments will also break as a result of this PR.