### PR TITLE
Add configs for text colors

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/ClickButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/ClickButtonWidget.java
@@ -9,6 +9,7 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -25,7 +26,7 @@ public class ClickButtonWidget extends Widget {
 
     protected TextureArea buttonTexture = GuiTextures.VANILLA_BUTTON.getSubArea(0.0, 0.0, 1.0, 0.5);
     protected final String displayText;
-    protected int textColor = 0xFFFFFF;
+    protected int textColor = ConfigHolder.client.machineUILightTextColor;
     protected final Consumer<ClickData> onPressCallback;
     protected boolean shouldClientCallback;
     protected Supplier<Boolean> shouldDisplay;

--- a/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
@@ -9,6 +9,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
 import gregtech.api.util.function.BooleanConsumer;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -29,7 +30,7 @@ public class CycleButtonWidget extends Widget {
 
     protected TextureArea buttonTexture = GuiTextures.VANILLA_BUTTON.getSubArea(0.0, 0.0, 1.0, 0.5);
     private final String[] optionNames;
-    private int textColor = 0xFFFFFF;
+    private int textColor = ConfigHolder.client.machineUILightTextColor;
     private final IntSupplier currentOptionSupplier;
     private final IntConsumer setOptionExecutor;
     protected int currentOption;

--- a/src/main/java/gregtech/api/gui/widgets/DynamicLabelWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/DynamicLabelWidget.java
@@ -3,6 +3,7 @@ package gregtech.api.gui.widgets;
 import gregtech.api.gui.Widget;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraftforge.fml.relauncher.Side;
@@ -23,7 +24,7 @@ public class DynamicLabelWidget extends Widget {
     private final int color;
 
     public DynamicLabelWidget(int xPosition, int yPosition, Supplier<String> text) {
-        this(xPosition, yPosition, text, 0x404040);
+        this(xPosition, yPosition, text, ConfigHolder.client.machineUIDarkTextColor);
     }
 
     public DynamicLabelWidget(int xPosition, int yPosition, Supplier<String> text, int color) {

--- a/src/main/java/gregtech/api/gui/widgets/IncrementButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/IncrementButtonWidget.java
@@ -8,6 +8,7 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -93,7 +94,7 @@ public class IncrementButtonWidget extends Widget {
             text = "+" + text;
         drawText(text,
                 position.x + size.width / 2f - (fontRenderer.getStringWidth(text) / 2f) * textScale,
-                position.y + size.height / 2f - (fontRenderer.FONT_HEIGHT / 2f) * textScale, textScale, 0xFFFFFF);
+                position.y + size.height / 2f - (fontRenderer.FONT_HEIGHT / 2f) * textScale, textScale, ConfigHolder.client.machineUILightTextColor);
     }
 
     @Override

--- a/src/main/java/gregtech/api/gui/widgets/LabelWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/LabelWidget.java
@@ -4,6 +4,7 @@ import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -27,7 +28,7 @@ public class LabelWidget extends Widget {
     private List<String> texts;
 
     public LabelWidget(int xPosition, int yPosition, String text, Object... formatting) {
-        this(xPosition, yPosition, text, 0x404040, formatting);
+        this(xPosition, yPosition, text, ConfigHolder.client.machineUIDarkTextColor, formatting);
     }
 
     public LabelWidget(int xPosition, int yPosition, String text, int color) {

--- a/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
@@ -10,6 +10,7 @@ import gregtech.api.gui.resources.IGuiTexture;
 import gregtech.api.util.*;
 import gregtech.client.utils.RenderUtil;
 import gregtech.client.utils.TooltipHelper;
+import gregtech.common.ConfigHolder;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -287,7 +288,7 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
                 GlStateManager.scale(0.5, 0.5, 1);
                 String s = TextFormattingUtil.formatLongToCompactString(lastFluidStack.amount, 4) + "L";
                 FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
-                fontRenderer.drawStringWithShadow(s, (pos.x + (size.width / 3F)) * 2 - fontRenderer.getStringWidth(s) + 21, (pos.y + (size.height / 3F) + 6) * 2, 0xFFFFFF);
+                fontRenderer.drawStringWithShadow(s, (pos.x + (size.width / 3F)) * 2 - fontRenderer.getStringWidth(s) + 21, (pos.y + (size.height / 3F) + 6) * 2, ConfigHolder.client.machineUILightTextColor);
                 GlStateManager.popMatrix();
             }
             GlStateManager.enableBlend();

--- a/src/main/java/gregtech/api/gui/widgets/SimpleTextWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SimpleTextWidget.java
@@ -4,6 +4,7 @@ import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -47,7 +48,7 @@ public class SimpleTextWidget extends Widget {
     }
 
     public SimpleTextWidget(int xPosition, int yPosition, String formatLocale, Supplier<String> textSupplier) {
-        this(xPosition, yPosition, formatLocale, 0x404040, textSupplier, false);
+        this(xPosition, yPosition, formatLocale, ConfigHolder.client.machineUIDarkTextColor, textSupplier, false);
     }
 
     public SimpleTextWidget setShadow(boolean shadow) {

--- a/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
@@ -8,6 +8,7 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
 import gregtech.api.util.function.FloatConsumer;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -26,7 +27,7 @@ public class SliderWidget extends Widget {
     private TextureArea backgroundArea = GuiTextures.SLIDER_BACKGROUND;
     private TextureArea sliderIcon = GuiTextures.SLIDER_ICON;
     private final BiFunction<String, Float, String> textSupplier = DEFAULT_TEXT_SUPPLIER;
-    private int textColor = 0xFFFFFF;
+    private int textColor = ConfigHolder.client.machineUILightTextColor;
 
     private final float min;
     private final float max;

--- a/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
+++ b/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
@@ -2,6 +2,7 @@ package gregtech.api.gui.widgets;
 
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
@@ -42,7 +43,7 @@ public class TextFieldWidget2 extends Widget {
     private Function<String, String> validator = s -> s;
     private boolean initialised = false;
     private boolean centered;
-    private int textColor = 0xFFFFFF;
+    private int textColor = ConfigHolder.client.machineUILightTextColor;
     private int markedColor = 0x2F72A8;
     private boolean postFixRight = false;
     private int maxLength = 32;
@@ -465,7 +466,7 @@ public class TextFieldWidget2 extends Widget {
     }
 
     /**
-     * @param textColor text color. Default is 0xFFFFFF (white)
+     * @param textColor text color. Default is {@link ConfigHolder.ClientOptions#machineUILightTextColor}
      */
     public TextFieldWidget2 setTextColor(int textColor) {
         this.textColor = textColor;

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -391,8 +391,8 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     protected ModularUI.Builder createUITemplate(EntityPlayer entityPlayer) {
         ModularUI.Builder builder = ModularUI.extendedBuilder();
         builder.image(7, 4, 162, 121, GuiTextures.DISPLAY);
-        builder.label(11, 9, getMetaFullName(), 0xFFFFFF);
-        builder.widget(new AdvancedTextWidget(11, 19, this::addDisplayText, 0xFFFFFF)
+        builder.label(11, 9, getMetaFullName(), ConfigHolder.client.machineUILightTextColor);
+        builder.widget(new AdvancedTextWidget(11, 19, this::addDisplayText, ConfigHolder.client.machineUILightTextColor)
                 .setMaxWidthLimit(156)
                 .setClickHandler(this::handleDisplayClick));
         if (shouldShowVoidingModeButton()) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
@@ -177,8 +177,8 @@ public abstract class RecipeMapSteamMultiblockController extends MultiblockWithD
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND_STEAM.get(ConfigHolder.machines.steelSteamMultiblocks), 176, 216);
         builder.shouldColor(false);
         builder.image(7, 4, 162, 121, GuiTextures.DISPLAY_STEAM.get(ConfigHolder.machines.steelSteamMultiblocks));
-        builder.label(11, 9, getMetaFullName(), 0xFFFFFF);
-        builder.widget(new AdvancedTextWidget(11, 19, this::addDisplayText, 0xFFFFFF)
+        builder.label(11, 9, getMetaFullName(), ConfigHolder.client.machineUILightTextColor);
+        builder.widget(new AdvancedTextWidget(11, 19, this::addDisplayText, ConfigHolder.client.machineUILightTextColor)
                 .setMaxWidthLimit(156)
                 .setClickHandler(this::handleDisplayClick));
         builder.bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT_STEAM.get(ConfigHolder.machines.steelSteamMultiblocks), 7, 134);

--- a/src/main/java/gregtech/api/util/GTJEIUtility.java
+++ b/src/main/java/gregtech/api/util/GTJEIUtility.java
@@ -1,6 +1,7 @@
 package gregtech.api.util;
 
 import gregtech.api.worldgen.config.OreDepositDefinition;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
@@ -117,7 +118,7 @@ public class GTJEIUtility {
                 dimDisplayPosX = dimStartXPos;
             }
 
-            fontRenderer.drawString(fullDimName, dimDisplayPosX, dimStartYPos, 0x111111);
+            fontRenderer.drawString(fullDimName, dimDisplayPosX, dimStartYPos, ConfigHolder.client.jeiUITextColor);
 
             //Increment the dimension name display position
             dimDisplayPosX = dimDisplayPosX + dimDisplayLength;

--- a/src/main/java/gregtech/api/util/GTStringUtils.java
+++ b/src/main/java/gregtech/api/util/GTStringUtils.java
@@ -8,6 +8,7 @@ import gregtech.api.pipenet.block.material.BlockMaterialPipe;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockCompressed;
 import gregtech.common.blocks.BlockFrame;
 import gregtech.common.items.MetaItems;
@@ -99,6 +100,6 @@ public final class GTStringUtils {
         //Ensure that the string is centered
         int startPosition = (maxLength - fontRenderer.getStringWidth(stringToDraw)) / 2;
 
-        fontRenderer.drawString(stringToDraw, startPosition, 1, 0x111111);
+        fontRenderer.drawString(stringToDraw, startPosition, 1, ConfigHolder.client.jeiUITextColor);
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -1,6 +1,7 @@
 package gregtech.common;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import net.minecraftforge.common.config.Config;
 
 @Config(modid = GTValues.MODID)
@@ -119,7 +120,7 @@ public class ConfigHolder {
 
         /**
          * <strong>Addons mods should not reference this config directly.</strong>
-         * Use {@link gregtech.api.GregTechAPI#highTier} instead.
+         * Use {@link GregTechAPI#isHighTier()} instead.
          */
         @Config.Comment({"If High Tier (>UV-tier) GT content should be registered.",
                 "Items and Machines enabled with this config will have missing recipes by default.",
@@ -330,15 +331,33 @@ public class ConfigHolder {
         @Config.RequiresMcRestart
         public int maxNumSounds = 512;
 
-        @Config.Comment({"The default color to overlay onto machines.", "16777215 (0xFFFFFF in decimal) is no coloring (like GTCE).",
-                "13819135 (0xD2DCFF in decimal) is the classic blue from GT5 (default)."})
+        @Config.Comment({"The default color to overlay onto machines.",
+                "16777215 (0xFFFFFF) is no coloring (like GTCE).",
+                "13819135 (0xD2DCFF) is the classic blue from GT5 (default)."})
         @Config.RangeInt(min = 0, max = 0xFFFFFF)
         public int defaultPaintingColor = 0xD2DCFF;
 
-        @Config.Comment({"The default color to overlay onto Machine (and other) UIs.", "16777215 (0xFFFFFF) is no coloring (like GTCE).",
-                "13819135 (0xD2DCFF in decimal) is the classic blue from GT5 (default)."})
+        @Config.Comment({"The default color to overlay onto Machine (and other) UIs.",
+                "16777215 (0xFFFFFF) is no coloring (like GTCE).",
+                "13819135 (0xD2DCFF) is the classic blue from GT5 (default)."})
         @Config.RangeInt(min = 0, max = 0xFFFFFF)
         public int defaultUIColor = 0xD2DCFF;
+
+        @Config.Comment({"The default color used for dark text in Machine (and other) UIs.",
+                "4210752 (0x404040) is the default MC Gui color (default)."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
+        public int machineUIDarkTextColor = 0x404040;
+
+        @Config.Comment({"The default color used for light text in Machine (and other) UIs.",
+                "Default: 16777215 (0xFFFFFF)."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
+        public int machineUILightTextColor = 0xFFFFFF;
+
+        @Config.Comment({"The default color used for text in JEI UIs.",
+                "4210752 (0x404040) is the default MC GUI color (default).",
+                "1118481 (0x111111) is the classic darker GT text color."})
+        @Config.RangeInt(min = 0, max = 0xFFFFFF)
+        public int jeiUITextColor = 0x404040;
 
         // requires mc restart, color is set upon jei plugin registration
         @Config.Comment({"The color to use as a background for the Multiblock Preview JEI Page.",

--- a/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
@@ -23,6 +23,7 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.Position;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.RenderUtil;
+import gregtech.common.ConfigHolder;
 import gregtech.common.terminal.app.prospector.widget.WidgetOreList;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -465,12 +466,12 @@ public class CoverDigitalInterface extends CoverBehavior implements IFastRenderM
         primaryGroup.addWidget(new ClickButtonWidget(40, 45, 20, 20, "-1", (data) -> setMode(slot - (data.isShiftClick ? 10 : 1))));
         primaryGroup.addWidget(new ClickButtonWidget(140, 45, 20, 20, "+1", (data) -> setMode(slot + (data.isShiftClick ? 10 : 1))));
         primaryGroup.addWidget(new ImageWidget(60, 45, 80, 20, GuiTextures.DISPLAY));
-        primaryGroup.addWidget(new SimpleTextWidget(100, 55, "", 16777215, () -> Integer.toString(this.slot)));
+        primaryGroup.addWidget(new SimpleTextWidget(100, 55, "", ConfigHolder.client.machineUILightTextColor, () -> Integer.toString(this.slot)));
 
         primaryGroup.addWidget(new LabelWidget(10, 75, "metaitem.cover.digital.title.spin", 0));
         primaryGroup.addWidget(new ClickButtonWidget(40, 70, 20, 20, "R", (data) -> setMode(this.spin.rotateY())));
         primaryGroup.addWidget(new ImageWidget(60, 70, 80, 20, GuiTextures.DISPLAY));
-        primaryGroup.addWidget(new SimpleTextWidget(100, 80, "", 16777215, () -> this.spin.toString()));
+        primaryGroup.addWidget(new SimpleTextWidget(100, 80, "", ConfigHolder.client.machineUILightTextColor, () -> this.spin.toString()));
         ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 202).widget(primaryGroup).bindPlayerInventory(player.inventory, GuiTextures.SLOT, 8, 120);
         return builder.build(this, player);
     }

--- a/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
@@ -9,6 +9,7 @@ import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
+import gregtech.common.ConfigHolder;
 import gregtech.common.covers.filter.FluidFilter;
 import gregtech.common.covers.filter.FluidFilterContainer;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -328,7 +329,7 @@ public class CoverFluidRegulator extends CoverPump {
                 .setMaxLength(10)
                 .setScale(0.6f));
 
-        stackSizeGroup.addWidget(new SimpleTextWidget(129, 78, "", 0xFFFFFF, () -> bucketMode.localeName).setScale(0.6f));
+        stackSizeGroup.addWidget(new SimpleTextWidget(129, 78, "", ConfigHolder.client.machineUILightTextColor, () -> bucketMode.localeName).setScale(0.6f));
 
         return super.buildUI(builder.widget(filterGroup).widget(stackSizeGroup), player);
     }

--- a/src/main/java/gregtech/common/covers/CoverFluidVoidingAdvanced.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidVoidingAdvanced.java
@@ -1,6 +1,5 @@
 package gregtech.common.covers;
 
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
@@ -12,12 +11,11 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.BlockRenderLayer;
-import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -188,7 +186,7 @@ public class CoverFluidVoidingAdvanced extends CoverFluidVoiding {
                 .setMaxLength(10)
                 .setScale(0.6f));
 
-        stackSizeGroup.addWidget(new SimpleTextWidget(129, 47, "", 0xFFFFFF, () -> bucketMode.localeName).setScale(0.6f));
+        stackSizeGroup.addWidget(new SimpleTextWidget(129, 47, "", ConfigHolder.client.machineUILightTextColor, () -> bucketMode.localeName).setScale(0.6f));
 
         stackSizeGroup.addWidget(new CycleButtonWidget(114, 53, 30, 20,
                 BucketMode.class, this::getBucketMode, mode -> {

--- a/src/main/java/gregtech/common/covers/CoverMachineController.java
+++ b/src/main/java/gregtech/common/covers/CoverMachineController.java
@@ -14,6 +14,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.*;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -120,7 +121,7 @@ public class CoverMachineController extends CoverBehavior implements CoverWithUI
                 .widget(new SliderWidget("cover.machine_controller.redstone", 10, 24, 156, 20, 1.0f, 15.0f,
                         minRedstoneStrength, it -> setMinRedstoneStrength((int) it)))
                 .widget(new ClickButtonWidget(10, 48, 134, 18, "", data -> cycleNextControllerMode()))
-                .widget(new SimpleTextWidget(77, 58, "", 0xFFFFFF, () -> getControllerMode().getName()).setShadow(true))
+                .widget(new SimpleTextWidget(77, 58, "", ConfigHolder.client.machineUILightTextColor, () -> getControllerMode().getName()).setShadow(true))
                 .widget(new SlotWidget(displayInventory, 0, 148, 48, false, false)
                         .setBackgroundTexture(GuiTextures.SLOT))
                 .widget(new CycleButtonWidget(48, 70, 80, 18, this::isInverted, this::setInverted,

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -17,6 +17,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
+import gregtech.common.ConfigHolder;
 import gregtech.common.covers.filter.ItemFilterContainer;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.item.EntityItem;
@@ -234,7 +235,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
         builder.widget(new ClickButtonWidget(10, 20, 20, 20, "-1", data -> adjustSuckingRange(-1)));
         builder.widget(new ClickButtonWidget(146, 20, 20, 20, "+1", data -> adjustSuckingRange(+1)));
         builder.widget(new ImageWidget(30, 20, 116, 20, GuiTextures.DISPLAY));
-        builder.widget(new SimpleTextWidget(88, 30, "gregtech.machine.item_collector.gui.collect_range", 0xFFFFFF, () -> Integer.toString(itemSuckingRange)));
+        builder.widget(new SimpleTextWidget(88, 30, "gregtech.machine.item_collector.gui.collect_range", ConfigHolder.client.machineUILightTextColor, () -> Integer.toString(itemSuckingRange)));
 
         for (int y = 0; y < rowSize; y++) {
             for (int x = 0; x < rowSize; x++) {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
@@ -17,6 +17,7 @@ import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.common.metatileentities.storage.MetaTileEntityQuantumTank;
 import net.minecraft.client.resources.I18n;
@@ -114,7 +115,7 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
         TankWidget tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
                 .setHideTooltip(true).setAlwaysShowFull(true);
         builder.widget(tankWidget);
-        builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
+        builder.label(11, 20, "gregtech.gui.fluid_amount", ConfigHolder.client.machineUILightTextColor);
         builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
         builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
         return builder.label(6, 6, title)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeMiner.java
@@ -31,6 +31,7 @@ import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockMetalCasing;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.core.sound.GTSoundEvents;
@@ -338,11 +339,11 @@ public class MetaTileEntityLargeMiner extends MultiblockWithDisplayBase implemen
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         ModularUI.Builder builder = ModularUI.extendedBuilder();
         builder.image(7, 4, 162, 121, GuiTextures.DISPLAY);
-        builder.label(11, 9, this.getMetaFullName(), 0xFFFFFF);
+        builder.label(11, 9, this.getMetaFullName(), ConfigHolder.client.machineUILightTextColor);
         builder.widget((new AdvancedTextWidget(11, 19, this::addDisplayText,
-                0xFFFFFF)).setMaxWidthLimit(139).setClickHandler(this::handleDisplayClick));
+                ConfigHolder.client.machineUILightTextColor)).setMaxWidthLimit(139).setClickHandler(this::handleDisplayClick));
         builder.widget((new AdvancedTextWidget(63, 30, this::addDisplayText2,
-                0xFFFFFF)).setMaxWidthLimit(68).setClickHandler(this::handleDisplayClick));
+                ConfigHolder.client.machineUILightTextColor)).setMaxWidthLimit(68).setClickHandler(this::handleDisplayClick));
         builder.bindPlayerInventory(entityPlayer.inventory, 134);
 
         builder.widget(new ToggleButtonWidget(133, 107, 18, 18,

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
@@ -19,6 +19,7 @@ import gregtech.api.pipenet.tile.TileEntityPipeBase;
 import gregtech.api.util.FacingPos;
 import gregtech.api.util.GTLog;
 import gregtech.client.utils.RenderUtil;
+import gregtech.common.ConfigHolder;
 import gregtech.common.covers.CoverDigitalInterface;
 import gregtech.common.gui.widget.WidgetARGB;
 import gregtech.common.gui.widget.monitor.WidgetCoverList;
@@ -497,7 +498,7 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
                     .widget(new ClickButtonWidget(50, 50, 20, 20, "-1", (data) -> setConfig(this.slot, ((float) Math.round((scale - (data.isShiftClick ? 1.0f : 0.1f)) * 10) / 10), this.frameColor)))
                     .widget(new ClickButtonWidget(130, 50, 20, 20, "+1", (data) -> setConfig(this.slot, ((float) Math.round((scale + (data.isShiftClick ? 1.0f : 0.1f)) * 10) / 10), this.frameColor)))
                     .widget(new ImageWidget(70, 50, 60, 20, GuiTextures.DISPLAY))
-                    .widget(new SimpleTextWidget(100, 60, "", 16777215, () -> Float.toString(scale)))
+                    .widget(new SimpleTextWidget(100, 60, "", ConfigHolder.client.machineUILightTextColor, () -> Float.toString(scale)))
 
                     .widget(new LabelWidget(15, 85, "monitor.gui.title.argb", 0xFFFFFFFF))
                     .widget(new WidgetARGB(50, 80, 20, this.frameColor, (color) -> setConfig(this.slot, this.scale, color)))
@@ -506,7 +507,7 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
                     .widget(new ClickButtonWidget(50, 105, 20, 20, "-1", (data) -> setConfig(this.slot - 1, this.scale, this.frameColor)))
                     .widget(new ClickButtonWidget(130, 105, 20, 20, "+1", (data) -> setConfig(this.slot + 1, this.scale, this.frameColor)))
                     .widget(new ImageWidget(70, 105, 60, 20, GuiTextures.DISPLAY))
-                    .widget(new SimpleTextWidget(100, 115, "", 16777215, () -> Integer.toString(slot)))
+                    .widget(new SimpleTextWidget(100, 115, "", ConfigHolder.client.machineUILightTextColor, () -> Integer.toString(slot)))
 
                     .widget(new LabelWidget(15, 135, "monitor.gui.title.plugin", 0xFFFFFFFF))
                     .widget(new SlotWidget(inventory, 0, 50, 130, true, true)

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -22,6 +22,7 @@ import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
+import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.storage.MetaTileEntityQuantumTank;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -185,9 +186,9 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         TankWidget tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
                 .setHideTooltip(true).setAlwaysShowFull(true);
         builder.widget(tankWidget);
-        builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
-        builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
-        builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
+        builder.label(11, 20, "gregtech.gui.fluid_amount", ConfigHolder.client.machineUILightTextColor);
+        builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, ConfigHolder.client.machineUILightTextColor);
+        builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, ConfigHolder.client.machineUILightTextColor);
         return builder.label(6, 6, title)
                 .widget(new FluidContainerSlotWidget(importItems, 0, 90, 16, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -394,8 +394,8 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
                             .setButtonTexture(GuiTextures.MAINTENANCE_ICON).setTooltipText("gregtech.machine.maintenance_hatch_tool_slot.tooltip"));
         }
         if (isConfigurable) {
-            builder.widget(new AdvancedTextWidget(5, 25, getTextWidgetText("duration", this::getDurationMultiplier), 0x404040))
-                    .widget(new AdvancedTextWidget(5, 39, getTextWidgetText("time", this::getTimeMultiplier), 0x404040))
+            builder.widget(new AdvancedTextWidget(5, 25, getTextWidgetText("duration", this::getDurationMultiplier), ConfigHolder.client.machineUIDarkTextColor))
+                    .widget(new AdvancedTextWidget(5, 39, getTextWidgetText("time", this::getTimeMultiplier), ConfigHolder.client.machineUIDarkTextColor))
                     .widget(new ClickButtonWidget(9, 18 * 3 + 16 - 18, 12, 12, "-", this::decInternalMultiplier))
                     .widget(new ClickButtonWidget(9 + 18 * 2, 18 * 3 + 16 - 18, 12, 12, "+", this::incInternalMultiplier));
         }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMiner.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMiner.java
@@ -128,9 +128,9 @@ public class SteamMiner extends MetaTileEntity implements IMiner, IControllable,
 
         builder.image(7, 16, 105, 75, GuiTextures.DISPLAY_STEAM.get(false))
                 .label(6, 6, getMetaFullName());
-        builder.widget(new AdvancedTextWidget(10, 19, this::addDisplayText, 0xFFFFFF)
+        builder.widget(new AdvancedTextWidget(10, 19, this::addDisplayText, ConfigHolder.client.machineUILightTextColor)
                 .setMaxWidthLimit(84));
-        builder.widget(new AdvancedTextWidget(70, 19, this::addDisplayText2, 0xFFFFFF)
+        builder.widget(new AdvancedTextWidget(70, 19, this::addDisplayText2, ConfigHolder.client.machineUILightTextColor)
                 .setMaxWidthLimit(84));
 
 

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
@@ -130,9 +130,9 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
                 .setHideTooltip(true).setAlwaysShowFull(true);
         builder.widget(tankWidget);
         builder.shouldColor(false);
-        builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
-        builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
-        builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
+        builder.label(11, 20, "gregtech.gui.fluid_amount", ConfigHolder.client.machineUILightTextColor);
+        builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, ConfigHolder.client.machineUILightTextColor);
+        builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, ConfigHolder.client.machineUILightTextColor);
         return builder.label(6, 6, title)
                 .widget(new FluidContainerSlotWidget(importItems, 0, 90, 17, false)
                         .setBackgroundTexture(GuiTextures.SLOT_STEAM.get(IS_STEEL), GuiTextures.IN_SLOT_OVERLAY_STEAM.get(IS_STEEL)))

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -19,6 +19,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.TooltipHelper;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -114,7 +115,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEne
             }
         }));
 
-        builder.dynamicLabel(7, 110, () -> "Energy I/O per sec: " + this.lastEnergyIOPerSec, 0x232323);
+        builder.dynamicLabel(7, 110, () -> "Energy I/O per sec: " + this.lastEnergyIOPerSec, ConfigHolder.client.machineUIDarkTextColor);
 
         builder.widget(new CycleButtonWidget(7, 139, 77, 20, () -> active, value -> active = value, "gregtech.creative.activity.off", "gregtech.creative.activity.on"));
         builder.widget(new CycleButtonWidget(85, 139, 77, 20, () -> source, value -> {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -24,6 +24,7 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.custom.QuantumStorageRenderer;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -309,7 +310,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
         Builder builder = ModularUI.defaultBuilder();
         int leftButtonStartX = 7;
         builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
-        builder.widget(new AdvancedTextWidget(11, 20, this::addDisplayInformation, 0xFFFFFF));
+        builder.widget(new AdvancedTextWidget(11, 20, this::addDisplayInformation, ConfigHolder.client.machineUILightTextColor));
         return builder.label(6, 6, getMetaFullName())
                 .widget(new SlotWidget(importItems, 0, 90, 17, true, true)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -23,6 +23,7 @@ import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.custom.QuantumStorageRenderer;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
@@ -298,10 +299,10 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
 
         return ModularUI.defaultBuilder()
                 .widget(new ImageWidget(7, 16, 81, 46, GuiTextures.DISPLAY))
-                .widget(new LabelWidget(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF))
+                .widget(new LabelWidget(11, 20, "gregtech.gui.fluid_amount", ConfigHolder.client.machineUILightTextColor))
                 .widget(tankWidget)
-                .dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF)
-                .dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF)
+                .dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, ConfigHolder.client.machineUILightTextColor)
+                .dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, ConfigHolder.client.machineUILightTextColor)
                 .label(6, 6, getMetaFullName())
                 .widget(new FluidContainerSlotWidget(importItems, 0, 90, 17, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))

--- a/src/main/java/gregtech/integration/jei/basic/GTFluidVeinCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/GTFluidVeinCategory.java
@@ -6,6 +6,7 @@ import gregtech.api.util.GTStringUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.worldgen.config.BedrockFluidDepositDefinition;
 import gregtech.api.worldgen.config.WorldGenRegistry;
+import gregtech.common.ConfigHolder;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -94,37 +95,37 @@ public class GTFluidVeinCategory extends BasicRecipeCategory<GTFluidVeinInfo, GT
         // Vein Weight information
         String veinWeight = I18n.format("gregtech.jei.fluid.vein_weight", weight);
         weightLength = minecraft.fontRenderer.getStringWidth(veinWeight);
-        minecraft.fontRenderer.drawString(veinWeight, textStartX, startPosY, 0x111111);
+        minecraft.fontRenderer.drawString(veinWeight, textStartX, startPosY, ConfigHolder.client.jeiUITextColor);
 
         // Vein Minimum Yield information
         String veinMinYield = I18n.format("gregtech.jei.fluid.min_yield", yields[0]);
         minYieldLength = minecraft.fontRenderer.getStringWidth(veinMinYield);
-        minecraft.fontRenderer.drawString(veinMinYield, textStartX, startPosY + FONT_HEIGHT + 1, 0x111111);
+        minecraft.fontRenderer.drawString(veinMinYield, textStartX, startPosY + FONT_HEIGHT + 1, ConfigHolder.client.jeiUITextColor);
 
         // Vein Maximum Yield information
         String veinMaxYield = I18n.format("gregtech.jei.fluid.max_yield", yields[1]);
         maxYieldLength = minecraft.fontRenderer.getStringWidth(veinMaxYield);
-        minecraft.fontRenderer.drawString(veinMaxYield, textStartX, startPosY + 2 * FONT_HEIGHT + 1, 0x111111);
+        minecraft.fontRenderer.drawString(veinMaxYield, textStartX, startPosY + 2 * FONT_HEIGHT + 1, ConfigHolder.client.jeiUITextColor);
 
         // Vein Depletion Chance information
         String veinDepletionChance = I18n.format("gregtech.jei.fluid.depletion_chance", depletionChance);
         depletionChanceLength = minecraft.fontRenderer.getStringWidth(veinDepletionChance);
-        minecraft.fontRenderer.drawString(veinDepletionChance, textStartX, startPosY + 3 * FONT_HEIGHT + 1, 0x111111);
+        minecraft.fontRenderer.drawString(veinDepletionChance, textStartX, startPosY + 3 * FONT_HEIGHT + 1, ConfigHolder.client.jeiUITextColor);
 
         // Vein Depletion Amount information
         String veinDepletionAmount = I18n.format("gregtech.jei.fluid.depletion_amount", depletionAmount);
         depletionAmountLength = minecraft.fontRenderer.getStringWidth(veinDepletionAmount);
-        minecraft.fontRenderer.drawString(veinDepletionAmount, textStartX, startPosY + 4 * FONT_HEIGHT + 1, 0x111111);
+        minecraft.fontRenderer.drawString(veinDepletionAmount, textStartX, startPosY + 4 * FONT_HEIGHT + 1, ConfigHolder.client.jeiUITextColor);
 
         // Vein Depleted Yield information
         String veinDepletedYield = I18n.format("gregtech.jei.fluid.depleted_rate", depletedYield);
         depletedYieldLength = minecraft.fontRenderer.getStringWidth(veinDepletedYield);
-        minecraft.fontRenderer.drawString(veinDepletedYield, textStartX, startPosY + 5 * FONT_HEIGHT + 1, 0x111111);
+        minecraft.fontRenderer.drawString(veinDepletedYield, textStartX, startPosY + 5 * FONT_HEIGHT + 1, ConfigHolder.client.jeiUITextColor);
 
         // Vein Dimensions information
         String veinDimension = I18n.format("gregtech.jei.fluid.dimension") + " ";
         int dimensionLength = minecraft.fontRenderer.getStringWidth(veinDimension);
-        minecraft.fontRenderer.drawString(veinDimension, textStartX, startPosY + 6 * FONT_HEIGHT + 1, 0x111111);
+        minecraft.fontRenderer.drawString(veinDimension, textStartX, startPosY + 6 * FONT_HEIGHT + 1, ConfigHolder.client.jeiUITextColor);
 
         GTJEIUtility.drawMultiLineCommaSeparatedDimensionList(namedDimensions, dimensions.get(), minecraft.fontRenderer, textStartX,  startPosY + 6 * FONT_HEIGHT + 1, textStartX + dimensionLength);
 

--- a/src/main/java/gregtech/integration/jei/basic/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/GTOreCategory.java
@@ -6,6 +6,7 @@ import gregtech.api.util.GTStringUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.config.WorldGenRegistry;
+import gregtech.common.ConfigHolder;
 import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -117,23 +118,23 @@ public class GTOreCategory extends BasicRecipeCategory<GTOreInfo, GTOreInfo> {
         //Give room for 5 lines of 5 ores each, so 25 unique ores in the vein
         //73 is SLOT_HEIGHT * (NUM_OF_SLOTS - 1) + 1
         if (baseYPos >= SLOT_HEIGHT * NUM_OF_SLOTS) {
-            minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, baseXPos, baseYPos + 1, 0x111111);
+            minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, baseXPos, baseYPos + 1, ConfigHolder.client.jeiUITextColor);
         } else {
-            minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, baseXPos, SLOT_HEIGHT * (NUM_OF_SLOTS - 1) + 1, 0x111111);
+            minecraft.fontRenderer.drawString("Spawn Range: " + minHeight + "-" + maxHeight, baseXPos, SLOT_HEIGHT * (NUM_OF_SLOTS - 1) + 1, ConfigHolder.client.jeiUITextColor);
             //Update the position at which the spawn information ends
             baseYPos = 73;
         }
 
         //Create the Weight
-        minecraft.fontRenderer.drawString("Vein Weight: " + weight, baseXPos, baseYPos + FONT_HEIGHT, 0x111111);
+        minecraft.fontRenderer.drawString("Vein Weight: " + weight, baseXPos, baseYPos + FONT_HEIGHT, ConfigHolder.client.jeiUITextColor);
 
         //Create the Dimensions
-        minecraft.fontRenderer.drawString("Dimensions: ", baseXPos, baseYPos + (2 * FONT_HEIGHT), 0x111111);
+        minecraft.fontRenderer.drawString("Dimensions: ", baseXPos, baseYPos + (2 * FONT_HEIGHT), ConfigHolder.client.jeiUITextColor);
 
         GTJEIUtility.drawMultiLineCommaSeparatedDimensionList(namedDimensions, dimension.get(), minecraft.fontRenderer, baseXPos, baseYPos + 3 * FONT_HEIGHT, dimDisplayPos);
 
         //Label the Surface Identifier
-        minecraft.fontRenderer.drawSplitString("SurfaceMaterial", 15, 92, minecraft.fontRenderer.getStringWidth("Surface"), 0x111111);
+        minecraft.fontRenderer.drawSplitString("SurfaceMaterial", 15, 92, minecraft.fontRenderer.getStringWidth("Surface"), ConfigHolder.client.jeiUITextColor);
 
     }
 }

--- a/src/main/java/gregtech/integration/jei/basic/MaterialTreeCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/MaterialTreeCategory.java
@@ -7,6 +7,7 @@ import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.common.ConfigHolder;
 import gregtech.integration.jei.utils.render.DrawableRegistry;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -257,30 +258,30 @@ public class MaterialTreeCategory extends BasicRecipeCategory<MaterialTree, Mate
         int linesDrawn = 0;
         if (minecraft.fontRenderer.getStringWidth(materialName) > 176) {
             minecraft.fontRenderer.drawString(minecraft.fontRenderer.trimStringToWidth(materialName, 171) + "...",
-                    0, 0, 0x111111);
+                    0, 0, ConfigHolder.client.jeiUITextColor);
             linesDrawn++;
-        } else if (materialName.length() != 0) {
-            minecraft.fontRenderer.drawString(materialName, 0, 0, 0x111111);
+        } else if (!materialName.isEmpty()) {
+            minecraft.fontRenderer.drawString(materialName, 0, 0, ConfigHolder.client.jeiUITextColor);
             linesDrawn++;
         }
         if (minecraft.fontRenderer.getStringWidth(materialFormula) > 176) {
             minecraft.fontRenderer.drawString(minecraft.fontRenderer.trimStringToWidth(materialFormula, 171) + "...",
-                    0, FONT_HEIGHT * linesDrawn, 0x111111);
+                    0, FONT_HEIGHT * linesDrawn, ConfigHolder.client.jeiUITextColor);
             linesDrawn++;
-        } else if (materialFormula.length() != 0) {
-            minecraft.fontRenderer.drawString(materialFormula, 0, FONT_HEIGHT * linesDrawn, 0x111111);
+        } else if (!materialFormula.isEmpty()) {
+            minecraft.fontRenderer.drawString(materialFormula, 0, FONT_HEIGHT * linesDrawn, ConfigHolder.client.jeiUITextColor);
             linesDrawn++;
         }
         // don't think theres a good way to get the coil tier other than this
         if (materialBFTemp != 0) {
-            TemperatureProperty.getInstance().drawInfo(minecraft, 0, FONT_HEIGHT * linesDrawn, 0x111111, materialBFTemp);
+            TemperatureProperty.getInstance().drawInfo(minecraft, 0, FONT_HEIGHT * linesDrawn, ConfigHolder.client.jeiUITextColor, materialBFTemp);
             linesDrawn++;
         }
-        minecraft.fontRenderer.drawString(materialAvgM, 0, FONT_HEIGHT * linesDrawn, 0x111111);
+        minecraft.fontRenderer.drawString(materialAvgM, 0, FONT_HEIGHT * linesDrawn, ConfigHolder.client.jeiUITextColor);
         linesDrawn++;
-        minecraft.fontRenderer.drawString(materialAvgN, 0, FONT_HEIGHT * linesDrawn, 0x111111);
+        minecraft.fontRenderer.drawString(materialAvgN, 0, FONT_HEIGHT * linesDrawn, ConfigHolder.client.jeiUITextColor);
         linesDrawn++;
-        minecraft.fontRenderer.drawString(materialAvgP, 0, FONT_HEIGHT * linesDrawn, 0x111111);
+        minecraft.fontRenderer.drawString(materialAvgP, 0, FONT_HEIGHT * linesDrawn, ConfigHolder.client.jeiUITextColor);
     }
 
     // a couple wrappers to make the code look less terrible

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -13,8 +13,9 @@ import gregtech.api.util.CTRecipeHelper;
 import gregtech.api.util.ClipboardUtil;
 import gregtech.api.util.GTUtility;
 import gregtech.client.utils.TooltipHelper;
-import gregtech.integration.groovy.GroovyScriptCompat;
+import gregtech.common.ConfigHolder;
 import gregtech.integration.RecipeCompatUtil;
+import gregtech.integration.groovy.GroovyScriptCompat;
 import gregtech.integration.jei.utils.AdvancedRecipeWrapper;
 import gregtech.integration.jei.utils.JeiButton;
 import mezz.jei.api.ingredients.IIngredients;
@@ -124,13 +125,13 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         super.drawInfo(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
         int yPosition = recipeHeight - getPropertyListHeight();
         if (!recipe.hasProperty(PrimitiveProperty.getInstance())) {
-            minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
-            minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);
+            minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, ConfigHolder.client.jeiUITextColor);
+            minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, ConfigHolder.client.jeiUITextColor);
         } else yPosition -= LINE_HEIGHT * 2;
-        minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += LINE_HEIGHT, 0x111111);
+        minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", recipe.getDuration() / 20f), 0, yPosition += LINE_HEIGHT, ConfigHolder.client.jeiUITextColor);
         for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getPropertyValues()) {
             if (!propertyEntry.getKey().isHidden()) {
-                propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += LINE_HEIGHT, 0x111111, propertyEntry.getValue());
+                propertyEntry.getKey().drawInfo(minecraft, 0, yPosition += LINE_HEIGHT, ConfigHolder.client.jeiUITextColor, propertyEntry.getValue());
             }
         }
     }


### PR DESCRIPTION
## What
This PR adds configs for choosing the colors of text in Machines, the JEI plugin, and more. They are client-side only configs, which are intended to improve accessibility and ResourcePack compatibility.

Additionally, it also changes the default color for the JEI plugin to be the same as regular MC GUIs.

## Outcome
Adds configs to change text colors.

## Potential Compatibility Issues
Addons will need to update to respect the new configs, but will not break.
