### PR TITLE
Fix tooltip in App Store terminal App

### DIFF
--- a/src/main/java/gregtech/common/terminal/app/appstore/AppPageWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/appstore/AppPageWidget.java
@@ -61,7 +61,7 @@ public class AppPageWidget extends TerminalDialogWidget {
                         TerminalTheme.COLOR_7.getColor(),
                         TerminalTheme.COLOR_3.getColor())
                 .setIcon(GuiTextures.ICON_REMOVE)
-                .setHoverText("terminal.guide_editor.remove")
+                .setHoverText("terminal.store.close")
                 .setClickListener(cd->close()));
         if (store.getOs().isRemote()) {
             // profile

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5316,6 +5316,7 @@ terminal.battery.low_energy=Low power! Plz recharge the terminal.
 terminal.store.description=App store, check out what you got? Install and upgrade the app.
 terminal.store.match=Detected required item in inventory, install/upgrade App?
 terminal.store.miss=Requires %s (%d).
+terminal.store.close=Close
 
 terminal.ar.open=Open AR
 


### PR DESCRIPTION
## What
Fixes the close tooltip in the Terminal App Store App. Closes #1776 


## Outcome
Correct the tooltip for the App Store closing
