### PR TITLE
Move to new JEI maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,12 +69,7 @@ repositories {
         url 'https://maven.cleanroommc.com'
     }
     maven {
-        // JEI
-        name 'Progwml6 Maven'
-        url 'https://dvs1.progwml6.com/files/maven/'
-    }
-    maven {
-        // CraftTweaker and JEI Backup
+        // CraftTweaker and JEI
         name 'BlameJared Maven'
         url 'https://maven.blamejared.com'
     }


### PR DESCRIPTION
## What
Removes the progwm16 maven in favor of the crafttweaker one, where JEI is now hosted. Mezz has stated that the CT maven is the new maven that JEI is hosted on, and will get all builds going forward (although the new 1.12.2 builds are not on either maven)


## Outcome
Removes a now no longer needed maven entry
