### PR TITLE
Fix Groovyscript PID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     // causing crashes at run-time when deobfuscated
     implementation files("libs/groovyscript-0.4.0.jar")
     //implementation fg.deobf("curse.maven:groovyscript-${grs_pid}:${grs_fid}")
-    compileOnly rfg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
+    compileOnlyApi rfg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
 
     // Tests
     testImplementation "org.junit.jupiter:junit-jupiter:${junit_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ ctm_pid = 267602
 ctm_fid = 2915363
 ### GRS 0.3.0
 # suppress inspection "UnusedProperty"
-grs_pid = 68757
+grs_pid = 687577
 # suppress inspection "UnusedProperty"
 grs_fid = 4426112
 ### AE2 0.55.6


### PR DESCRIPTION
## What
Fixes the Groovyscript Project ID in gradle.properties, moves AE to `compileOnlyAPI`


## Outcome
Fix GS Project ID
