### PR TITLE
Multiblock Energy Input Changes

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerHandler.java
@@ -283,4 +283,17 @@ public class EnergyContainerHandler extends MTETrait implements IEnergyContainer
     public interface IEnergyChangeListener {
         void onEnergyChanged(IEnergyContainer container, boolean isInitialChange);
     }
+
+    @Override
+    public String toString() {
+        return "EnergyContainerHandler{" +
+                "maxCapacity=" + maxCapacity +
+                ", energyStored=" + energyStored +
+                ", maxInputVoltage=" + maxInputVoltage +
+                ", maxInputAmperage=" + maxInputAmperage +
+                ", maxOutputVoltage=" + maxOutputVoltage +
+                ", maxOutputAmperage=" + maxOutputAmperage +
+                ", amps=" + amps +
+                '}';
+    }
 }

--- a/src/main/java/gregtech/api/capability/impl/EnergyContainerList.java
+++ b/src/main/java/gregtech/api/capability/impl/EnergyContainerList.java
@@ -3,14 +3,99 @@ package gregtech.api.capability.impl;
 import gregtech.api.capability.IEnergyContainer;
 import net.minecraft.util.EnumFacing;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class EnergyContainerList implements IEnergyContainer {
 
     private final List<IEnergyContainer> energyContainerList;
+    private final long inputVoltage;
+    private final long outputVoltage;
+    private final long inputAmperage;
+    private final long outputAmperage;
 
-    public EnergyContainerList(List<IEnergyContainer> energyContainerList) {
+    public EnergyContainerList(@Nonnull List<IEnergyContainer> energyContainerList) {
         this.energyContainerList = energyContainerList;
+        long totalInputVoltage = 0;
+        long totalOutputVoltage = 0;
+        long inputAmperage = 0;
+        long outputAmperage = 0;
+        for (IEnergyContainer container : energyContainerList) {
+            totalInputVoltage += container.getInputVoltage() * container.getInputAmperage();
+            totalOutputVoltage += container.getOutputVoltage() * container.getOutputAmperage();
+            inputAmperage += container.getInputAmperage();
+            outputAmperage += container.getOutputAmperage();
+        }
+
+        long[] voltageAmperage = calculateVoltageAmperage(totalInputVoltage, inputAmperage);
+        this.inputVoltage = voltageAmperage[0];
+        this.inputAmperage = voltageAmperage[1];
+        voltageAmperage = calculateVoltageAmperage(totalOutputVoltage, outputAmperage);
+        this.outputVoltage = voltageAmperage[0];
+        this.outputAmperage = voltageAmperage[1];
+    }
+
+    /**
+     * Computes the correct max voltage and amperage values
+     *
+     * @param voltage the sum of voltage * amperage for each hatch
+     * @param amperage the total amperage of all hatches
+     *
+     * @return [newVoltage, newAmperage]
+     */
+    @Nonnull
+    private static long[] calculateVoltageAmperage(long voltage, long amperage) {
+        if (voltage > 1 && amperage > 1) {
+            // don't operate if there is no voltage or no amperage
+            if (hasPrimeFactorGreaterThanTwo(amperage)) {
+                // scenarios like 3A, 5A, 6A, etc.
+                // treated as 1A of the sum of voltage * amperage for each hatch
+                amperage = 1;
+            } else if (isPowerOfFour(amperage)) {
+                // scenarios like 4A, 16A, etc.
+                // treated as 1A of the sum of voltage * amperage for each hatch
+                amperage = 1;
+            } else if (amperage % 4 == 0) {
+                // scenarios like 8A, 32A, etc.
+                // reduced to an amperage < 4 and equivalent voltage for the new amperage
+                while (amperage > 4) {
+                    amperage /= 4;
+                }
+                voltage /= amperage;
+            } else if (amperage == 2) {
+                // exactly 2A, all other cases covered by earlier checks
+                // reduced to the voltage per amp
+                voltage /= amperage;
+            } else {
+                // fallback case, that should never be hit
+                // forced to 1A to prevent excess power draw/output if something falls through
+                amperage = 1;
+            }
+        }
+        return new long[]{voltage, amperage};
+    }
+
+    private static boolean hasPrimeFactorGreaterThanTwo(long l) {
+        int i = 2;
+        final long max = l / 2;
+        while (i <= max) {
+            if (l % i == 0) {
+                if (i > 2) return true;
+                l /= i;
+            } else {
+                i++;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if a number is a power of 4. Does not include 1, despite it being 4**0.
+     */
+    private static boolean isPowerOfFour(long l) {
+        if (l == 0) return false;
+        if ((l & (l - 1)) != 0) return false;
+        return (l & 0x55555555) != 0;
     }
 
     @Override
@@ -77,32 +162,34 @@ public class EnergyContainerList implements IEnergyContainer {
         return energyCapacity;
     }
 
+    /**
+     * Always < 4. A list with amps > 4 will always be compacted into more voltage at fewer amps.
+     *
+     * @return maximum amount of receivable energy packets per tick
+     */
     @Override
     public long getInputAmperage() {
-        return 1L;
+        return this.inputAmperage;
     }
 
+    /**
+     * Always < 4. A list with amps > 4 will always be compacted into more voltage at fewer amps.
+     *
+     * @return maximum amount of output-able energy packets per tick
+     */
     @Override
     public long getOutputAmperage() {
-        return 1L;
+        return this.outputAmperage;
     }
 
     @Override
     public long getInputVoltage() {
-        long inputVoltage = 0L;
-        for (IEnergyContainer container : energyContainerList) {
-            inputVoltage += container.getInputVoltage() * container.getInputAmperage();
-        }
-        return inputVoltage;
+        return this.inputVoltage;
     }
 
     @Override
     public long getOutputVoltage() {
-        long outputVoltage = 0L;
-        for (IEnergyContainer container : energyContainerList) {
-            outputVoltage += container.getOutputVoltage() * container.getOutputAmperage();
-        }
-        return outputVoltage;
+        return this.outputVoltage;
     }
 
     @Override
@@ -113,5 +200,18 @@ public class EnergyContainerList implements IEnergyContainer {
     @Override
     public boolean outputsEnergy(EnumFacing side) {
         return true;
+    }
+
+    @Override
+    public String toString() {
+        return "EnergyContainerList{" +
+                "energyContainerList=" + energyContainerList +
+                ", energyStored=" + getEnergyStored() +
+                ", energyCapacity=" + getEnergyCapacity() +
+                ", inputVoltage=" + inputVoltage +
+                ", inputAmperage=" + inputAmperage +
+                ", outputVoltage=" + outputVoltage +
+                ", outputAmperage=" + outputAmperage +
+                '}';
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -203,8 +203,13 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                                                boolean checkFluidIn,
                                                boolean checkFluidOut,
                                                boolean checkMuffler) {
-        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler)
-                .or(checkEnergyIn ? abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3).setPreviewCount(1) : new TraceabilityPredicate());
+        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler);
+
+        if (checkEnergyIn) {
+            predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1)
+                    .setMaxGlobalLimited(2)
+                    .setPreviewCount(1));
+        }
 
         if (checkItemIn) {
             if (recipeMap.getMaxInputs() > 0) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -71,6 +71,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         return tier == 0 ? 16 : 64;
     }
 
+    @Nonnull
     @Override
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
@@ -79,7 +80,10 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                 .aisle("XXX", "XSX", "XXX")
                 .where('L', states(getCasingState()))
                 .where('S', selfPredicate())
-                .where('X', states(getCasingState()).setMinGlobalLimited(tier == 0 ? 11 : 4).or(autoAbilities())
+                .where('X', states(getCasingState())
+                        .setMinGlobalLimited(tier == 0 ? 11 : 4)
+                        .or(autoAbilities(false, true, true, true, true, true, true))
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1)) // no energy hatch maximum
                         .or(abilities(MultiblockAbility.MACHINE_HATCH).setExactLimit(1)))
                 .where('#', air())
                 .build();

--- a/src/test/java/gregtech/api/capability/impl/EnergyContainerListTest.java
+++ b/src/test/java/gregtech/api/capability/impl/EnergyContainerListTest.java
@@ -13,7 +13,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
-import static gregtech.api.GTValues.V;
+import static gregtech.api.GTValues.*;
 import static org.hamcrest.CoreMatchers.is;
 
 public class EnergyContainerListTest {
@@ -35,8 +35,13 @@ public class EnergyContainerListTest {
 
     @Nonnull
     private static IEnergyContainer createContainer(int amps) {
+        return createContainer(amps, LV);
+    }
+
+    @Nonnull
+    private static IEnergyContainer createContainer(int amps, int tier) {
         return EnergyContainerHandler.receiverContainer(createDummyMTE(),
-                V[gregtech.api.GTValues.LV] * 64L * amps, V[gregtech.api.GTValues.LV], amps);
+                V[tier] * 64L * amps, V[tier], amps);
     }
 
     @Nonnull
@@ -148,6 +153,13 @@ public class EnergyContainerListTest {
 
         // 32A of LV should become 2A of 512
         check(new EnergyContainerList(list), 512, 2);
+
+        list = new ArrayList<>();
+        list.add(createContainer(2));
+        list.add(createContainer(2, MV));
+
+        // 2.5A of MV should become 1A of 320
+        check(new EnergyContainerList(list), 320, 1);
     }
 
     private static void check(@Nonnull EnergyContainerList list, long inputVoltage, long inputAmperage) {

--- a/src/test/java/gregtech/api/capability/impl/EnergyContainerListTest.java
+++ b/src/test/java/gregtech/api/capability/impl/EnergyContainerListTest.java
@@ -1,0 +1,157 @@
+package gregtech.api.capability.impl;
+
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.gui.ModularUI;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ResourceLocation;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+import static gregtech.api.GTValues.V;
+import static org.hamcrest.CoreMatchers.is;
+
+public class EnergyContainerListTest {
+
+    @Nonnull
+    private static MetaTileEntity createDummyMTE() {
+        return new MetaTileEntity(new ResourceLocation("")) {
+            @Override
+            public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
+                return null;
+            }
+
+            @Override
+            protected ModularUI createUI(EntityPlayer entityPlayer) {
+                return null;
+            }
+        };
+    }
+
+    @Nonnull
+    private static IEnergyContainer createContainer(int amps) {
+        return EnergyContainerHandler.receiverContainer(createDummyMTE(),
+                V[gregtech.api.GTValues.LV] * 64L * amps, V[gregtech.api.GTValues.LV], amps);
+    }
+
+    @Nonnull
+    private static EnergyContainerList createList(int size, int ampsPerHatch) {
+        List<IEnergyContainer> list = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            list.add(createContainer(ampsPerHatch));
+        }
+        return new EnergyContainerList(list);
+    }
+
+    @Test
+    public void test2A() {
+        // 1x 2A of LV should become 2A of 32
+        check(createList(1, 2), 32, 2);
+
+        // 2x 2A of LV should become 1A of 128
+        check(createList(2, 2), 128, 1);
+
+        // 3x 2A of LV should become 1A of 192
+        check(createList(3, 2), 192, 1);
+
+        // 4x 2A of LV should become 2A of 128
+        check(createList(4, 2), 128, 2);
+
+        // 5x 2A of LV should become 1A of 320
+        check(createList(5, 2), 320, 1);
+    }
+
+    @Test
+    public void test4A() {
+        // 1x 4A of LV should become 1A of 128
+        check(createList(1, 4), 128, 1);
+
+        // 2x 4A of LV should become 2A of 128
+        check(createList(2, 4), 128, 2);
+
+        // 3x 4A of LV should become 1A of 384
+        check(createList(3, 4), 384, 1);
+
+        // 4x 4A of LV should become 1A of 512
+        check(createList(4, 4), 512, 1);
+
+        // 5x 4A of LV should become 1A of 640
+        check(createList(5, 4), 640, 1);
+    }
+
+    @Test
+    public void test16A() {
+        // 1x 16A of LV should become 1A of 512
+        check(createList(1, 16), 512, 1);
+
+        // 2x 16A of LV should become 2A of 512
+        check(createList(2, 16), 512, 2);
+
+        // 3x 16A of LV should become 1A of 1536
+        check(createList(3, 16), 1536, 1);
+
+        // 4x 16A of LV should become 1A of 2048
+        check(createList(4, 16), 2048, 1);
+
+        // 5x 16A of LV should become 1A of 2560
+        check(createList(5, 16), 2560, 1);
+    }
+
+    @Test
+    public void testMixed() {
+        List<IEnergyContainer> list = new ArrayList<>();
+        list.add(createContainer(2));
+        list.add(createContainer(4));
+
+        // 6A of LV should become 1A of 192
+        check(new EnergyContainerList(list), 192, 1);
+
+        list = new ArrayList<>();
+        list.add(createContainer(2));
+        list.add(createContainer(4));
+        list.add(createContainer(16));
+
+        // 22A of LV should become 1A of 704
+        check(new EnergyContainerList(list), 704, 1);
+
+        list = new ArrayList<>();
+        list.add(createContainer(4));
+        list.add(createContainer(4));
+        list.add(createContainer(16));
+
+        // 24A of LV should become 1A of 768
+        check(new EnergyContainerList(list), 768, 1);
+
+        list = new ArrayList<>();
+        list.add(createContainer(4));
+        list.add(createContainer(4));
+        list.add(createContainer(4));
+        list.add(createContainer(4));
+        list.add(createContainer(16));
+
+        // 32A of LV should become 2A of 512
+        check(new EnergyContainerList(list), 512, 2);
+
+        list = new ArrayList<>();
+        list.add(createContainer(2));
+        list.add(createContainer(2));
+        list.add(createContainer(2));
+        list.add(createContainer(2));
+        list.add(createContainer(4));
+        list.add(createContainer(4));
+        list.add(createContainer(16));
+
+        // 32A of LV should become 2A of 512
+        check(new EnergyContainerList(list), 512, 2);
+    }
+
+    private static void check(@Nonnull EnergyContainerList list, long inputVoltage, long inputAmperage) {
+        MatcherAssert.assertThat(list.getInputVoltage(), is(inputVoltage));
+        MatcherAssert.assertThat(list.getInputAmperage(), is(inputAmperage));
+    }
+}


### PR DESCRIPTION
## What
This PR makes changes to how multiblocks handle energy inputs. 

First, `EnergyContainerList` has been modified to better handle its voltage and amperage. These changes are better explained and reflected in the tests and implementation added with this PR, than can be done in text.

Next, multiblock maximum energy inputs have been reduced from 3 to 2. This is due to the above changes, where adding a 3rd energy hatch does not change the tier of the multiblock. For example, two 2A LV inputs make an MV multiblock. But three 2A LV hatches is only 1.5A of MV, which is still considered MV for recipe logic. This applies to both overclocking and recipe search.

The Processing Array is a special case for the above energy hatch constraint, and it has been changed to have no upper maximum, to allow further recipe overclocking.

## Implementation Details
All of the test cases and scenarios for voltage and amperage combinations should be covered in `EnergyContainerList`, but some may have slipped through. 

## Outcome
Fixes inconsistencies with multiblock overclocking and recipe search with multiple, potentially mixed energy hatches.

## Potential Compatibility Issues
`EnergyContainerList` will no longer dynamically update Input/Output Voltage and Amperage when the contents of the list changes. This should not affect anything within the base mod, but may affect addons using it.

Setups using more than 2 energy hatches will break, as multiblock structures will unform.
