### PR TITLE
Add tooltip to display fluid in units of 144

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -1,5 +1,6 @@
 package gregtech.api.gui.widgets;
 
+import gregtech.api.GTValues;
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.ingredient.IIngredientSlot;
@@ -16,6 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -171,6 +173,9 @@ public class TankWidget extends Widget implements IIngredientSlot {
                         tooltips.add(s);
                     }
                 }
+
+                // Add tooltip showing how many "ingot moles" (increments of 144) this fluid is if shift is held
+                addIngotMolFluidTooltip(lastFluidInTank, tooltips);
 
             } else {
                 tooltips.add(LocalizationUtils.format("gregtech.fluid.empty"));
@@ -346,5 +351,18 @@ public class TankWidget extends Widget implements IIngredientSlot {
             }
         }
         return false;
+    }
+
+    public static void addIngotMolFluidTooltip(FluidStack fluidStack, List<String> tooltip) {
+        // Add tooltip showing how many "ingot moles" (increments of 144) this fluid is if shift is held
+        if (TooltipHelper.isShiftDown() && fluidStack.amount > GTValues.L) {
+            int numIngots = fluidStack.amount / GTValues.L;
+            int extra = fluidStack.amount % GTValues.L;
+            String fluidAmount = String.format(" %,d L = %,d * %d L", fluidStack.amount, numIngots, GTValues.L);
+            if (extra != 0) {
+                fluidAmount += String.format(" + %d L", extra);
+            }
+            tooltip.add(TextFormatting.GRAY + LocalizationUtils.format("gregtech.gui.amount_raw") + fluidAmount);
+        }
     }
 }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -2,6 +2,7 @@ package gregtech.integration.jei.recipe;
 
 import gregtech.api.GTValues;
 import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
@@ -111,8 +112,10 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     }
 
     public void addFluidTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
-        boolean notConsumed = input && isNotConsumedFluid(slotIndex);
+        FluidStack fluidStack = (FluidStack) ingredient;
+        TankWidget.addIngotMolFluidTooltip(fluidStack, tooltip);
 
+        boolean notConsumed = input && isNotConsumedFluid(slotIndex);
         if (notConsumed) {
             tooltip.add(TooltipHelper.BLINKING_CYAN + I18n.format("gregtech.recipe.not_consumed"));
         }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4872,6 +4872,7 @@ gregtech.fluid.state_plasma=§aState: Plasma
 gregtech.fluid.type_acid.tooltip=§6Acidic! Handle with care!
 gregtech.gui.fuel_amount=Fuel Amount:
 gregtech.gui.fluid_amount=Fluid Amount:
+gregtech.gui.amount_raw=Amount:
 gregtech.gui.toggle_view.disabled=Toggle View (Fluids)
 gregtech.gui.toggle_view.enabled=Toggle View (Items)
 gregtech.gui.overclock.enabled=Overclocking Enabled./nClick to Disable


### PR DESCRIPTION
Displays a tooltip like this when shift is held on a tank widget (in machines or in JEI). Only displays if the fluid amount is greater than 144L
![image](https://user-images.githubusercontent.com/10861407/236018478-c91945b2-128d-4158-bd7b-db4da8c4221d.png)
