### PR TITLE
Stop using GNU Trove collections

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,3 +52,10 @@ dependencies {
 minecraft {
     injectedTags.put('DEP_VERSION_STRING', "required-after:gregtech@[${modVersion},);")
 }
+
+configurations {
+    compileClassPath {
+        // exclude GNU trove, FastUtil is superior and still updated
+        exclude group: "net.sf.trove4j", module: "trove4j"
+    }
+}

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -1,7 +1,7 @@
 package gregtech.api.capability.impl;
 
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 public class ItemHandlerList implements IItemHandlerModifiable {
 
-    private final TIntObjectMap<IItemHandler> handlerBySlotIndex = new TIntObjectHashMap<>();
+    private final Int2ObjectMap<IItemHandler> handlerBySlotIndex = new Int2ObjectOpenHashMap<>();
     private final Map<IItemHandler, Integer> baseIndexOffset = new IdentityHashMap<>();
 
     public ItemHandlerList(List<? extends IItemHandler> itemHandlerList) {

--- a/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaOreDictItem.java
@@ -2,13 +2,14 @@ package gregtech.api.items.metaitem;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
-import gnu.trove.map.hash.TIntObjectHashMap;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.material.info.MaterialIconType;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.SmallDigits;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.ItemStack;
@@ -54,7 +55,7 @@ public class MetaOreDictItem extends StandardMetaItem {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerModels() {
-        TIntObjectHashMap<ModelResourceLocation> alreadyRegistered = new TIntObjectHashMap<>();
+        Int2ObjectMap<ModelResourceLocation> alreadyRegistered = new Int2ObjectOpenHashMap<>();
         for (Map.Entry<Short, OreDictValueItem> metaItem : ITEMS.entrySet()) {
             OrePrefix prefix = metaItem.getValue().orePrefix;
             MaterialIconSet materialIconSet = metaItem.getValue().materialIconSet;

--- a/src/main/java/gregtech/api/pipenet/PipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/PipeNet.java
@@ -447,11 +447,10 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
             allNodesList.appendTag(nodeTag);
         }
 
-        for (NodeDataType nodeData : alreadyWritten.keySet()) {
-            int wirePropertiesIndex = alreadyWritten.get(nodeData);
+        for (Object2IntMap.Entry<NodeDataType> entry : alreadyWritten.object2IntEntrySet()) {
             NBTTagCompound propertiesTag = new NBTTagCompound();
-            propertiesTag.setInteger("index", wirePropertiesIndex);
-            writeNodeData(nodeData, propertiesTag);
+            propertiesTag.setInteger("index", entry.getIntValue());
+            writeNodeData(entry.getKey(), propertiesTag);
             wirePropertiesList.appendTag(propertiesTag);
         }
 

--- a/src/main/java/gregtech/api/pipenet/PipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/PipeNet.java
@@ -1,9 +1,9 @@
 package gregtech.api.pipenet;
 
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.TObjectIntMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.map.hash.TObjectIntHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.EnumFacing;
@@ -389,7 +389,7 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
     protected void deserializeAllNodeList(NBTTagCompound compound) {
         NBTTagList allNodesList = compound.getTagList("NodeIndexes", NBT.TAG_COMPOUND);
         NBTTagList wirePropertiesList = compound.getTagList("WireProperties", NBT.TAG_COMPOUND);
-        TIntObjectMap<NodeDataType> readProperties = new TIntObjectHashMap<>();
+        Int2ObjectMap<NodeDataType> readProperties = new Int2ObjectOpenHashMap<>();
 
         for (int i = 0; i < wirePropertiesList.tagCount(); i++) {
             NBTTagCompound propertiesTag = wirePropertiesList.getCompoundTagAt(i);
@@ -417,7 +417,8 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
         NBTTagCompound compound = new NBTTagCompound();
         NBTTagList allNodesList = new NBTTagList();
         NBTTagList wirePropertiesList = new NBTTagList();
-        TObjectIntMap<NodeDataType> alreadyWritten = new TObjectIntHashMap<>(10, 0.5f, -1);
+        Object2IntMap<NodeDataType> alreadyWritten = new Object2IntOpenHashMap<>(10, 0.5f);
+        alreadyWritten.defaultReturnValue(-1);
         int currentIndex = 0;
 
         for (Entry<BlockPos, Node<NodeDataType>> entry : allNodes.entrySet()) {

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -6,8 +6,6 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
-import gnu.trove.map.TByteObjectMap;
-import gnu.trove.map.hash.TByteObjectHashMap;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.capability.IMultipleTankHandler;
@@ -32,6 +30,8 @@ import gregtech.common.ConfigHolder;
 import gregtech.integration.groovy.GroovyScriptModule;
 import gregtech.integration.groovy.VirtualizedRecipeMap;
 import gregtech.modules.GregTechModules;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
@@ -87,7 +87,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private final boolean modifyItemOutputs;
     private final boolean modifyFluidInputs;
     private final boolean modifyFluidOutputs;
-    protected final TByteObjectMap<TextureArea> slotOverlays;
+    protected final Byte2ObjectMap<TextureArea> slotOverlays;
     protected TextureArea specialTexture;
     protected int[] specialTexturePosition;
     protected TextureArea progressBarTexture;
@@ -169,7 +169,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                      @Nonnull R defaultRecipeBuilder,
                      boolean isHidden) {
         this.unlocalizedName = unlocalizedName;
-        this.slotOverlays = new TByteObjectHashMap<>();
+        this.slotOverlays = new Byte2ObjectOpenHashMap<>();
         this.progressBarTexture = GuiTextures.PROGRESS_BAR_ARROW;
         this.moveType = MoveType.HORIZONTAL;
 

--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -343,9 +343,10 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
                 int lowestY = entry.getValue().getRight();
                 LongSet generatedBlocks = new LongOpenHashSet();
                 boolean generatedOreVein = false;
-                LongIterator iterator = blockIndexList.iterator();
-                while (iterator.hasNext()) {
-                    long blockIndex = iterator.nextLong();
+                // enhanced for loops cause boxing and unboxing with FastUtil collections
+                //noinspection ForLoopReplaceableByForEach
+                for (int i = 0; i < blockIndexList.size(); i++) {
+                    long blockIndex = blockIndexList.get(i);
                     int xyzValue = (int) (blockIndex >> 32);
                     int blockX = (byte) xyzValue;
                     int blockZ = (byte) (xyzValue >> 8);

--- a/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
+++ b/src/main/java/gregtech/api/worldgen/generator/CachedGridEntry.java
@@ -13,6 +13,7 @@ import gregtech.api.worldgen.populator.VeinChunkPopulator;
 import gregtech.api.worldgen.shape.IBlockGeneratorAccess;
 import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
@@ -200,7 +201,7 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
     }
 
     public void triggerVeinsGeneration() {
-        this.veinGeneratedMap = new HashMap<>();
+        this.veinGeneratedMap = new Object2ObjectOpenHashMap<>();
         if (!cachedDepositMap.isEmpty()) {
             int currentCycle = 0;
             int maxCycles = ConfigHolder.worldgen.minVeinsInSection + (ConfigHolder.worldgen.additionalVeinsInSection == 0 ? 0 : gridRandom.nextInt(ConfigHolder.worldgen.additionalVeinsInSection + 1));
@@ -303,8 +304,8 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
 
     public static class ChunkDataEntry {
 
-        private final Map<OreDepositDefinition, MutablePair<LongList, Integer>> oreBlocks = new HashMap<>();
-        private final Map<OreDepositDefinition, LongSet> generatedBlocksSet = new HashMap<>();
+        private final Map<OreDepositDefinition, MutablePair<LongList, Integer>> oreBlocks = new Object2ObjectOpenHashMap<>();
+        private final Map<OreDepositDefinition, LongSet> generatedBlocksSet = new Object2ObjectOpenHashMap<>();
         private final List<OreDepositDefinition> generatedOres = new ArrayList<>();
         private final int chunkX;
         private final int chunkZ;
@@ -342,7 +343,9 @@ public class CachedGridEntry implements GridEntryInfo, IBlockGeneratorAccess, IB
                 int lowestY = entry.getValue().getRight();
                 LongSet generatedBlocks = new LongOpenHashSet();
                 boolean generatedOreVein = false;
-                for (long blockIndex : blockIndexList) {
+                LongIterator iterator = blockIndexList.iterator();
+                while (iterator.hasNext()) {
+                    long blockIndex = iterator.nextLong();
                     int xyzValue = (int) (blockIndex >> 32);
                     int blockX = (byte) xyzValue;
                     int blockZ = (byte) (xyzValue >> 8);

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -5,8 +5,6 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
@@ -24,6 +22,8 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
 import gregtech.common.covers.filter.ItemFilterContainer;
 import gregtech.common.pipelike.itempipe.tile.TileEntityItemPipe;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
@@ -326,10 +326,10 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
     protected static class TypeItemInfo {
         public final ItemStack itemStack;
         public final Object filterSlot;
-        public final TIntList slots;
+        public final IntList slots;
         public int totalCount;
 
-        public TypeItemInfo(ItemStack itemStack, Object filterSlot, TIntList slots, int totalCount) {
+        public TypeItemInfo(ItemStack itemStack, Object filterSlot, IntList slots, int totalCount) {
             this.itemStack = itemStack;
             this.filterSlot = filterSlot;
             this.slots = slots;
@@ -362,7 +362,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
                 continue;
             }
             if (!result.containsKey(itemStack)) {
-                TypeItemInfo itemInfo = new TypeItemInfo(itemStack.copy(), transferSlotIndex, new TIntArrayList(), 0);
+                TypeItemInfo itemInfo = new TypeItemInfo(itemStack.copy(), transferSlotIndex, new IntArrayList(), 0);
                 itemInfo.totalCount += itemStack.getCount();
                 itemInfo.slots.add(srcIndex);
                 result.put(itemStack.copy(), itemInfo);

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -13,6 +13,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.block.BlockDragonEgg;
 import net.minecraft.block.state.IBlockState;
@@ -94,10 +95,12 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
         if (getOffsetTimer() % 200 == 0 || isFirstTick()) {
             updateConnectedCrystals();
         }
+
         int totalEnergyGeneration = 0;
-        for (int connectedCrystalId : connectedCrystalsIds) {
+        IntIterator itr = connectedCrystalsIds.iterator();
+        while (itr.hasNext()) {
             //since we don't check quite often, check twice before outputting energy
-            if (getWorld().getEntityByID(connectedCrystalId) instanceof EntityEnderCrystal) {
+            if (getWorld().getEntityByID(itr.nextInt()) instanceof EntityEnderCrystal) {
                 totalEnergyGeneration += hasDragonEggAmplifier ? 128 : 32;
             }
         }
@@ -189,8 +192,9 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
     }
 
     private void resetConnectedEnderCrystals() {
-        for (int connectedEnderCrystal : connectedCrystalsIds) {
-            EntityEnderCrystal entityEnderCrystal = (EntityEnderCrystal) getWorld().getEntityByID(connectedEnderCrystal);
+        IntIterator itr = connectedCrystalsIds.iterator();
+        while (itr.hasNext()) {
+            EntityEnderCrystal entityEnderCrystal = (EntityEnderCrystal) getWorld().getEntityByID(itr.nextInt());
             if (entityEnderCrystal != null && getPos().equals(entityEnderCrystal.getBeamTarget())) {
                 //on removal, reset ender crystal beam location so somebody can use it
                 entityEnderCrystal.setBeamTarget(null);

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -13,7 +13,6 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.block.BlockDragonEgg;
 import net.minecraft.block.state.IBlockState;
@@ -97,10 +96,11 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
         }
 
         int totalEnergyGeneration = 0;
-        IntIterator itr = connectedCrystalsIds.iterator();
-        while (itr.hasNext()) {
+        // enhanced for loops cause boxing and unboxing with FastUtil collections
+        //noinspection ForLoopReplaceableByForEach
+        for (int i = 0; i < connectedCrystalsIds.size(); i++) {
             //since we don't check quite often, check twice before outputting energy
-            if (getWorld().getEntityByID(itr.nextInt()) instanceof EntityEnderCrystal) {
+            if (getWorld().getEntityByID(connectedCrystalsIds.get(i)) instanceof EntityEnderCrystal) {
                 totalEnergyGeneration += hasDragonEggAmplifier ? 128 : 32;
             }
         }
@@ -192,9 +192,10 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
     }
 
     private void resetConnectedEnderCrystals() {
-        IntIterator itr = connectedCrystalsIds.iterator();
-        while (itr.hasNext()) {
-            EntityEnderCrystal entityEnderCrystal = (EntityEnderCrystal) getWorld().getEntityByID(itr.nextInt());
+        // enhanced for loops cause boxing and unboxing with FastUtil collections
+        //noinspection ForLoopReplaceableByForEach
+        for (int i = 0; i < connectedCrystalsIds.size(); i++) {
+            EntityEnderCrystal entityEnderCrystal = (EntityEnderCrystal) getWorld().getEntityByID(connectedCrystalsIds.get(i));
             if (entityEnderCrystal != null && getPos().equals(entityEnderCrystal.getBeamTarget())) {
                 //on removal, reset ender crystal beam location so somebody can use it
                 entityEnderCrystal.setBeamTarget(null);

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -4,8 +4,6 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
 import gregtech.api.GTValues;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -14,6 +12,8 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.block.BlockDragonEgg;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -49,7 +49,7 @@ import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
 
 public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
 
-    private final TIntList connectedCrystalsIds = new TIntArrayList();
+    private final IntList connectedCrystalsIds = new IntArrayList();
     private boolean hasDragonEggAmplifier = false;
     private boolean isActive = false;
 
@@ -95,7 +95,7 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
             updateConnectedCrystals();
         }
         int totalEnergyGeneration = 0;
-        for (int connectedCrystalId : connectedCrystalsIds.toArray()) {
+        for (int connectedCrystalId : connectedCrystalsIds) {
             //since we don't check quite often, check twice before outputting energy
             if (getWorld().getEntityByID(connectedCrystalId) instanceof EntityEnderCrystal) {
                 totalEnergyGeneration += hasDragonEggAmplifier ? 128 : 32;
@@ -189,7 +189,7 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
     }
 
     private void resetConnectedEnderCrystals() {
-        for (int connectedEnderCrystal : connectedCrystalsIds.toArray()) {
+        for (int connectedEnderCrystal : connectedCrystalsIds) {
             EntityEnderCrystal entityEnderCrystal = (EntityEnderCrystal) getWorld().getEntityByID(connectedEnderCrystal);
             if (entityEnderCrystal != null && getPos().equals(entityEnderCrystal.getBeamTarget())) {
                 //on removal, reset ender crystal beam location so somebody can use it


### PR DESCRIPTION
## What
This PR replaces all usages of GNU Trove collections with FastUtil ones. It can be extremely difficult to inspect the contents of Trove collections when debugging, and often lack good `toString` implementations as well, which does not aid in debugging either.

## Outcome
Stops using GNU Trove collections.
