### PR TITLE
Add harvest tools to GT blocks

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockGlassCasing.java
@@ -21,7 +21,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class BlockGlassCasing extends VariantActiveBlock<BlockGlassCasing.CasingType> {
 
     public BlockGlassCasing() {
-        super(Material.IRON);
+        super(Material.GLASS);
         setTranslationKey("transparent_casing");
         setHardness(5.0F);
         setResistance(5.0F);

--- a/src/main/java/gregtech/common/blocks/BlockGregStairs.java
+++ b/src/main/java/gregtech/common/blocks/BlockGregStairs.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks;
 
 import gregtech.api.GregTechAPI;
+import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.BlockStairs;
 import net.minecraft.block.state.IBlockState;
 
@@ -10,5 +11,6 @@ public class BlockGregStairs extends BlockStairs {
         super(state);
         setCreativeTab(GregTechAPI.TAB_GREGTECH_DECORATIONS);
         this.useNeighborBrightness = true;
+        this.setHarvestLevel(ToolClasses.AXE, 0);
     }
 }

--- a/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
@@ -1,6 +1,5 @@
 package gregtech.common.blocks.foam;
 
-import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.Block;
@@ -40,7 +39,6 @@ public class BlockFoam extends BlockColored {
         setHardness(0.5f);
         setLightOpacity(0);
         setTickRandomly(true);
-        setHarvestLevel(ToolClasses.SHOVEL, 0);
         this.isReinforced = isReinforced;
     }
 

--- a/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
+++ b/src/main/java/gregtech/common/blocks/foam/BlockFoam.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks.foam;
 
+import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.Block;
@@ -39,6 +40,7 @@ public class BlockFoam extends BlockColored {
         setHardness(0.5f);
         setLightOpacity(0);
         setTickRandomly(true);
+        setHarvestLevel(ToolClasses.SHOVEL, 0);
         this.isReinforced = isReinforced;
     }
 

--- a/src/main/java/gregtech/common/blocks/wood/BlockGregFence.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregFence.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks.wood;
 
 import gregtech.api.GregTechAPI;
+import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.BlockFence;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.MapColor;
@@ -14,5 +15,6 @@ public class BlockGregFence extends BlockFence {
         setResistance(5.0F);
         setSoundType(SoundType.WOOD);
         setCreativeTab(GregTechAPI.TAB_GREGTECH_DECORATIONS);
+        setHarvestLevel(ToolClasses.AXE, 0);
     }
 }

--- a/src/main/java/gregtech/common/blocks/wood/BlockGregFenceGate.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregFenceGate.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks.wood;
 
 import gregtech.api.GregTechAPI;
+import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.BlockFenceGate;
 import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.SoundType;
@@ -8,10 +9,11 @@ import net.minecraft.block.SoundType;
 public class BlockGregFenceGate extends BlockFenceGate {
 
     public BlockGregFenceGate() {
-        super( BlockPlanks.EnumType.OAK);
+        super(BlockPlanks.EnumType.OAK);
         setHardness(2.0F);
         setResistance(5.0F);
         setSoundType(SoundType.WOOD);
         setCreativeTab(GregTechAPI.TAB_GREGTECH_DECORATIONS);
+        setHarvestLevel(ToolClasses.AXE, 0);
     }
 }

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberDoor.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberDoor.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks.wood;
 
+import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.BlockDoor;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
@@ -19,6 +20,7 @@ public class BlockRubberDoor extends BlockWoodenDoor {
 
     public BlockRubberDoor(Supplier<ItemStack> itemSupplier) {
         super(itemSupplier);
+        setHarvestLevel(ToolClasses.AXE, 0);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockRubberLog.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks.wood;
 
 import gregtech.api.GregTechAPI;
+import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.common.items.MetaItems;
 import net.minecraft.block.BlockLog;
 import net.minecraft.block.properties.PropertyBool;
@@ -25,6 +26,7 @@ public class BlockRubberLog extends BlockLog {
                 .withProperty(NATURAL, false));
         setTranslationKey("rubber_log");
         setCreativeTab(GregTechAPI.TAB_GREGTECH);
+        setHarvestLevel(ToolClasses.AXE, 0);
     }
 
     @Nonnull

--- a/src/main/java/gregtech/common/blocks/wood/BlockWoodenDoor.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockWoodenDoor.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks.wood;
 
+import gregtech.api.items.toolitem.ToolClasses;
 import net.minecraft.block.BlockDoor;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -22,6 +23,7 @@ public class BlockWoodenDoor extends BlockDoor {
         setHardness(3);
         setSoundType(SoundType.WOOD);
         disableStats();
+        setHarvestLevel(ToolClasses.AXE, 0);
     }
 
     @Override


### PR DESCRIPTION
## What
Some mods, such as NoTreePunching, seem to depend on certain blocks having harvest tools to function as expected, but some GT blocks like wood logs do not currently have harvest tools assigned. This PR aims to fix these blocks.

## Implementation Details
One could look for any blocks that I've missed, and furthermore, BlockFoam's harvest tool could be changed (although I think it should still stay).

## Outcome
Adds proper harvest tools to GT logs (fixing NoTreePunching compatibility)

## Potential Compatibility Issues
In the case that any mods depended on these blocks not having harvest tools, they would be broken by this mod.
