### PR TITLE
Remove unneeded RecipePropertyStorage logging

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -328,10 +328,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (previousRecipe == null)
             return true;
 
-        CleanroomType requiredType = null;
-        if (previousRecipe.hasProperty(CleanroomProperty.getInstance())) {
-            requiredType = previousRecipe.getProperty(CleanroomProperty.getInstance(), null);
-        }
+        CleanroomType requiredType = previousRecipe.getProperty(CleanroomProperty.getInstance(), null);
 
         if (requiredType == null) return true;
 
@@ -396,10 +393,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return true if the recipe is allowed to be used, else false
      */
     public boolean checkRecipe(@Nonnull Recipe recipe) {
-        CleanroomType requiredType = null;
-        if (recipe.hasProperty(CleanroomProperty.getInstance())) {
-            requiredType = recipe.getProperty(CleanroomProperty.getInstance(), null);
-        }
+        CleanroomType requiredType = recipe.getProperty(CleanroomProperty.getInstance(), null);
 
         if (requiredType == null) return true;
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/EmptyRecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/EmptyRecipePropertyStorage.java
@@ -1,12 +1,10 @@
 package gregtech.api.recipes.recipeproperties;
 
-import gregtech.api.util.GTLog;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-public class EmptyRecipePropertyStorage implements IRecipePropertyStorage {
+public final class EmptyRecipePropertyStorage implements IRecipePropertyStorage {
 
     public static final EmptyRecipePropertyStorage INSTANCE = new EmptyRecipePropertyStorage();
 
@@ -46,8 +44,6 @@ public class EmptyRecipePropertyStorage implements IRecipePropertyStorage {
 
     @Override
     public <T> T getRecipePropertyValue(RecipeProperty<T> recipeProperty, T defaultValue) {
-        GTLog.logger.warn("There is no property with key {}", recipeProperty.getKey());
-        GTLog.logger.warn(STACKTRACE, new IllegalArgumentException());
         return defaultValue;
     }
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipePropertyStorage.java
@@ -89,11 +89,6 @@ public class RecipePropertyStorage implements IRecipePropertyStorage {
         Object value = recipeProperties.get(recipeProperty);
 
         if (value == null) {
-            if (defaultValue == null) {
-                return null;
-            }
-            GTLog.logger.warn("There is no property with key {}", recipeProperty.getKey());
-            GTLog.logger.warn(STACKTRACE, new IllegalArgumentException());
             return defaultValue;
         }
 
@@ -128,9 +123,6 @@ public class RecipePropertyStorage implements IRecipePropertyStorage {
             if (recipeProperty.getKey().equals(key))
                 return recipeProperty;
         }
-
-        GTLog.logger.warn("There is no property with key {}", key);
-        GTLog.logger.warn(STACKTRACE, new IllegalArgumentException());
 
         return null;
     }


### PR DESCRIPTION
## What
Removes the error logging in RecipePropertyStorage classes. The retrieval methods already actslike a `getOrDefault()`, so the caller should be expected to handle the default value accordingly, instead of being met with an logged error when the property is not present.

## Outcome
Removes unneeded RecipePropertyStorage logging.
