### PR TITLE
Fix behavior of OreProperty#setOreByProducts

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -885,7 +885,7 @@ public class Material implements Comparable<Material> {
 
         public Builder addOreByproducts(Material... byproducts) {
             properties.ensureSet(PropertyKey.ORE);
-            properties.getProperty(PropertyKey.ORE).setOreByProducts(byproducts);
+            properties.getProperty(PropertyKey.ORE).addOreByProducts(byproducts);
             return this;
         }
 

--- a/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 public class OreProperty implements IMaterialProperty {
@@ -157,7 +158,31 @@ public class OreProperty implements IMaterialProperty {
         return this.separatedInto;
     }
 
-    public void setOreByProducts(Material... materials) {
+    /**
+     * Set the ore byproducts for this property
+     *
+     * @param materials the materials to use as byproducts
+     */
+    public void setOreByProducts(@Nonnull Material... materials) {
+        setOreByProducts(Arrays.asList(materials));
+    }
+
+    /**
+     * Set the ore byproducts for this property
+     *
+     * @param materials the materials to use as byproducts
+     */
+    public void setOreByProducts(@Nonnull Collection<Material> materials) {
+        this.oreByProducts.clear();
+        this.oreByProducts.addAll(materials);
+    }
+
+    /**
+     * Add ore byproducts to this property
+     *
+     * @param materials the materials to add as byproducts
+     */
+    public void addOreByProducts(@Nonnull Material... materials) {
         this.oreByProducts.addAll(Arrays.asList(materials));
     }
 


### PR DESCRIPTION
## What
Fixes `OreProperty#setOreByProducts` adding instead of setting. This resulted in unexpected behavior with addons attempting to modify the byproducts of a material. A new method to mimic the old behavior of addition was added as well, `#addOreByProducts`.

## Outcome
Fixes behavior of `OreProperty#setOreByProducts`.

## Potential Compatibility Issues
Mods will likely not have relied on the old behavior, but if they did, they will need to move to the `add` method. No compile-time incompatibilities are expected otherwise.
