### PR TITLE
Fix non GT tile entities in manual multiblock previews

### DIFF
--- a/src/main/java/gregtech/api/pattern/MultiblockShapeInfo.java
+++ b/src/main/java/gregtech/api/pattern/MultiblockShapeInfo.java
@@ -54,6 +54,10 @@ public class MultiblockShapeInfo {
             return where(symbol, new BlockInfo(blockState));
         }
 
+        public Builder where(char symbol, IBlockState blockState, TileEntity tileEntity) {
+            return where(symbol, new BlockInfo(blockState, tileEntity));
+        }
+
         public Builder where(char symbol, MetaTileEntity tileEntity, EnumFacing frontSide) {
             MetaTileEntityHolder holder = new MetaTileEntityHolder();
             holder.setMetaTileEntity(tileEntity);
@@ -87,14 +91,15 @@ public class MultiblockShapeInfo {
                     for (int x = 0; x < maxX; x++) {
                         BlockInfo info = symbolMap.getOrDefault(columnEntry.charAt(x), BlockInfo.EMPTY);
                         TileEntity tileEntity = info.getTileEntity();
-                        if (tileEntity != null) {
-                            MetaTileEntityHolder holder = (MetaTileEntityHolder) tileEntity;
+                        if (tileEntity instanceof MetaTileEntityHolder holder) {
                             final MetaTileEntity mte = holder.getMetaTileEntity();
                             holder = new MetaTileEntityHolder();
                             holder.setMetaTileEntity(mte);
                             holder.getMetaTileEntity().onPlacement();
                             holder.getMetaTileEntity().setFrontFacing(mte.getFrontFacing());
                             info = new BlockInfo(info.getBlockState(), holder);
+                        } else if (tileEntity != null) {
+                            info = new BlockInfo(info.getBlockState(), tileEntity);
                         }
                         blockInfos[x][y][z] = info;
                     }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -471,9 +471,10 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             TileEntity tileEntity = blockInfo.getTileEntity();
             if (tileEntity != null) {
                 this.isTile = true;
-                MetaTileEntity mte = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();
-                if (mte instanceof MultiblockControllerBase)
-                    this.isController = true;
+                if (tileEntity instanceof IGregTechTileEntity iGregTechTileEntity) {
+                    MetaTileEntity mte = iGregTechTileEntity.getMetaTileEntity();
+                    this.isController = mte instanceof MultiblockControllerBase;
+                }
             }
         }
 


### PR DESCRIPTION
## What
Allows non-GT tile entities to work properly in multiblock previews when done manually.

## Outcome
Prevents crashes when attempting to use tile entities in a manual structure preview.
