### PR TITLE
clean up MetaPrefixItem internals

### DIFF
--- a/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
+++ b/src/main/java/gregtech/api/items/materialitem/MetaPrefixItem.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class MetaPrefixItem extends StandardMetaItem {
 
@@ -49,7 +50,7 @@ public class MetaPrefixItem extends StandardMetaItem {
         purifyMap.put(OrePrefix.dustPure, OrePrefix.dust);
     }
 
-    public MetaPrefixItem(OrePrefix orePrefix) {
+    public MetaPrefixItem(@Nonnull OrePrefix orePrefix) {
         super();
         this.prefix = orePrefix;
         this.setCreativeTab(GregTechAPI.TAB_GREGTECH_MATERIALS);
@@ -67,7 +68,7 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     public void registerOreDict() {
         for (short metaItem : metaItems.keySet()) {
-            Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(metaItem);
+            Material material = getMaterial(metaItem);
             ItemStack item = new ItemStack(this, 1, metaItem);
             OreDictUnifier.registerOre(item, prefix, material);
             registerSpecialOreDict(item, material, prefix);
@@ -94,17 +95,17 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     @Nonnull
     @Override
-    public String getItemStackDisplayName(ItemStack itemStack) {
-        Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(itemStack.getItemDamage());
+    public String getItemStackDisplayName(@Nonnull ItemStack itemStack) {
+        Material material = getMaterial(itemStack);
         if (material == null || prefix == null) return "";
         return prefix.getLocalNameForItem(material);
     }
 
     @Override
     @SideOnly(Side.CLIENT)
-    protected int getColorForItemStack(ItemStack stack, int tintIndex) {
+    protected int getColorForItemStack(@Nonnull ItemStack stack, int tintIndex) {
         if (tintIndex == 0) {
-            Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(stack.getMetadata());
+            Material material = getMaterial(stack);
             if (material == null)
                 return 0xFFFFFF;
             return material.getMaterialRGB();
@@ -114,15 +115,14 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     @Override
     @SideOnly(Side.CLIENT)
-    @SuppressWarnings("ConstantConditions")
     public void registerModels() {
         Map<Short, ModelResourceLocation> alreadyRegistered = new Short2ObjectOpenHashMap<>();
         for (short metaItem : metaItems.keySet()) {
-            MaterialIconSet materialIconSet = GregTechAPI.MATERIAL_REGISTRY.getObjectById(metaItem).getMaterialIconSet();
+            MaterialIconSet materialIconSet = getMaterial(metaItem).getMaterialIconSet();
 
             short registrationKey = (short) (prefix.id + materialIconSet.id);
             if (!alreadyRegistered.containsKey(registrationKey)) {
-                ResourceLocation resourceLocation = prefix.materialIconType.getItemModelPath(materialIconSet);
+                ResourceLocation resourceLocation = Objects.requireNonNull(prefix.materialIconType).getItemModelPath(materialIconSet);
                 ModelBakery.registerItemVariants(this, resourceLocation);
                 alreadyRegistered.put(registrationKey, new ModelResourceLocation(resourceLocation, "inventory"));
             }
@@ -133,7 +133,7 @@ public class MetaPrefixItem extends StandardMetaItem {
         // Make some default models for meta prefix items without any materials associated
         if (metaItems.keySet().isEmpty()) {
             MaterialIconSet defaultIcon = MaterialIconSet.DULL;
-            ResourceLocation defaultLocation = OrePrefix.ingot.materialIconType.getItemModelPath(defaultIcon);
+            ResourceLocation defaultLocation = Objects.requireNonNull(OrePrefix.ingot.materialIconType).getItemModelPath(defaultIcon);
             ModelBakery.registerItemVariants(this, defaultLocation);
         }
     }
@@ -147,8 +147,7 @@ public class MetaPrefixItem extends StandardMetaItem {
     @Override
     public void onUpdate(@Nonnull ItemStack itemStack, @Nonnull World worldIn, @Nonnull Entity entityIn, int itemSlot, boolean isSelected) {
         super.onUpdate(itemStack, worldIn, entityIn, itemSlot, isSelected);
-        if (metaItems.containsKey((short) itemStack.getItemDamage()) && entityIn instanceof EntityLivingBase) {
-            EntityLivingBase entity = (EntityLivingBase) entityIn;
+        if (metaItems.containsKey((short) itemStack.getItemDamage()) && entityIn instanceof EntityLivingBase entity) {
             if (entityIn.ticksExisted % 20 == 0) {
                 if (prefix.heatDamageFunction == null) return;
 
@@ -175,15 +174,43 @@ public class MetaPrefixItem extends StandardMetaItem {
     @SideOnly(Side.CLIENT)
     public void addInformation(@Nonnull ItemStack itemStack, @Nullable World worldIn, @Nonnull List<String> lines, @Nonnull ITooltipFlag tooltipFlag) {
         super.addInformation(itemStack, worldIn, lines, tooltipFlag);
-        int damage = itemStack.getItemDamage();
-        Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
+        Material material = getMaterial(itemStack);
         if (prefix == null || material == null) return;
         addMaterialTooltip(lines, itemStack);
     }
 
-    public static Material getMaterial(ItemStack itemStack) {
-        int damage = itemStack.getItemDamage();
-        return GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
+    /**
+     * For general use. Can return null if the stack metadata is an invalid material ID.
+     * Requires the ItemStack's item to be a MetaPrefixItem.
+     *
+     * @return the material
+     */
+    @Nullable
+    public Material getMaterial(@Nonnull ItemStack stack) {
+        return GregTechAPI.MATERIAL_REGISTRY.getObjectById(stack.getMetadata());
+    }
+
+    /**
+     * For registration use only. Assumes the metadata is a valid material ID.
+     *
+     * @return the material
+     */
+    @Nonnull
+    protected Material getMaterial(int metadata) {
+        return Objects.requireNonNull(GregTechAPI.MATERIAL_REGISTRY.getObjectById(metadata));
+    }
+
+    /**
+     * Attempt to get a material from an ItemStack, whose item may not be a MetaPrefixItem.
+     *
+     * @return the material
+     */
+    @Nullable
+    public static Material tryGetMaterial(@Nonnull ItemStack itemStack) {
+        if (itemStack.getItem() instanceof MetaPrefixItem metaPrefixItem) {
+            return metaPrefixItem.getMaterial(itemStack);
+        }
+        return null;
     }
 
     public OrePrefix getOrePrefix() {
@@ -192,8 +219,7 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     @Override
     public int getItemBurnTime(@Nonnull ItemStack itemStack) {
-        int damage = itemStack.getItemDamage();
-        Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
+        Material material = getMaterial(itemStack);
         DustProperty property = material == null ? null : material.getProperty(PropertyKey.DUST);
         if (property != null) return (int) (property.getBurnTime() * prefix.getMaterialAmount(material) / GTValues.M);
         return super.getItemBurnTime(itemStack);
@@ -201,10 +227,8 @@ public class MetaPrefixItem extends StandardMetaItem {
     }
 
     @Override
-    public boolean isBeaconPayment(ItemStack stack) {
-        int damage = stack.getMetadata();
-
-        Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
+    public boolean isBeaconPayment(@Nonnull ItemStack stack) {
+        Material material = getMaterial(stack);
         if (material != null && this.prefix != OrePrefix.ingot && this.prefix != OrePrefix.gem) {
             ToolProperty property = material.getProperty(PropertyKey.TOOL);
             return property != null && property.getToolHarvestLevel() >= 2;
@@ -214,11 +238,10 @@ public class MetaPrefixItem extends StandardMetaItem {
 
     @Override
     public boolean onEntityItemUpdate(EntityItem itemEntity) {
-        int damage = itemEntity.getItem().getMetadata();
         if (itemEntity.getEntityWorld().isRemote)
             return false;
 
-        Material material = GregTechAPI.MATERIAL_REGISTRY.getObjectById(damage);
+        Material material = getMaterial(itemEntity.getItem());
         if (!purifyMap.containsKey(this.prefix))
             return false;
 
@@ -240,9 +263,9 @@ public class MetaPrefixItem extends StandardMetaItem {
         return false;
     }
 
-    protected void addMaterialTooltip(List<String> lines, ItemStack itemStack) {
+    protected void addMaterialTooltip(@Nonnull List<String> lines, @Nonnull ItemStack itemStack) {
         if (this.prefix.tooltipFunc != null) {
-            lines.addAll(this.prefix.tooltipFunc.apply(MetaPrefixItem.getMaterial(itemStack)));
+            lines.addAll(this.prefix.tooltipFunc.apply(getMaterial(itemStack)));
         }
     }
 }

--- a/src/main/java/gregtech/api/util/GTStringUtils.java
+++ b/src/main/java/gregtech/api/util/GTStringUtils.java
@@ -27,9 +27,9 @@ public final class GTStringUtils {
             MetaItem<?> metaItem = (MetaItem<?>) stack.getItem();
             MetaItem<?>.MetaValueItem metaValueItem = metaItem.getItem(stack);
             if (metaValueItem == null) {
-                if (metaItem instanceof MetaPrefixItem) {
-                    Material material = MetaPrefixItem.getMaterial(stack);
-                    OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
+                if (metaItem instanceof MetaPrefixItem metaPrefixItem) {
+                    Material material = metaPrefixItem.getMaterial(stack);
+                    OrePrefix orePrefix = metaPrefixItem.getOrePrefix();
                     return "(MetaItem) OrePrefix: " + orePrefix.name + ", Material: " + material + " * " + stack.getCount();
                 }
             } else {

--- a/src/main/java/gregtech/common/command/CommandRecipeCheck.java
+++ b/src/main/java/gregtech/common/command/CommandRecipeCheck.java
@@ -231,9 +231,9 @@ public class CommandRecipeCheck extends CommandBase {
             MetaItem<?> metaItem = (MetaItem<?>) stack.getItem();
             MetaValueItem metaValueItem = metaItem.getItem(stack);
             if (metaValueItem == null) {
-                if (metaItem instanceof MetaPrefixItem) {
-                    Material material = MetaPrefixItem.getMaterial(stack);
-                    OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
+                if (metaItem instanceof MetaPrefixItem metaPrefixItem) {
+                    Material material = metaPrefixItem.getMaterial(stack);
+                    OrePrefix orePrefix = metaPrefixItem.getOrePrefix();
                     return "(MetaItem) OrePrefix: " + orePrefix.name + ", Material: " + material + " * " + stack.getCount();
                 }
             } else {


### PR DESCRIPTION
## What
Cleans up some MetaPrefixItem internals

## Implementation Details
The two new `getMaterial()` methods are intentionally left non-static for future material registry-related work.

## Outcome
Cleans up some internals of MetaPrefixItem.

## Potential Compatibility Issues
This PR renames the original static `MetaPrefixItem.getMaterial` method to `tryGetMaterial`, and provides better checking for what the method is most likely intended to do. It is unlikely that other mods utilize it though.
