### PR TITLE
Give GTFO 500 more material IDs

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -91,8 +91,8 @@ public class Materials {
          * - Gregicality: 3000-19999
          * - Gregification: 20000-20999
          * - HtmlTech: 21000-21499
-         * - GregTech Food Option: 21500-21999
-         * - PCM's Ore Addon: 22000-23599
+         * - GregTech Food Option: 21500-22499
+         * - FREE RANGE 22500-23599
          * - MechTech: 23600-23999
          * - FREE RANGE 24000-31999
          * - Reserved for CraftTweaker: 32000-32767


### PR DESCRIPTION
As GTFO continues to expand, it's fairly likely it will run out of material IDs, of which only 500 are allotted. This PR updates the list in Materials.java to give it some of the room previously assigned to the now-defunct PCM's Ore Addon.