### PR TITLE
Fix invalid MultiblockShapeInfo with non-square multiblocks

### DIFF
--- a/src/main/java/gregtech/api/pattern/MultiblockShapeInfo.java
+++ b/src/main/java/gregtech/api/pattern/MultiblockShapeInfo.java
@@ -8,7 +8,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 
-import java.lang.reflect.Array;
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,12 +17,16 @@ import java.util.function.Supplier;
 
 public class MultiblockShapeInfo {
 
-    private final BlockInfo[][][] blocks; //[z][y][x]
+    /** {@code [x][y][z]} */
+    private final BlockInfo[][][] blocks;
 
     public MultiblockShapeInfo(BlockInfo[][][] blocks) {
         this.blocks = blocks;
     }
 
+    /**
+     * @return the blocks in an array of format: {@code [x][y][z]}
+     */
     public BlockInfo[][][] getBlocks() {
         return blocks;
     }
@@ -70,13 +74,17 @@ public class MultiblockShapeInfo {
             } else throw new IllegalArgumentException("Supplier must supply either a MetaTileEntity or an IBlockState! Actual: " + part.getClass());
         }
 
+        @Nonnull
         private BlockInfo[][][] bakeArray() {
-            BlockInfo[][][] blockInfos = (BlockInfo[][][]) Array.newInstance(BlockInfo.class, shape.get(0)[0].length(), shape.get(0).length, shape.size());
-            for (int z = 0; z < blockInfos.length; z++) { //z
+            final int maxZ = shape.size();
+            final int maxY = shape.get(0).length;
+            final int maxX = shape.get(0)[0].length();
+            BlockInfo[][][] blockInfos = new BlockInfo[maxX][maxY][maxZ];
+            for (int z = 0; z < maxZ; z++) {
                 String[] aisleEntry = shape.get(z);
-                for (int y = 0; y < shape.get(0).length; y++) {
+                for (int y = 0; y < maxY; y++) {
                     String columnEntry = aisleEntry[y];
-                    for (int x = 0; x < columnEntry.length(); x++) {
+                    for (int x = 0; x < maxX; x++) {
                         BlockInfo info = symbolMap.getOrDefault(columnEntry.charAt(x), BlockInfo.EMPTY);
                         TileEntity tileEntity = info.getTileEntity();
                         if (tileEntity != null) {


### PR DESCRIPTION
## What
This PR fixes a JEI plugin error where Multiblocks manually specifying their `MultiblockShapeInfo` with the builder would cause `ArrayIndexOutOfBoundsException`s if the base was not square (for example aisle count != string length). This happened because the Z and X maximums were swapped in the for loops, which would only leave square shapes unaffected.

This did not occur when the structure preview was autogenerated, as it does not use the builder.

## Outcome
Fixes JEI plugin errors with non-square manually specified JEI previews.
