### PR TITLE
Fix RecipeMap#onRecipeBuild generics

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -60,7 +60,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     protected boolean hidden = false;
     protected boolean isCTRecipe = false;
     protected int parallel = 0;
-    protected Consumer<RecipeBuilder<?>> onBuildAction = null;
+    protected Consumer<R> onBuildAction = null;
     protected EnumValidationResult recipeStatus = EnumValidationResult.VALID;
     protected IRecipePropertyStorage recipePropertyStorage = null;
     protected boolean recipePropertyStorageErrored = false;
@@ -794,7 +794,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return out;
     }
 
-    protected R onBuild(Consumer<RecipeBuilder<?>> consumer) {
+    protected R onBuild(Consumer<R> consumer) {
         this.onBuildAction = consumer;
         return (R) this;
     }
@@ -806,7 +806,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public void buildAndRegister() {
         if (onBuildAction != null) {
-            onBuildAction.accept(this);
+            onBuildAction.accept((R) this);
         }
         ValidationResult<Recipe> validationResult = build();
         recipeMap.addRecipe(validationResult);

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -104,7 +104,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private final WeakHashMap<AbstractMapIngredient, WeakReference<AbstractMapIngredient>> fluidIngredientRoot = new WeakHashMap<>();
 
 
-    private Consumer<RecipeBuilder<?>> onRecipeBuildAction;
+    private Consumer<R> onRecipeBuildAction;
     protected SoundEvent sound;
     private RecipeMap<?> smallRecipeMap;
 
@@ -249,7 +249,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return this;
     }
 
-    public RecipeMap<R> onRecipeBuild(Consumer<RecipeBuilder<?>> consumer) {
+    public RecipeMap<R> onRecipeBuild(Consumer<R> consumer) {
         onRecipeBuildAction = consumer;
         return this;
     }


### PR DESCRIPTION
## What
Fixes the generics in `RecipeMap#onRecipeBuild` so the `RecipeBuilder` type is not erased when used. This allows easier access of builder-specific fields as it will no longer require casting the builder to the correct type first.


## Outcome
Fixes `RecipeMap#onRecipeBuild` generics.
