### PR TITLE
Better cache strategy for ore dictionary / ore dictionary filter

### DIFF
--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -162,7 +162,7 @@ public final class ModHandler {
     public static ItemStack getBurningFuelRemainder(ItemStack fuelStack) {
         float remainderChance;
         ItemStack remainder;
-        if (OreDictUnifier.getOreDictionaryNames(fuelStack).contains("fuelCoke")) {
+        if (OreDictUnifier.hasOreDictionary(fuelStack, "fuelCoke")) {
             remainder = OreDictUnifier.get(OrePrefix.dust, Materials.Ash);
             remainderChance = 0.5f;
         } else {

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -172,7 +172,7 @@ public class OreDictUnifier {
     }
 
     @Nonnull
-    public static Set<String> getOreDictionaryNames(ItemStack itemStack) {
+    public static Set<String> getOreDictionaryNames(@Nonnull ItemStack itemStack) {
         if (itemStack.isEmpty()) return Collections.emptySet();
         ItemVariantMap<Set<String>> nameEntry = stackOreDictName.get(itemStack.getItem());
         if (nameEntry == null) return Collections.emptySet();
@@ -192,6 +192,21 @@ public class OreDictUnifier {
     public static ItemVariantMap<Set<String>> getOreDictionaryEntry(@Nonnull Item item) {
         ItemVariantMap.Mutable<Set<String>> entry = stackOreDictName.get(item);
         return entry == null ? ItemVariantMap.empty() : ItemVariantMap.unmodifiableSetView(entry);
+    }
+
+    public static boolean hasOreDictionary(@Nonnull ItemStack itemStack, @Nonnull String oreDictName) {
+        if (itemStack.isEmpty()) return false;
+        ItemVariantMap<Set<String>> nameEntry = stackOreDictName.get(itemStack.getItem());
+        if (nameEntry == null) return false;
+
+        short itemDamage = (short) GTUtility.getActualItemDamageFromStack(itemStack);
+        Set<String> names = nameEntry.getEntry(itemDamage);
+        if (names != null && names.contains(oreDictName)) return true;
+
+        if (itemDamage == GTValues.W) return false;
+
+        Set<String> wildcardNames = nameEntry.getEntry(GTValues.W);
+        return wildcardNames != null && wildcardNames != names && wildcardNames.contains(oreDictName);
     }
 
     public static List<ItemStack> getAllWithOreDictionaryName(String oreDictionaryName) {

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -177,7 +177,7 @@ public class OreDictUnifier {
         if (itemStack.isEmpty()) return Collections.emptySet();
         ItemVariantMap<Set<String>> nameEntry = stackOreDictName.get(itemStack.getItem());
         if (nameEntry == null) return Collections.emptySet();
-        short itemDamage = (short) GTUtility.getActualItemDamageFromStack(itemStack);
+        short itemDamage = (short) itemStack.getItemDamage();
         Set<String> names = nameEntry.get(itemDamage);
         Set<String> wildcardNames = itemDamage == GTValues.W ? null : nameEntry.get(GTValues.W);
         if (names == null) {
@@ -210,7 +210,7 @@ public class OreDictUnifier {
         ItemVariantMap<Set<String>> nameEntry = stackOreDictName.get(itemStack.getItem());
         if (nameEntry == null) return false;
 
-        short itemDamage = (short) GTUtility.getActualItemDamageFromStack(itemStack);
+        short itemDamage = (short) itemStack.getItemDamage();
         Set<String> names = nameEntry.get(itemDamage);
         if (names != null && names.contains(oreDictName)) return true;
 

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -188,10 +188,20 @@ public class OreDictUnifier {
         }
     }
 
-    @Nonnull
+    @Nullable
     public static ItemVariantMap<Set<String>> getOreDictionaryEntry(@Nonnull Item item) {
         ItemVariantMap.Mutable<Set<String>> entry = stackOreDictName.get(item);
+        return entry == null ? null : ItemVariantMap.unmodifiableSetView(entry);
+    }
+
+    @Nonnull
+    public static ItemVariantMap<Set<String>> getOreDictionaryEntryOrEmpty(@Nonnull Item item) {
+        ItemVariantMap.Mutable<Set<String>> entry = stackOreDictName.get(item);
         return entry == null ? ItemVariantMap.empty() : ItemVariantMap.unmodifiableSetView(entry);
+    }
+
+    public static boolean hasOreDictionaryEntry(@Nonnull Item item) {
+        return stackOreDictName.containsKey(item);
     }
 
     public static boolean hasOreDictionary(@Nonnull ItemStack itemStack, @Nonnull String oreDictName) {

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -2,20 +2,19 @@ package gregtech.api.unification;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.MarkerMaterial;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemAndMetadata;
-import gregtech.api.unification.stack.ItemMaterialInfo;
-import gregtech.api.unification.stack.MaterialStack;
-import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.api.unification.stack.*;
 import gregtech.api.util.CustomModPriorityComparator;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.MinecraftForge;
@@ -42,7 +41,7 @@ public class OreDictUnifier {
     private static final Map<ItemAndMetadata, ItemMaterialInfo> materialUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<ItemAndMetadata, UnificationEntry> stackUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<UnificationEntry, ArrayList<ItemAndMetadata>> stackUnificationItems = new Object2ObjectOpenHashMap<>();
-    private static final Map<ItemAndMetadata, Set<String>> stackOreDictName = new Object2ObjectOpenHashMap<>();
+    private static final Map<Item, ItemVariantMap.Mutable<Set<String>>> stackOreDictName = new Object2ObjectOpenHashMap<>();
     private static final Map<String, List<ItemStack>> oreDictNameStacks = new Object2ObjectOpenHashMap<>();
 
     @Nullable
@@ -105,10 +104,16 @@ public class OreDictUnifier {
 
     @SubscribeEvent
     public static void onItemRegistration(OreRegisterEvent event) {
-        ItemAndMetadata key = new ItemAndMetadata(event.getOre());
         String oreName = event.getName();
         //cache this registration by name
-        stackOreDictName.computeIfAbsent(key, k -> new HashSet<>()).add(oreName);
+        ItemVariantMap.Mutable<Set<String>> entry = stackOreDictName.computeIfAbsent(event.getOre().getItem(),
+                item -> item.getHasSubtypes() ? new MultiItemVariantMap<>() : new SingleItemVariantMap<>());
+        Set<String> set = entry.getEntry(event.getOre());
+        if (set == null) {
+            set = new HashSet<>();
+            entry.setEntry(event.getOre(), set);
+        }
+        set.add(oreName);
         List<ItemStack> itemStackListForOreDictName = oreDictNameStacks.computeIfAbsent(oreName, k -> new ArrayList<>());
         addAndSort(itemStackListForOreDictName, event.getOre().copy(), getItemStackComparator());
 
@@ -154,6 +159,7 @@ public class OreDictUnifier {
 
         //finally register item
         if (orePrefix != null && (material != null || orePrefix.isSelfReferencing)) {
+            ItemAndMetadata key = new ItemAndMetadata(event.getOre());
             UnificationEntry unificationEntry = new UnificationEntry(orePrefix, material);
             ArrayList<ItemAndMetadata> itemListForUnifiedEntry = stackUnificationItems.computeIfAbsent(unificationEntry, p -> new ArrayList<>());
             addAndSort(itemListForUnifiedEntry, key, getSimpleItemStackComparator());
@@ -165,18 +171,27 @@ public class OreDictUnifier {
         }
     }
 
+    @Nonnull
     public static Set<String> getOreDictionaryNames(ItemStack itemStack) {
         if (itemStack.isEmpty()) return Collections.emptySet();
-        ItemAndMetadata key = new ItemAndMetadata(itemStack);
-        Set<String> names = stackOreDictName.get(key);
-        Set<String> wildcardNames = key.isWildcard() ? null : stackOreDictName.get(key.toWildcard());
+        ItemVariantMap<Set<String>> nameEntry = stackOreDictName.get(itemStack.getItem());
+        if (nameEntry == null) return Collections.emptySet();
+        short itemDamage = (short) GTUtility.getActualItemDamageFromStack(itemStack);
+        Set<String> names = nameEntry.getEntry(itemDamage);
+        Set<String> wildcardNames = itemDamage == GTValues.W ? null : nameEntry.getEntry(GTValues.W);
         if (names == null) {
             return wildcardNames == null ? Collections.emptySet() : Collections.unmodifiableSet(wildcardNames);
-        } else if (wildcardNames == null) {
+        } else if (wildcardNames == null || names == wildcardNames) { // single variant items have identical entries
             return Collections.unmodifiableSet(names);
         } else {
             return Sets.union(names, wildcardNames);
         }
+    }
+
+    @Nonnull
+    public static ItemVariantMap<Set<String>> getOreDictionaryEntry(@Nonnull Item item) {
+        ItemVariantMap.Mutable<Set<String>> entry = stackOreDictName.get(item);
+        return entry == null ? ItemVariantMap.empty() : ItemVariantMap.unmodifiableSetView(entry);
     }
 
     public static List<ItemStack> getAllWithOreDictionaryName(String oreDictionaryName) {

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -13,6 +13,7 @@ import gregtech.api.util.CustomModPriorityComparator;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -108,10 +109,10 @@ public class OreDictUnifier {
         //cache this registration by name
         ItemVariantMap.Mutable<Set<String>> entry = stackOreDictName.computeIfAbsent(event.getOre().getItem(),
                 item -> item.getHasSubtypes() ? new MultiItemVariantMap<>() : new SingleItemVariantMap<>());
-        Set<String> set = entry.getEntry(event.getOre());
+        Set<String> set = entry.get(event.getOre());
         if (set == null) {
-            set = new HashSet<>();
-            entry.setEntry(event.getOre(), set);
+            set = new ObjectOpenHashSet<>();
+            entry.put(event.getOre(), set);
         }
         set.add(oreName);
         List<ItemStack> itemStackListForOreDictName = oreDictNameStacks.computeIfAbsent(oreName, k -> new ArrayList<>());
@@ -177,8 +178,8 @@ public class OreDictUnifier {
         ItemVariantMap<Set<String>> nameEntry = stackOreDictName.get(itemStack.getItem());
         if (nameEntry == null) return Collections.emptySet();
         short itemDamage = (short) GTUtility.getActualItemDamageFromStack(itemStack);
-        Set<String> names = nameEntry.getEntry(itemDamage);
-        Set<String> wildcardNames = itemDamage == GTValues.W ? null : nameEntry.getEntry(GTValues.W);
+        Set<String> names = nameEntry.get(itemDamage);
+        Set<String> wildcardNames = itemDamage == GTValues.W ? null : nameEntry.get(GTValues.W);
         if (names == null) {
             return wildcardNames == null ? Collections.emptySet() : Collections.unmodifiableSet(wildcardNames);
         } else if (wildcardNames == null || names == wildcardNames) { // single variant items have identical entries
@@ -210,12 +211,12 @@ public class OreDictUnifier {
         if (nameEntry == null) return false;
 
         short itemDamage = (short) GTUtility.getActualItemDamageFromStack(itemStack);
-        Set<String> names = nameEntry.getEntry(itemDamage);
+        Set<String> names = nameEntry.get(itemDamage);
         if (names != null && names.contains(oreDictName)) return true;
 
         if (itemDamage == GTValues.W) return false;
 
-        Set<String> wildcardNames = nameEntry.getEntry(GTValues.W);
+        Set<String> wildcardNames = nameEntry.get(GTValues.W);
         return wildcardNames != null && wildcardNames != names && wildcardNames.contains(oreDictName);
     }
 

--- a/src/main/java/gregtech/api/unification/stack/EmptyVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/EmptyVariantMap.java
@@ -1,0 +1,34 @@
+package gregtech.api.unification.stack;
+
+import javax.annotation.Nullable;
+
+/**
+ * An unmodifiable {@link ItemVariantMap} instance with no elements.
+ *
+ * @see ItemVariantMap#empty()
+ */
+final class EmptyVariantMap implements ItemVariantMap<Object> {
+
+    static final EmptyVariantMap INSTANCE = new EmptyVariantMap();
+
+    @Override
+    public boolean hasNonWildcardEntry() {
+        return false;
+    }
+
+    @Override
+    public boolean hasEntry(short meta) {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Object getEntry(short meta) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyEntry";
+    }
+}

--- a/src/main/java/gregtech/api/unification/stack/EmptyVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/EmptyVariantMap.java
@@ -17,13 +17,13 @@ final class EmptyVariantMap implements ItemVariantMap<Object> {
     }
 
     @Override
-    public boolean hasEntry(short meta) {
+    public boolean has(short meta) {
         return false;
     }
 
     @Nullable
     @Override
-    public Object getEntry(short meta) {
+    public Object get(short meta) {
         return null;
     }
 

--- a/src/main/java/gregtech/api/unification/stack/ItemAndMetadata.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemAndMetadata.java
@@ -1,7 +1,6 @@
 package gregtech.api.unification.stack;
 
 import gregtech.api.GTValues;
-import gregtech.api.util.GTUtility;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -20,7 +19,7 @@ public final class ItemAndMetadata {
 
     public ItemAndMetadata(@Nonnull ItemStack itemStack) {
         this.item = itemStack.getItem();
-        this.itemDamage = GTUtility.getActualItemDamageFromStack(itemStack);
+        this.itemDamage = itemStack.getItemDamage();
     }
 
     @Nonnull

--- a/src/main/java/gregtech/api/unification/stack/ItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemVariantMap.java
@@ -24,7 +24,7 @@ public interface ItemVariantMap<E> {
 
     /**
      * @return {@code true} if there's any nonnull value associated with some item
-     * metadata, excluding metadata value of {@code 32767}; i.e. "wildcard".
+     * metadata, excluding metadata value of {@link GTValues#W} {@code (32767)}.
      * @see #hasWildcardEntry()
      */
     boolean hasNonWildcardEntry();
@@ -34,7 +34,7 @@ public interface ItemVariantMap<E> {
      * @return {@code true} if there's a nonnull value associated with given item
      * metadata, {@code false} otherwise.
      */
-    boolean hasEntry(short meta);
+    boolean has(short meta);
 
     /**
      * Get value associated with given item metadata. The associated value is always
@@ -46,7 +46,7 @@ public interface ItemVariantMap<E> {
      * values associated.
      */
     @Nullable
-    E getEntry(short meta);
+    E get(short meta);
 
     /**
      * @return {@code true} if there's no value associated with any item metadata.
@@ -57,11 +57,11 @@ public interface ItemVariantMap<E> {
 
     /**
      * @return {@code true} if there's a nonnull value associated with item
-     * metadata {@code 32767}; i.e. "wildcard".
+     * metadata {@link GTValues#W} {@code (32767)}.
      * @see #hasNonWildcardEntry()
      */
     default boolean hasWildcardEntry() {
-        return hasEntry(GTValues.W);
+        return has(GTValues.W);
     }
 
     /**
@@ -69,8 +69,8 @@ public interface ItemVariantMap<E> {
      * @return {@code true} if there's a nonnull value associated with item damage of
      * the item, {@code false} otherwise.
      */
-    default boolean hasEntry(@Nonnull ItemStack stack) {
-        return hasEntry((short) GTUtility.getActualItemDamageFromStack(stack));
+    default boolean has(@Nonnull ItemStack stack) {
+        return has((short) GTUtility.getActualItemDamageFromStack(stack));
     }
 
     /**
@@ -83,8 +83,8 @@ public interface ItemVariantMap<E> {
      * no values associated.
      */
     @Nullable
-    default E getEntry(@Nonnull ItemStack stack) {
-        return getEntry((short) GTUtility.getActualItemDamageFromStack(stack));
+    default E get(@Nonnull ItemStack stack) {
+        return get((short) GTUtility.getActualItemDamageFromStack(stack));
     }
 
     /**
@@ -133,7 +133,7 @@ public interface ItemVariantMap<E> {
          * there was no such value.
          */
         @Nullable
-        E setEntry(short meta, @Nullable E e);
+        E put(short meta, @Nullable E e);
 
         /**
          * Associates item damage of the item to given value; previous association will be
@@ -146,8 +146,8 @@ public interface ItemVariantMap<E> {
          * there was no such value.
          */
         @Nullable
-        default E setEntry(@Nonnull ItemStack stack, @Nullable E e) {
-            return setEntry((short) GTUtility.getActualItemDamageFromStack(stack), e);
+        default E put(@Nonnull ItemStack stack, @Nullable E e) {
+            return put((short) GTUtility.getActualItemDamageFromStack(stack), e);
         }
     }
 }

--- a/src/main/java/gregtech/api/unification/stack/ItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemVariantMap.java
@@ -1,7 +1,6 @@
 package gregtech.api.unification.stack;
 
 import gregtech.api.GTValues;
-import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
 
 import javax.annotation.Nonnull;
@@ -70,7 +69,7 @@ public interface ItemVariantMap<E> {
      * the item, {@code false} otherwise.
      */
     default boolean has(@Nonnull ItemStack stack) {
-        return has((short) GTUtility.getActualItemDamageFromStack(stack));
+        return has((short) stack.getItemDamage());
     }
 
     /**
@@ -84,7 +83,7 @@ public interface ItemVariantMap<E> {
      */
     @Nullable
     default E get(@Nonnull ItemStack stack) {
-        return get((short) GTUtility.getActualItemDamageFromStack(stack));
+        return get((short) stack.getItemDamage());
     }
 
     /**
@@ -147,7 +146,7 @@ public interface ItemVariantMap<E> {
          */
         @Nullable
         default E put(@Nonnull ItemStack stack, @Nullable E e) {
-            return put((short) GTUtility.getActualItemDamageFromStack(stack), e);
+            return put((short) stack.getItemDamage(), e);
         }
     }
 }

--- a/src/main/java/gregtech/api/unification/stack/ItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemVariantMap.java
@@ -1,0 +1,153 @@
+package gregtech.api.unification.stack;
+
+import gregtech.api.GTValues;
+import gregtech.api.util.GTUtility;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
+
+/**
+ * An abstraction of dictionary-like collection with each item variant as keys.
+ * <p>
+ * Despite the name, the actual implementation of the class may be unrelated to maps.
+ * Nonetheless, this class supports map-like access to whatever form of data they're
+ * holding, with additional methods like {@link #hasNonWildcardEntry()} to help
+ * certain operations special to item variants.
+ *
+ * @param <E> type of the elements
+ * @see SingleItemVariantMap
+ * @see MultiItemVariantMap
+ */
+public interface ItemVariantMap<E> {
+
+    /**
+     * @return {@code true} if there's any nonnull value associated with some item
+     * metadata, excluding metadata value of {@code 32767}; i.e. "wildcard".
+     * @see #hasWildcardEntry()
+     */
+    boolean hasNonWildcardEntry();
+
+    /**
+     * @param meta item metadata
+     * @return {@code true} if there's a nonnull value associated with given item
+     * metadata, {@code false} otherwise.
+     */
+    boolean hasEntry(short meta);
+
+    /**
+     * Get value associated with given item metadata. The associated value is always
+     * nonnull; if {@code null} is returned, it indicates the metadata is not associated
+     * with any value at the moment.
+     *
+     * @param meta item metadata
+     * @return value associated with given item metadata, or {@code null} if there's no
+     * values associated.
+     */
+    @Nullable
+    E getEntry(short meta);
+
+    /**
+     * @return {@code true} if there's no value associated with any item metadata.
+     */
+    default boolean isEmpty() {
+        return !hasWildcardEntry() && !hasNonWildcardEntry();
+    }
+
+    /**
+     * @return {@code true} if there's a nonnull value associated with item
+     * metadata {@code 32767}; i.e. "wildcard".
+     * @see #hasNonWildcardEntry()
+     */
+    default boolean hasWildcardEntry() {
+        return hasEntry(GTValues.W);
+    }
+
+    /**
+     * @param stack item stack
+     * @return {@code true} if there's a nonnull value associated with item damage of
+     * the item, {@code false} otherwise.
+     */
+    default boolean hasEntry(@Nonnull ItemStack stack) {
+        return hasEntry((short) GTUtility.getActualItemDamageFromStack(stack));
+    }
+
+    /**
+     * Get value associated with item damage of the item. The associated value is always
+     * nonnull; if {@code null} is returned, it indicates the metadata is not associated
+     * with any value at the moment.
+     *
+     * @param stack item stack
+     * @return value associated with item damage of the item, or {@code null} if there's
+     * no values associated.
+     */
+    @Nullable
+    default E getEntry(@Nonnull ItemStack stack) {
+        return getEntry((short) GTUtility.getActualItemDamageFromStack(stack));
+    }
+
+    /**
+     * Returns an unmodifiable view of {@code map}. The returned variant map will return set of elements
+     * wrapped with {@link java.util.Collections#unmodifiableSet(Set) Collections#unmodifiableSet}.
+     *
+     * @param map variant map to wrap
+     * @param <E> type of the element
+     * @return an unmodifiable view of {@code map} with {@link Set} of elements as values.
+     */
+    @Nonnull
+    static <E> ItemVariantMap<Set<E>> unmodifiableSetView(@Nonnull ItemVariantMap<? extends Set<E>> map) {
+        return new UnmodifiableSetViewVariantMap<>(map);
+    }
+
+    /**
+     * @param <E> type of the element
+     * @return an unmodifiable instance of variant map with no entries.
+     */
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    static <E> ItemVariantMap<E> empty() {
+        return (ItemVariantMap<E>) EmptyVariantMap.INSTANCE;
+    }
+
+    /**
+     * {@link ItemVariantMap} with methods for modification.
+     *
+     * @param <E> type of the elements
+     */
+    interface Mutable<E> extends ItemVariantMap<E> {
+
+        /**
+         * Discard all associated value contained in this variant map.
+         */
+        void clear();
+
+        /**
+         * Associates the item metadata to given value; previous association will be
+         * overwritten. If {@code null} was provided as value, the association is removed
+         * instead.
+         *
+         * @param meta item metadata
+         * @param e    new value, or {@code null} for entry removal
+         * @return previous value associated with given item metadata, or {@code null} if
+         * there was no such value.
+         */
+        @Nullable
+        E setEntry(short meta, @Nullable E e);
+
+        /**
+         * Associates item damage of the item to given value; previous association will be
+         * overwritten. If {@code null} was provided as value, the association is removed
+         * instead.
+         *
+         * @param stack item stack
+         * @param e     new value, or {@code null} for entry removal
+         * @return previous value associated with given item metadata, or {@code null} if
+         * there was no such value.
+         */
+        @Nullable
+        default E setEntry(@Nonnull ItemStack stack, @Nullable E e) {
+            return setEntry((short) GTUtility.getActualItemDamageFromStack(stack), e);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/unification/stack/MultiItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/MultiItemVariantMap.java
@@ -26,7 +26,7 @@ public final class MultiItemVariantMap<E> implements ItemVariantMap.Mutable<E> {
     }
 
     @Override
-    public boolean hasEntry(short meta) {
+    public boolean has(short meta) {
         if (meta == GTValues.W) {
             return this.wildcardEntry != null;
         } else {
@@ -36,7 +36,7 @@ public final class MultiItemVariantMap<E> implements ItemVariantMap.Mutable<E> {
 
     @Nullable
     @Override
-    public E getEntry(short meta) {
+    public E get(short meta) {
         if (meta == GTValues.W) {
             return this.wildcardEntry;
         } else if (this.itemDamageEntries != null) {
@@ -48,7 +48,7 @@ public final class MultiItemVariantMap<E> implements ItemVariantMap.Mutable<E> {
 
     @Nullable
     @Override
-    public E setEntry(short meta, @Nullable E e) {
+    public E put(short meta, @Nullable E e) {
         if (meta == GTValues.W) {
             E cache = this.wildcardEntry;
             this.wildcardEntry = e;

--- a/src/main/java/gregtech/api/unification/stack/MultiItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/MultiItemVariantMap.java
@@ -1,0 +1,93 @@
+package gregtech.api.unification.stack;
+
+import gregtech.api.GTValues;
+import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
+import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@link ItemVariantMap} implementation backed by a hashmap. Each metadata is
+ * treated as separate entry in hashmap, and get/set accesses treat each metadata
+ * as a unique item variant.
+ *
+ * @param <E> type of the elements
+ */
+public final class MultiItemVariantMap<E> implements ItemVariantMap.Mutable<E> {
+
+    @Nullable
+    private Short2ObjectOpenHashMap<E> itemDamageEntries;
+    @Nullable
+    private E wildcardEntry;
+
+    @Override
+    public boolean hasNonWildcardEntry() {
+        return this.itemDamageEntries != null && !this.itemDamageEntries.isEmpty();
+    }
+
+    @Override
+    public boolean hasEntry(short meta) {
+        if (meta == GTValues.W) {
+            return this.wildcardEntry != null;
+        } else {
+            return this.itemDamageEntries != null && this.itemDamageEntries.containsKey(meta);
+        }
+    }
+
+    @Nullable
+    @Override
+    public E getEntry(short meta) {
+        if (meta == GTValues.W) {
+            return this.wildcardEntry;
+        } else if (this.itemDamageEntries != null) {
+            return this.itemDamageEntries.get(meta);
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    @Override
+    public E setEntry(short meta, @Nullable E e) {
+        if (meta == GTValues.W) {
+            E cache = this.wildcardEntry;
+            this.wildcardEntry = e;
+            return cache;
+        } else if (e != null) {
+            if (this.itemDamageEntries == null) {
+                this.itemDamageEntries = new Short2ObjectOpenHashMap<>();
+            }
+            return this.itemDamageEntries.put(meta, e);
+        } else {
+            if (this.itemDamageEntries != null) {
+                return this.itemDamageEntries.remove(meta);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    @Override
+    public void clear() {
+        this.itemDamageEntries = null;
+        this.wildcardEntry = null;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder stb = new StringBuilder().append("MultiItemVariantMap[");
+        boolean first = true;
+        if (itemDamageEntries != null) {
+            for (Short2ObjectMap.Entry<E> e : itemDamageEntries.short2ObjectEntrySet()) {
+                if (first) first = false;
+                else stb.append(',');
+                stb.append(e.getShortKey()).append("=").append(e.getValue());
+            }
+        }
+        if (wildcardEntry != null) {
+            if (!first) stb.append(',');
+            stb.append("*=").append(wildcardEntry);
+        }
+        return stb.append(']').toString();
+    }
+}

--- a/src/main/java/gregtech/api/unification/stack/SingleItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/SingleItemVariantMap.java
@@ -5,7 +5,7 @@ import javax.annotation.Nullable;
 /**
  * {@link ItemVariantMap} implementation which holds one shared value for all
  * variants of an item. All operations, including set accesses like
- * {@link #setEntry(short, Object)}, regardless of the metadata value provided,
+ * {@link #put(short, Object)}, regardless of the metadata value provided,
  * will retrieve or modify the same and only entry of this collection.
  *
  * @param <E> type of the elements
@@ -15,7 +15,7 @@ public final class SingleItemVariantMap<E> implements ItemVariantMap.Mutable<E> 
     @Nullable
     private E entry;
 
-    public boolean hasEntry() {
+    public boolean has() {
         return entry != null;
     }
 
@@ -32,7 +32,7 @@ public final class SingleItemVariantMap<E> implements ItemVariantMap.Mutable<E> 
      * @return previous valued contained, or {@code null} if there was no such value.
      */
     @Nullable
-    public E setEntry(@Nullable E e) {
+    public E put(@Nullable E e) {
         E cache = this.entry;
         this.entry = e;
         return cache;
@@ -44,20 +44,20 @@ public final class SingleItemVariantMap<E> implements ItemVariantMap.Mutable<E> 
     }
 
     @Override
-    public boolean hasEntry(short meta) {
+    public boolean has(short meta) {
         return entry != null;
     }
 
     @Nullable
     @Override
-    public E getEntry(short meta) {
+    public E get(short meta) {
         return entry;
     }
 
     @Nullable
     @Override
-    public E setEntry(short meta, @Nullable E e) {
-        return setEntry(e);
+    public E put(short meta, @Nullable E e) {
+        return put(e);
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/stack/SingleItemVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/SingleItemVariantMap.java
@@ -1,0 +1,74 @@
+package gregtech.api.unification.stack;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@link ItemVariantMap} implementation which holds one shared value for all
+ * variants of an item. All operations, including set accesses like
+ * {@link #setEntry(short, Object)}, regardless of the metadata value provided,
+ * will retrieve or modify the same and only entry of this collection.
+ *
+ * @param <E> type of the elements
+ */
+public final class SingleItemVariantMap<E> implements ItemVariantMap.Mutable<E> {
+
+    @Nullable
+    private E entry;
+
+    public boolean hasEntry() {
+        return entry != null;
+    }
+
+    /**
+     * @return the value contained
+     */
+    @Nullable
+    public E getEntry() {
+        return entry;
+    }
+
+    /**
+     * @param e new value, or {@code null} for entry removal
+     * @return previous valued contained, or {@code null} if there was no such value.
+     */
+    @Nullable
+    public E setEntry(@Nullable E e) {
+        E cache = this.entry;
+        this.entry = e;
+        return cache;
+    }
+
+    @Override
+    public boolean hasNonWildcardEntry() {
+        return entry != null;
+    }
+
+    @Override
+    public boolean hasEntry(short meta) {
+        return entry != null;
+    }
+
+    @Nullable
+    @Override
+    public E getEntry(short meta) {
+        return entry;
+    }
+
+    @Nullable
+    @Override
+    public E setEntry(short meta, @Nullable E e) {
+        return setEntry(e);
+    }
+
+    @Override
+    public void clear() {
+        this.entry = null;
+    }
+
+    @Override
+    public String toString() {
+        return "SingleItemVariantMap{" +
+                "entry=" + this.entry +
+                '}';
+    }
+}

--- a/src/main/java/gregtech/api/unification/stack/UnmodifiableSetViewVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/UnmodifiableSetViewVariantMap.java
@@ -1,0 +1,53 @@
+package gregtech.api.unification.stack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Unmodifiable view of another {@link ItemVariantMap} with {@link Set} of elements as values.
+ *
+ * @param <E> type of the elements
+ * @see ItemVariantMap#unmodifiableSetView(ItemVariantMap)
+ */
+final class UnmodifiableSetViewVariantMap<E> implements ItemVariantMap<Set<E>> {
+
+    private final ItemVariantMap<? extends Set<E>> delegate;
+
+    UnmodifiableSetViewVariantMap(@Nonnull ItemVariantMap<? extends Set<E>> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Nullable
+    @Override
+    public Set<E> getEntry(short meta) {
+        Set<E> set = delegate.getEntry(meta);
+        return set != null ? Collections.unmodifiableSet(set) : null;
+    }
+
+    @Override
+    public boolean hasNonWildcardEntry() {
+        return delegate.hasNonWildcardEntry();
+    }
+
+    @Override
+    public boolean hasEntry(short meta) {
+        return delegate.hasEntry(meta);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean hasWildcardEntry() {
+        return delegate.hasWildcardEntry();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/src/main/java/gregtech/api/unification/stack/UnmodifiableSetViewVariantMap.java
+++ b/src/main/java/gregtech/api/unification/stack/UnmodifiableSetViewVariantMap.java
@@ -21,8 +21,8 @@ final class UnmodifiableSetViewVariantMap<E> implements ItemVariantMap<Set<E>> {
 
     @Nullable
     @Override
-    public Set<E> getEntry(short meta) {
-        Set<E> set = delegate.getEntry(meta);
+    public Set<E> get(short meta) {
+        Set<E> set = delegate.get(meta);
         return set != null ? Collections.unmodifiableSet(set) : null;
     }
 
@@ -32,8 +32,8 @@ final class UnmodifiableSetViewVariantMap<E> implements ItemVariantMap<Set<E>> {
     }
 
     @Override
-    public boolean hasEntry(short meta) {
-        return delegate.hasEntry(meta);
+    public boolean has(short meta) {
+        return delegate.has(meta);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/BlockLamp.java
+++ b/src/main/java/gregtech/common/blocks/BlockLamp.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks;
 
+import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterials;
@@ -202,10 +203,7 @@ public class BlockLamp extends Block {
     }
 
     public void registerOreDict() {
-        for (int meta = 0; meta < getItemMetadataStates(); meta++) {
-            OreDictUnifier.registerOre(new ItemStack(this, 1, meta),
-                    OrePrefix.lampGt, MarkerMaterials.Color.COLORS.get(color));
-        }
+        OreDictUnifier.registerOre(new ItemStack(this, 1, GTValues.W), OrePrefix.lampGt, MarkerMaterials.Color.COLORS.get(color));
     }
 
     public static boolean isLightActive(IBlockState state) {

--- a/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
@@ -45,7 +45,7 @@ public class BlockFoam extends BlockColored {
     @Override
     public boolean onBlockActivated(@Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull IBlockState state, EntityPlayer playerIn, @Nonnull EnumHand hand, @Nonnull EnumFacing facing, float hitX, float hitY, float hitZ) {
         ItemStack stackInHand = playerIn.getHeldItem(hand);
-        if (!stackInHand.isEmpty() && OreDictUnifier.getOreDictionaryNames(stackInHand).contains("sand")) {
+        if (!stackInHand.isEmpty() && OreDictUnifier.hasOreDictionary(stackInHand, "sand")) {
             worldIn.setBlockState(pos, getPetrifiedBlock(state));
             worldIn.playSound(playerIn, pos, SoundEvents.BLOCK_SAND_PLACE, SoundCategory.BLOCKS, 1.0f, 1.0f);
             if (!playerIn.capabilities.isCreativeMode)

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -4,16 +4,15 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.DrawableWidget;
 import gregtech.api.gui.widgets.ImageWidget;
-import gregtech.api.util.ItemStackHashStrategy;
+import gregtech.api.unification.stack.ItemAndMetadata;
 import gregtech.api.util.oreglob.OreGlob;
 import gregtech.api.util.oreglob.OreGlobCompileResult;
 import gregtech.common.covers.filter.oreglob.impl.ImpossibleOreGlob;
 import gregtech.common.gui.widget.HighlightedTextField;
 import gregtech.common.gui.widget.orefilter.ItemOreFilterTestSlot;
 import gregtech.common.gui.widget.orefilter.OreGlobCompileStatusWidget;
-import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
-import it.unimi.dsi.fastutil.objects.Object2BooleanOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.text.TextFormatting;
@@ -22,13 +21,11 @@ import java.util.function.Consumer;
 
 public class OreDictionaryItemFilter extends ItemFilter {
 
-    private static final Hash.Strategy<ItemStack> HASH_STRATEGY = ItemStackHashStrategy.builder().compareItem(true).compareDamage(true).build();
-
     protected String expression = "";
     private OreGlob glob = ImpossibleOreGlob.getInstance();
     private boolean error;
 
-    private final Object2BooleanMap<ItemStack> matchCache = new Object2BooleanOpenCustomHashMap<>(HASH_STRATEGY);
+    private final Object2BooleanMap<ItemAndMetadata> matchCache = new Object2BooleanOpenHashMap<>();
 
     public String getExpression() {
         return expression;
@@ -123,12 +120,13 @@ public class OreDictionaryItemFilter extends ItemFilter {
 
     public boolean matchesItemStack(ItemStack itemStack) {
         if (this.error) return false;
-        Boolean cached = this.matchCache.get(itemStack);
+        ItemAndMetadata itemAndMetadata = new ItemAndMetadata(itemStack);
+        Boolean cached = this.matchCache.get(itemAndMetadata);
         if (cached != null) {
             return cached;
         }
         boolean matches = this.glob.matches(itemStack);
-        this.matchCache.put(itemStack, matches);
+        this.matchCache.put(itemAndMetadata, matches);
         return matches;
     }
 

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -142,7 +142,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
 
         ItemVariantMap.Mutable<Boolean> cacheEntry = this.matchCache.get(item);
         if (cacheEntry != null) {
-            Boolean cached = cacheEntry.getEntry(itemStack);
+            Boolean cached = cacheEntry.get(itemStack);
             if (cached != null) return cached;
         }
 
@@ -151,7 +151,8 @@ public class OreDictionaryItemFilter extends ItemFilter {
                 // no oredict entries associated
                 Boolean cached = this.noOreDictMatch.getEntry();
                 if (cached == null) {
-                    this.noOreDictMatch.setEntry(cached = this.glob.matches(""));
+                    cached = this.glob.matches("");
+                    this.noOreDictMatch.put(cached);
                 }
                 this.matchCache.put(item, this.noOreDictMatch);
                 return cached;
@@ -163,7 +164,7 @@ public class OreDictionaryItemFilter extends ItemFilter {
             this.matchCache.put(item, cacheEntry);
         }
         boolean matches = this.glob.matches(itemStack);
-        cacheEntry.setEntry(itemStack, matches);
+        cacheEntry.put(itemStack, matches);
         return matches;
     }
 

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -6,8 +6,8 @@ import gregtech.api.gui.widgets.DrawableWidget;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.stack.ItemVariantMap;
-import gregtech.api.unification.stack.SingleItemVariantMap;
 import gregtech.api.unification.stack.MultiItemVariantMap;
+import gregtech.api.unification.stack.SingleItemVariantMap;
 import gregtech.api.util.oreglob.OreGlob;
 import gregtech.api.util.oreglob.OreGlobCompileResult;
 import gregtech.common.covers.filter.oreglob.impl.ImpossibleOreGlob;
@@ -128,13 +128,23 @@ public class OreDictionaryItemFilter extends ItemFilter {
     public boolean matchesItemStack(ItemStack itemStack) {
         if (this.error) return false;
         Item item = itemStack.getItem();
+        ItemVariantMap<Set<String>> oreDictEntry = OreDictUnifier.getOreDictionaryEntry(item);
+
+        if (oreDictEntry == null) {
+            // no oredict entries associated
+            Boolean cached = this.noOreDictMatch.getEntry();
+            if (cached == null) {
+                cached = this.glob.matches("");
+            }
+            this.matchCache.put(item, this.noOreDictMatch);
+            return cached;
+        }
+
         ItemVariantMap.Mutable<Boolean> cacheEntry = this.matchCache.get(item);
         if (cacheEntry != null) {
             Boolean cached = cacheEntry.getEntry(itemStack);
             if (cached != null) return cached;
         }
-
-        ItemVariantMap<Set<String>> oreDictEntry = OreDictUnifier.getOreDictionaryEntry(item);
 
         if (cacheEntry == null) {
             if (oreDictEntry.isEmpty()) {

--- a/src/main/java/gregtech/common/items/tool/TorchPlaceBehavior.java
+++ b/src/main/java/gregtech/common/items/tool/TorchPlaceBehavior.java
@@ -76,8 +76,9 @@ public class TorchPlaceBehavior implements IToolBehavior {
             if (slotItem instanceof ItemBlock) {
                 ItemBlock slotItemBlock = (ItemBlock) slotItem;
                 Block slotBlock = slotItemBlock.getBlock();
-                if (slotBlock == Blocks.TORCH || OreDictUnifier.getOreDictionaryNames(slotStack).stream()
-                        .anyMatch(s -> "torch".equals(s) || "blockTorch".equals(s))) {
+                if (slotBlock == Blocks.TORCH ||
+                        OreDictUnifier.hasOreDictionary(slotStack, "torch") ||
+                        OreDictUnifier.hasOreDictionary(slotStack, "blockTorch")) {
                     IBlockState state = world.getBlockState(pos);
                     Block block = state.getBlock();
                     if (!block.isReplaceable(world, pos)) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityFisher.java
@@ -9,11 +9,10 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
-import gregtech.api.util.GTTransferUtils;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.client.renderer.texture.Textures;
 import gregtech.api.unification.OreDictUnifier;
-import gregtech.common.ConfigHolder;
+import gregtech.api.util.GTTransferUtils;
+import gregtech.client.renderer.texture.Textures;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.resources.I18n;
@@ -61,7 +60,7 @@ public class MetaTileEntityFisher extends TieredMetaTileEntity {
         int rowSize = (int) Math.sqrt(inventorySize);
 
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176,
-                18 + 18 * rowSize + 94)
+                        18 + 18 * rowSize + 94)
                 .label(10, 5, getMetaFullName())
                 .widget(new SlotWidget(importItems, 0, 18, 18, true, true)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.STRING_SLOT_OVERLAY));
@@ -117,7 +116,7 @@ public class MetaTileEntityFisher extends TieredMetaTileEntity {
             @Nonnull
             @Override
             public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-                if (OreDictUnifier.getOreDictionaryNames(stack).contains("string")) {
+                if (OreDictUnifier.hasOreDictionary(stack, "string")) {
                     return super.insertItem(slot, stack, simulate);
                 }
                 return stack;


### PR DESCRIPTION
## What
This PR introduces better cache strategy for ore filter match cache and ore dictionary to item caches in OreDictUnifier.

## Implementation Details
Previous iteration of ore filter match cache used raw `ItemStack`s to store match result. Not only it negatively impacts performance memory-wise (ItemStacks can hold surprisingly large amount of data, unsurprisingly) ItemStacks can theoretically be modified, which would break cache map and cause lookup failure.

Also there is better ways the caches can be handled; just using item and damage as keys have a possibility of producing redundant cache entry and bloating cache map even more. For example, vanilla saplings all have `treeSapling` ore dictionary entry because all variants of the item is covered by the wildcard entry. If we can reuse one cache for all variant of the same item, that's 5 potential entry removed from cache map. Let's say, a mod-added item exists that have 1,000 variants which all of them have wildcard ore dictionary entry. That's 999 potential entry removed from cache map.

Likewise, ore dictionary caches in OreDictUnifier have some rooms for improvement. Currently the map is searched twice for non-wildcard entry and wildcard entry for each `getOreDictionaryNames`. As `Item` class uses default identity hashcode impl, it's plausible to suspect some amount of hashcode collisions are inevitable, which might affect `ItemAndMetadata` lookups.

Another point of improvement is reusing match result for no-oredict items. Current cache calculates and stores the match for each and every no-oredict items checked. Ideally we would reuse one cache for all of them.

I've made custom data collection `ItemVariantMap`, essentially an abstracted form of short to value map. Separating item and metadata into two collection should reduce amount of map searches required for `OreDictUnifier#getOreDictionaryNames` to one.

`ItemVariantMap` have two main implementations - `SingleItemVariantMap`, which shares one data for all variations, and `MultiItemVariantMap`, which holds data for each metadata. These two variations are utilized in both `OreDictUnifier` and `OreDictionaryItemFilter`.

Lastly, things like these:
```java
OreDictUnifier.getOreDictionaryNames(stack).contains("string")
```

were changed to use more efficient method, to avoid the cost of building union wrappers.

## Additional Information
I'm not pleased with how overblown this PR is, but I can't think of better ways to make these. If you have any concerns regarding actual benefit of this changes, please contact Department of Bikeshedding.

The premise of `ItemVariantMap` is that all subtyped items have (1) no ore dictionary, or (2) only a wildcard ore dictionary entry, or (3) have multiple ore dictionary definition with optional wildcard ore dictionary entry. If some subtyped items have only one or two non-wildcard oredict entries, then this approach would become somewhat suboptimal.

## Potential Compatibility Issues
None
