### PR TITLE
Support for recipes with empty output

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -80,13 +80,18 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private int maxOutputs;
     private int maxFluidInputs;
     private int maxFluidOutputs;
-    private final boolean modifyItemInputs, modifyItemOutputs, modifyFluidInputs, modifyFluidOutputs;
+    private final boolean modifyItemInputs;
+    private final boolean modifyItemOutputs;
+    private final boolean modifyFluidInputs;
+    private final boolean modifyFluidOutputs;
     protected final TByteObjectMap<TextureArea> slotOverlays;
     protected TextureArea specialTexture;
     protected int[] specialTexturePosition;
     protected TextureArea progressBarTexture;
     protected MoveType moveType;
     public final boolean isHidden;
+
+    private boolean allowEmptyOutput;
 
     private final VirtualizedRecipeMap virtualizedRecipeMap;
     private final Branch lookup = new Branch();
@@ -101,6 +106,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private RecipeMap<?> smallRecipeMap;
 
     /**
+     * Create and register new instance of RecipeMap with specified properties.
+     *
      * @deprecated Use {@link RecipeMap#RecipeMap(String, int, int, int, int, R, boolean)}
      */
     @SuppressWarnings("unused")
@@ -112,56 +119,51 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     /**
-     * @param unlocalizedName the unlocalized name for the RecipeMap
-     * @param maxInputs the maximum item inputs
-     * @param maxOutputs the maximum item outputs
-     * @param maxFluidInputs the maximum fluid inputs
-     * @param maxFluidOutputs the maximum fluid outputs
+     * Create and register new instance of RecipeMap with specified properties. All
+     * maximum I/O size for item and fluids will be able to be modified.
+     *
+     * @param unlocalizedName      the unlocalized name for the RecipeMap
+     * @param maxInputs            the maximum item inputs
+     * @param maxOutputs           the maximum item outputs
+     * @param maxFluidInputs       the maximum fluid inputs
+     * @param maxFluidOutputs      the maximum fluid outputs
      * @param defaultRecipeBuilder the default RecipeBuilder for the RecipeMap
-     * @param isHidden if the RecipeMap should have a category in JEI
+     * @param isHidden             if the RecipeMap should have a category in JEI
      */
-    public RecipeMap(@Nonnull String unlocalizedName, @Nonnegative int maxInputs, @Nonnegative int maxOutputs,
-                     @Nonnegative int maxFluidInputs, @Nonnegative int maxFluidOutputs, @Nonnull R defaultRecipeBuilder,
+    public RecipeMap(@Nonnull String unlocalizedName,
+                     @Nonnegative int maxInputs,
+                     @Nonnegative int maxOutputs,
+                     @Nonnegative int maxFluidInputs,
+                     @Nonnegative int maxFluidOutputs,
+                     @Nonnull R defaultRecipeBuilder,
                      boolean isHidden) {
-        this.unlocalizedName = unlocalizedName;
-        this.slotOverlays = new TByteObjectHashMap<>();
-        this.progressBarTexture = GuiTextures.PROGRESS_BAR_ARROW;
-        this.moveType = MoveType.HORIZONTAL;
-
-        this.maxInputs = maxInputs;
-        this.maxFluidInputs = maxFluidInputs;
-        this.maxOutputs = maxOutputs;
-        this.maxFluidOutputs = maxFluidOutputs;
-
-        this.modifyItemInputs = true;
-        this.modifyItemOutputs = true;
-        this.modifyFluidInputs = true;
-        this.modifyFluidOutputs = true;
-
-        this.isHidden = isHidden;
-        defaultRecipeBuilder.setRecipeMap(this);
-        this.recipeBuilderSample = defaultRecipeBuilder;
-        RECIPE_MAP_REGISTRY.put(unlocalizedName, this);
-
-        this.virtualizedRecipeMap = GroovyScriptCompat.isLoaded() ? new VirtualizedRecipeMap(this) : null;
+        this(unlocalizedName,
+                maxInputs, true, maxOutputs, true,
+                maxFluidInputs, true, maxFluidOutputs, true,
+                defaultRecipeBuilder, isHidden);
     }
 
     /**
-     * @param unlocalizedName the unlocalized name for the RecipeMap
-     * @param maxInputs the maximum item inputs
-     * @param modifyItemInputs If the Maximum Item Inputs should be modified
-     * @param maxOutputs the maximum item outputs
-     * @param modifyItemOutputs If the Maximum Item Outputs should be modified
-     * @param maxFluidInputs the maximum fluid inputs
-     * @param modifyFluidInputs If the Maximum Fluid Inputs should be modified
-     * @param maxFluidOutputs the maximum fluid outputs
-     * @param modifyFluidOutputs If the Maximum Fluid Outputs should be modified
+     * Create and register new instance of RecipeMap with specified properties.
+     *
+     * @param unlocalizedName      the unlocalized name for the RecipeMap
+     * @param maxInputs            the maximum item inputs
+     * @param modifyItemInputs     if modification of the maximum item input is permitted
+     * @param maxOutputs           the maximum item outputs
+     * @param modifyItemOutputs    if modification of the maximum item output is permitted
+     * @param maxFluidInputs       the maximum fluid inputs
+     * @param modifyFluidInputs    if modification of the maximum fluid input is permitted
+     * @param maxFluidOutputs      the maximum fluid outputs
+     * @param modifyFluidOutputs   if modification of the maximum fluid output is permitted
      * @param defaultRecipeBuilder the default RecipeBuilder for the RecipeMap
-     * @param isHidden if the RecipeMap should have a category in JEI
+     * @param isHidden             if the RecipeMap should have a category in JEI
      */
-    public RecipeMap(@Nonnull String unlocalizedName, @Nonnegative int maxInputs, boolean modifyItemInputs, @Nonnegative int maxOutputs,
-                     boolean modifyItemOutputs, @Nonnegative int maxFluidInputs, boolean modifyFluidInputs,
-                     @Nonnegative int maxFluidOutputs, boolean modifyFluidOutputs, @Nonnull R defaultRecipeBuilder,
+    public RecipeMap(@Nonnull String unlocalizedName,
+                     @Nonnegative int maxInputs, boolean modifyItemInputs,
+                     @Nonnegative int maxOutputs, boolean modifyItemOutputs,
+                     @Nonnegative int maxFluidInputs, boolean modifyFluidInputs,
+                     @Nonnegative int maxFluidOutputs, boolean modifyFluidOutputs,
+                     @Nonnull R defaultRecipeBuilder,
                      boolean isHidden) {
         this.unlocalizedName = unlocalizedName;
         this.slotOverlays = new TByteObjectHashMap<>();
@@ -246,6 +248,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return this;
     }
 
+    public RecipeMap<R> allowEmptyOutput() {
+        this.allowEmptyOutput = true;
+        return this;
+    }
+
     public RecipeMap<R> setSmallRecipeMap(RecipeMap<?> recipeMap) {
         this.smallRecipeMap = recipeMap;
         return this;
@@ -257,6 +264,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     /**
      * Internal usage <strong>only</strong>, use {@link RecipeBuilder#buildAndRegister()}
+     *
      * @param validationResult the validation result from building the recipe
      */
     public void addRecipe(@Nonnull ValidationResult<Recipe> validationResult) {
@@ -328,8 +336,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
-        boolean emptyOutputs = recipe.getOutputs().isEmpty() && recipe.getFluidOutputs().isEmpty() && recipe.getChancedOutputs().isEmpty();
-        if (recipe.getEUt() > 0 && emptyOutputs) {
+        boolean emptyOutputs = !this.allowEmptyOutput && recipe.getEUt() > 0 &&
+                recipe.getOutputs().isEmpty() && recipe.getFluidOutputs().isEmpty() && recipe.getChancedOutputs().isEmpty();
+        if (emptyOutputs) {
             GTLog.logger.error("Invalid amount of recipe outputs. Recipe outputs are empty.");
             GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
             if (recipe.getIsCTRecipe()) {
@@ -337,14 +346,6 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
             }
             recipeStatus = EnumValidationResult.INVALID;
-        }
-        if (emptyInputs && emptyOutputs) {
-            GTLog.logger.error("Invalid recipe. Inputs and Outputs are empty.");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Recipe is empty"));
-            if (recipe.getIsCTRecipe()) {
-                CraftTweakerAPI.logError("Invalid recipe. Inputs and Outputs are empty.");
-                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Recipe is empty"));
-            }
         }
 
         int amount = recipe.getInputs().size();
@@ -441,7 +442,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     /**
      * Prepares Items and Fluids for use in recipe search
      *
-     * @param items the items to prepare
+     * @param items  the items to prepare
      * @param fluids the fluids to prepare
      * @return a List of Lists of AbstractMapIngredients used for finding recipes
      */
@@ -467,8 +468,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     /**
      * Finds a recipe using Items and Fluids.
-     * @param items a collection of items
-     * @param fluids a collection of fluids
+     *
+     * @param items     a collection of items
+     * @param fluids    a collection of fluids
      * @param canHandle a predicate for determining if a recipe is valid
      * @return the recipe found
      */
@@ -660,7 +662,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * @param collidingRecipes the list to store recipe collisions
      */
     private void recurseIngredientTreeFindRecipeCollisions(@Nonnull List<List<AbstractMapIngredient>> ingredients,
-                                                                  @Nonnull Branch branchRoot, @Nonnull Set<Recipe> collidingRecipes) {
+                                                           @Nonnull Branch branchRoot, @Nonnull Set<Recipe> collidingRecipes) {
         // Try each ingredient as a starting point, adding it to the skip-list.
         // The skip-list is a packed long, where each 1 bit represents an index to skip
         for (int i = 0; i < ingredients.size(); i++) {
@@ -966,7 +968,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * Determine the correct root nodes for an ingredient
      *
      * @param ingredient the ingredient to check
-     * @param branchMap the branch containing the nodes
+     * @param branchMap  the branch containing the nodes
      * @return the correct nodes for the ingredient
      */
     @Nonnull
@@ -979,7 +981,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * Converts a list of {@link GTRecipeInput}s for Fluids into a List of {@link AbstractMapIngredient}s.
      * Do not supply GTRecipeInputs dealing with any other type of input other than Fluids.
      *
-     * @param list the list of MapIngredients to add to
+     * @param list        the list of MapIngredients to add to
      * @param fluidInputs the GTRecipeInputs to convert
      */
     protected void buildFromRecipeFluids(@Nonnull List<List<AbstractMapIngredient>> list, @Nonnull List<GTRecipeInput> fluidInputs) {
@@ -992,9 +994,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     /**
      * Retrieves a cached ingredient, or inserts a default one
      *
-     * @param list the list to append to
+     * @param list              the list to append to
      * @param defaultIngredient the ingredient to use as a default value, if not cached
-     * @param cache the ingredient root to retrieve from
+     * @param cache             the ingredient root to retrieve from
      */
     protected static void retrieveCachedIngredient(@Nonnull List<List<AbstractMapIngredient>> list, @Nonnull AbstractMapIngredient defaultIngredient,
                                                    @Nonnull WeakHashMap<AbstractMapIngredient, WeakReference<AbstractMapIngredient>> cache) {
@@ -1010,7 +1012,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     /**
      * Populates a list of MapIngredients from a list of FluidStacks
      *
-     * @param list the list to populate
+     * @param list        the list to populate
      * @param ingredients the ingredients to convert
      */
     protected void buildFromFluidStacks(@Nonnull List<List<AbstractMapIngredient>> list, @Nonnull Iterable<FluidStack> ingredients) {
@@ -1041,7 +1043,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * Converts a list of {@link GTRecipeInput}s for Items into a List of {@link AbstractMapIngredient}s.
      * Do not supply GTRecipeInputs dealing with any other type of input other than Items.
      *
-     * @param list the list of MapIngredients to add to
+     * @param list   the list of MapIngredients to add to
      * @param inputs the GTRecipeInputs to convert
      */
     protected void buildFromRecipeItems(List<List<AbstractMapIngredient>> list, @Nonnull List<GTRecipeInput> inputs) {
@@ -1086,7 +1088,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     /**
      * Populates a list of MapIngredients from a list of ItemStacks
      *
-     * @param list the list to populate
+     * @param list        the list to populate
      * @param ingredients the ingredients to convert
      */
     protected void buildFromItemStacks(@Nonnull List<List<AbstractMapIngredient>> list, @Nonnull ItemStack[] ingredients) {

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -1129,29 +1129,34 @@ public class RecipeMaps {
     public static final RecipeMap<FuelRecipeBuilder> COMBUSTION_GENERATOR_FUELS = new RecipeMap<>("combustion_generator", 0, 0, 1, 0, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.FURNACE_OVERLAY_2)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.COMBUSTION);
+            .setSound(GTSoundEvents.COMBUSTION)
+            .allowEmptyOutput();
 
     @ZenProperty
     public static final RecipeMap<FuelRecipeBuilder> GAS_TURBINE_FUELS = new RecipeMap<>("gas_turbine", 0, 0, 1, 0, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.DARK_CANISTER_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.TURBINE);
+            .setSound(GTSoundEvents.TURBINE)
+            .allowEmptyOutput();
 
     @ZenProperty
     public static final RecipeMap<FuelRecipeBuilder> STEAM_TURBINE_FUELS = new RecipeMap<>("steam_turbine", 0, 0, 1, 1, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.CENTRIFUGE_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.TURBINE);
+            .setSound(GTSoundEvents.TURBINE)
+            .allowEmptyOutput();
 
     @ZenProperty
     public static final RecipeMap<FuelRecipeBuilder> SEMI_FLUID_GENERATOR_FUELS = new RecipeMap<>("semi_fluid_generator", 0, 0, 1, 0, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.FURNACE_OVERLAY_2)
             .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE, MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.COMBUSTION);
+            .setSound(GTSoundEvents.COMBUSTION)
+            .allowEmptyOutput();
 
     @ZenProperty
     public static final RecipeMap<FuelRecipeBuilder> PLASMA_GENERATOR_FUELS = new RecipeMap<>("plasma_generator", 0, 0, 1, 1, new FuelRecipeBuilder(), false)
             .setSlotOverlay(false, true, true, GuiTextures.CENTRIFUGE_OVERLAY)
             .setProgressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR, MoveType.HORIZONTAL)
-            .setSound(GTSoundEvents.TURBINE);
+            .setSound(GTSoundEvents.TURBINE)
+            .allowEmptyOutput();
 }


### PR DESCRIPTION
## What
This PR adds an extra flag in `RecipeMap` to enable creation of recipemaps with empty outputs allowed.

## Implementation Details
Recipes with empty outputs are not allowed by default. The exceptions were for fuel recipes, which is checked with hardcoded convention of negative EU/t indicating the recipe is a fuel recipe.

In this PR, a new flag, `allowEmptyOutput`, is added to `RecipeMap`. Setting the flag to `true` makes empty output check to be bypassed during recipe validation. There's no option of un-setting the flag.

Additionally, I've removed the check right below empty output check, as it is already checked by above statements and does not affect the actual validation result.

The other changes are just minor documentation changes and cleanups.

## Outcome
Addons may be able to 

## Additional Information
To retain compatibility, the negative EU/t is still explicitly checked. We should remove the check after giving some time for users to migrate to `allowEmptyOutput` flag.

## Potential Compatibility Issues
None
