### PR TITLE
Small refactor for drawing recipe properties on JEI

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -856,6 +856,32 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     /**
+     * This height is used to determine size of background texture on JEI.
+     */
+    public int getPropertyHeightShift() {
+        int maxPropertyCount = 0;
+        if (shouldShiftWidgets()) {
+            for (Recipe recipe : getRecipeList()) {
+                if (recipe.getPropertyCount() > maxPropertyCount)
+                    maxPropertyCount = recipe.getPropertyCount();
+            }
+        }
+        return maxPropertyCount * 10; // GTRecipeWrapper#LINE_HEIGHT
+    }
+
+    private boolean shouldShiftWidgets() {
+        return getMaxInputs() + getMaxOutputs() >= 6 ||
+                getMaxFluidInputs() + getMaxFluidOutputs() >= 6;
+    }
+
+    /**
+     * This height is used to determine Y position to start drawing info on JEI.
+     */
+    public int getPropertyListHeight(Recipe recipe) {
+        return (recipe.getUnhiddenPropertyCount() + 3) * 10 - 3; // GTRecipeWrapper#LINE_HEIGHT
+    }
+
+    /**
      * Adds a recipe to the map. (recursive part)
      *
      * @param recipe      the recipe to add.

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -23,5 +24,10 @@ public class RecipeMapCokeOven<R extends RecipeBuilder<R>> extends RecipeMap<R> 
         addSlot(builder, 106, 10, 0, exportItems, null, false, true);
         addSlot(builder, 106, 28, 0, null, exportFluids, true, true);
         return builder;
+    }
+
+    @Override
+    public int getPropertyListHeight(Recipe recipe) {
+        return 4;
     }
 }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -18,7 +18,7 @@ public abstract class RecipeProperty<T> {
     @SideOnly(Side.CLIENT)
     public abstract void drawInfo(Minecraft minecraft, int x, int y, int color, Object value);
 
-    public int getDrawHeight(Object value) {
+    public int getInfoHeight(Object value) {
         return 10; // GTRecipeWrapper#LINE_HEIGHT
     }
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -18,6 +18,10 @@ public abstract class RecipeProperty<T> {
     @SideOnly(Side.CLIENT)
     public abstract void drawInfo(Minecraft minecraft, int x, int y, int color, Object value);
 
+    public int getDrawHeight(Object value) {
+        return 10; // GTRecipeWrapper#LINE_HEIGHT
+    }
+
     public boolean isOfType(Class<?> otherType) {
         return this.type == otherType;
     }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -122,7 +122,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     @Override
     public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         super.drawInfo(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
-        int yPosition = recipeHeight - getPropertyListHeight();
+        int yPosition = recipeHeight - recipeMap.getPropertyListHeight(recipe);
         if (!recipe.hasProperty(PrimitiveProperty.getInstance())) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
             minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);
@@ -130,7 +130,9 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += LINE_HEIGHT, 0x111111);
         for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getPropertyValues()) {
             if (!propertyEntry.getKey().isHidden()) {
-                propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += LINE_HEIGHT, 0x111111, propertyEntry.getValue());
+                RecipeProperty<?> property = propertyEntry.getKey();
+                Object value = propertyEntry.getValue();
+                property.drawInfo(minecraft, 0, yPosition += property.getDrawHeight(value), 0x111111, value);
             }
         }
     }
@@ -174,11 +176,5 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     public boolean isNotConsumedFluid(int slot) {
         if (slot >= recipe.getFluidInputs().size()) return false;
         return recipe.getFluidInputs().get(slot).isNonConsumable();
-    }
-
-    private int getPropertyListHeight() {
-        if (recipeMap == RecipeMaps.COKE_OVEN_RECIPES)
-            return LINE_HEIGHT - 6; // fun hack TODO Make this easier to position
-        return (recipe.getUnhiddenPropertyCount() + 3) * LINE_HEIGHT - 3;
     }
 }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -5,7 +5,6 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.recipeproperties.PrimitiveProperty;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
@@ -132,7 +131,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
             if (!propertyEntry.getKey().isHidden()) {
                 RecipeProperty<?> property = propertyEntry.getKey();
                 Object value = propertyEntry.getValue();
-                property.drawInfo(minecraft, 0, yPosition += property.getDrawHeight(value), 0x111111, value);
+                property.drawInfo(minecraft, 0, yPosition += property.getInfoHeight(value), 0x111111, value);
             }
         }
     }

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -9,7 +9,6 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.integration.jei.GTJeiPlugin;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
@@ -61,7 +60,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 (exportFluids = new FluidTankList(false, exportFluidTanks)), 0
         ).build(new BlankUIHolder(), Minecraft.getMinecraft().player);
         this.modularUI.initWidgets();
-        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + getPropertyShiftAmount(recipeMap));
+        this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3 + recipeMap.getPropertyHeightShift());
         categoryMap.put(recipeMap, this);
     }
 
@@ -193,21 +192,5 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
 
     public static HashMap<RecipeMap<?>, RecipeMapCategory> getCategoryMap() {
         return categoryMap;
-    }
-
-    private static boolean shouldShiftWidgets(@Nonnull RecipeMap<?> recipeMap) {
-        return recipeMap.getMaxInputs() + recipeMap.getMaxOutputs() >= 6 ||
-                recipeMap.getMaxFluidInputs() + recipeMap.getMaxFluidOutputs() >= 6;
-    }
-
-    private static int getPropertyShiftAmount(@Nonnull RecipeMap<?> recipeMap) {
-        int maxPropertyCount = 0;
-        if (shouldShiftWidgets(recipeMap)) {
-            for (Recipe recipe : recipeMap.getRecipeList()) {
-                if (recipe.getPropertyCount() > maxPropertyCount)
-                    maxPropertyCount = recipe.getPropertyCount();
-            }
-        }
-        return maxPropertyCount * FONT_HEIGHT;
     }
 }


### PR DESCRIPTION
## What
This PR does some refactor for drawing recipe properties on JEI.

## Implementation Details
Move some private methods in `GTRecipeWrapper` and `RecipeMapCategory` to public method on `RecipeMap`, so that recipemaps can override them.

## Outcome
Allow more customizability for drawing `RecipeProperty` on JEI.

## Additional Information
One property is used to draw two lines in this recipemap.
![2023-04-19_13 18 47](https://user-images.githubusercontent.com/40035906/232966081-89fb67b4-d1d0-4f95-9a9c-14832e48de0b.png)


## Potential Compatibility Issues
Removed only private methods, no incompatibility expected
