### PR TITLE
Add jabel for Java17 syntax

### DIFF
--- a/.github/workflows/pr_artifact.yml
+++ b/.github/workflows/pr_artifact.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
 
       - name: Build Project
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pr_artifact.yml
+++ b/.github/workflows/pr_artifact.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '17'
 
       - name: Build Project

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
 
       - name: Run Tests
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '17'
 
       - name: Run Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
       
       - name: Build Project
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '17'
       
       - name: Build Project

--- a/.github/workflows/update_gradle_cache.yml
+++ b/.github/workflows/update_gradle_cache.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
 
       - name: Update Cache
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/update_gradle_cache.yml
+++ b/.github/workflows/update_gradle_cache.yml
@@ -10,7 +10,7 @@ on:
       - "gradle**" # covers gradle folder, gradle.properties, gradlew
       - "build.gradle*"
       - "settings.gradle*"
-      - "src/main/resources/META-INF/*_at.cfg" # access transformers
+      - "src/main/resources/*_at.cfg" # access transformers
 
 jobs:
   Update_Cache:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '17'
 
       - name: Update Cache

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ import org.jetbrains.gradle.ext.Gradle
 plugins {
     id 'java'
     id 'java-library'
-    id 'maven-publish'
     id 'eclipse'
     id 'org.jetbrains.gradle.plugin.idea-ext' version "$idea_ext_version"
     id 'com.gtnewhorizons.retrofuturagradle' version "$rfg_version"
@@ -20,12 +19,17 @@ version = project.mod_version
 group = project.maven_group
 archivesBaseName = project.archives_base_name
 
+// Declare java compilation and java compatibility versions as groovy variables to prevent configuration errors when
+// extracting values from the gradle.properties file
+def javaVersion = project.java_version
+def javaCompatVersion = project.java_compat_version
+
 // Set the toolchain version to decouple the Java we run Gradle with from the Java used to compile and run the mod
 java {
     toolchain {
-        // Azul covers the most platforms for Java 8 toolchains, crucially including MacOS arm64
+        // Azul covers the most platforms for Java 8+ toolchains, crucially including MacOS arm64
         vendor.set(JvmVendorSpec.AZUL)
-        languageVersion.set(JavaLanguageVersion.of(project.java_version))
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
     }
 
     // Generate sources when building and publishing
@@ -35,7 +39,28 @@ java {
 }
 
 tasks.withType(JavaCompile).configureEach {
+    // prevent compiling MC with newer java versions
+    if (it.name in ['compileMcLauncherJava', 'compilePatchedMcJava']) {
+        return
+    }
+
     options.encoding 'UTF-8'
+
+    if (it.name == 'compileTestJava') {
+        // ensure tests are compiled with java8 to support forge's use of sun reflection classes
+        // These were removed in later java versions
+        sourceCompatibility = targetCompatibility = java_compat_version
+    } else {
+        // Enable Java17 for all other compilation tasks
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaCompatVersion
+        options.release.set(Integer.parseInt(javaCompatVersion))
+
+        javaCompiler.set(javaToolchains.compilerFor {
+            languageVersion.set(JavaLanguageVersion.of(javaVersion))
+            vendor.set(JvmVendorSpec.AZUL)
+        })
+    }
 }
 
 configurations {
@@ -120,6 +145,10 @@ dependencies {
     testImplementation rfg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
 
     // Compile-Time Dependencies
+    annotationProcessor "com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}"
+    compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}") {
+        transitive = false // We only care about the 1 annotation class
+    }
 
     // GroovyScript dependency
     implementation "zone.rong:mixinbooter:${mixinbooter_version}"
@@ -180,6 +209,11 @@ jar {
 }
 
 test {
+    // ensure tests are run with java8 to support forge's use of sun reflection classes
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(java_compat_version)
+    }.get()
+
     testLogging {
         events TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.FAILED
         exceptionFormat TestExceptionFormat.FULL

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,14 @@ dependencies {
     //implementation fg.deobf("curse.maven:groovyscript-${grs_pid}:${grs_fid}")
     compileOnlyApi rfg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
 
+    // Compile-Time Dependencies
+    annotationProcessor "com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}"
+    compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}") {
+        transitive = false // We only care about the 1 annotation class
+    }
+    // Allow jdk.unsupported classes like sun.misc.Unsafe, workaround for JDK-8206937 and fixes Forge crashes in tests.
+    patchedMinecraft "me.eigenraven.java8unsupported:java-8-unsupported-shim:${unsupported_shim_version}"
+
     // Tests
     testImplementation "org.junit.jupiter:junit-jupiter:${junit_version}"
     testImplementation "org.hamcrest:hamcrest:${hamcrest_version}"
@@ -138,14 +146,12 @@ dependencies {
     // ae2 is a transitive dependency for MTE, so it's also needed at test-time
     testImplementation rfg.deobf("curse.maven:ae2-extended-life-${ae2_pid}:${ae2_fid}")
 
-    // Compile-Time Dependencies
-    annotationProcessor "com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}"
-    compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}") {
+    // allow Jabel to work in tests
+    testAnnotationProcessor "com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}"
+    testCompileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}") {
         transitive = false // We only care about the 1 annotation class
     }
-
-    // Allow jdk.unsupported classes like sun.misc.Unsafe, workaround for JDK-8206937 and fixes Forge crashes in tests.
-    patchedMinecraft "me.eigenraven.java8unsupported:java-8-unsupported-shim:${unsupported_shim_version}"
+    testCompileOnly "me.eigenraven.java8unsupported:java-8-unsupported-shim:${unsupported_shim_version}"
 
     // GroovyScript dependency
     implementation "zone.rong:mixinbooter:${mixinbooter_version}"
@@ -206,9 +212,9 @@ jar {
 }
 
 test {
-    // ensure tests are run with java8 to support forge's use of sun reflection classes
+    // ensure tests are run with java8
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(java_compat_version)
+        languageVersion = JavaLanguageVersion.of(javaCompatVersion)
     }.get()
 
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -46,21 +46,15 @@ tasks.withType(JavaCompile).configureEach {
 
     options.encoding 'UTF-8'
 
-    if (it.name == 'compileTestJava') {
-        // ensure tests are compiled with java8 to support forge's use of sun reflection classes
-        // These were removed in later java versions
-        sourceCompatibility = targetCompatibility = java_compat_version
-    } else {
-        // Enable Java17 for all other compilation tasks
-        sourceCompatibility = javaVersion
-        targetCompatibility = javaCompatVersion
-        options.release.set(Integer.parseInt(javaCompatVersion))
+    // Enable Java17 for all other compilation tasks
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaCompatVersion
+    options.release.set(Integer.parseInt(javaCompatVersion))
 
-        javaCompiler.set(javaToolchains.compilerFor {
-            languageVersion.set(JavaLanguageVersion.of(javaVersion))
-            vendor.set(JvmVendorSpec.AZUL)
-        })
-    }
+    javaCompiler.set(javaToolchains.compilerFor {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+        vendor.set(JvmVendorSpec.AZUL)
+    })
 }
 
 configurations {
@@ -149,6 +143,9 @@ dependencies {
     compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}") {
         transitive = false // We only care about the 1 annotation class
     }
+
+    // Allow jdk.unsupported classes like sun.misc.Unsafe, workaround for JDK-8206937 and fixes Forge crashes in tests.
+    patchedMinecraft "me.eigenraven.java8unsupported:java-8-unsupported-shim:${unsupported_shim_version}"
 
     // GroovyScript dependency
     implementation "zone.rong:mixinbooter:${mixinbooter_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,6 +51,7 @@ java_compat_version = 8
 
 ## Jabel Dependencies
 jabel_version = 1.0.0
+unsupported_shim_version = 1.0.0
 
 # Deployment
 deployment_debug = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,11 @@ hamcrest_version = 2.2
 foojay_version = 0.4.0
 idea_ext_version = 1.1.7
 rfg_version = 1.3.+
-java_version = 8
+java_version = 17
+java_compat_version = 8
+
+## Jabel Dependencies
+jabel_version = 1.0.0
 
 # Deployment
 deployment_debug = false

--- a/src/test/java/jabel/TestModernJavaSyntax.java
+++ b/src/test/java/jabel/TestModernJavaSyntax.java
@@ -1,0 +1,78 @@
+package jabel;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Tests to ensure compilation with Java 17 and running with Java 8 is functional
+ */
+public class TestModernJavaSyntax {
+
+    // Java Functionality Tests
+
+    @Test
+    public void testSwitchPatternMatching() {
+        MatcherAssert.assertThat(getLengthSwitch("hello"), CoreMatchers.is(5));
+        MatcherAssert.assertThat(getLengthSwitch("goodbye"), CoreMatchers.is(7));
+        MatcherAssert.assertThat(getLengthSwitch("wrong"), CoreMatchers.is(-1));
+    }
+
+    private static int getLengthSwitch(@Nonnull String s) {
+        return switch (s) {
+            case "hello" -> 5;
+            case "goodbye" -> 7;
+            default -> -1;
+        };
+    }
+
+    @Test
+    public void testInstanceOfPatternMatching() {
+        MatcherAssert.assertThat(getLengthInstanceOf("hello"), CoreMatchers.is(5));
+        MatcherAssert.assertThat(getLengthInstanceOf(new Object()), CoreMatchers.is(-1));
+    }
+
+    private static int getLengthInstanceOf(Object o) {
+        if (o instanceof String s) {
+            return s.length();
+        }
+        return -1;
+    }
+
+    @Test
+    public void testVarKeyword() {
+        var arr = "hello".toCharArray();
+
+        MatcherAssert.assertThat(arr.length, CoreMatchers.is(5));
+    }
+
+    @Test
+    public void testMultiLineString() {
+        String s = """
+                hello
+                goodbye
+                """;
+
+        MatcherAssert.assertThat(s.split("\n").length, CoreMatchers.is(2));
+    }
+
+    // JVM tests
+
+    // this test will only run if the jvm is on java8
+    @EnabledOnJre(JRE.JAVA_8)
+    @Test
+    public void testJava8RuntimeMethod1() {
+        // succeed if the test runs
+        MatcherAssert.assertThat(true, CoreMatchers.anything());
+    }
+
+    @Test
+    public void testJava8RuntimeMethod2() {
+        // ensure the runtime is on java 8 with the system property
+        MatcherAssert.assertThat(System.getProperty("java.version"), CoreMatchers.containsString("1.8.0"));
+    }
+}


### PR DESCRIPTION
## What
Adds the Jabel compiler plugin to enable Java17 syntax, while compiling to Java8 bytecode.

## Outcome
Allows for Java17 syntax.

## Potential Compatibility Issues
Built jar files are fully compatible with Java8. Compilation and building in dev will require a Java17 JDK.
