### PR TITLE
fix AL not running recipes without research properties

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
@@ -18,6 +18,7 @@ import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
+import gregtech.api.recipes.recipeproperties.ResearchProperty;
 import gregtech.api.util.GTUtility;
 import gregtech.client.particle.GTLaserBeamParticle;
 import gregtech.client.particle.GTParticleManager;
@@ -312,7 +313,7 @@ public class MetaTileEntityAssemblyLine extends RecipeMapMultiblockController {
             }
         }
 
-        if (!ConfigHolder.machines.enableResearch) {
+        if (!ConfigHolder.machines.enableResearch || !recipe.hasProperty(ResearchProperty.getInstance())) {
             return super.checkRecipe(recipe, consumeIfSuccess);
         }
 


### PR DESCRIPTION
Fixes the AL not running recipes that do not have research properties.