### PR TITLE
Progression tweaks

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -694,7 +694,7 @@ public class ElementMaterials {
 
         Tantalum = new Material.Builder(104, "tantalum")
                 .ingot().fluid()
-                .color(0x78788c).iconSet(METALLIC)
+                .color(0x69B7FF).iconSet(METALLIC)
                 .flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(Elements.Ta)
                 .fluidTemp(3290)

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -662,7 +662,7 @@ public class ElementMaterials {
                 .color(0x3C3C50).iconSet(METALLIC)
                 .flags(GENERATE_FOIL)
                 .element(Elements.Si)
-                .blastTemp(1687) // no gas tier for silicon
+                .blastTemp(2273) // no gas tier for silicon
                 .build();
 
         Silver = new Material.Builder(100, "silver")

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -695,7 +695,7 @@ public class ElementMaterials {
         Tantalum = new Material.Builder(104, "tantalum")
                 .ingot().fluid()
                 .color(0x78788c).iconSet(METALLIC)
-                .flags(STD_METAL, GENERATE_FOIL)
+                .flags(STD_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(Elements.Ta)
                 .fluidTemp(3290)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -305,7 +305,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Iron, 1, Aluminium, 1, Chrome, 1)
                 .cableProperties(GTValues.V[3], 4, 3)
-                .blastTemp(1800, GasTier.LOW, VA[MV], 1000)
+                .blastTemp(1800, GasTier.LOW, VA[HV], 900)
                 .fluidTemp(1708)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -84,9 +84,9 @@ public class SecondDegreeMaterials {
         // Free ID 2009
 
         Apatite = new Material.Builder(2010, "apatite")
-                .gem(1).ore(4, 2)
+                .gem(1).ore(2, 2)
                 .color(0xC8C8FF).iconSet(DIAMOND)
-                .flags(NO_SMASHING, NO_SMELTING, CRYSTALLIZABLE, GENERATE_BOLT_SCREW)
+                .flags(NO_SMASHING, NO_SMELTING, CRYSTALLIZABLE, GENERATE_BOLT_SCREW, DISABLE_DECOMPOSITION)
                 .components(Calcium, 5, Phosphate, 3, Chlorine, 1)
                 .build();
 

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -596,13 +596,13 @@ public class MetaItem1 extends StandardMetaItem {
 
         // Boules: ID 361-370
         SILICON_BOULE = addItem(361, "boule.silicon");
-        GLOWSTONE_BOULE = addItem(362, "boule.glowstone");
+        PHOSPHORUS_BOULE = addItem(362, "boule.glowstone");
         NAQUADAH_BOULE = addItem(363, "boule.naquadah");
         NEUTRONIUM_BOULE = addItem(364, "boule.neutronium");
 
         // Boule-Direct Wafers: ID 371-380
         SILICON_WAFER = addItem(371, "wafer.silicon");
-        GLOWSTONE_WAFER = addItem(372, "wafer.glowstone");
+        PHOSPHORUS_WAFER = addItem(372, "wafer.glowstone");
         NAQUADAH_WAFER = addItem(373, "wafer.naquadah");
         NEUTRONIUM_WAFER = addItem(374, "wafer.neutronium");
 

--- a/src/main/java/gregtech/common/items/MetaItems.java
+++ b/src/main/java/gregtech/common/items/MetaItems.java
@@ -279,11 +279,11 @@ public final class MetaItems {
     public static final Map<MarkerMaterial, MetaValueItem> GLASS_LENSES = new HashMap<>();
 
     public static MetaItem<?>.MetaValueItem SILICON_BOULE;
-    public static MetaItem<?>.MetaValueItem GLOWSTONE_BOULE;
+    public static MetaItem<?>.MetaValueItem PHOSPHORUS_BOULE;
     public static MetaItem<?>.MetaValueItem NAQUADAH_BOULE;
     public static MetaItem<?>.MetaValueItem NEUTRONIUM_BOULE;
     public static MetaItem<?>.MetaValueItem SILICON_WAFER;
-    public static MetaItem<?>.MetaValueItem GLOWSTONE_WAFER;
+    public static MetaItem<?>.MetaValueItem PHOSPHORUS_WAFER;
     public static MetaItem<?>.MetaValueItem NAQUADAH_WAFER;
     public static MetaItem<?>.MetaValueItem NEUTRONIUM_WAFER;
 

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -209,6 +209,8 @@ public class MetaTileEntities {
     public static MetaTileEntityDrum ALUMINIUM_DRUM;
     public static MetaTileEntityDrum STEEL_DRUM;
     public static MetaTileEntityDrum STAINLESS_STEEL_DRUM;
+    public static MetaTileEntityDrum TITANIUM_DRUM;
+    public static MetaTileEntityDrum TUNGSTENSTEEL_DRUM;
     public static MetaTileEntityDrum GOLD_DRUM;
     public static MetaTileEntityCrate WOODEN_CRATE;
     public static MetaTileEntityCrate BRONZE_CRATE;
@@ -682,7 +684,9 @@ public class MetaTileEntities {
         STEEL_DRUM = registerMetaTileEntity(1612, new MetaTileEntityDrum(gregtechId("drum.steel"), Materials.Steel, 64000));
         ALUMINIUM_DRUM = registerMetaTileEntity(1613, new MetaTileEntityDrum(gregtechId("drum.aluminium"), Materials.Aluminium, 128000));
         STAINLESS_STEEL_DRUM = registerMetaTileEntity(1614, new MetaTileEntityDrum(gregtechId("drum.stainless_steel"), Materials.StainlessSteel, 256000));
-        GOLD_DRUM = registerMetaTileEntity(1615, new MetaTileEntityDrum(gregtechId("drum.gold"), Materials.Gold, 32000));
+        TITANIUM_DRUM = registerMetaTileEntity(1615, new MetaTileEntityDrum(gregtechId("drum.titanium"), Materials.Titanium, 512000));
+        TUNGSTENSTEEL_DRUM = registerMetaTileEntity(1616, new MetaTileEntityDrum(gregtechId("drum.tungstensteel"), Materials.TungstenSteel, 1024000));
+        GOLD_DRUM = registerMetaTileEntity(1617, new MetaTileEntityDrum(gregtechId("drum.gold"), Materials.Gold, 32000));
 
         // Crates, IDs 1625-1639
         WOODEN_CRATE = registerMetaTileEntity(1625, new MetaTileEntityCrate(gregtechId("crate.wood"), Materials.Wood, 27));

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -209,6 +209,7 @@ public class MetaTileEntities {
     public static MetaTileEntityDrum ALUMINIUM_DRUM;
     public static MetaTileEntityDrum STEEL_DRUM;
     public static MetaTileEntityDrum STAINLESS_STEEL_DRUM;
+    public static MetaTileEntityDrum GOLD_DRUM;
     public static MetaTileEntityCrate WOODEN_CRATE;
     public static MetaTileEntityCrate BRONZE_CRATE;
     public static MetaTileEntityCrate ALUMINIUM_CRATE;
@@ -681,6 +682,7 @@ public class MetaTileEntities {
         STEEL_DRUM = registerMetaTileEntity(1612, new MetaTileEntityDrum(gregtechId("drum.steel"), Materials.Steel, 64000));
         ALUMINIUM_DRUM = registerMetaTileEntity(1613, new MetaTileEntityDrum(gregtechId("drum.aluminium"), Materials.Aluminium, 128000));
         STAINLESS_STEEL_DRUM = registerMetaTileEntity(1614, new MetaTileEntityDrum(gregtechId("drum.stainless_steel"), Materials.StainlessSteel, 256000));
+        GOLD_DRUM = registerMetaTileEntity(1615, new MetaTileEntityDrum(gregtechId("drum.gold"), Materials.Gold, 32000));
 
         // Crates, IDs 1625-1639
         WOODEN_CRATE = registerMetaTileEntity(1625, new MetaTileEntityCrate(gregtechId("crate.wood"), Materials.Wood, 27));

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -432,6 +432,13 @@ public class CircuitRecipes {
                 .output(SMD_RESISTOR, 16)
                 .duration(160).EUt(VA[HV]).buildAndRegister();
 
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(dust, Carbon)
+                .input(wireFine, Tantalum, 4)
+                .fluidInputs(Polyethylene.getFluid(L * 2))
+                .output(SMD_RESISTOR, 32)
+                .duration(160).EUt(VA[HV]).buildAndRegister();
+
         // SMD Diode
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, GalliumArsenide)
@@ -446,6 +453,13 @@ public class CircuitRecipes {
                 .input(wireFine, AnnealedCopper, 8)
                 .fluidInputs(Polyethylene.getFluid(L))
                 .output(SMD_TRANSISTOR, 16)
+                .duration(160).EUt(VA[HV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(foil, Gallium)
+                .input(wireFine, Tantalum, 8)
+                .fluidInputs(Polyethylene.getFluid(L))
+                .output(SMD_TRANSISTOR, 32)
                 .duration(160).EUt(VA[HV]).buildAndRegister();
 
         // SMD Capacitor
@@ -485,6 +499,13 @@ public class CircuitRecipes {
                 .output(SMD_INDUCTOR, 16)
                 .duration(160).EUt(VA[HV]).buildAndRegister();
 
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(ring, NickelZincFerrite)
+                .input(wireFine, Tantalum, 4)
+                .fluidInputs(Polyethylene.getFluid(L))
+                .output(SMD_INDUCTOR, 32)
+                .duration(160).EUt(VA[HV]).buildAndRegister();
+
         // Advanced SMD Resistor
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Graphene)
@@ -495,11 +516,11 @@ public class CircuitRecipes {
 
         // Advanced SMD Diode
         ASSEMBLER_RECIPES.recipeBuilder()
-                .input(dustSmall, IndiumGalliumPhosphide)
-                .input(wireFine, NiobiumTitanium, 4)
-                .fluidInputs(Polybenzimidazole.getFluid(L / 2))
-                .output(ADVANCED_SMD_DIODE, 16)
-                .EUt(3840).duration(150).buildAndRegister();
+                .input(dust, IndiumGalliumPhosphide)
+                .input(wireFine, NiobiumTitanium, 16)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 2))
+                .output(ADVANCED_SMD_DIODE, 64)
+                .EUt(3840).duration(640).buildAndRegister();
 
         // Advanced SMD Transistor
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -670,10 +691,10 @@ public class CircuitRecipes {
         // Phenolic Board
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(dust, Wood)
-                .notConsumable(SHAPE_MOLD_PLATE)
+                .circuitMeta(1)
                 .fluidInputs(Glue.getFluid(50))
                 .output(PHENOLIC_BOARD)
-                .duration(30).EUt(VA[ULV]).buildAndRegister();
+                .duration(150).EUt(VA[LV]).buildAndRegister();
 
         // Good Circuit Board
         ModHandler.addShapedRecipe("good_circuit_board", GOOD_CIRCUIT_BOARD.getStackForm(),
@@ -809,7 +830,7 @@ public class CircuitRecipes {
         // Multi-Layer Fiber Reinforced Epoxy Board
         CHEMICAL_RECIPES.recipeBuilder().duration(500).EUt(VA[HV])
                 .input(FIBER_BOARD, 2)
-                .input(foil, Platinum, 8)
+                .input(foil, Palladium, 8)
                 .fluidInputs(SulfuricAcid.getFluid(500))
                 .output(MULTILAYER_FIBER_BOARD)
                 .cleanroom(CleanroomType.CLEANROOM)

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -37,15 +37,17 @@ public class CircuitRecipes {
 
         BLAST_RECIPES.recipeBuilder()
                 .input(dust, Silicon, 64)
-                .input(dust, Glowstone, 8)
+                .input(dust, Phosphorus, 8)
+                .input(dustSmall, GalliumArsenide, 2)
                 .fluidInputs(Nitrogen.getFluid(8000))
-                .output(GLOWSTONE_BOULE)
+                .output(PHOSPHORUS_BOULE)
                 .blastFurnaceTemp(2484)
                 .duration(12000).EUt(VA[HV]).buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder()
                 .input(block, Silicon, 16)
                 .input(ingot, Naquadah)
+                .input(dust, GalliumArsenide)
                 .fluidInputs(Argon.getFluid(8000))
                 .output(NAQUADAH_BOULE)
                 .blastFurnaceTemp(5400)
@@ -54,6 +56,7 @@ public class CircuitRecipes {
         BLAST_RECIPES.recipeBuilder()
                 .input(block, Silicon, 32)
                 .input(ingot, Neutronium, 4)
+                .input(dust, GalliumArsenide, 2)
                 .fluidInputs(Xenon.getFluid(8000))
                 .output(NEUTRONIUM_BOULE)
                 .blastFurnaceTemp(6484)
@@ -66,8 +69,8 @@ public class CircuitRecipes {
                 .duration(400).EUt(64).buildAndRegister();
 
         CUTTER_RECIPES.recipeBuilder()
-                .input(GLOWSTONE_BOULE)
-                .output(GLOWSTONE_WAFER, 32)
+                .input(PHOSPHORUS_BOULE)
+                .output(PHOSPHORUS_WAFER, 32)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .duration(800).EUt(VA[HV]).buildAndRegister();
 
@@ -86,48 +89,48 @@ public class CircuitRecipes {
 
         // Wafer engraving
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Red).output(INTEGRATED_LOGIC_CIRCUIT_WAFER, 16).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Green).output(RANDOM_ACCESS_MEMORY_WAFER, 16).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.LightBlue).output(CENTRAL_PROCESSING_UNIT_WAFER, 16).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Blue).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Blue).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Blue).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Blue).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Blue).output(ULTRA_LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 16).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Orange).output(LOW_POWER_INTEGRATED_CIRCUIT_WAFER, 16).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[MV]).input(SILICON_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER).buildAndRegister();
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(50).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Cyan).output(SIMPLE_SYSTEM_ON_CHIP_WAFER, 16).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Gray).output(NAND_MEMORY_CHIP_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Pink).output(NOR_MEMORY_CHIP_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Brown).output(POWER_INTEGRATED_CIRCUIT_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 
-        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(GLOWSTONE_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
+        LASER_ENGRAVER_RECIPES.recipeBuilder().duration(900).EUt(VA[HV]).input(PHOSPHORUS_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(500).EUt(VA[EV]).input(NAQUADAH_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER, 4).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
         LASER_ENGRAVER_RECIPES.recipeBuilder().duration(200).EUt(VA[IV]).input(NEUTRONIUM_WAFER).notConsumable(craftingLens, Color.Yellow).output(SYSTEM_ON_CHIP_WAFER, 8).cleanroom(CleanroomType.CLEANROOM).buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -91,7 +91,7 @@ public class CraftingRecipeLoader {
         ModHandler.addShapedRecipe("nano_saber", NANO_SABER.getStackForm(), "PIC", "PIC", "XEX", 'P', new UnificationEntry(OrePrefix.plate, Materials.Platinum), 'I', new UnificationEntry(OrePrefix.plate, Ruridit), 'C', CARBON_FIBER_PLATE.getStackForm(), 'X', new UnificationEntry(OrePrefix.circuit, Tier.EV), 'E', ENERGIUM_CRYSTAL.getStackForm());
 
         ModHandler.addShapedRecipe("solar_panel_basic", COVER_SOLAR_PANEL.getStackForm(), "WGW", "CPC", 'W', SILICON_WAFER.getStackForm(), 'G', "paneGlass", 'C', new UnificationEntry(OrePrefix.circuit, Tier.LV), 'P', CARBON_FIBER_PLATE.getStackForm());
-        ModHandler.addShapedRecipe("solar_panel_ulv", COVER_SOLAR_PANEL_ULV.getStackForm(), "WGW", "CAC", "P P", 'W', GLOWSTONE_WAFER.getStackForm(), 'G', "paneGlass", 'C', new UnificationEntry(OrePrefix.circuit, Tier.HV), 'P', OreDictUnifier.get(OrePrefix.plate, GalliumArsenide), 'A', OreDictUnifier.get(OrePrefix.wireGtQuadruple, Graphene));
+        ModHandler.addShapedRecipe("solar_panel_ulv", COVER_SOLAR_PANEL_ULV.getStackForm(), "WGW", "CAC", "P P", 'W', PHOSPHORUS_WAFER.getStackForm(), 'G', "paneGlass", 'C', new UnificationEntry(OrePrefix.circuit, Tier.HV), 'P', OreDictUnifier.get(OrePrefix.plate, GalliumArsenide), 'A', OreDictUnifier.get(OrePrefix.wireGtQuadruple, Graphene));
         ModHandler.addShapedRecipe("solar_panel_lv", COVER_SOLAR_PANEL_LV.getStackForm(), "WGW", "CAC", "P P", 'W', NAQUADAH_WAFER.getStackForm(), 'G', MetaBlocks.TRANSPARENT_CASING.getItemVariant(
                 BlockGlassCasing.CasingType.TEMPERED_GLASS), 'C', new UnificationEntry(OrePrefix.circuit, Tier.LuV), 'P', OreDictUnifier.get(OrePrefix.plate, IndiumGalliumPhosphide), 'A', OreDictUnifier.get(OrePrefix.wireGtHex, Graphene));
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -656,6 +656,8 @@ public class MachineRecipeLoader {
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Steel, 2).input(plate, Steel, 4).outputs(STEEL_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Aluminium, 2).input(plate, Aluminium, 4).outputs(ALUMINIUM_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, StainlessSteel, 2).input(plate, StainlessSteel, 4).outputs(STAINLESS_STEEL_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Titanium, 2).input(plate, Titanium, 4).outputs(TITANIUM_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, TungstenSteel, 2).input(plate, TungstenSteel, 4).outputs(TUNGSTENSTEEL_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Gold, 2).input(plate, Gold, 4).outputs(GOLD_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, Polyethylene, 4).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE).duration(100).buildAndRegister();
@@ -1017,6 +1019,8 @@ public class MachineRecipeLoader {
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_steel", MetaTileEntities.STEEL_DRUM.getStackForm(), MetaTileEntities.STEEL_DRUM.getStackForm());
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_aluminium", MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), MetaTileEntities.ALUMINIUM_DRUM.getStackForm());
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_stainless_steel", MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_titanium", MetaTileEntities.TITANIUM_DRUM.getStackForm(), MetaTileEntities.TITANIUM_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_tungstensteel", MetaTileEntities.TUNGSTENSTEEL_DRUM.getStackForm(), MetaTileEntities.TUNGSTENSTEEL_DRUM.getStackForm());
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_gold", MetaTileEntities.GOLD_DRUM.getStackForm(), MetaTileEntities.GOLD_DRUM.getStackForm());
 
         // Cells

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -764,10 +764,10 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(2000))
                 .buildAndRegister();
 
-        BLAST_RECIPES.recipeBuilder().duration(240).EUt(VA[MV]).blastFurnaceTemp(1200)
+        BLAST_RECIPES.recipeBuilder().duration(240).EUt(VA[MV]).blastFurnaceTemp(2273)
                 .input(dust, SiliconDioxide)
                 .input(dust, Carbon, 2)
-                .output(ingot, Silicon)
+                .output(ingotHot, Silicon)
                 .output(dustTiny, Ash)
                 .fluidOutputs(CarbonMonoxide.getFluid(2000))
                 .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -656,6 +656,7 @@ public class MachineRecipeLoader {
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Steel, 2).input(plate, Steel, 4).outputs(STEEL_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Aluminium, 2).input(plate, Aluminium, 4).outputs(ALUMINIUM_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, StainlessSteel, 2).input(plate, StainlessSteel, 4).outputs(STAINLESS_STEEL_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
+        ASSEMBLER_RECIPES.recipeBuilder().EUt(16).input(stickLong, Gold, 2).input(plate, Gold, 4).outputs(GOLD_DRUM.getStackForm()).duration(200).circuitMeta(2).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, Polyethylene, 4).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE).duration(100).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).input(foil, SiliconeRubber, 2).input(CARBON_MESH).fluidInputs(Polyethylene.getFluid(288)).output(DUCT_TAPE, 2).duration(100).buildAndRegister();
@@ -1016,6 +1017,7 @@ public class MachineRecipeLoader {
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_steel", MetaTileEntities.STEEL_DRUM.getStackForm(), MetaTileEntities.STEEL_DRUM.getStackForm());
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_aluminium", MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), MetaTileEntities.ALUMINIUM_DRUM.getStackForm());
         ModHandler.addShapelessNBTClearingRecipe("drum_nbt_stainless_steel", MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm());
+        ModHandler.addShapelessNBTClearingRecipe("drum_nbt_gold", MetaTileEntities.GOLD_DRUM.getStackForm(), MetaTileEntities.GOLD_DRUM.getStackForm());
 
         // Cells
         ModHandler.addShapedNBTClearingRecipe("cell_nbt_regular", MetaItems.FLUID_CELL.getStackForm(), " C", "  ", 'C', MetaItems.FLUID_CELL.getStackForm());

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
@@ -344,12 +344,6 @@ public class MetaTileEntityLoader {
 
         registerMachineRecipe(MetaTileEntities.CHARGER, "WTW", "WMW", "BCB", 'M', HULL, 'W', WIRE_QUAD, 'T', OreDictNames.chestWood, 'B', CABLE, 'C', CIRCUIT);
 
-        registerMachineRecipe(MetaTileEntities.FLUID_IMPORT_HATCH, " G", " M", 'M', HULL, 'G', GLASS);
-        registerMachineRecipe(MetaTileEntities.FLUID_EXPORT_HATCH, " M", " G", 'M', HULL, 'G', GLASS);
-
-        registerMachineRecipe(MetaTileEntities.ITEM_IMPORT_BUS, " C", " M", 'M', HULL, 'C', OreDictNames.chestWood);
-        registerMachineRecipe(MetaTileEntities.ITEM_EXPORT_BUS, " M", " C", 'M', HULL, 'C', OreDictNames.chestWood);
-
         ModHandler.addShapedRecipe(true, "wooden_crate", MetaTileEntities.WOODEN_CRATE.getStackForm(), "RPR", "PsP", "RPR", 'P', "plankWood", 'R', new UnificationEntry(OrePrefix.screw, Materials.Iron));
         ModHandler.addShapedRecipe(true, "bronze_crate", MetaTileEntities.BRONZE_CRATE.getStackForm(), "RPR", "PhP", "RPR", 'P', new UnificationEntry(OrePrefix.plate, Materials.Bronze), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Bronze));
         ModHandler.addShapedRecipe(true, "steel_crate", MetaTileEntities.STEEL_CRATE.getStackForm(), "RPR", "PhP", "RPR", 'P', new UnificationEntry(OrePrefix.plate, Materials.Steel), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Steel));
@@ -363,6 +357,8 @@ public class MetaTileEntityLoader {
         ModHandler.addShapedRecipe(true, "steel_drum", MetaTileEntities.STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Steel), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Steel));
         ModHandler.addShapedRecipe(true, "aluminium_drum", MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Aluminium), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Aluminium));
         ModHandler.addShapedRecipe(true, "stainless_steel_drum", MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.StainlessSteel), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.StainlessSteel));
+        ModHandler.addShapedRecipe(true, "titanium_drum", MetaTileEntities.GOLD_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Titanium), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Titanium));
+        ModHandler.addShapedRecipe(true, "tungstensteel_drum", MetaTileEntities.GOLD_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.TungstenSteel), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.TungstenSteel));
         ModHandler.addShapedRecipe(true, "gold_drum", MetaTileEntities.GOLD_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Gold), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Gold));
 
         // Hermetic Casings

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
@@ -363,6 +363,7 @@ public class MetaTileEntityLoader {
         ModHandler.addShapedRecipe(true, "steel_drum", MetaTileEntities.STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Steel), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Steel));
         ModHandler.addShapedRecipe(true, "aluminium_drum", MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Aluminium), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Aluminium));
         ModHandler.addShapedRecipe(true, "stainless_steel_drum", MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.StainlessSteel), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.StainlessSteel));
+        ModHandler.addShapedRecipe(true, "gold_drum", MetaTileEntities.GOLD_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Gold), 'R', new UnificationEntry(OrePrefix.stickLong, Materials.Gold));
 
         // Hermetic Casings
         ModHandler.addShapedRecipe(true, "hermetic_casing_lv", MetaBlocks.HERMETIC_CASING.getItemVariant(HERMETIC_LV), "PPP", "PFP", "PPP", 'P', new UnificationEntry(OrePrefix.plate, Materials.Steel), 'F', new UnificationEntry(OrePrefix.pipeLargeFluid, Materials.Polyethylene));

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -1,7 +1,11 @@
 package gregtech.loaders.recipe;
 
+import gregtech.api.GTValues;
+import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.stack.UnificationEntry;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
@@ -15,6 +19,30 @@ import static gregtech.common.metatileentities.MetaTileEntities.*;
 public class MetaTileEntityMachineRecipeLoader {
 
     public static void init() {
+
+        // Fluid Hatches
+        registerHatchBusRecipe(ULV, FLUID_IMPORT_HATCH[ULV], FLUID_EXPORT_HATCH[ULV], new ItemStack(Blocks.GLASS));
+        registerHatchBusRecipe(LV, FLUID_IMPORT_HATCH[LV], FLUID_EXPORT_HATCH[LV], new ItemStack(Blocks.GLASS));
+        registerHatchBusRecipe(MV, FLUID_IMPORT_HATCH[MV], FLUID_EXPORT_HATCH[MV], BRONZE_DRUM.getStackForm());
+        registerHatchBusRecipe(HV, FLUID_IMPORT_HATCH[HV], FLUID_EXPORT_HATCH[HV], STEEL_DRUM.getStackForm());
+        registerHatchBusRecipe(EV, FLUID_IMPORT_HATCH[EV], FLUID_EXPORT_HATCH[EV], ALUMINIUM_DRUM.getStackForm());
+        registerHatchBusRecipe(IV, FLUID_IMPORT_HATCH[IV], FLUID_EXPORT_HATCH[IV], STAINLESS_STEEL_DRUM.getStackForm());
+        registerHatchBusRecipe(LuV, FLUID_IMPORT_HATCH[LuV], FLUID_EXPORT_HATCH[LuV], TITANIUM_DRUM.getStackForm());
+        registerHatchBusRecipe(ZPM, FLUID_IMPORT_HATCH[ZPM], FLUID_EXPORT_HATCH[ZPM], TUNGSTENSTEEL_DRUM.getStackForm());
+        registerHatchBusRecipe(UV, FLUID_IMPORT_HATCH[UV], FLUID_EXPORT_HATCH[UV], QUANTUM_TANK[0].getStackForm());
+        registerHatchBusRecipe(UHV, FLUID_IMPORT_HATCH[UHV], FLUID_EXPORT_HATCH[UHV], QUANTUM_TANK[1].getStackForm());
+
+        // Item Buses
+        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new ItemStack(Blocks.CHEST));
+        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new ItemStack(Blocks.CHEST));
+        registerHatchBusRecipe(MV, ITEM_IMPORT_BUS[MV], ITEM_EXPORT_BUS[MV], BRONZE_CRATE.getStackForm());
+        registerHatchBusRecipe(HV, ITEM_IMPORT_BUS[HV], ITEM_EXPORT_BUS[HV], STEEL_CRATE.getStackForm());
+        registerHatchBusRecipe(EV, ITEM_IMPORT_BUS[EV], ITEM_EXPORT_BUS[EV], ALUMINIUM_CRATE.getStackForm());
+        registerHatchBusRecipe(IV, ITEM_IMPORT_BUS[IV], ITEM_EXPORT_BUS[IV], STAINLESS_STEEL_CRATE.getStackForm());
+        registerHatchBusRecipe(LuV, ITEM_IMPORT_BUS[LuV], ITEM_EXPORT_BUS[LuV], TITANIUM_CRATE.getStackForm());
+        registerHatchBusRecipe(ZPM, ITEM_IMPORT_BUS[ZPM], ITEM_EXPORT_BUS[ZPM], TUNGSTENSTEEL_CRATE.getStackForm());
+        registerHatchBusRecipe(UV, ITEM_IMPORT_BUS[UV], ITEM_EXPORT_BUS[UV], QUANTUM_CHEST[0].getStackForm());
+        registerHatchBusRecipe(UHV, ITEM_IMPORT_BUS[UHV], ITEM_EXPORT_BUS[UHV], QUANTUM_CHEST[1].getStackForm());
 
         // Energy Output Hatches
 
@@ -552,7 +580,7 @@ public class MetaTileEntityMachineRecipeLoader {
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(HULL[LV])
-                .circuitMeta(1)
+                .circuitMeta(8)
                 .output(MAINTENANCE_HATCH)
                 .duration(100).EUt(VA[LV]).buildAndRegister();
 
@@ -628,5 +656,107 @@ public class MetaTileEntityMachineRecipeLoader {
                 .circuitMeta(2)
                 .output(ADVANCED_FLUID_DRILLING_RIG)
                 .duration(400).EUt(VA[LuV]).buildAndRegister();
+    }
+
+    private static void registerHatchBusRecipe(int tier, MetaTileEntity inputBus, MetaTileEntity outputBus, ItemStack extra) {
+        // Glue recipe for ULV and LV
+        // 250L for ULV, 500L for LV
+        if (tier <= GTValues.LV) {
+            int fluidAmount = tier == GTValues.ULV ? 250 : 500;
+            ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(HULL[tier])
+                    .inputs(extra)
+                    .fluidInputs(Glue.getFluid(fluidAmount))
+                    .circuitMeta(1)
+                    .output(inputBus)
+                    .duration(300).EUt(VA[tier]).buildAndRegister();
+
+            ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(HULL[tier])
+                    .inputs(extra)
+                    .fluidInputs(Glue.getFluid(fluidAmount))
+                    .circuitMeta(2)
+                    .output(outputBus)
+                    .duration(300).EUt(VA[tier]).buildAndRegister();
+        }
+
+        // Polyethylene recipe for HV and below
+        // 72L for ULV, 144L for LV, 288L for MV, 432L for HV
+        if (tier <= GTValues.HV) {
+            int peAmount = getFluidAmount(tier + 4);
+            ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(HULL[tier])
+                    .inputs(extra)
+                    .fluidInputs(Polyethylene.getFluid(peAmount))
+                    .circuitMeta(1)
+                    .output(inputBus)
+                    .duration(300).EUt(VA[tier]).buildAndRegister();
+
+            ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(HULL[tier])
+                    .inputs(extra)
+                    .fluidInputs(Polyethylene.getFluid(peAmount))
+                    .circuitMeta(2)
+                    .output(outputBus)
+                    .duration(300).EUt(VA[tier]).buildAndRegister();
+        }
+
+        // Polytetrafluoroethylene recipe for LuV and below
+        // 36L for ULV, 72L for LV, 144L for MV, 288L for HV, 432L for EV, 576L for IV, 720L for LuV
+        if (tier <= GTValues.LuV) {
+            int ptfeAmount = getFluidAmount(tier + 3);
+            ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(HULL[tier])
+                    .inputs(extra)
+                    .fluidInputs(Polytetrafluoroethylene.getFluid(ptfeAmount))
+                    .circuitMeta(1)
+                    .output(inputBus)
+                    .duration(300).EUt(VA[tier]).buildAndRegister();
+
+            ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(HULL[tier])
+                    .inputs(extra)
+                    .fluidInputs(Polytetrafluoroethylene.getFluid(ptfeAmount))
+                    .circuitMeta(2)
+                    .output(outputBus)
+                    .duration(300).EUt(VA[tier]).buildAndRegister();
+        }
+
+        // PBI recipe for all
+        // 4L for ULV, 9L for LV, 18L for MV, 36L for HV, 72L for EV, 144L for IV,
+        // 288L for LuV, 432L for ZPM, 576L for UV, 720L for UHV
+        // Use a Math.min() call on tier so that UHV hatches are still UV voltage
+        int pbiAmount = getFluidAmount(tier);
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(HULL[tier])
+                .inputs(extra)
+                .fluidInputs(Polybenzimidazole.getFluid(pbiAmount))
+                .circuitMeta(1)
+                .output(inputBus)
+                .duration(300).EUt(VA[Math.min(GTValues.UV, tier)]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(HULL[tier])
+                .inputs(extra)
+                .fluidInputs(Polybenzimidazole.getFluid(pbiAmount))
+                .circuitMeta(2)
+                .output(outputBus)
+                .duration(300).EUt(VA[Math.min(GTValues.UV, tier)]).buildAndRegister();
+    }
+
+    private static int getFluidAmount(int offsetTier) {
+        switch (offsetTier) {
+            case 0: return 4;
+            case 1: return 9;
+            case 2: return 18;
+            case 3: return 36;
+            case 4: return 72;
+            case 5: return 144;
+            case 6: return 288;
+            case 7: return 432;
+            case 8: return 576;
+            case 9:
+            default: return 720;
+        }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ChemicalBathRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ChemicalBathRecipes.java
@@ -6,11 +6,10 @@ import gregtech.common.blocks.StoneVariantBlock.StoneVariant;
 import gregtech.common.blocks.wood.BlockGregPlanks;
 import net.minecraft.init.Items;
 
-import static gregtech.api.GTValues.ULV;
-import static gregtech.api.GTValues.VA;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CHEMICAL_BATH_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
-import static gregtech.api.unification.ore.OrePrefix.dust;
+import static gregtech.api.unification.ore.OrePrefix.*;
 
 public class ChemicalBathRecipes {
 
@@ -77,5 +76,29 @@ public class ChemicalBathRecipes {
                 .output(dust, TungsticAcid, 7)
                 .output(dust, LithiumChloride, 4)
                 .duration(210).EUt(960).buildAndRegister();
+
+        CHEMICAL_BATH_RECIPES.recipeBuilder()
+                .input(ingotHot, Kanthal)
+                .fluidInputs(Water.getFluid(100))
+                .output(ingot, Kanthal)
+                .duration(400).EUt(VA[MV]).buildAndRegister();
+
+        CHEMICAL_BATH_RECIPES.recipeBuilder()
+                .input(ingotHot, Kanthal)
+                .fluidInputs(DistilledWater.getFluid(100))
+                .output(ingot, Kanthal)
+                .duration(250).EUt(VA[MV]).buildAndRegister();
+
+        CHEMICAL_BATH_RECIPES.recipeBuilder()
+                .input(ingotHot, Silicon)
+                .fluidInputs(Water.getFluid(100))
+                .output(ingot, Silicon)
+                .duration(400).EUt(VA[MV]).buildAndRegister();
+
+        CHEMICAL_BATH_RECIPES.recipeBuilder()
+                .input(ingotHot, Silicon)
+                .fluidInputs(DistilledWater.getFluid(100))
+                .output(ingot, Silicon)
+                .duration(250).EUt(VA[MV]).buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/GemSlurryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/GemSlurryRecipes.java
@@ -4,8 +4,7 @@ import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.CENTRIFUGE_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.MIXER_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
-import static gregtech.api.unification.ore.OrePrefix.dust;
-import static gregtech.api.unification.ore.OrePrefix.dustTiny;
+import static gregtech.api.unification.ore.OrePrefix.*;
 
 public class GemSlurryRecipes {
 
@@ -13,7 +12,7 @@ public class GemSlurryRecipes {
 
         // Ruby
         MIXER_RECIPES.recipeBuilder().duration(280).EUt(VA[EV])
-                .input(dust, Ruby, 6)
+                .input(crushed, Ruby, 2)
                 .fluidInputs(AquaRegia.getFluid(3000))
                 .fluidOutputs(RubySlurry.getFluid(3000))
                 .buildAndRegister();
@@ -22,17 +21,15 @@ public class GemSlurryRecipes {
                 .fluidInputs(RubySlurry.getFluid(3000))
                 .output(dust, Aluminium, 2)
                 .output(dust, Chrome)
-                .chancedOutput(dustTiny, Titanium, 2000, 0)
-                .chancedOutput(dustTiny, Iron, 2000, 0)
-                .chancedOutput(dustTiny, Vanadium, 2000, 0)
-                .fluidOutputs(Oxygen.getFluid(3000))
-                .fluidOutputs(NitricAcid.getFluid(1000))
-                .fluidOutputs(HydrochloricAcid.getFluid(2000))
+                .chancedOutput(dust, Titanium, 200, 0)
+                .chancedOutput(dust, Iron, 200, 0)
+                .chancedOutput(dust, Vanadium, 200, 0)
+                .fluidOutputs(DilutedHydrochloricAcid.getFluid(2000))
                 .buildAndRegister();
 
         // Sapphire
         MIXER_RECIPES.recipeBuilder().duration(280).EUt(VA[EV])
-                .input(dust, Sapphire, 5)
+                .input(crushed, Sapphire, 2)
                 .fluidInputs(AquaRegia.getFluid(3000))
                 .fluidOutputs(SapphireSlurry.getFluid(3000))
                 .buildAndRegister();
@@ -40,17 +37,15 @@ public class GemSlurryRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(VA[HV])
                 .fluidInputs(SapphireSlurry.getFluid(3000))
                 .output(dust, Aluminium, 2)
-                .chancedOutput(dustTiny, Titanium, 2000, 0)
-                .chancedOutput(dustTiny, Iron, 2000, 0)
-                .chancedOutput(dustTiny, Vanadium, 2000, 0)
-                .fluidOutputs(Oxygen.getFluid(3000))
-                .fluidOutputs(NitricAcid.getFluid(1000))
-                .fluidOutputs(HydrochloricAcid.getFluid(2000))
+                .chancedOutput(dust, Titanium, 200, 0)
+                .chancedOutput(dust, Iron, 200, 0)
+                .chancedOutput(dust, Vanadium, 200, 0)
+                .fluidOutputs(DilutedHydrochloricAcid.getFluid(2000))
                 .buildAndRegister();
 
         // Green Sapphire
         MIXER_RECIPES.recipeBuilder().duration(280).EUt(VA[EV])
-                .input(dust, GreenSapphire, 5)
+                .input(crushed, GreenSapphire, 2)
                 .fluidInputs(AquaRegia.getFluid(3000))
                 .fluidOutputs(GreenSapphireSlurry.getFluid(3000))
                 .buildAndRegister();
@@ -58,13 +53,11 @@ public class GemSlurryRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(VA[HV])
                 .fluidInputs(GreenSapphireSlurry.getFluid(3000))
                 .output(dust, Aluminium, 2)
-                .chancedOutput(dustTiny, Beryllium, 2000, 0)
-                .chancedOutput(dustTiny, Titanium, 2000, 0)
-                .chancedOutput(dustTiny, Iron, 2000, 0)
-                .chancedOutput(dustTiny, Vanadium, 2000, 0)
-                .fluidOutputs(Oxygen.getFluid(3000))
-                .fluidOutputs(NitricAcid.getFluid(1000))
-                .fluidOutputs(HydrochloricAcid.getFluid(2000))
+                .chancedOutput(dust, Beryllium, 200, 0)
+                .chancedOutput(dust, Titanium, 200, 0)
+                .chancedOutput(dust, Iron, 200, 0)
+                .chancedOutput(dust, Vanadium, 200, 0)
+                .fluidOutputs(DilutedHydrochloricAcid.getFluid(2000))
                 .buildAndRegister();
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PetrochemRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PetrochemRecipes.java
@@ -53,9 +53,9 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(RawOil.getFluid(100))
-                .fluidOutputs(SulfuricHeavyFuel.getFluid(15))
+                .fluidOutputs(SulfuricHeavyFuel.getFluid(10))
                 .fluidOutputs(SulfuricLightFuel.getFluid(50))
-                .fluidOutputs(SulfuricNaphtha.getFluid(20))
+                .fluidOutputs(SulfuricNaphtha.getFluid(150))
                 .fluidOutputs(SulfuricGas.getFluid(60))
                 .duration(20).EUt(96).buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -462,6 +462,13 @@ public class SeparationRecipes {
                 .fluidOutputs(Water.getFluid(1000))
                 .duration(64).EUt(VA[LV]).buildAndRegister();
 
+        ELECTROLYZER_RECIPES.recipeBuilder()
+                .input(dust, Apatite, 9)
+                .output(dust, Calcium, 5)
+                .output(dust, Phosphorus, 3)
+                .fluidOutputs(Chlorine.getFluid(1000))
+                .duration(288).EUt(60).buildAndRegister();
+
         // Thermal Centrifuge
         THERMAL_CENTRIFUGE_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.COBBLESTONE, 1, GTValues.W))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -57,10 +57,15 @@ public class SeparationRecipes {
                 .duration(24).EUt(5).buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder()
-                .input(OrePrefix.ore, Oilsands)
+                .input(ore, Oilsands)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 5000)
-                .fluidOutputs(Oil.getFluid(500))
-                .duration(200).EUt(5).buildAndRegister();
+                .fluidOutputs(OilHeavy.getFluid(2000))
+                .duration(200).EUt(30).buildAndRegister();
+
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(7)
+                .input(dust, Oilsands)
+                .fluidOutputs(OilHeavy.getFluid(1000))
+                .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(144).EUt(5)
                 .inputs(new ItemStack(Items.NETHER_WART))
@@ -283,11 +288,6 @@ public class SeparationRecipes {
                 .output(dustTiny, Barite)
                 .chancedOutput(dustTiny, Chromite, 7500, 750)
                 .chancedOutput(dustTiny, Ilmenite, 5000, 500)
-                .buildAndRegister();
-
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(5)
-                .input(dust, Oilsands)
-                .fluidOutputs(Oil.getFluid(1000))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(60).EUt(VA[LV])

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -117,6 +117,14 @@ public class PartsRecipeHandler {
                 .circuitMeta(1)
                 .buildAndRegister();
 
+        RecipeMaps.BENDER_RECIPES.recipeBuilder()
+                .input(ingot, material)
+                .output(foilPrefix, material, 4)
+                .duration((int) material.getMass())
+                .EUt(24)
+                .circuitMeta(10)
+                .buildAndRegister();
+
         if (material.hasFlag(NO_SMASHING)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
                     .input(ingot, material)

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -539,7 +539,7 @@ metaitem.glass_lens.black.name=Glass Lens (Black)
 #CIRCUITS LOCALIZATION
 metaitem.boule.silicon.name=Monocrystalline Silicon Boule
 metaitem.boule.silicon.tooltip=Raw Circuit
-metaitem.boule.glowstone.name=Glowstone-doped Monocrystalline Silicon Boule
+metaitem.boule.glowstone.name=Phosphorus-doped Monocrystalline Silicon Boule
 metaitem.boule.glowstone.tooltip=Raw Circuit
 metaitem.boule.naquadah.name=Naquadah-doped Monocrystalline Silicon Boule
 metaitem.boule.naquadah.tooltip=Raw Circuit
@@ -547,7 +547,7 @@ metaitem.boule.neutronium.name=Neutronium-doped Monocrystalline Silicon Boule
 metaitem.boule.neutronium.tooltip=Raw Circuit
 metaitem.wafer.silicon.name=Silicon Wafer
 metaitem.wafer.silicon.tooltip=Raw Circuit
-metaitem.wafer.glowstone.name=Glowstone-doped Wafer
+metaitem.wafer.glowstone.name=Phosphorus-doped Wafer
 metaitem.wafer.glowstone.tooltip=Raw Circuit
 metaitem.wafer.naquadah.name=Naquadah-doped Wafer
 metaitem.wafer.naquadah.tooltip=Raw Circuit

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2514,9 +2514,9 @@ gregtech.machine.drum.bronze.name=Bronze Drum
 gregtech.machine.drum.steel.name=Steel Drum
 gregtech.machine.drum.aluminium.name=Aluminium Drum
 gregtech.machine.drum.stainless_steel.name=Stainless Steel Drum
-gregtech.machine.drum.gold.name=Gold Drum
 gregtech.machine.drum.titanium.name=Titanium Drum
 gregtech.machine.drum.tungstensteel.name=Tungstensteel Drum
+gregtech.machine.drum.gold.name=Gold Drum
 
 gregtech.machine.drum.enable_output=Will drain Fluid to downward adjacent Tanks
 gregtech.machine.drum.disable_output=Will not drain Fluid

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2514,6 +2514,7 @@ gregtech.machine.drum.bronze.name=Bronze Drum
 gregtech.machine.drum.steel.name=Steel Drum
 gregtech.machine.drum.aluminium.name=Aluminium Drum
 gregtech.machine.drum.stainless_steel.name=Stainless Steel Drum
+gregtech.machine.drum.gold.name=Gold Drum
 gregtech.machine.drum.titanium.name=Titanium Drum
 gregtech.machine.drum.tungstensteel.name=Tungstensteel Drum
 


### PR DESCRIPTION
This PR adjusts some aspects of progression, primarily in the early game, though in other areas as well.

## Coils
Kanthal and Nichrome have always been too close to each other in progression, leading to Kanthal coils often simply being made just as a stepping stone to Nichrome immediately after.

I changed Silicon's EBF recipe to require Kanthal coils. Silicon is required for Transistors, for the first HV circuits. This moves Kanthal coils to late MV, instead of mid-HV. Additionally, I added Chemical Bath recipes to cool both Hot Kanthal and Hot Silicon Ingots, using Water (or Distilled Water for a speed bonus). Ultimately this change means 4 things:
1. Kanthal and Nichrome coils are no longer right next to eachother in progression
2. MV Chemical Bath is required MV progression
3. I also changed Kanthal's EBF recipe to HV, meaning the player must upgrade their EBF energy hatches for this
3. Players can realize the benefits of a better set of coils earlier than previously

## Circuits and Circuit Components
Firstly, the Glowstone-doped Boule was changed to Phosphorus-doped. This helps to address two issues, being
1. Glowstone is a difficult to acquire material from GT methods
2. Phosphorus has little use in standard GT progression

As a result, I modified Apatite's electrolysis recipe to give Phosphorus directly instead of Phosphate, but also halved its ore multiplier (8 -> 4). Overall, this is still a significant buff to Phosphorus production.
<br>

Next, I added Gallium Arsenide to all Boule recipes, instead of just the first. The first Boule takes 2 Small Dust as before. The second boule takes 1 Dust. The 3rd Boule takes 2, and the last Boule takes 4. This helps to keep Gallium Arsenide (and more generally, Arsenic) a relevant material throughout the game, without significantly increasing the demand on the material.
<br>

Next, I added a few new recipes using Tantalum to SMDs, similar to how the SMD Capacitor can use Tantalum to get increased yield. The original recipes were not changed, only superior alternatives were added. However, the ASMD Diode had its recipe changed to no longer use a Small Dust of InGaP, and was simply multiplied up until it could be a full dust. Additionally, its duration was adjusted to match the production rate of other ASMD components.
<br>

Lastly, I adjusted a couple recipes relating to Circuit Boards. First (and more minor), I removed the Plate Mold from the Phenolic Board recipe, instead favoring a Programmed Circuit. This change feels reasonable, as this was the only recipe involving a Mold outside of the Fluid Solidifier, and with ghost circuits, this does not affect the cost. Additionally, I increased the duration and EU/t of this recipe to better align with other circuit board recipes.

Additionally, I adjusted the Extreme Circuit Board craft to require Palladium foils in one of the steps, instead of Platinum Foils in both steps. This should help to provide variety in materials needed in mid-late game, and provide something to spend Palladium on, as we have few things requiring it right now.

## Gem Slurries
The Gem Slurry recipes have always been quite underwhelming, involving a high-power and time cost setup with the only gain being a chance at some tiny dusts. I significantly reduced the input required in the recipe, as well as changing it to input Crushed Ore instead of Dust. Additionally, I made the recipe lossy on some of the solution used to make the slurry. This combined with the fact that most ore byproduct opportunities are lost I think makes this a viable, though not overpowered alternative to traditional ore processing for these materials. Lastly, I adjusted the chances of the outputs so that I could convert the Tiny Dusts to full Dusts with lower chance.

## Misc
- Tantalum was given a better color, as it was just another gray metal before
- Added a recipe for Ingot -> Foil in the bender directly with Circuit 10. The duration being less than if done Ingot -> Plate -> Foil is intentional, as it is meant to promote players setting up dedicated Benders for Foils with this change. Circuit 10 was chosen in case of an addon or modpack adding Plates with thicknesses between single and dense.