### PR TITLE
polarizer voltage tweaks

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -60,13 +60,22 @@ public class GTValues {
     /**
      * The Voltage Tiers. Use this Array instead of the old named Voltage Variables
      */
-    public static final long[] V = new long[]{8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432, 134217728, 536870912, Integer.MAX_VALUE};
+    public static final long[] V = {8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432, 134217728, 536870912, Integer.MAX_VALUE};
 
+    /**
+     * The Voltage Tiers divided by 2.
+     */
+    public static final int[] VH = {4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824};
 
     /**
      * The Voltage Tiers adjusted for cable loss. Use this for recipe EU/t to avoid full-amp recipes
      */
-    public static final int[] VA = new int[]{7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320, 31457280, 125829120, 503316480, 2013265920};
+    public static final int[] VA = {7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320, 31457280, 125829120, 503316480, 2013265920};
+
+    /**
+     * The Voltage Tiers adjusted for cable loss, divided by 2.
+     */
+    public static final int[] VHA = {7, 16, 60, 240, 960, 3840, 15360, 61440, 245760, 983040, 3932160, 15728640, 62914560, 251658240, 1006632960};
 
     public static final int ULV = 0;
     public static final int LV = 1;

--- a/src/main/java/gregtech/loaders/recipe/handlers/PolarizingRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PolarizingRecipeHandler.java
@@ -5,14 +5,14 @@ import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
+import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.IngotProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
 import net.minecraft.item.ItemStack;
 
-import static gregtech.api.GTValues.LV;
-import static gregtech.api.GTValues.VA;
+import static gregtech.api.GTValues.*;
 
 public class PolarizingRecipeHandler {
 
@@ -35,7 +35,7 @@ public class PolarizingRecipeHandler {
                     .input(polarizingPrefix, material)
                     .outputs(magneticStack)
                     .duration((int) ((int) material.getMass() * polarizingPrefix.getMaterialAmount(material) / GTValues.M))
-                    .EUt(8 * getVoltageMultiplier(material))
+                    .EUt(getVoltageMultiplier(material))
                     .buildAndRegister();
 
             ModHandler.addSmeltingRecipe(new UnificationEntry(polarizingPrefix, magneticMaterial),
@@ -44,7 +44,9 @@ public class PolarizingRecipeHandler {
     }
 
     private static int getVoltageMultiplier(Material material) {
+        if (material == Materials.Iron || material == Materials.Steel) return VH[LV];
+        if (material == Materials.Neodymium) return VH[HV];
+        if (material == Materials.Samarium) return VH[IV];
         return material.getBlastTemperature() >= 1200 ? VA[LV] : 2;
     }
-
 }


### PR DESCRIPTION
## What
Adjusts the voltage of polarizer recipes:
- Iron and Steel use 16EU/t (LV)
- Neodymium uses 256EU/t (HV)
- Samarium uses 4096EU/t (IV)

Also adds two new arrays to GTValues: `VH` and `VHA`, short for "Voltage Half" and "Voltage Half Adjusted," and stores `V` and `VA` respectively but divided by 2. They will be generally useful going forwards as well.

## Outcome
Adjusts polarizer recipe voltages
