### PR TITLE
Add method to un-ignore materials for OrePrefixes

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.Validate;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -593,6 +594,11 @@ public class OrePrefix {
     @ZenMethod
     public void setIgnored(Material material) {
         ignoredMaterials.add(material);
+    }
+
+    @ZenMethod
+    public void removeIgnored(@Nonnull Material material) {
+        ignoredMaterials.remove(material);
     }
 
     public boolean isMarkerPrefix() {


### PR DESCRIPTION
## What
Allows addons and scripting mods to un-ignore a material for an OrePrefix. This is useful for cases such as Borosilicate Glass, which has the plate ignored by default.

## Outcome
Adds method to un-ignore materials for OrePrefixes.
