### PR TITLE
Fix potential packet decoding memory leak

### DIFF
--- a/src/main/java/gregtech/core/network/internal/NetworkHandler.java
+++ b/src/main/java/gregtech/core/network/internal/NetworkHandler.java
@@ -1,12 +1,12 @@
 package gregtech.core.network.internal;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
+import gregtech.api.modules.ModuleStage;
 import gregtech.api.network.IClientExecutor;
 import gregtech.api.network.INetworkHandler;
 import gregtech.api.network.IPacket;
 import gregtech.api.network.IServerExecutor;
-import gregtech.api.GregTechAPI;
-import gregtech.api.modules.ModuleStage;
 import gregtech.core.CoreModule;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.network.NetHandlerPlayClient;
@@ -139,6 +139,7 @@ public class NetworkHandler implements INetworkHandler {
         PacketBuffer payload = (PacketBuffer) proxyPacket.payload();
         IPacket packet = packetHandler.getPacketClass(payload.readVarInt()).newInstance();
         packet.decode(payload);
+        payload.release();
         return packet;
     }
 }


### PR DESCRIPTION
## What
Fixes a Netty warning for buffers not being released prior to being garbage collected. This would potentially cause memory leaks.

An example of this warning is as follows:
```
SEVERE: LEAK: ByteBuf.release() was not called before it's garbage-collected. See http://netty.io/wiki/reference-counted-objects.html for more information.
WARNING: 1 leak records were discarded because the leak record count is limited to 4. Use system property io.netty.leakDetection.maxRecords to increase the limit.
Recent access records: 4
#4:
        io.netty.buffer.AdvancedLeakAwareByteBuf.readBoolean(AdvancedLeakAwareByteBuf.java:390)
        net.minecraft.network.PacketBuffer.readBoolean(PacketBuffer.java:859)
        gregtech.api.net.packets.CPacketKeysPressed.decode(CPacketKeysPressed.java:38)
        gregtech.api.net.NetworkUtils.proxy2packet(NetworkUtils.java:47)
        gregtech.api.net.NetworkHandler.onServerPacket(NetworkHandler.java:90)
```

## Outcome
Fixes a potential memory leak with packet decoding.
