### PR TITLE
Fix clean multiblocks config with the PA

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -325,19 +325,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return true if the recipe can progress, otherwise false
      */
     protected boolean canProgressRecipe() {
-        if (previousRecipe == null)
-            return true;
-
-        CleanroomType requiredType = previousRecipe.getProperty(CleanroomProperty.getInstance(), null);
-
-        if (requiredType == null) return true;
-
-        if (getMetaTileEntity() instanceof IMultiblockController && ConfigHolder.machines.cleanMultiblocks) return true;
-
-        ICleanroomProvider cleanroomProvider = ((ICleanroomReceiver) getMetaTileEntity()).getCleanroom();
-        if (cleanroomProvider == null) return false;
-
-        return cleanroomProvider.isClean() && cleanroomProvider.getTypes().contains(requiredType);
+        if (previousRecipe == null) return true;
+        return checkCleanroomRequirement(previousRecipe);
     }
 
     /**
@@ -393,16 +382,28 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return true if the recipe is allowed to be used, else false
      */
     public boolean checkRecipe(@Nonnull Recipe recipe) {
-        CleanroomType requiredType = recipe.getProperty(CleanroomProperty.getInstance(), null);
+        return checkCleanroomRequirement(recipe);
+    }
 
+    /**
+     * @param recipe the recipe to check
+     * @return if the cleanroom requirement is met
+     */
+    protected boolean checkCleanroomRequirement(@Nonnull Recipe recipe) {
+        CleanroomType requiredType = recipe.getProperty(CleanroomProperty.getInstance(), null);
         if (requiredType == null) return true;
 
-        if (getMetaTileEntity() instanceof IMultiblockController && ConfigHolder.machines.cleanMultiblocks) return true;
+        MetaTileEntity mte = getMetaTileEntity();
+        if (mte instanceof ICleanroomReceiver receiver) {
+            if (ConfigHolder.machines.cleanMultiblocks && mte instanceof IMultiblockController) return true;
 
-        ICleanroomProvider cleanroomProvider = ((ICleanroomReceiver) getMetaTileEntity()).getCleanroom();
-        if (cleanroomProvider == null) return false;
+            ICleanroomProvider cleanroomProvider = receiver.getCleanroom();
+            if (cleanroomProvider == null) return false;
 
-        return cleanroomProvider.isClean() && cleanroomProvider.getTypes().contains(requiredType);
+            return cleanroomProvider.isClean() && cleanroomProvider.checkCleanroomType(requiredType);
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
@@ -9,14 +9,26 @@ public final class DummyCleanroom implements ICleanroomProvider {
     private final boolean allowsAllTypes;
     private final Collection<CleanroomType> allowedTypes;
 
-    public DummyCleanroom(@Nonnull Collection<CleanroomType> allowedTypes) {
-        this.allowsAllTypes = false;
-        this.allowedTypes = allowedTypes;
+    /**
+     * Create a Dummy Cleanroom that provides specific types
+     * @param types the types to provide
+     */
+    @Nonnull
+    public static DummyCleanroom createForTypes(@Nonnull Collection<CleanroomType> types) {
+        return new DummyCleanroom(types, false);
     }
 
-    public DummyCleanroom(boolean allowsAllTypes) {
+    /**
+     * Create a Dummy Cleanroom that provides all types
+     */
+    @Nonnull
+    public static DummyCleanroom createForAllTypes() {
+        return new DummyCleanroom(Collections.emptyList(), true);
+    }
+
+    private DummyCleanroom(@Nonnull Collection<CleanroomType> allowedTypes, boolean allowsAllTypes) {
+        this.allowedTypes = allowedTypes;
         this.allowsAllTypes = allowsAllTypes;
-        this.allowedTypes = Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
@@ -1,0 +1,53 @@
+package gregtech.api.metatileentity.multiblock;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+
+public final class DummyCleanroom implements ICleanroomProvider {
+
+    private final boolean allowsAllTypes;
+    private final Collection<CleanroomType> allowedTypes;
+
+    public DummyCleanroom(@Nonnull Collection<CleanroomType> allowedTypes) {
+        this.allowsAllTypes = false;
+        this.allowedTypes = allowedTypes;
+    }
+
+    public DummyCleanroom(boolean allowsAllTypes) {
+        this.allowsAllTypes = allowsAllTypes;
+        this.allowedTypes = Collections.emptyList();
+    }
+
+    @Override
+    public boolean isClean() {
+        return true;
+    }
+
+    @Override
+    public boolean drainEnergy(boolean simulate) {
+        return true;
+    }
+
+    @Override
+    public long getEnergyInputPerSecond() {
+        return 0;
+    }
+
+    @Override
+    public int getEnergyTier() {
+        return 0;
+    }
+
+    @Override
+    public boolean checkCleanroomType(@Nonnull CleanroomType type) {
+        if (allowsAllTypes) return true;
+        return allowedTypes.contains(type);
+    }
+
+    @Override
+    public void setCleanAmount(int amount) {}
+
+    @Override
+    public void adjustCleanAmount(int amount) {}
+}

--- a/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomProvider.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomProvider.java
@@ -1,6 +1,6 @@
 package gregtech.api.metatileentity.multiblock;
 
-import java.util.Set;
+import javax.annotation.Nonnull;
 
 /**
  * Implement this interface in order to make a TileEntity into a block that provides a Cleanroom to other blocks
@@ -8,9 +8,10 @@ import java.util.Set;
 public interface ICleanroomProvider {
 
     /**
-     * @return a {@link Set} of {@link CleanroomType} which the cleanroom provides
+     * @param type the type to check
+     * @return if the type is fulfilled
      */
-    Set<CleanroomType> getTypes();
+    boolean checkCleanroomType(@Nonnull CleanroomType type);
 
     /**
      * Sets the cleanroom's clean amount

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -5,7 +5,6 @@ import appeng.core.features.AEFeature;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
-import com.google.common.collect.Sets;
 import gregtech.api.GTValues;
 import gregtech.api.capability.*;
 import gregtech.api.capability.impl.CleanroomLogic;
@@ -497,8 +496,8 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase implement
     }
 
     @Override
-    public Set<CleanroomType> getTypes() {
-        return Sets.newHashSet(this.cleanroomType);
+    public boolean checkCleanroomType(@Nonnull CleanroomType type) {
+        return type == this.cleanroomType;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -170,7 +170,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
     @SuppressWarnings("InnerClassMayBeStatic")
     protected class ProcessingArrayWorkable extends MultiblockRecipeLogic {
 
-        private static final ICleanroomProvider DUMMY_CLEANROOM = new DummyCleanroom(true);
+        private static final ICleanroomProvider DUMMY_CLEANROOM = DummyCleanroom.createForAllTypes();
 
         ItemStack currentMachineStack = ItemStack.EMPTY;
         MetaTileEntity mte = null;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -170,6 +170,8 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
     @SuppressWarnings("InnerClassMayBeStatic")
     protected class ProcessingArrayWorkable extends MultiblockRecipeLogic {
 
+        private static final ICleanroomProvider DUMMY_CLEANROOM = new DummyCleanroom(true);
+
         ItemStack currentMachineStack = ItemStack.EMPTY;
         MetaTileEntity mte = null;
         //The Voltage Tier of the machines the PA is operating upon, from GTValues.V
@@ -261,12 +263,15 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                 holder.setWorld(this.metaTileEntity.getWorld());
 
                 // Set the cleanroom of the MTEs to the PA's cleanroom reference
-                ICleanroomProvider cleanroom = controller.getCleanroom();
-                if (cleanroom != null && mte instanceof ICleanroomReceiver) {
-                    ((ICleanroomReceiver) mte).setCleanroom(cleanroom);
+                if (mte instanceof ICleanroomReceiver receiver) {
+                    if (ConfigHolder.machines.cleanMultiblocks) {
+                        receiver.setCleanroom(DUMMY_CLEANROOM);
+                    } else {
+                        ICleanroomProvider provider = controller.getCleanroom();
+                        if (provider != null) receiver.setCleanroom(provider);
+                    }
                 }
             }
-
 
             //Find the voltage tier of the machine.
             this.machineTier = mte instanceof ITieredMetaTileEntity ? ((ITieredMetaTileEntity) mte).getTier() : 0;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -36,7 +36,7 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
     }
 
     // must come after the static block
-    private static final ICleanroomProvider DUMMY_CLEANROOM = new DummyCleanroom(CLEANED_TYPES);
+    private static final ICleanroomProvider DUMMY_CLEANROOM = DummyCleanroom.createForTypes(CLEANED_TYPES);
 
     public MetaTileEntityCleaningMaintenanceHatch(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId);

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -8,10 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.CleanroomType;
-import gregtech.api.metatileentity.multiblock.ICleanroomProvider;
-import gregtech.api.metatileentity.multiblock.ICleanroomReceiver;
-import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
+import gregtech.api.metatileentity.multiblock.*;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
@@ -32,13 +29,14 @@ import java.util.Set;
 
 public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMaintenanceHatch {
 
-    private static final CleaningMaintenanceHatchDummyCleanroom DUMMY_CLEANROOM = new CleaningMaintenanceHatchDummyCleanroom();
-
     protected static final Set<CleanroomType> CLEANED_TYPES = new ObjectOpenHashSet<>();
 
     static {
         CLEANED_TYPES.add(CleanroomType.CLEANROOM);
     }
+
+    // must come after the static block
+    private static final ICleanroomProvider DUMMY_CLEANROOM = new DummyCleanroom(CLEANED_TYPES);
 
     public MetaTileEntityCleaningMaintenanceHatch(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId);
@@ -116,44 +114,5 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
     @SuppressWarnings("unused")
     public static ImmutableSet<CleanroomType> getCleanroomTypes() {
         return ImmutableSet.copyOf(CLEANED_TYPES);
-    }
-
-    protected static class CleaningMaintenanceHatchDummyCleanroom implements ICleanroomProvider {
-
-        public CleaningMaintenanceHatchDummyCleanroom() {/**/}
-
-        @Override
-        public boolean isClean() {
-            return true;
-        }
-
-        @Override
-        public boolean drainEnergy(boolean simulate) {
-            return true;
-        }
-
-        @Override
-        public long getEnergyInputPerSecond() {
-            return 0;
-        }
-
-        @Override
-        public int getEnergyTier() {
-            return 0;
-        }
-
-        @Nonnull
-        @Override
-        public Set<CleanroomType> getTypes() {
-            return getCleanroomTypes();
-        }
-
-        @Override
-        public void setCleanAmount(int amount) {
-        }
-
-        @Override
-        public void adjustCleanAmount(int amount) {
-        }
     }
 }


### PR DESCRIPTION
## What
This PR fixes the clean multiblocks config not working properly with the PA.

## Outcome
Fixes the PA not working with the clean multiblocks config.

## Potential Compatibility Issues
This PR makes changes to the ICleanroomProvider interface, which will break mods using them, requiring an update on their end.