### PR TITLE
Allow Miner Logic to be Reset by Machine Controller or Soft Mallet

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -457,6 +457,15 @@ public class MinerLogic {
     }
 
     /**
+     * Resets the pipe length to zero
+     */
+    private void resetPipeLength() {
+        this.pipeLength = 0;
+        this.metaTileEntity.writeCustomData(GregtechDataCodes.PUMP_HEAD_LEVEL, b -> b.writeInt(pipeLength));
+        this.metaTileEntity.markDirty();
+    }
+
+    /**
      * renders the pipe beneath the miner
      */
     public void renderPipe(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -339,6 +339,7 @@ public class MinerLogic {
         this.isDone = false;
         blocksToMine.clear();
         checkBlocksToMine();
+        resetPipeLength();
     }
 
     /**
@@ -688,10 +689,8 @@ public class MinerLogic {
             this.isWorkingEnabled = isWorkingEnabled;
             metaTileEntity.markDirty();
             if (metaTileEntity.getWorld() != null && !metaTileEntity.getWorld().isRemote) {
-                if (!isWorkingEnabled && checkCanMine()) {
-                    resetArea();
-                    resetPipeLength();
-                }
+                if (!isWorkingEnabled && checkCanMine()) resetArea();
+
                 this.metaTileEntity.writeCustomData(GregtechDataCodes.WORKING_ENABLED, buf -> buf.writeBoolean(isWorkingEnabled));
             }
         }

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -688,6 +688,10 @@ public class MinerLogic {
             this.isWorkingEnabled = isWorkingEnabled;
             metaTileEntity.markDirty();
             if (metaTileEntity.getWorld() != null && !metaTileEntity.getWorld().isRemote) {
+                if (!isWorkingEnabled && checkCanMine()) {
+                    resetArea();
+                    resetPipeLength();
+                }
                 this.metaTileEntity.writeCustomData(GregtechDataCodes.WORKING_ENABLED, buf -> buf.writeBoolean(isWorkingEnabled));
             }
         }


### PR DESCRIPTION
## What
Reset miner logic when the miner is disabled and if there are blocks to mine

## Implementation Details
Adds check in `setWorkingEnabled()` if logic was disabled and there are blocks to mine, then reset miner logic

## Outcome
People can use machine controllers or soft mallets to reset mining logic, instead of needing to break and replace the controller/machine

## Additional Information
https://github.com/GregTechCEu/GregTech/assets/44148655/c4e49271-50a6-4e33-939c-b44e478b56c6

I've done some profiling with spark to try and see the effects from this change
https://spark.lucko.me/NIZzROQV6V - baseline, no machines running (7ms)
https://spark.lucko.me/In3fSz30yu - Large Miner running and being reset every four blocks mined (228ms)
https://spark.lucko.me/xqmBsdtzjZ - Large Miner running continuously, without being reset (45ms)

https://spark.lucko.me/E0VgKJulHT - Large Miner being reset every four blocks mined via break/replace (220ms)

## Potential Compatibility Issues
none afaik
