### PR TITLE
Support for increasing cracking unit item inputs

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -430,7 +430,7 @@ public class RecipeMaps {
      * </pre>
      */
     @ZenProperty
-    public static final RecipeMap<SimpleRecipeBuilder> CRACKING_RECIPES = new RecipeMapCrackerUnit<>("cracker", 1, false, 0, true, 2, false, 2, true, new SimpleRecipeBuilder(), false)
+    public static final RecipeMap<SimpleRecipeBuilder> CRACKING_RECIPES = new RecipeMapCrackerUnit<>("cracker", 1, true, 0, true, 2, false, 2, true, new SimpleRecipeBuilder(), false)
             .setSlotOverlay(false, true, GuiTextures.CRACKING_OVERLAY_1)
             .setSlotOverlay(true, true, GuiTextures.CRACKING_OVERLAY_2)
             .setSlotOverlay(false, false, GuiTextures.CIRCUIT_OVERLAY)

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCrackerUnit.java
@@ -23,7 +23,18 @@ public class RecipeMapCrackerUnit<R extends RecipeBuilder<R>> extends RecipeMap<
     @Override
     public ModularUI.Builder createJeiUITemplate(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
         ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
-        addSlot(builder, 52, 24 + yOffset, 0, importItems, importFluids, false, false);
+        if (getMaxInputs() == 1) {
+            addSlot(builder, 52, 24 + yOffset, 0, importItems, importFluids, false, false);
+        } else {
+            int[] grid = determineSlotsGrid(getMaxInputs());
+            for (int y = 0; y < grid[1]; y++) {
+                for (int x = 0; x < grid[0]; x++) {
+                    addSlot(builder, 34 + (x * 18) - (Math.max(0, grid[0] - 2) * 18), 24 + (y * 18) - (Math.max(0, grid[1] - 1) * 18) + yOffset,
+                            y * grid[0] + x, importItems, importFluids, false, false);
+                }
+            }
+        }
+
         addInventorySlotGroup(builder, exportItems, exportFluids, true, yOffset);
         addSlot(builder, 52, 24 + yOffset + 19 + 18, 0, importItems, importFluids, true, false);
         addSlot(builder, 34, 24 + yOffset + 19 + 18, 1, importItems, importFluids, true, false);


### PR DESCRIPTION
## What
This PR adds support for increasing the amount of item inputs in the Cracking Unit RecipeMap. This is useful to modpacks and addons.

## Outcome
Allows increasing Cracking Unit max item inputs.
