### PR TITLE
Fix ItemStack count GUI overlap in Crafting Station

### DIFF
--- a/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListSlotWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListSlotWidget.java
@@ -44,7 +44,9 @@ public class ItemListSlotWidget extends Widget {
         int stackX = position.x + 1;
         int stackY = position.y + 1;
         if (itemInfo != null) {
-            ItemStack itemStack = itemInfo.getItemStack();
+            ItemStack itemStack = itemInfo.getItemStack().copy();
+            // Set the count to 1 to prevent stack size from being drawn in drawItemStack
+            itemStack.setCount(1);
             String itemAmountStr = formatItemAmount(itemInfo.getTotalItemAmount());
             drawItemStack(itemStack, stackX, stackY, null);
             drawStringFixedCorner(itemAmountStr, stackX + 17, stackY + 17, 16777215, true, 0.5f);

--- a/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListSlotWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/craftingstation/ItemListSlotWidget.java
@@ -44,12 +44,15 @@ public class ItemListSlotWidget extends Widget {
         int stackX = position.x + 1;
         int stackY = position.y + 1;
         if (itemInfo != null) {
-            ItemStack itemStack = itemInfo.getItemStack().copy();
+            ItemStack itemStack = itemInfo.getItemStack();
+            // Used to reset the ItemStack count after drawing. Avoids copying the itemStack
+            int cachedCount = itemStack.getCount();
             // Set the count to 1 to prevent stack size from being drawn in drawItemStack
             itemStack.setCount(1);
             String itemAmountStr = formatItemAmount(itemInfo.getTotalItemAmount());
             drawItemStack(itemStack, stackX, stackY, null);
             drawStringFixedCorner(itemAmountStr, stackX + 17, stackY + 17, 16777215, true, 0.5f);
+            itemStack.setCount(cachedCount);
         }
         if (isMouseOverElement(mouseX, mouseY)) {
             drawSelectionOverlay(stackX, stackY, 16, 16);


### PR DESCRIPTION
## What
Fixes the itemstack count GUI overlap, described in #1744. Closes #1744.

the `drawItemStack` method will draw the count of the itemstack, if it is not equal to 1. In addition, I noticed that this did not work when the stacksize was > 64 (maybe > max stack size, depending on the stack). 

However, the following method, `drawStringFixedCorner`, takes into account the full stack size of the stored item, rendering that correctly.


## Outcome
Fix ItemStack count GUI overlap in the Crafting Station.
