### PR TITLE
Allow matching any or no nbt tag in CT

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTNBTMultiItemMatcher.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTNBTMultiItemMatcher.java
@@ -47,6 +47,8 @@ public class CTNBTMultiItemMatcher implements NBTMatcher {
 
         final Set<Map.Entry<String, NBTBase>> toCheck = tagCompound.tagMap.entrySet();
         for (NBTTagCompound requirement : list) {
+            // special case which considers an empty nbt tag as allowing any or no NBT
+            if (requirement.isEmpty()) return true;
             // return if the tag to check has everything the recipe requires, ignoring extraneous tags on toCheck
             if (toCheck.containsAll(requirement.tagMap.entrySet())) return true;
         }

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -13,6 +13,8 @@ import gregtech.api.recipes.ingredients.GTRecipeFluidInput;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.ingredients.GTRecipeItemInput;
 import gregtech.api.recipes.ingredients.GTRecipeOreInput;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTCondition;
+import gregtech.api.recipes.ingredients.nbtmatch.NBTMatcher;
 import gregtech.api.util.ItemStackHashStrategy;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
 import net.minecraft.item.ItemStack;
@@ -162,6 +164,10 @@ public class CTRecipeBuilder {
     @Nonnull
     private static GTRecipeInput tryConstructNBTInput(@Nonnull GTRecipeInput input, @Nullable NBTTagCompound compound) {
         if (compound == null) return input; // do not use nbt matching, if there is no tag to check
+        if (compound.isEmpty()) {
+            // special case which considers an empty nbt tag as allowing any or no NBT
+            return input.setNBTMatchingCondition(NBTMatcher.ANY, NBTCondition.ANY);
+        }
         return input.setNBTMatchingCondition(new CTNBTMatcher(compound), null);
     }
 


### PR DESCRIPTION
## What
Allows CT to have inputs which match any or no NBT tag. This behavior is created when the input is provided with an empty NBT tag, which is consistent with how CT interacts with other mods.

Documentation for this behavior will be added to the wiki as well.

## Outcome
Fixes #1688.
