### PR TITLE
Add hashCode and equals for RecipeMap

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -1365,6 +1365,17 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return "RecipeMap{" + "unlocalizedName='" + unlocalizedName + '\'' + '}';
     }
 
+    @Override
+    public int hashCode() {
+        return unlocalizedName.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RecipeMap)) return false;
+        return ((RecipeMap<?>) obj).unlocalizedName.equals(this.unlocalizedName);
+    }
+
     @FunctionalInterface
     @ZenClass("mods.gregtech.recipe.IChanceFunction")
     @ZenRegister


### PR DESCRIPTION
Simply used `unlocalizedName` since it is a unique signifier for RecipeMap objects