### PR TITLE
Fix wildcard ingredients in the recipe search tree

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -958,8 +958,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
             });
 
             // left branches are always either empty or contain recipes.
-            // If there's a recipe present, the addition is finished
-            if (r.left().isPresent()) return true;
+            // If there's a recipe present, the addition is finished for this ingredient
+            // Cannot return here, since each ingredient to add is a separate path to the recipe
+            if (r.left().isPresent()) continue;
 
             // recursive part: apply the addition for the next ingredient in the list, for the right branch.
             // the right branch only contains ingredients, or is empty when the left branch is present

--- a/src/test/java/gregtech/api/recipes/RecipeMapTest.java
+++ b/src/test/java/gregtech/api/recipes/RecipeMapTest.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes;
 
 import gregtech.Bootstrap;
+import gregtech.api.GTValues;
 import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.recipes.map.AbstractMapIngredient;
 import gregtech.api.recipes.map.MapFluidIngredient;
@@ -248,5 +249,24 @@ public class RecipeMapTest {
         map.put(ing2FromGTRecipeInput, ing2FromGTRecipeInput);
 
         MatcherAssert.assertThat(map.keySet().size(), is(2));
+    }
+
+    @Test
+    public void wildcardInput() {
+        // test that all variants of a wildcard input can be used to find a recipe
+        RecipeMap<?> recipeMap = new RecipeMap<>("test", 1, 4, 0, 0, new SimpleRecipeBuilder(), false);
+        recipeMap.recipeBuilder()
+                .inputs(new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, GTValues.W))
+                .outputs(new ItemStack(Blocks.COBBLESTONE, 1))
+                .EUt(1).duration(1)
+                .buildAndRegister();
+
+        for (int i = 0; i < 16; i++) { // Blocks.STAINED_HARDENED_CLAY has 16 variants
+            Recipe recipe = recipeMap.findRecipe(Integer.MAX_VALUE,
+                    Collections.singletonList(new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, i)),
+                    Collections.emptyList());
+
+            MatcherAssert.assertThat(recipe, notNullValue());
+        }
     }
 }


### PR DESCRIPTION
## What
This PR fixes wildcard ingredients not being fully added to the recipe search tree. The changes made in this PR ensures every ingredient the wildcard represents is added as a pathway to the recipe, instead of a smaller amount.

## Outcome
Fixes issues with wildcard ingredients as recipe inputs. Closes #1714.
