### PR TITLE
Fix toSmallDigits converting isotopes into small numbers

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -59,7 +59,7 @@ public class Material implements Comparable<Material> {
      */
     private String chemicalFormula;
 
-    // TODO Fix isotope tooltips being set toSmallDownNumbers
+    @Nonnull
     private String calculateChemicalFormula() {
         if (chemicalFormula != null) return this.chemicalFormula;
         if (materialInfo.element != null) {
@@ -68,7 +68,7 @@ public class Material implements Comparable<Material> {
         if (!materialInfo.componentList.isEmpty()) {
             StringBuilder components = new StringBuilder();
             for (MaterialStack component : materialInfo.componentList)
-                components.append(component.toString());
+                components.append(component.toFormatted());
             return components.toString();
         }
         return "";

--- a/src/main/java/gregtech/api/unification/stack/MaterialStack.java
+++ b/src/main/java/gregtech/api/unification/stack/MaterialStack.java
@@ -7,6 +7,8 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import stanhebben.zenscript.annotations.ZenProperty;
 
+import javax.annotation.Nonnull;
+
 @ZenClass("mods.gregtech.material.MaterialStack")
 @ZenRegister
 public class MaterialStack {
@@ -48,21 +50,29 @@ public class MaterialStack {
         return material.hashCode();
     }
 
-    @Override
-    @ZenMethod
-    public String toString() {
-        String string = "";
-        if (material.getChemicalFormula().isEmpty()) {
-            string += "?";
+    @ZenMethod("toString")
+    @Nonnull
+    public String toFormatted() {
+        final String chemicalFormula = material.getChemicalFormula();
+
+        StringBuilder builder = new StringBuilder(chemicalFormula.length());
+        if (chemicalFormula.isEmpty()) {
+            builder.append('?');
         } else if (material.getMaterialComponents().size() > 1) {
-            string += '(' + material.getChemicalFormula() + ')';
+            builder.append('(');
+            builder.append(chemicalFormula);
+            builder.append(')');
         } else {
-            string += material.getChemicalFormula();
+            builder.append(chemicalFormula);
         }
         if (amount > 1) {
-            string += SmallDigits.toSmallDownNumbers(Long.toString(amount));
+            builder.append(SmallDigits.toSmallDownNumbers(String.valueOf(amount)));
         }
-        return string;
+        return builder.toString();
     }
 
+    @Override
+    public String toString() {
+        return "MaterialStack{material=" + material + ", amount=" + amount + '}';
+    }
 }

--- a/src/main/java/gregtech/api/util/SmallDigits.java
+++ b/src/main/java/gregtech/api/util/SmallDigits.java
@@ -1,33 +1,47 @@
 package gregtech.api.util;
 
-public class SmallDigits {
+import javax.annotation.Nonnull;
 
+public final class SmallDigits {
+
+    @SuppressWarnings("UnnecessaryUnicodeEscape")
     private static final int SMALL_DOWN_NUMBER_BASE = '\u2080';
+    @SuppressWarnings("UnnecessaryUnicodeEscape")
     private static final int SMALL_UP_NUMBER_BASE = '\u2080';
     private static final int NUMBER_BASE = '0';
 
+    private SmallDigits() {}
+
+    @Nonnull
     public static String toSmallUpNumbers(String string) {
-        char[] charArray = string.toCharArray();
-        for (int i = 0; i < charArray.length; i++) {
-            int relativeIndex = charArray[i] - NUMBER_BASE;
-            if (relativeIndex >= 0 && relativeIndex <= 9) {
-                int newChar = SMALL_UP_NUMBER_BASE + relativeIndex;
-                charArray[i] = (char) newChar;
-            }
-        }
-        return new String(charArray);
+        return convert(string, SMALL_UP_NUMBER_BASE);
     }
 
+    @Nonnull
     public static String toSmallDownNumbers(String string) {
+        return convert(string, SMALL_DOWN_NUMBER_BASE);
+    }
+
+    @Nonnull
+    private static String convert(@Nonnull String string, int base) {
+        boolean hasPrecedingDash = false;
         char[] charArray = string.toCharArray();
         for (int i = 0; i < charArray.length; i++) {
-            int relativeIndex = charArray[i] - NUMBER_BASE;
+            char c = charArray[i];
+            boolean isDash = c == '-';
+            if (isDash) hasPrecedingDash = true;
+
+            int relativeIndex = c - NUMBER_BASE;
             if (relativeIndex >= 0 && relativeIndex <= 9) {
-                int newChar = SMALL_DOWN_NUMBER_BASE + relativeIndex;
-                charArray[i] = (char) newChar;
+                if (!hasPrecedingDash) {
+                    // no preceding dash, so convert the char
+                    charArray[i] = (char) (base + relativeIndex);
+                }
+            } else if (!isDash && hasPrecedingDash) {
+                // was a non-number, so invalidate the previously seen dash
+                hasPrecedingDash = false;
             }
         }
         return new String(charArray);
     }
-
 }

--- a/src/test/java/gregtech/api/util/SmallDigitsTest.java
+++ b/src/test/java/gregtech/api/util/SmallDigitsTest.java
@@ -1,0 +1,33 @@
+package gregtech.api.util;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+
+public class SmallDigitsTest {
+
+    @Test
+    public void testNoNumbers() {
+        String formula = "ZnS";
+        MatcherAssert.assertThat(SmallDigits.toSmallDownNumbers(formula), is(formula));
+    }
+
+    @Test
+    public void testNoNesting() {
+        MatcherAssert.assertThat(SmallDigits.toSmallDownNumbers("Cu3Sn"), is("Cu₃Sn"));
+    }
+
+    @Test
+    public void testNested() {
+        MatcherAssert.assertThat(SmallDigits.toSmallDownNumbers("(CuAu4)(ZnCu3)Fe2(Ni(AuAgCu3)Fe3)4"), is("(CuAu₄)(ZnCu₃)Fe₂(Ni(AuAgCu₃)Fe₃)₄"));
+    }
+
+    @Test
+    public void testDashes() {
+        String formula = "U-238";
+        MatcherAssert.assertThat(SmallDigits.toSmallDownNumbers(formula), is(formula));
+
+        MatcherAssert.assertThat(SmallDigits.toSmallDownNumbers("(U-238)2"), is("(U-238)₂"));
+    }
+}


### PR DESCRIPTION
## What
Fixes `SmallDigits#toSmallDownNumbers` (and toSmallUp) converting isotope strings into incorrect formats. This would previously be seen with a formula such as `"U-238"`, where the 238 would be converted to smaller numbers. This PR fixes this behavior by not converting any numbers with a preceding `'-'` character.

## Implementation Details
`MaterialStack#toString`'s previous implementation was moved to a new method, `toFormatted`. This allows for easier debugging with an unformated toString(). The `@ZenMethod` annotation was modified to maintain existing behavior with CT.

## Outcome
Fixes isotope formulas being converted to small numbers in some scenarios.
