### PR TITLE
Use HTTPS in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
Updates the License File to use HTTPS, which is now in the current version of the [LGPL 3.0 License](https://www.gnu.org/licenses/lgpl-3.0.txt). This change now makes our file identical to the official version.
