### PR TITLE
Track repetitions for each aisle in multiblocks

### DIFF
--- a/src/main/java/gregtech/api/pattern/BlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/BlockPattern.java
@@ -174,7 +174,6 @@ public class BlockPattern {
                             } else {
                                 z++;//continue searching for the first aisle
                             }
-//                            validRepetitions = 0;
                             continue loop;
                         }
                     }


### PR DESCRIPTION
# What
Keeps track of the amount of repetitions for each aisle in the structure. This allows easier access for how many times multiblocks are expanded, which is useful for changing recipes based on this information for example.

## Implementation Details
The array stores the amount of times each aisle is seen, and the index of each value is the index of the aisle in the structure definition.

## Outcome
Tracks repetitions for each aisle in multiblocks.
