### PR TITLE
Add Multiplier for Keep/Supply Exact on Robot Arms with Smart Filters

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -113,6 +113,13 @@ public class CoverRoboticArm extends CoverConveyor {
             Object filterSlotIndex = iterator.next();
             GroupItemInfo sourceInfo = sourceItemAmounts.get(filterSlotIndex);
             int itemToKeepAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot);
+
+            // get the max we can keep from the item filter variable
+            int maxMultiplier = Math.floorDiv(sourceInfo.totalCount, itemToKeepAmount);
+
+            // multiply up to the total count of all the items
+            itemToKeepAmount *= Math.min(itemFilterContainer.getTransferStackSize(), maxMultiplier);
+
             int itemAmount = 0;
             if (currentItemAmount.containsKey(filterSlotIndex)) {
                 GroupItemInfo destItemInfo = currentItemAmount.get(filterSlotIndex);

--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -68,7 +68,14 @@ public class CoverRoboticArm extends CoverConveyor {
         while (iterator.hasNext()) {
             TypeItemInfo sourceInfo = sourceItemAmount.get(iterator.next());
             int itemAmount = sourceInfo.totalCount;
+
+            // get the max we can extract from the item filter variable
             int itemToMoveAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot);
+            int maxMultiplier = Math.floorDiv(Math.min(itemAmount, maxTransferAmount), itemToMoveAmount);
+
+            // multiply up to the total count of all the items
+            itemToMoveAmount *= Math.min(itemFilterContainer.getTransferStackSize(), maxMultiplier);
+
             if (itemAmount >= itemToMoveAmount) {
                 sourceInfo.totalCount = itemToMoveAmount;
             } else {

--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -70,7 +70,7 @@ public class CoverRoboticArm extends CoverConveyor {
             int itemAmount = sourceInfo.totalCount;
             int itemToMoveAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot);
 
-            if (maxTransferAmount > 1) {
+            if (itemFilterContainer.getTransferStackSize() > 1 && itemToMoveAmount * 2 <= itemAmount) {
                 // get the max we can extract from the item filter variable
                 int maxMultiplier = Math.floorDiv(Math.min(itemAmount, maxTransferAmount), itemToMoveAmount);
 
@@ -116,7 +116,7 @@ public class CoverRoboticArm extends CoverConveyor {
             GroupItemInfo sourceInfo = sourceItemAmounts.get(filterSlotIndex);
             int itemToKeepAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot);
 
-            if (maxTransferAmount > 1) {
+            if (itemFilterContainer.getTransferStackSize() > 1 && itemToKeepAmount * 2 <= sourceInfo.totalCount) {
                 // get the max we can keep from the item filter variable
                 int maxMultiplier = Math.floorDiv(sourceInfo.totalCount, itemToKeepAmount);
 

--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -68,13 +68,15 @@ public class CoverRoboticArm extends CoverConveyor {
         while (iterator.hasNext()) {
             TypeItemInfo sourceInfo = sourceItemAmount.get(iterator.next());
             int itemAmount = sourceInfo.totalCount;
-
-            // get the max we can extract from the item filter variable
             int itemToMoveAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot);
-            int maxMultiplier = Math.floorDiv(Math.min(itemAmount, maxTransferAmount), itemToMoveAmount);
 
-            // multiply up to the total count of all the items
-            itemToMoveAmount *= Math.min(itemFilterContainer.getTransferStackSize(), maxMultiplier);
+            if (maxTransferAmount > 1) {
+                // get the max we can extract from the item filter variable
+                int maxMultiplier = Math.floorDiv(Math.min(itemAmount, maxTransferAmount), itemToMoveAmount);
+
+                // multiply up to the total count of all the items
+                itemToMoveAmount *= Math.min(itemFilterContainer.getTransferStackSize(), maxMultiplier);
+            }
 
             if (itemAmount >= itemToMoveAmount) {
                 sourceInfo.totalCount = itemToMoveAmount;
@@ -114,11 +116,13 @@ public class CoverRoboticArm extends CoverConveyor {
             GroupItemInfo sourceInfo = sourceItemAmounts.get(filterSlotIndex);
             int itemToKeepAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot);
 
-            // get the max we can keep from the item filter variable
-            int maxMultiplier = Math.floorDiv(sourceInfo.totalCount, itemToKeepAmount);
+            if (maxTransferAmount > 1) {
+                // get the max we can keep from the item filter variable
+                int maxMultiplier = Math.floorDiv(sourceInfo.totalCount, itemToKeepAmount);
 
-            // multiply up to the total count of all the items
-            itemToKeepAmount *= Math.min(itemFilterContainer.getTransferStackSize(), maxMultiplier);
+                // multiply up to the total count of all the items
+                itemToKeepAmount *= Math.min(itemFilterContainer.getTransferStackSize(), maxMultiplier);
+            }
 
             int itemAmount = 0;
             if (currentItemAmount.containsKey(filterSlotIndex)) {

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -76,7 +76,7 @@ public class SmartItemFilter extends ItemFilter {
 
     @Override
     public boolean showGlobalTransferLimitSlider() {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1192,7 +1192,7 @@ cover.robotic_arm.title=Robotic Arm Settings (%s)
 cover.robotic_arm.transfer_mode.transfer_any=Transfer Any
 cover.robotic_arm.transfer_mode.transfer_exact=Supply Exact
 cover.robotic_arm.transfer_mode.keep_exact=Keep Exact
-cover.robotic_arm.transfer_mode.description=§eTransfer Any§r - in this mode, cover will transfer as many items matching its filter as possible./n§eSupply Exact§r - in this mode, cover will supply items in portions specified in item filter slots (or variable under this button for ore dictionary filter). If amount of items is less than portion size, items won't be moved./n§eKeep Exact§r - in this mode, cover will keep specified amount of items in the destination inventory, supplying additional amount of items if required./n§7Tip: left/right click on filter slots to change item amount,  use shift clicking to change amount faster.
+cover.robotic_arm.transfer_mode.description=§eTransfer Any§r - in this mode, cover will transfer as many items matching its filter as possible./n§eSupply Exact§r - in this mode, cover will supply items in portions specified in item filter slots (or variable under this button for ore dictionary filter). If amount of items is less than portion size, items won't be moved. If there's a smart filter, the variable under this button will act as a multiplier instead./n§eKeep Exact§r - in this mode, cover will keep specified amount of items in the destination inventory, supplying additional amount of items if required./n§7Tip: left/right click on filter slots to change item amount,  use shift clicking to change amount faster.
 
 cover.pump.title=Pump Cover Settings (%s)
 cover.pump.transfer_rate=%s


### PR DESCRIPTION
## What
This PR adds a multiplier to the keep/supply exact mode of robot arms with smart filters. 

## Implementation Details
I've allowed the smart filter to show the global transfer stack size when in a conveyor/robot arm, and am interpreting the value as a multiplier of the recipe stack size, up to a max multiplier. The max multiplier is so that the robot arm cannot try and supply exact more than the transfer rate which will make it stop working. Also adds lang explaining the new feature.

## Outcome
This makes electrolyzing/centrifuging recipes in parallel easier.

## Potential Compatibility Issues
None, as this is just a small change in logic.