### PR TITLE
Hide repair tooltip on tools if Unbreakable

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -735,27 +735,29 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         ));
 
         // repair info
-        if (TooltipHelper.isShiftDown()) {
-            Material material = getToolMaterial(stack);
+        if (!tagCompound.getBoolean(UNBREAKABLE_KEY)) {
+            if (TooltipHelper.isShiftDown()) {
+                Material material = getToolMaterial(stack);
+                String materialName = I18n.format(getToolMaterial(stack).getUnlocalizedName());
 
-            Collection<String> repairItems = new ArrayList<>();
-            if (ModHandler.isMaterialWood(material)) {
-                repairItems.add(OrePrefix.plank.getLocalNameForItem(material));
-            } else {
-                if (material.hasProperty(PropertyKey.INGOT)) {
-                    repairItems.add(OrePrefix.ingot.getLocalNameForItem(material));
-                } else if (material.hasProperty(PropertyKey.GEM)) {
-                    repairItems.add(OrePrefix.gem.getLocalNameForItem(material));
+                Collection<String> repairItems = new ArrayList<>();
+                if (ModHandler.isMaterialWood(material)) {
+                    repairItems.add(I18n.format("item.material.oreprefix.plank", materialName));
+                } else {
+                    if (material.hasProperty(PropertyKey.INGOT)) {
+                        repairItems.add(I18n.format("item.material.oreprefix.ingot", materialName));
+                    } else if (material.hasProperty(PropertyKey.GEM)) {
+                        repairItems.add(I18n.format("item.material.oreprefix.gem", materialName));
+                    }
+                    repairItems.add(I18n.format("item.material.oreprefix.plate", materialName));
                 }
-                repairItems.add(OrePrefix.plate.getLocalNameForItem(material));
+                tooltip.add(I18n.format("item.gt.tool.tooltip.repair_material", String.join(", ", repairItems)));
+            } else {
+                tooltip.add(I18n.format("item.gt.tool.tooltip.repair_info"));
             }
-            tooltip.add(I18n.format("item.gt.tool.tooltip.repair_material", String.join(", ", repairItems)));
-
-            if (this.isElectric()) {
-                tooltip.add(I18n.format("item.gt.tool.replace_tool_head"));
-            }
-        } else {
-            tooltip.add(I18n.format("item.gt.tool.tooltip.repair_info"));
+        }
+        if (this.isElectric()) {
+            tooltip.add(I18n.format("item.gt.tool.replace_tool_head"));
         }
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -738,18 +738,17 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         if (!tagCompound.getBoolean(UNBREAKABLE_KEY)) {
             if (TooltipHelper.isShiftDown()) {
                 Material material = getToolMaterial(stack);
-                String materialName = I18n.format(getToolMaterial(stack).getUnlocalizedName());
 
                 Collection<String> repairItems = new ArrayList<>();
                 if (ModHandler.isMaterialWood(material)) {
-                    repairItems.add(I18n.format("item.material.oreprefix.plank", materialName));
+                    repairItems.add(OrePrefix.plate.getLocalNameForItem(material));
                 } else {
                     if (material.hasProperty(PropertyKey.INGOT)) {
-                        repairItems.add(I18n.format("item.material.oreprefix.ingot", materialName));
+                        repairItems.add(OrePrefix.plate.getLocalNameForItem(material));
                     } else if (material.hasProperty(PropertyKey.GEM)) {
-                        repairItems.add(I18n.format("item.material.oreprefix.gem", materialName));
+                        repairItems.add(OrePrefix.plate.getLocalNameForItem(material));
                     }
-                    repairItems.add(I18n.format("item.material.oreprefix.plate", materialName));
+                    repairItems.add(OrePrefix.plate.getLocalNameForItem(material));
                 }
                 tooltip.add(I18n.format("item.gt.tool.tooltip.repair_material", String.join(", ", repairItems)));
             } else {


### PR DESCRIPTION
## What
Don't show the Repair information tooltip if the tool is unbreakable. Also always show the replacing tool head tooltip, because it should not be hidden when the tool is unbreakable, so it needed to be moved outside of its if statement.


## Outcome
Hide repair tooltip on tools if the tool is unbreakable.
