### PR TITLE
Allow filtering output hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -12,10 +12,7 @@ import gregtech.api.capability.impl.NotifiableFluidTank;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
-import gregtech.api.gui.widgets.FluidContainerSlotWidget;
-import gregtech.api.gui.widgets.ImageWidget;
-import gregtech.api.gui.widgets.SlotWidget;
-import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
@@ -30,9 +27,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.fluids.FluidTank;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -40,18 +39,24 @@ import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank>, IControllable {
 
     private static final int INITIAL_INVENTORY_SIZE = 8000;
 
     // only holding this for convenience
-    private final FluidTank fluidTank;
+    private final HatchFluidTank fluidTank;
     private boolean workingEnabled;
+
+    // export hatch-only fields
+    private boolean locked;
+    @Nullable
+    private FluidStack lockedFluid;
 
     public MetaTileEntityFluidHatch(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch) {
         super(metaTileEntityId, tier, isExportHatch);
-        this.fluidTank = new NotifiableFluidTank(getInventorySize(), this, isExportHatch);
+        this.fluidTank = new HatchFluidTank(getInventorySize(), this, isExportHatch);
         this.workingEnabled = true;
         initializeInventory();
     }
@@ -65,6 +70,12 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
         data.setBoolean("workingEnabled", workingEnabled);
+        if (isExportHatch) {
+            data.setBoolean("IsLocked", locked);
+            if (locked && lockedFluid != null) {
+                data.setTag("LockedFluid", lockedFluid.writeToNBT(new NBTTagCompound()));
+            }
+        }
         return data;
     }
 
@@ -76,6 +87,10 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         }
         if (data.hasKey("ContainerInventory")) {
             MetaTileEntityQuantumTank.legacyTankItemHandlerNBTReading(this, data.getCompoundTag("ContainerInventory"), 0, 1);
+        }
+        if (isExportHatch) {
+            this.locked = data.getBoolean("IsLocked");
+            this.lockedFluid = this.locked ? FluidStack.loadFluidStackFromNBT(data.getCompoundTag("LockedFluid")) : null;
         }
     }
 
@@ -121,12 +136,18 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     public void writeInitialSyncData(PacketBuffer buf) {
         super.writeInitialSyncData(buf);
         buf.writeBoolean(workingEnabled);
+        if (isExportHatch) {
+            buf.writeBoolean(locked);
+        }
     }
 
     @Override
     public void receiveInitialSyncData(PacketBuffer buf) {
         super.receiveInitialSyncData(buf);
         this.workingEnabled = buf.readBoolean();
+        if (isExportHatch) {
+            this.locked = buf.readBoolean();
+        }
     }
 
     @Override
@@ -180,21 +201,95 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     }
 
     public ModularUI.Builder createTankUI(IFluidTank fluidTank, String title, EntityPlayer entityPlayer) {
+        // Create base builder/widget references
         Builder builder = ModularUI.defaultBuilder();
-        builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
-        TankWidget tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
-                .setHideTooltip(true).setAlwaysShowFull(true);
-        builder.widget(tankWidget);
-        builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
-        builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
-        builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
+        TankWidget tankWidget;
+
+        // Add input/output-specific widgets
+        if (isExportHatch) {
+            tankWidget = new PhantomTankWidget(fluidTank, 69, 43, 18, 18,
+                    () -> this.lockedFluid,
+                    f -> {
+                        if (this.fluidTank.getFluidAmount() != 0) {
+                            return;
+                        }
+                        if (f == null) {
+                            this.setLocked(false);
+                            this.lockedFluid = null;
+                        } else {
+                            this.setLocked(true);
+                            this.lockedFluid = f.copy();
+                            this.lockedFluid.amount = 1;
+                        }
+                    })
+                    .setAlwaysShowFull(true).setDrawHoveringText(false);
+
+            builder.image(7, 16, 81, 46, GuiTextures.DISPLAY)
+                    .widget(new SlotWidget(exportItems, 0, 90, 44, true, false)
+                            .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY))
+                    .widget(new ToggleButtonWidget(7, 64, 18, 18,
+                            GuiTextures.BUTTON_LOCK, this::isLocked, this::setLocked)
+                            .setTooltipText("gregtech.gui.fluid_lock.tooltip")
+                            .shouldUseBaseBackground());
+        } else {
+            tankWidget = new TankWidget(fluidTank, 69, 52, 18, 18)
+                    .setAlwaysShowFull(true).setDrawHoveringText(false);
+
+            builder.image(7, 16, 81, 55, GuiTextures.DISPLAY)
+                    .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
+                    .widget(new SlotWidget(exportItems, 0, 90, 53, true, false)
+                            .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY));
+        }
+
+        // Add general widgets
         return builder.label(6, 6, title)
+                .label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF)
+                .widget(new AdvancedTextWidget(11, 30, getFluidAmountText(tankWidget), 0xFFFFFF))
+                .widget(new AdvancedTextWidget(11, 40, getFluidNameText(tankWidget), 0xFFFFFF))
+                .widget(tankWidget)
                 .widget(new FluidContainerSlotWidget(importItems, 0, 90, 16, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))
-                .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
-                .widget(new SlotWidget(exportItems, 0, 90, 53, true, false)
-                        .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY))
                 .bindPlayerInventory(entityPlayer.inventory);
+    }
+
+    private Consumer<List<ITextComponent>> getFluidNameText(TankWidget tankWidget) {
+        return (list) -> {
+            String fluidName = "";
+            // If there is no fluid in the tank
+            if (tankWidget.getFluidLocalizedName().isEmpty()) {
+                // But there is a locked fluid
+                if (this.lockedFluid != null) {
+                    fluidName = this.lockedFluid.getLocalizedName();
+                }
+            }
+            else {
+                fluidName = tankWidget.getFluidLocalizedName();
+            }
+
+            if (!fluidName.isEmpty()) {
+                list.add(new TextComponentString(fluidName));
+            }
+        };
+    }
+
+    private Consumer<List<ITextComponent>> getFluidAmountText(TankWidget tankWidget) {
+        return (list) -> {
+            String fluidAmount = "";
+
+            // Nothing in the tank
+            if (tankWidget.getFormattedFluidAmount().equals("0")) {
+                // Display Zero to show information about the locked fluid
+                if (this.lockedFluid != null) {
+                    fluidAmount = "0";
+                }
+            }
+            else {
+                fluidAmount = tankWidget.getFormattedFluidAmount();
+            }
+            if (!fluidAmount.isEmpty()) {
+                list.add(new TextComponentString(fluidAmount));
+            }
+        };
     }
 
     @Override
@@ -212,5 +307,54 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         tooltip.add(I18n.format("gregtech.tool_action.screwdriver.access_covers"));
         tooltip.add(I18n.format("gregtech.tool_action.wrench.set_facing"));
         super.addToolUsages(stack, world, tooltip, advanced);
+    }
+
+    private boolean isLocked() {
+        return this.locked;
+    }
+
+    private void setLocked(boolean locked) {
+        if (this.locked == locked) return;
+        this.locked = locked;
+        if (!getWorld().isRemote) {
+            markDirty();
+        }
+        if (locked && fluidTank.getFluid() != null) {
+            this.lockedFluid = fluidTank.getFluid().copy();
+            this.lockedFluid.amount = 1;
+            fluidTank.onContentsChanged();
+            return;
+        }
+        this.lockedFluid = null;
+        fluidTank.onContentsChanged();
+    }
+
+    private class HatchFluidTank extends NotifiableFluidTank {
+
+        public HatchFluidTank(int capacity, MetaTileEntity entityToNotify, boolean isExport) {
+            super(capacity, entityToNotify, isExport);
+        }
+
+        @Override
+        public int fillInternal(FluidStack resource, boolean doFill) {
+            int accepted = super.fillInternal(resource, doFill);
+            if (!isExportHatch) return accepted;
+            if (doFill && locked && lockedFluid == null) {
+                lockedFluid = resource.copy();
+                lockedFluid.amount = 1;
+            }
+            return accepted;
+        }
+
+        @Override
+        public boolean canFillFluidType(FluidStack fluid) {
+            if (!isExportHatch) return super.canFillFluidType(fluid);
+            return !locked || lockedFluid == null || fluid.isFluidEqual(lockedFluid);
+        }
+
+        @Override
+        public void onContentsChanged() {
+            super.onContentsChanged();
+        }
     }
 }


### PR DESCRIPTION
Allows for Output Hatches to lock their fluids. Tested a few scenarios:

- 1 Output Hatch locked to the correct fluid for a recipe works properly (runs as normal)
- 1 Output Hatch locked to the incorrect fluid for a recipe works properly (does not run)
- In the above scenario, when the lock is removed, the recipe works properly immediately (starts running, i.e. notifies the controller)
- 2 Output Hatches locked to the correct fluids works properly (runs as normal)

I also tested a more complex scenario:
1. Add 1 Output Hatch, locked to the desired Fluid.
2. Enable "Void Fluids" on the multiblock
3. Run a recipe that outputs 2 Fluids
4. Multiblock will run, outputting only the desired fluid.
5. This can be combined with a Fluid Detector Cover + Machine Controller Cover to automatically void an undesired Fluid, and shut off the multiblock if the desired Fluid's Hatch fills