### PR TITLE
Fix materials with one component having incorrect formulas

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -66,6 +66,13 @@ public class Material implements Comparable<Material> {
             return materialInfo.element.getSymbol();
         }
         if (!materialInfo.componentList.isEmpty()) {
+            // prevent parenthesis around single component materials
+            if (materialInfo.componentList.size() == 1) {
+                MaterialStack stack = materialInfo.componentList.get(0);
+                if (stack.amount == 1) {
+                    return stack.material.getChemicalFormula();
+                }
+            }
             StringBuilder components = new StringBuilder();
             for (MaterialStack component : materialInfo.componentList)
                 components.append(component.toFormatted());


### PR DESCRIPTION
## What
Fixes incorrect chemical formulas on some materials. For example, glass was previously `(SiO2)` but will now properly display as `SiO2` instead.

## Outcome
Fixes materials with one component having incorrect formulas.
