### PR TITLE
Fix custom MaterialIconSet not being registered for model

### DIFF
--- a/src/main/java/gregtech/api/unification/material/info/MaterialIconSet.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialIconSet.java
@@ -16,6 +16,9 @@ import java.util.Map;
 @ZenRegister
 public class MaterialIconSet {
 
+    // Keep this before all the static instatiations not to reset it
+    private static int idCounter = 0;
+
     public static final Map<String, MaterialIconSet> ICON_SETS = new HashMap<>();
     public static final MaterialIconSet DULL = new MaterialIconSet("dull", null, true);
     public static final MaterialIconSet METALLIC = new MaterialIconSet("metallic");
@@ -43,8 +46,6 @@ public class MaterialIconSet {
     public static final MaterialIconSet GAS = new MaterialIconSet("gas");
 
     // Implementation -----------------------------------------------------------------------------------------------
-
-    private static int idCounter = 0;
 
     public final String name;
     public final int id;


### PR DESCRIPTION
## What
This PR fixes `MaterialIconSet` registered by addons not being registered for item texture model.

## Implementation Details
Putting variable `idCounter` after static instantiations results in custom `MaterialIconSet`s having ids starting from 0 again.

## Outcome
Fix bug.
