### PR TITLE
make IMultiblockAbilityPart provide multiple MultiblockAbilities

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/IMultiblockAbilityPart.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IMultiblockAbilityPart.java
@@ -1,10 +1,11 @@
 package gregtech.api.metatileentity.multiblock;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface IMultiblockAbilityPart<T> extends IMultiblockPart {
 
-    MultiblockAbility<T> getAbility();
+    Collection<MultiblockAbility<T>> getAbilities();
 
     void registerAbilities(List<T> abilityList);
 

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -817,9 +817,10 @@ public class MetaTileEntities {
     }
 
     public static <T extends MetaTileEntity> T registerMetaTileEntity(int id, T sampleMetaTileEntity) {
-        if (sampleMetaTileEntity instanceof IMultiblockAbilityPart) {
-            IMultiblockAbilityPart<?> abilityPart = (IMultiblockAbilityPart<?>) sampleMetaTileEntity;
-            MultiblockAbility.registerMultiblockAbility(abilityPart.getAbility(), sampleMetaTileEntity);
+        if (sampleMetaTileEntity instanceof IMultiblockAbilityPart<?> abilityPart) {
+            for (MultiblockAbility<?> ability : abilityPart.getAbilities()) {
+                MultiblockAbility.registerMultiblockAbility(ability, sampleMetaTileEntity);
+            }
         }
         if (sampleMetaTileEntity instanceof MultiblockControllerBase && Loader.isModLoaded(GTValues.MODID_JEI)) {
             if (((MultiblockControllerBase) sampleMetaTileEntity).shouldShowInJei()) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -31,6 +31,8 @@ import net.minecraft.world.World;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.AMP_INDEX;
@@ -168,8 +170,8 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
     }
 
     @Override
-    public MultiblockAbility<IPassthroughHatch> getAbility() {
-        return MultiblockAbility.PASSTHROUGH_HATCH;
+    public Collection<MultiblockAbility<IPassthroughHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.PASSTHROUGH_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
@@ -3,7 +3,6 @@ package gregtech.common.metatileentities.electric;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEPartLocation;
 import appeng.me.helpers.AENetworkProxy;
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
@@ -23,7 +22,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -32,6 +30,8 @@ import net.minecraftforge.fml.common.Optional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
@@ -118,8 +118,8 @@ public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements 
     }
 
     @Override
-    public MultiblockAbility<IPassthroughHatch> getAbility() {
-        return MultiblockAbility.PASSTHROUGH_HATCH;
+    public Collection<MultiblockAbility<IPassthroughHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.PASSTHROUGH_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPumpHatch.java
@@ -32,6 +32,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidTank> {
@@ -88,8 +90,8 @@ public class MetaTileEntityPumpHatch extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public MultiblockAbility<IFluidTank> getAbility() {
-        return MultiblockAbility.PUMP_FLUID_HATCH;
+    public Collection<MultiblockAbility<IFluidTank>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.PUMP_FLUID_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityTankValve.java
@@ -27,6 +27,8 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidHandler> {
@@ -117,8 +119,8 @@ public class MetaTileEntityTankValve extends MetaTileEntityMultiblockPart implem
     }
 
     @Override
-    public MultiblockAbility<IFluidHandler> getAbility() {
-        return MultiblockAbility.TANK_VALVE;
+    public Collection<MultiblockAbility<IFluidHandler>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.TANK_VALVE);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityAutoMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityAutoMaintenanceHatch.java
@@ -11,8 +11,8 @@ import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
-import net.minecraft.client.resources.I18n;
 import gregtech.common.metatileentities.MetaTileEntities;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -22,6 +22,8 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityAutoMaintenanceHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IMaintenanceHatch>, IMaintenanceHatch {
@@ -105,8 +107,8 @@ public class MetaTileEntityAutoMaintenanceHatch extends MetaTileEntityMultiblock
     }
 
     @Override
-    public MultiblockAbility<IMaintenanceHatch> getAbility() {
-        return MultiblockAbility.MAINTENANCE_HATCH;
+    public Collection<MultiblockAbility<IMaintenanceHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.MAINTENANCE_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityDataAccessHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityDataAccessHatch.java
@@ -201,8 +201,8 @@ public class MetaTileEntityDataAccessHatch extends MetaTileEntityMultiblockNotif
     }
 
     @Override
-    public MultiblockAbility<IDataAccessHatch> getAbility() {
-        return MultiblockAbility.DATA_ACCESS_HATCH;
+    public Collection<MultiblockAbility<IDataAccessHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.DATA_ACCESS_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -25,6 +25,8 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IEnergyContainer> {
@@ -86,8 +88,8 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
     }
 
     @Override
-    public MultiblockAbility<IEnergyContainer> getAbility() {
-        return isExportHatch ? MultiblockAbility.OUTPUT_ENERGY : MultiblockAbility.INPUT_ENERGY;
+    public Collection<MultiblockAbility<IEnergyContainer>> getAbilities() {
+        return Collections.singletonList(isExportHatch ? MultiblockAbility.OUTPUT_ENERGY : MultiblockAbility.INPUT_ENERGY);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -39,6 +39,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank>, IControllable {
@@ -165,8 +167,8 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     }
 
     @Override
-    public MultiblockAbility<IFluidTank> getAbility() {
-        return isExportHatch ? MultiblockAbility.EXPORT_FLUIDS : MultiblockAbility.IMPORT_FLUIDS;
+    public Collection<MultiblockAbility<IFluidTank>> getAbilities() {
+        return Collections.singletonList(isExportHatch ? MultiblockAbility.EXPORT_FLUIDS : MultiblockAbility.IMPORT_FLUIDS);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -37,6 +37,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IItemHandlerModifiable>, IControllable {
@@ -125,8 +127,8 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     }
 
     @Override
-    public MultiblockAbility<IItemHandlerModifiable> getAbility() {
-        return isExportHatch ? MultiblockAbility.EXPORT_ITEMS : MultiblockAbility.IMPORT_ITEMS;
+    public Collection<MultiblockAbility<IItemHandlerModifiable>> getAbilities() {
+        return Collections.singletonList(isExportHatch ? MultiblockAbility.EXPORT_ITEMS : MultiblockAbility.IMPORT_ITEMS);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -26,6 +26,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IItemHandlerModifiable> {
@@ -44,8 +46,8 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
     }
 
     @Override
-    public MultiblockAbility<IItemHandlerModifiable> getAbility() {
-        return MultiblockAbility.MACHINE_HATCH;
+    public Collection<MultiblockAbility<IItemHandlerModifiable>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.MACHINE_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -46,9 +46,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -475,8 +473,8 @@ public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart
     }
 
     @Override
-    public MultiblockAbility<IMaintenanceHatch> getAbility() {
-        return MultiblockAbility.MAINTENANCE_HATCH;
+    public Collection<MultiblockAbility<IMaintenanceHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.MAINTENANCE_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
@@ -33,6 +33,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IMufflerHatch>, ITieredMetaTileEntity, IMufflerHatch {
@@ -160,8 +162,8 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     }
 
     @Override
-    public MultiblockAbility<IMufflerHatch> getAbility() {
-        return MultiblockAbility.MUFFLER_HATCH;
+    public Collection<MultiblockAbility<IMufflerHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.MUFFLER_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -33,6 +33,8 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.IFluidTank;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotifiablePart implements IMultiblockAbilityPart<IFluidTank>, IControllable {
@@ -177,8 +179,8 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
     }
 
     @Override
-    public MultiblockAbility<IFluidTank> getAbility() {
-        return isExportHatch ? MultiblockAbility.EXPORT_FLUIDS : MultiblockAbility.IMPORT_FLUIDS;
+    public Collection<MultiblockAbility<IFluidTank>> getAbilities() {
+        return Collections.singletonList(isExportHatch ? MultiblockAbility.EXPORT_FLUIDS : MultiblockAbility.IMPORT_FLUIDS);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -26,6 +26,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
@@ -136,8 +138,8 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     }
 
     @Override
-    public MultiblockAbility<IPassthroughHatch> getAbility() {
-        return MultiblockAbility.PASSTHROUGH_HATCH;
+    public Collection<MultiblockAbility<IPassthroughHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.PASSTHROUGH_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -25,6 +25,8 @@ import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblockPart implements IPassthroughHatch, IMultiblockAbilityPart<IPassthroughHatch> {
@@ -138,8 +140,8 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     }
 
     @Override
-    public MultiblockAbility<IPassthroughHatch> getAbility() {
-        return MultiblockAbility.PASSTHROUGH_HATCH;
+    public Collection<MultiblockAbility<IPassthroughHatch>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.PASSTHROUGH_HATCH);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -35,6 +35,8 @@ import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IRotorHolder>, IRotorHolder {
@@ -86,8 +88,8 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     }
 
     @Override
-    public MultiblockAbility<IRotorHolder> getAbility() {
-        return MultiblockAbility.ROTOR_HOLDER;
+    public Collection<MultiblockAbility<IRotorHolder>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.ROTOR_HOLDER);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamHatch.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.steam.multiblockpart;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.capability.impl.CommonFluidFilters;
 import gregtech.api.capability.impl.FilteredFluidHandler;
 import gregtech.api.capability.impl.FilteredItemHandler;
 import gregtech.api.capability.impl.FluidTankList;
@@ -17,7 +18,6 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
-import gregtech.api.capability.impl.CommonFluidFilters;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleOverlayRenderer;
@@ -36,6 +36,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IFluidTank> {
@@ -109,8 +111,8 @@ public class MetaTileEntitySteamHatch extends MetaTileEntityMultiblockPart imple
     }
 
     @Override
-    public MultiblockAbility<IFluidTank> getAbility() {
-        return MultiblockAbility.STEAM;
+    public Collection<MultiblockAbility<IFluidTank>> getAbilities() {
+        return Collections.singletonList(MultiblockAbility.STEAM);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/multiblockpart/MetaTileEntitySteamItemBus.java
@@ -25,6 +25,8 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class MetaTileEntitySteamItemBus extends MetaTileEntityItemBus implements IMultiblockAbilityPart<IItemHandlerModifiable> {
@@ -42,8 +44,8 @@ public class MetaTileEntitySteamItemBus extends MetaTileEntityItemBus implements
     }
 
     @Override
-    public MultiblockAbility<IItemHandlerModifiable> getAbility() {
-        return isExportHatch ? MultiblockAbility.STEAM_EXPORT_ITEMS : MultiblockAbility.STEAM_IMPORT_ITEMS;
+    public Collection<MultiblockAbility<IItemHandlerModifiable>> getAbilities() {
+        return Collections.singletonList(isExportHatch ? MultiblockAbility.STEAM_EXPORT_ITEMS : MultiblockAbility.STEAM_IMPORT_ITEMS);
     }
 
     @Override


### PR DESCRIPTION
## What
Makes `IMultiblockAbilityPart` provide a `Collection<MultiblockAbility>`. This allows more granular control over hatch requirements, and also paves the way for more complex hatches in the future.

## Outcome
Makes `IMultiblockAbilityPart` provide a `Collection<MultiblockAbility>`.

## Potential Compatibility Issues
This change is not backwards compatible and all existing hatch implementations will need updating to use the new method.
