### PR TITLE
Fix infinite bus collapsing

### DIFF
--- a/src/main/java/gregtech/api/util/GTHashMaps.java
+++ b/src/main/java/gregtech/api/util/GTHashMaps.java
@@ -1,6 +1,7 @@
 package gregtech.api.util;
 
 import gregtech.api.recipes.FluidKey;
+import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenCustomHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap;
@@ -16,7 +17,7 @@ import java.util.Set;
 
 public final class GTHashMaps {
 
-    private GTHashMaps() {/**/}
+    private GTHashMaps() {}
 
     /**
      * Maps all items in the {@link IItemHandler} into a {@link ItemStack}, {@link Integer} value as amount
@@ -26,7 +27,19 @@ public final class GTHashMaps {
      */
     @Nonnull
     public static Object2IntMap<ItemStack> fromItemHandler(@Nonnull IItemHandler inputs) {
-        final Object2IntMap<ItemStack> map = new Object2IntOpenCustomHashMap<>(ItemStackHashStrategy.comparingAllButCount());
+        return fromItemHandler(inputs, false);
+    }
+
+    /**
+     * Maps all items in the {@link IItemHandler} into a {@link ItemStack}, {@link Integer} value as amount
+     *
+     * @param inputs The inventory handler of the inventory
+     * @param linked If the Map should be a Linked Map to preserve insertion order
+     * @return a {@link Map} of {@link ItemStack} and {@link Integer} as amount on the inventory
+     */
+    @Nonnull
+    public static Object2IntMap<ItemStack> fromItemHandler(@Nonnull IItemHandler inputs, boolean linked) {
+        final Object2IntMap<ItemStack> map = createItemStackMap(linked);
 
         // Create a single stack of the combined count for each item
 
@@ -48,7 +61,19 @@ public final class GTHashMaps {
      */
     @Nonnull
     public static Object2IntMap<ItemStack> fromItemStackCollection(@Nonnull Iterable<ItemStack> inputs) {
-        final Object2IntMap<ItemStack> map = new Object2IntOpenCustomHashMap<>(ItemStackHashStrategy.comparingAllButCount());
+        return fromItemStackCollection(inputs, false);
+    }
+
+    /**
+     * Maps all items in the {@link ItemStack} {@link Collection} into a {@link ItemStack}, {@link Integer} value as amount
+     *
+     * @param inputs The inventory handler of the inventory
+     * @param linked If the Map should be a Linked Map to preserve insertion order
+     * @return a {@link Map} of {@link ItemStack} and {@link Integer} as amount on the inventory
+     */
+    @Nonnull
+    public static Object2IntMap<ItemStack> fromItemStackCollection(@Nonnull Iterable<ItemStack> inputs, boolean linked) {
+        final Object2IntMap<ItemStack> map = createItemStackMap(linked);
 
         // Create a single stack of the combined count for each item
 
@@ -59,6 +84,12 @@ public final class GTHashMaps {
         }
 
         return map;
+    }
+
+    @Nonnull
+    private static Object2IntMap<ItemStack> createItemStackMap(boolean linked) {
+        ItemStackHashStrategy strategy = ItemStackHashStrategy.comparingAllButCount();
+        return linked ? new Object2IntLinkedOpenCustomHashMap<>(strategy) : new Object2IntOpenCustomHashMap<>(strategy);
     }
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -16,7 +16,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.util.GTHashMaps;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
@@ -68,16 +67,10 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
                 }
             }
             // Only attempt to auto collapse the inventory contents once the bus has been notified
-            if (isAutoCollapse() && this.isAttachedToMultiBlock()) {
-                MultiblockControllerBase controller = getController();
-                if (controller != null) {
-                    List<IItemHandlerModifiable> notified = isExportHatch ? controller.getNotifiedItemOutputList() : controller.getNotifiedItemInputList();
-                    IItemHandlerModifiable inventory = isExportHatch ? getExportItems() : getImportItems();
-                    if (notified.contains(inventory)) {
-                        collapseInventorySlotContents(inventory);
-                        // collapsing re-notifies, so prevent attempts to collapse again
-                        notified.remove(inventory);
-                    }
+            if (isAutoCollapse()) {
+                IItemHandlerModifiable inventory = (isExportHatch ? this.getExportItems() : this.getImportItems());
+                if (isExportHatch ? this.getNotifiedItemOutputList().contains(inventory) : this.getNotifiedItemInputList().contains(inventory)) {
+                    collapseInventorySlotContents(inventory);
                 }
             }
         }


### PR DESCRIPTION
## What
Fixes a bug causing buses to infinitely collapse items in some scenarios.

This was caused by inconsistent item ordering due to the use of a regular HashMap, and was fixed by using LinkedHashMap to preserve insertion order.

## Outcome
Fixes #1841.
