### PR TITLE
Fix crash with Jabel on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,8 @@ dependencies {
 
     // Compile-Time Dependencies
     annotationProcessor "com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}"
+    // workaround for https://github.com/bsideup/jabel/issues/174
+    annotationProcessor "net.java.dev.jna:jna-platform:5.13.0"
     compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabel_version}") {
         transitive = false // We only care about the 1 annotation class
     }


### PR DESCRIPTION
## What
Running task from gradle panel on IDE might cause crash on Windows. Relevant issue on Jabel: https://github.com/bsideup/jabel/issues/174

## Implementation Details
Add a dependency for JNA.

## Outcome
Fix crash.

## Additional Information
Also tested here: https://github.com/GTNewHorizons/ExampleMod1.7.10/pull/176