### PR TITLE
Slightly improve MTETrait's network ID lookup

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MTETrait.java
+++ b/src/main/java/gregtech/api/metatileentity/MTETrait.java
@@ -15,6 +15,12 @@ public abstract class MTETrait {
     private static final Object2IntFunction<String> traitIds = new Object2IntOpenHashMap<>();
     private static int rollingNetworkId = 0;
 
+    private static final int NO_NETWORK_ID = -1;
+
+    static {
+        traitIds.defaultReturnValue(NO_NETWORK_ID);
+    }
+
     protected final MetaTileEntity metaTileEntity;
     private final int networkId;
 
@@ -27,12 +33,12 @@ public abstract class MTETrait {
         this.metaTileEntity = metaTileEntity;
 
         final String traitName = getName();
-        if (!traitIds.containsKey(traitName)) {
-            this.networkId = rollingNetworkId++;
-            traitIds.put(traitName, this.networkId);
-        } else {
-            this.networkId = traitIds.getInt(traitName);
+        int networkId = traitIds.getInt(traitName);
+        if (networkId == NO_NETWORK_ID) {
+            networkId = rollingNetworkId++;
+            traitIds.put(traitName, networkId);
         }
+        this.networkId = networkId;
         metaTileEntity.addMetaTileEntityTrait(this);
     }
 


### PR DESCRIPTION
## What
This PR slightly improves network ID lookup strategy of `MTETrait`.

## Implementation Details
Previously network ID map was being searched twice on each network ID lookup, to (1) check if the entry exists and (2) retrieve the network ID associated with the trait name. In the PR the number of lookup is reduced to one.

## Potential Compatibility Issues
This PR contains a critical compat break of reducing possible number of unique `MTETrait` network IDs from `4,294,967,296` to `4,294,967,295`.
