### PR TITLE
Add fertilizer compat with EnderIO and Immersive Engineering

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/tool/BelljarHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/tool/BelljarHandler.java
@@ -1,0 +1,14 @@
+package blusunrize.immersiveengineering.api.tool;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/BluSunrize/ImmersiveEngineering/blob/master/src/main/java/blusunrize/immersiveengineering/api/tool/BelljarHandler.java">BelljarHandler.java</a>
+ */
+public final class BelljarHandler {
+
+    private BelljarHandler() {/**/}
+
+    public static void registerBasicItemFertilizer(@SuppressWarnings("unused") final ItemStack stack,
+                                                   @SuppressWarnings("unused") final float growthMultiplier) {/**/}
+}

--- a/src/api/java/crazypants/enderio/api/farm/IFertilizer.java
+++ b/src/api/java/crazypants/enderio/api/farm/IFertilizer.java
@@ -1,0 +1,10 @@
+package crazypants.enderio.api.farm;
+
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/SleepyTrousers/EnderIO/blob/master/enderio-base/src/main/java/crazypants/enderio/api/farm/IFertilizer.java">IFertilizer.java</a>
+ */
+public interface IFertilizer extends IForgeRegistryEntry<IFertilizer> {
+
+}

--- a/src/api/java/crazypants/enderio/base/farming/fertilizer/Bonemeal.java
+++ b/src/api/java/crazypants/enderio/base/farming/fertilizer/Bonemeal.java
@@ -1,0 +1,15 @@
+package crazypants.enderio.base.farming.fertilizer;
+
+import crazypants.enderio.api.farm.IFertilizer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/SleepyTrousers/EnderIO/blob/master/enderio-base/src/main/java/crazypants/enderio/base/farming/fertilizer/Bonemeal.java">Bonemeal.java</a>
+ */
+public class Bonemeal extends IForgeRegistryEntry.Impl<IFertilizer> implements IFertilizer {
+
+    public Bonemeal(@SuppressWarnings("unused") @Nonnull ItemStack stack) {/**/}
+}

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -126,7 +126,8 @@ public class GTValues {
             MODID_APPENG = "appliedenergistics2",
             MODID_JEI = "jei",
             MODID_GROOVYSCRIPT = "groovyscript",
-            MODID_NC = "nuclearcraft";
+            MODID_NC = "nuclearcraft",
+            MODID_IE = "immersiveengineering";
 
     private static Boolean isClient;
 

--- a/src/main/java/gregtech/integration/IntegrationModule.java
+++ b/src/main/java/gregtech/integration/IntegrationModule.java
@@ -1,0 +1,60 @@
+package gregtech.integration;
+
+import blusunrize.immersiveengineering.api.tool.BelljarHandler;
+import crazypants.enderio.api.farm.IFertilizer;
+import crazypants.enderio.base.farming.fertilizer.Bonemeal;
+import gregtech.api.GTValues;
+import gregtech.api.modules.GregTechModule;
+import gregtech.common.items.MetaItems;
+import gregtech.modules.BaseGregTechModule;
+import gregtech.modules.GregTechModules;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+
+@GregTechModule(
+        moduleID = GregTechModules.MODULE_INTEGRATION,
+        containerID = GTValues.MODID,
+        name = "GregTech Mod Integration",
+        descriptionKey = "gregtech.modules.integration.description"
+)
+public class IntegrationModule extends BaseGregTechModule {
+
+    public static final Logger logger = LogManager.getLogger("GregTech Mod Integration");
+
+    @Nonnull
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+    @Nonnull
+    @Override
+    public List<Class<?>> getEventBusSubscribers() {
+        return Collections.singletonList(IntegrationModule.class);
+    }
+
+    @Override
+    public void init(FMLInitializationEvent event) {
+        super.init(event);
+
+        if (Loader.isModLoaded(GTValues.MODID_IE)) {
+            BelljarHandler.registerBasicItemFertilizer(MetaItems.FERTILIZER.getStackForm(), 1.25f);
+            logger.info("Registered Immersive Engineering Compat");
+        }
+    }
+
+    @Optional.Method(modid = GTValues.MODID_EIO)
+    @SubscribeEvent
+    public static void registerFertilizer(@Nonnull RegistryEvent.Register<IFertilizer> event) {
+        event.getRegistry().register(new Bonemeal(MetaItems.FERTILIZER.getStackForm()));
+        logger.info("Registered EnderIO Compat");
+    }
+}

--- a/src/main/java/gregtech/modules/GregTechModules.java
+++ b/src/main/java/gregtech/modules/GregTechModules.java
@@ -6,6 +6,7 @@ public class GregTechModules implements IModuleContainer {
 
     public static final String MODULE_CORE = "core";
     public static final String MODULE_TOOLS = "tools";
+    public static final String MODULE_INTEGRATION = "integration";
 
     // Integration modules
     public static final String MODULE_JEI = "jei_integration";


### PR DESCRIPTION
## What
This PR adds compat for GT Fertilizer with the EnderIO Farming Station and the Immersive Engineering "Belljar" Garden Cloche. 

## Implementation Details
Current values chosen for fertilizer are equivalent to bone meal in each mod. These can be adjusted if we wish to differentiate our own fertilizer further.

## Outcome
Adds fertilizer compat with EnderIO and Immersive Engineering.
