### PR TITLE
Fix Quantum Chest item voiding

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -526,63 +526,78 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
 
         @Nonnull
         @Override
-        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, @Nonnull ItemStack insertedStack, boolean simulate) {
 
-            if (stack.isEmpty()) {
+            if (insertedStack.isEmpty()) {
                 return ItemStack.EMPTY;
             }
 
             if (itemsStoredInside > 0L &&
                     !itemStack.isEmpty() &&
-                    !areItemStackIdentical(itemStack, stack)) {
-                return stack;
+                    !areItemStackIdentical(itemStack, insertedStack)) {
+                return insertedStack;
             }
 
             // The Quantum Chest automatically populates the export slot, so we need to check what is contained in it
             ItemStack exportItems = getExportItems().getStackInSlot(0);
 
             // Check if the item being inserted matches the item in the export slot
-            boolean insertMatching = areItemStackIdentical(stack, exportItems);
+            boolean insertMatching = areItemStackIdentical(insertedStack, exportItems);
 
             // If the item being inserted does not match the item in the export slot, insert into the input slot and do not virtualize
             if (!insertMatching) {
-                return MetaTileEntityQuantumChest.this.importItems.insertItem(0, stack, simulate);
+                return MetaTileEntityQuantumChest.this.importItems.insertItem(0, insertedStack, simulate);
             }
 
-            int insertedAmount;
+            int virtualizedAmount;
             int amountInsertedIntoExport;
 
             int spaceInExport = Math.abs(exportItems.getCount() - exportItems.getMaxStackSize());
 
             // Attempt to insert into the export slot first
-            amountInsertedIntoExport = Math.min(spaceInExport, stack.getCount());
+            amountInsertedIntoExport = Math.min(spaceInExport, insertedStack.getCount());
 
             // If we had more Items than would fit into the export slot, virtualize the remainder
-            if (amountInsertedIntoExport < stack.getCount()) {
+            if (amountInsertedIntoExport < insertedStack.getCount()) {
                 long amountLeftInChest = itemStack.isEmpty() ? maxStoredItems : maxStoredItems - itemsStoredInside;
-                insertedAmount = (int) Math.min(stack.getCount() - amountInsertedIntoExport, amountLeftInChest);
+                virtualizedAmount = (int) Math.min(insertedStack.getCount() - amountInsertedIntoExport, amountLeftInChest);
 
             }
             // Return early, as we did not virtualize anything, as it all fit into the output slot
             else {
-                return MetaTileEntityQuantumChest.this.exportItems.insertItem(0, stack, simulate);
+                return MetaTileEntityQuantumChest.this.exportItems.insertItem(0, insertedStack, simulate);
             }
 
             ItemStack remainingStack = ItemStack.EMPTY;
 
             // If we are at the maximum that the chest can hold
-            if (stack.getCount() - amountInsertedIntoExport > insertedAmount) {
-                remainingStack = stack.copy();
-                remainingStack.setCount(stack.getCount() - insertedAmount);
+            if (insertedStack.getCount() - amountInsertedIntoExport > virtualizedAmount) {
+                remainingStack = insertedStack.copy();
+                remainingStack.setCount(insertedStack.getCount() - virtualizedAmount);
             }
             if (!simulate) {
-                if (itemStack.isEmpty()) {
-                    MetaTileEntityQuantumChest.this.itemStack = stack.copy();
-                    MetaTileEntityQuantumChest.this.itemsStoredInside = insertedAmount;
-                } else {
-                    MetaTileEntityQuantumChest.this.itemsStoredInside += insertedAmount;
+                if (remainingStack.isEmpty()) {
+                    if (itemStack.isEmpty()) {
+                        ItemStack virtualStack = insertedStack.copy();
+                        virtualStack.setCount(virtualizedAmount);
+                        MetaTileEntityQuantumChest.this.itemStack = virtualStack;
+                        MetaTileEntityQuantumChest.this.itemsStoredInside = virtualizedAmount;
+                    } else {
+                        MetaTileEntityQuantumChest.this.itemsStoredInside += virtualizedAmount;
+                    }
+
+                    if (amountInsertedIntoExport != 0) {
+                        ItemStack insertedStackCopy = insertedStack.copy();
+                        insertedStackCopy.setCount(amountInsertedIntoExport);
+                        MetaTileEntityQuantumChest.this.exportItems.insertItem(0, insertedStackCopy, simulate);
+                    }
+                    return insertedStack;
+                }
+                else {
+                    MetaTileEntityQuantumChest.this.itemsStoredInside += remainingStack.getCount();
                 }
             }
+
             return remainingStack;
         }
     }


### PR DESCRIPTION
## What
Fixes Quantum Chest item voiding. Closes #1736 

This was happening because in cases where the initial virtualized items were being set up, we were not inserting the non-virtualized items into the output slot


## Outcome
Fixes quantum chest item voiding when setting up virtual items