### PR TITLE
Apply recipe modifications in dedicated stages

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -658,6 +658,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
 
         int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
         int maximumTier = getOverclockForTier(getMaximumOverclockVoltage());
+        if (maximumTier <= GTValues.LV) return 0;
 
         // The maximum number of overclocks is determined by the difference between the tier the recipe is running at,
         // and the maximum tier that the machine can overclock to.

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -604,7 +604,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * Method for modifying the overclock results, such as for Multiblock coil bonuses.
      * Is always called, even if no overclocks are performed.
      *
-     * @param overclockResults The overclocked recipe duration and EUt, in format [duration, EUt]
+     * @param overclockResults The overclocked recipe EUt and duration, in format [EUt, duration]
      * @param storage the RecipePropertyStorage of the recipe being processed
      */
     protected void modifyOverclockPost(int[] overclockResults, @Nonnull IRecipePropertyStorage storage) {}

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -535,7 +535,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     protected boolean setupAndConsumeRecipeInputs(@Nonnull Recipe recipe, @Nonnull IItemHandlerModifiable importInventory) {
         this.overclockResults = calculateOverclock(recipe);
 
-        performNonOverclockBonuses(overclockResults);
+        modifyOverclockPost(overclockResults, recipe.getRecipePropertyStorage());
 
         if (!hasEnoughPower(overclockResults)) {
             return false;
@@ -601,14 +601,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * A stub method for modifying the overclock results.
-     * Useful for Multiblock coil bonuses
+     * Method for modifying the overclock results, such as for Multiblock coil bonuses.
+     * Is always called, even if no overclocks are performed.
      *
-     * @param overclockResults The overclocked recipe duration and EUt
+     * @param overclockResults The overclocked recipe duration and EUt, in format [duration, EUt]
+     * @param storage the RecipePropertyStorage of the recipe being processed
      */
-    protected void performNonOverclockBonuses(int[] overclockResults) {
-
-    }
+    protected void modifyOverclockPost(int[] overclockResults, @Nonnull IRecipePropertyStorage storage) {}
 
     /**
      * Calculates the overclocked Recipe's final duration and EU/t
@@ -616,15 +615,10 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @param recipe the recipe to run
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
+    @Nonnull
     protected int[] calculateOverclock(@Nonnull Recipe recipe) {
-        int recipeEUt = recipe.getEUt();
-        int recipeDuration = recipe.getDuration();
-        // Cannot overclock, keep recipe the same
-        if (!checkCanOverclock(recipeEUt))
-            return new int[]{recipeEUt, recipeDuration};
-
         // invert EU for overclocking calculations (so it increases in the positive direction)
-        boolean negativeEU = recipeEUt < 0;
+        boolean negativeEU = recipe.getEUt() < 0;
 
         // perform the actual overclocking
         int[] overclockResult = performOverclocking(recipe);
@@ -636,34 +630,33 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * @param recipeEUt the EU/t of the recipe attempted to be run
-     * @return true if the recipe is able to overclock, else false
-     */
-    protected boolean checkCanOverclock(int recipeEUt) {
-        if (!isAllowOverclocking()) return false;
-
-        // Check if the voltage to run at is higher than the recipe, and that it is not ULV tier
-
-        // The maximum tier that the machine can overclock to
-        int overclockTier = getOverclockForTier(getMaximumOverclockVoltage());
-        // If the maximum tier that the machine can overclock to is ULV, return false.
-        // There is no overclocking allowed in ULV
-        if (overclockTier <= GTValues.LV) return false;
-        int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
-
-        // Do overclock if the overclock tier is greater than the recipe tier
-        return overclockTier > recipeTier;
-    }
-
-    /**
      * Determines the maximum number of overclocks that can be performed for a recipe.
      * Then performs overclocking on the Recipe.
      *
      * @param recipe the recipe to overclock
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
+    @Nonnull
     protected int[] performOverclocking(@Nonnull Recipe recipe) {
-        int recipeTier = GTUtility.getTierByVoltage(recipe.getEUt());
+        int[] values = {recipe.getEUt(), recipe.getDuration(), getNumberOfOCs(recipe.getEUt())};
+        modifyOverclockPre(values, recipe.getRecipePropertyStorage());
+
+        if (values[2] <= 0) {
+            // number of OCs is <= 0, so do not overclock
+            return new int[]{values[0], values[1]};
+        }
+
+        return runOverclockingLogic(recipe.getRecipePropertyStorage(), values[0], getMaximumOverclockVoltage(), values[1], values[2]);
+    }
+
+    /**
+     * @param recipeEUt the EUt of the recipe
+     * @return the number of times to overclock the recipe
+     */
+    protected int getNumberOfOCs(int recipeEUt) {
+        if (!isAllowOverclocking()) return 0;
+
+        int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
         int maximumTier = getOverclockForTier(getMaximumOverclockVoltage());
 
         // The maximum number of overclocks is determined by the difference between the tier the recipe is running at,
@@ -671,11 +664,17 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         int numberOfOCs = maximumTier - recipeTier;
         if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
 
-        // cannot overclock, so return the starting values
-        if (numberOfOCs <= 0) return new int[]{recipe.getEUt(), recipe.getDuration()};
-
-        return runOverclockingLogic(recipe.getRecipePropertyStorage(), recipe.getEUt(), getMaximumOverclockVoltage(), recipe.getDuration(), numberOfOCs);
+        return numberOfOCs;
     }
+
+    /**
+     * Perform changes to the recipe EUt, duration, and OC count before overclocking.
+     * Is always called, even if no overclocks are to be performed.
+     *
+     * @param values  an array of [recipeEUt, recipeDuration, numberOfOCs]
+     * @param storage the RecipePropertyStorage of the recipe being processed
+     */
+    protected void modifyOverclockPre(@Nonnull int[] values, @Nonnull IRecipePropertyStorage storage) {}
 
     /**
      * Calls the desired overclocking logic to be run for the recipe.
@@ -689,6 +688,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @param amountOC        the maximum amount of overclocks to perform
      * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
+    @Nonnull
     protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int duration, int amountOC) {
         return standardOverclockingLogic(
                 Math.abs(recipeEUt),

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -16,11 +16,12 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
         super(tileEntity, recipeMap, energyContainer);
     }
 
+    @Nonnull
     @Override
     protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
         // no overclocking happens other than parallelization,
         // so return the recipe's values, with EUt made positive for it to be made negative later
-        return new int[]{recipeEUt * -1, recipeDuration};
+        return new int[]{-recipeEUt, recipeDuration};
     }
 
     @Nonnull

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -29,6 +29,7 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
+        // duration bonus
         if (maintenanceValues.getSecond() != 1.0) {
             values[1] = (int) Math.round(values[1] / maintenanceValues.getSecond());
         }
@@ -38,6 +39,8 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     protected void modifyOverclockPost(int[] overclockResults, @Nonnull IRecipePropertyStorage storage) {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+
+        // duration penalty
         if (maintenanceValues.getFirst() > 0) {
             overclockResults[1] = (int) (overclockResults[1] * (1 - 0.1 * maintenanceValues.getFirst()));
         }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -1,13 +1,10 @@
 package gregtech.api.capability.impl;
 
-import gregtech.api.capability.IMaintenanceHatch;
-import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
-import gregtech.common.ConfigHolder;
+import net.minecraft.util.Tuple;
 
 import javax.annotation.Nonnull;
 
@@ -19,29 +16,31 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         super(tileEntity);
     }
 
+    @Nonnull
     @Override
     protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
-        // apply maintenance penalties
-        MultiblockWithDisplayBase displayBase = this.metaTileEntity instanceof MultiblockWithDisplayBase ? (MultiblockWithDisplayBase) metaTileEntity : null;
-        int numMaintenanceProblems = displayBase == null ? 0 : displayBase.getNumMaintenanceProblems();
-
-        int[] overclock = null;
-        if (displayBase != null && ConfigHolder.machines.enableMaintenance && displayBase.hasMaintenanceMechanics()) {
-            IMaintenanceHatch hatch = displayBase.getAbilities(MultiblockAbility.MAINTENANCE_HATCH).get(0);
-            double durationMultiplier = hatch.getDurationMultiplier();
-            if (durationMultiplier != 1.0) {
-                overclock = new int[]{recipeEUt * -1, (int) Math.round(recipeDuration / durationMultiplier)};
-            }
-        }
-        if (overclock == null) {
-            overclock = new int[]{recipeEUt * -1, recipeDuration};
-        }
-
-        overclock[1] = (int) (overclock[1] * (1 - 0.1 * numMaintenanceProblems));
-
         // no overclocking happens other than parallelization,
         // so return the recipe's values, with EUt made positive for it to be made negative later
-        return overclock;
+        return new int[]{-recipeEUt, recipeDuration};
+    }
+
+    @Override
+    protected void modifyOverclockPre(@Nonnull int[] values, @Nonnull IRecipePropertyStorage storage) {
+        // apply maintenance penalties
+        Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+
+        if (maintenanceValues.getSecond() != 1.0) {
+            values[1] = (int) Math.round(values[1] / maintenanceValues.getSecond());
+        }
+    }
+
+    @Override
+    protected void modifyOverclockPost(int[] overclockResults, @Nonnull IRecipePropertyStorage storage) {
+        // apply maintenance penalties
+        Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+        if (maintenanceValues.getFirst() > 0) {
+            overclockResults[1] = (int) (overclockResults[1] * (1 - 0.1 * maintenanceValues.getFirst()));
+        }
     }
 
     @Nonnull

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -26,7 +26,7 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
 
     @Override
     protected void modifyOverclockPre(@Nonnull int[] values, @Nonnull IRecipePropertyStorage storage) {
-        // apply maintenance penalties
+        // apply maintenance bonuses
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         // duration bonus

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -252,7 +252,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     protected void modifyOverclockPre(@Nonnull int[] values, @Nonnull IRecipePropertyStorage storage) {
         super.modifyOverclockPre(values, storage);
 
-        // apply maintenance penalties
+        // apply maintenance bonuses
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         // duration bonus

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -255,6 +255,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
+        // duration bonus
         if (maintenanceValues.getSecond() != 1.0) {
             values[1] = (int) Math.round(values[1] * maintenanceValues.getSecond());
         }
@@ -266,6 +267,8 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+
+        // duration penalty
         if (maintenanceValues.getFirst() > 0) {
             overclockResults[1] = (int) (overclockResults[1] * (1 + 0.1 * maintenanceValues.getFirst()));
         }

--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -43,6 +43,7 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
         return GTValues.LV;
     }
 
+    @Nonnull
     @Override
     protected int[] runOverclockingLogic(@Nonnull IRecipePropertyStorage propertyStorage, int recipeEUt, long maxVoltage, int recipeDuration, int amountOC) {
         return standardOverclockingLogic(

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -185,6 +185,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
         tryDoVenting();
     }
 
+    @Nonnull
     @Override
     protected int[] calculateOverclock(@Nonnull Recipe recipe) {
 

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -71,8 +71,8 @@ public class OverclockingLogic {
      * @return the discounted EU/t
      */
     public static int applyCoilEUtDiscount(int recipeEUt, int providedTemp, int requiredTemp) {
-        if (requiredTemp < OverclockingLogic.COIL_EUT_DISCOUNT_TEMPERATURE) return recipeEUt;
-        int amountEUtDiscount = OverclockingLogic.calculateAmountCoilEUtDiscount(providedTemp, requiredTemp);
+        if (requiredTemp < COIL_EUT_DISCOUNT_TEMPERATURE) return recipeEUt;
+        int amountEUtDiscount = calculateAmountCoilEUtDiscount(providedTemp, requiredTemp);
         if (amountEUtDiscount < 1) return recipeEUt;
         return (int) (recipeEUt * Math.min(1, Math.pow(0.95, amountEUtDiscount)));
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -10,6 +10,7 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockMetalCasing;
@@ -110,7 +111,8 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected void performNonOverclockBonuses(int[] resultOverclock) {
+        protected void modifyOverclockPost(int[] resultOverclock, @Nonnull IRecipePropertyStorage storage) {
+            super.modifyOverclockPost(resultOverclock, storage);
 
             int coilTier = ((MetaTileEntityCrackingUnit) metaTileEntity).getCoilTier();
             if (coilTier <= 0)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -29,7 +29,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
-import net.minecraft.util.Tuple;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -42,7 +41,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 import static gregtech.api.GTValues.ULV;
-import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
 
 public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController implements IMachineHatchMultiblock {
 
@@ -299,32 +297,18 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
-        protected int[] calculateOverclock(@Nonnull Recipe recipe) {
-            int recipeEUt = recipe.getEUt();
-            int recipeDuration = recipe.getDuration();
-            if (!isAllowOverclocking()) {
-                return new int[]{recipeEUt, recipeDuration};
-            }
+        protected int getNumberOfOCs(int recipeEUt) {
+            if (!isAllowOverclocking()) return 0;
 
-            // apply maintenance penalties
-            Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
+            int recipeTier = Math.max(0, GTUtility.getTierByVoltage(recipeEUt / Math.max(1, this.parallelRecipesPerformed)));
+            int maximumTier = Math.min(this.machineTier, GTUtility.getTierByVoltage(getMaxVoltage()));
 
-            int originalTier = Math.max(0, GTUtility.getTierByVoltage(recipeEUt / Math.max(1, this.parallelRecipesPerformed)));
-            int numOverclocks = Math.min(this.machineTier, GTUtility.getTierByVoltage(getMaxVoltage())) - originalTier;
+            // The maximum number of overclocks is determined by the difference between the tier the recipe is running at,
+            // and the maximum tier that the machine can overclock to.
+            int numberOfOCs = maximumTier - recipeTier;
+            if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
 
-            if (originalTier == ULV) numOverclocks--; // no ULV overclocking
-
-            // cannot overclock, so return the starting values
-            if (numOverclocks <= 0) return new int[]{recipe.getEUt(), recipe.getDuration()};
-
-            return standardOverclockingLogic(
-                    recipeEUt,
-                    getMaximumOverclockVoltage(),
-                    (int) Math.round(recipeDuration * maintenanceValues.getSecond()),
-                    numOverclocks,
-                    getOverclockingDurationDivisor(),
-                    getOverclockingVoltageMultiplier()
-            );
+            return numberOfOCs;
         }
 
         private ItemStack getMachineStack() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -10,6 +10,7 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockMachineCasing.MachineCasingType;
@@ -120,7 +121,8 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected void performNonOverclockBonuses(int[] resultOverclock) {
+        protected void modifyOverclockPost(int[] resultOverclock, @Nonnull IRecipePropertyStorage storage) {
+            super.modifyOverclockPost(resultOverclock, storage);
 
             int coilTier = ((MetaTileEntityPyrolyseOven) metaTileEntity).getCoilTier();
             if (coilTier == -1)

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -1,10 +1,12 @@
 package gregtech.api.capability.impl;
 
+import com.google.common.collect.ImmutableList;
 import gregtech.Bootstrap;
 import gregtech.api.GTValues;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
@@ -16,6 +18,7 @@ import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityItemBus;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMaintenanceHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -545,5 +548,212 @@ public class MultiblockRecipeLogicTest {
         mbl.completeRecipe();
         MatcherAssert.assertThat(AbstractRecipeLogic.areItemStacksEqual(mbl.getOutputInventory().getStackInSlot(0),
                 new ItemStack(Blocks.STONE, 1)), is(true));
+    }
+
+    @Test
+    public void testMaintenancePenalties() {
+        TestableMaintenanceHatch maintenanceHatch = new TestableMaintenanceHatch(gregtechId("maintenance.hatch"), false);
+
+        RecipeMapMultiblockController mbt = MetaTileEntities.registerMetaTileEntity(508,
+                new MetaTileEntityElectricBlastFurnace(
+                        // super function calls the world, which equal null in test
+                        new ResourceLocation(GTValues.MODID, "electric_blast_furnace")) {
+                    @Override
+                    public boolean canBeDistinct() {
+                        return false;
+                    }
+
+                    @Override
+                    public void reinitializeStructurePattern() {
+
+                    }
+
+                    // function checks for the temperature of the recipe against the coils
+                    @Override
+                    public boolean checkRecipe(@Nonnull Recipe recipe, boolean consumeIfSuccess) {
+                        return true;
+                    }
+
+                    // testing maintenance problems
+                    @Override
+                    public boolean hasMaintenanceMechanics() {
+                        return true;
+                    }
+
+                    // ignore muffler outputs
+                    @Override
+                    public boolean hasMufflerMechanics() {
+                        return false;
+                    }
+
+                    @Override
+                    public <T> List<T> getAbilities(MultiblockAbility<T> ability) {
+                        if (ability == MultiblockAbility.MAINTENANCE_HATCH) {
+                            //noinspection unchecked
+                            return (List<T>) ImmutableList.of(maintenanceHatch);
+                        }
+                        return super.getAbilities(ability);
+                    }
+                });
+
+        //isValid() check in the dirtying logic requires both a metatileentity and a holder
+        try {
+            Field field = MetaTileEntity.class.getDeclaredField("holder");
+            field.setAccessible(true);
+            field.set(mbt, new MetaTileEntityHolder());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            Field field = MetaTileEntityHolder.class.getDeclaredField("metaTileEntity");
+            field.setAccessible(true);
+            field.set(mbt.getHolder(), mbt);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        ((MetaTileEntityHolder) mbt.getHolder()).setWorld(DummyWorld.INSTANCE);
+
+        maintenanceHatch.myController = mbt;
+
+        //Controller and isAttachedToMultiBlock need the world so we fake it here.
+        MetaTileEntityItemBus importItemBus = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, false) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+        MetaTileEntityItemBus exportItemBus = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, true) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+
+        //Controller is a private field but we need that information
+        try {
+            Field field = MetaTileEntityMultiblockPart.class.getDeclaredField("controllerTile");
+            field.setAccessible(true);
+            field.set(importItemBus, mbt);
+            field.set(exportItemBus, mbt);
+            field.set(maintenanceHatch, mbt);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        MultiblockRecipeLogic mbl = new MultiblockRecipeLogic(mbt) {
+
+            @Override
+            protected long getEnergyStored() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected long getEnergyCapacity() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+                return true;
+            }
+
+            @Override
+            public long getMaxVoltage() {
+                return 32;
+            }
+
+            // since the hatches were not really added to a valid multiblock structure,
+            // refer to their inventories directly
+            @Override
+            protected IItemHandlerModifiable getInputInventory() {
+                return importItemBus.getImportItems();
+            }
+
+            @Override
+            protected IItemHandlerModifiable getOutputInventory() {
+                return exportItemBus.getExportItems();
+            }
+
+            @Override
+            protected IMultipleTankHandler getInputTank() {
+                return new FluidTankList(false);
+            }
+
+            @Override
+            protected IMultipleTankHandler getOutputTank() {
+                return new FluidTankList(false);
+            }
+
+            @Override
+            protected List<IItemHandlerModifiable> getInputBuses() {
+                List<IItemHandlerModifiable> a = new ArrayList<>();
+                a.add(importItemBus.getImportItems());
+                return a;
+            }
+        };
+
+        RecipeMaps.BLAST_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.CRAFTING_TABLE))
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(10).duration(10)
+                .blastFurnaceTemp(1)
+                .buildAndRegister();
+
+        // start off as fixed
+        for (int i = 0; i < 6; i++) {
+            mbt.setMaintenanceFixed(i);
+        }
+
+        // cause one problem
+        mbt.causeMaintenanceProblems();
+
+        MatcherAssert.assertThat(mbt.getNumMaintenanceProblems(), is(1));
+
+        IItemHandlerModifiable firstBus = mbl.getInputBuses().get(0);
+        firstBus.insertItem(0, new ItemStack(Blocks.CRAFTING_TABLE, 1), false);
+        mbl.trySearchNewRecipe();
+
+        // 1 problem is 10% slower. 10 * 1.1 = 11
+        MatcherAssert.assertThat(mbl.maxProgressTime, is(11));
+
+        mbl.completeRecipe();
+
+        // fix old problems
+        for (int i = 0; i < 6; i++) {
+            mbt.setMaintenanceFixed(i);
+        }
+
+        firstBus.insertItem(0, new ItemStack(Blocks.CRAFTING_TABLE, 1), false);
+        mbl.trySearchNewRecipe();
+
+        // 0 problems should have the regular duration of 10
+        MatcherAssert.assertThat(mbl.maxProgressTime, is(10));
+    }
+
+    // needed to prevent cyclic references in anonymous class creation
+    private static class TestableMaintenanceHatch extends MetaTileEntityMaintenanceHatch {
+
+        public RecipeMapMultiblockController myController;
+
+        public TestableMaintenanceHatch(ResourceLocation metaTileEntityId, boolean isConfigurable) {
+            super(metaTileEntityId, isConfigurable);
+        }
+
+        @Override
+        public MultiblockControllerBase getController() {
+            return myController;
+        }
     }
 }

--- a/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
@@ -191,6 +191,8 @@ public class OverclockingTest {
         int numberOfOCs = machineTier - recipeTier;
         if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
 
+        recipeVoltage = OverclockingLogic.applyCoilEUtDiscount(recipeVoltage, machineTemperature, recipeTemperature);
+
         // cannot overclock, so return the starting values
         if (numberOfOCs <= 0) return new int[]{recipeVoltage, recipeDuration};
 


### PR DESCRIPTION
## What
This PR modifies recipe logic to apply modifications to the recipe in separate phases: pre-overclock, overclocking, and post-overclock. Pre and Post are always called, but overclocking is not.

First, it moves the maintenance hatch pentalies to the pre and post-overclock phases. This will prevent overrides of overclocking-related methods from failing to apply these values. The configurable maintenance hatch duration bonuses are applied pre-overclock, and maintenance duration penalties are made post-overclock. This fixes #1676.

Next, it moves the calculation for the amount of overclocks to perform into a separate method. This reduces a lot of duplicated code across the variations of recipe logic. Doing so also allows the PA to no longer need to override `calculateOverclock(Recipe)`. 

Heating coil logic has been fixed to respect maintenance hatch values as well. The EUt reduction bonus from coils is also now applied in the pre-overclock phase, instead of in the overclocking method itself. 

## Outcome
Refactors recipe value modification to prevent large code copy pastes. Fixes #1676.

## Potential Compatibility Issues
This PR removes/renames `performNonOverclockBonuses(int[])` and replaces it with `modifyOverclockPost(int[], IRecipePropertyStorage)`. It also removes `checkCanOverclock(int)`. Addons calling these old methods will need updating.

Additionally, addons with overrides of other recipe logic functions may no longer behave the same. They will want/need to refactor their own logic to utilize the new methods, to ensure their behavior is unaffected.
