### PR TITLE
Pass mouseX and mouseY to recipe property draw

### DIFF
--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -18,6 +18,11 @@ public abstract class RecipeProperty<T> {
     @SideOnly(Side.CLIENT)
     public abstract void drawInfo(Minecraft minecraft, int x, int y, int color, Object value);
 
+    @SideOnly(Side.CLIENT)
+    public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value, int mouseX, int mouseY) {
+        drawInfo(minecraft, x, y, color, value);
+    }
+
     public int getInfoHeight(Object value) {
         return 10; // GTRecipeWrapper#LINE_HEIGHT
     }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -131,7 +131,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
             if (!propertyEntry.getKey().isHidden()) {
                 RecipeProperty<?> property = propertyEntry.getKey();
                 Object value = propertyEntry.getValue();
-                property.drawInfo(minecraft, 0, yPosition += property.getInfoHeight(value), 0x111111, value);
+                property.drawInfo(minecraft, 0, yPosition += property.getInfoHeight(value), 0x111111, value, mouseX, mouseY);
             }
         }
     }


### PR DESCRIPTION
Passes mouseX and mouseY to recipe properties to be optionally used for drawing the text. Does not have an API break