### PR TITLE
fix missing recipe category copy in RecipeBuilder

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -87,6 +87,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.duration = recipe.getDuration();
         this.EUt = recipe.getEUt();
         this.hidden = recipe.isHidden();
+        this.category = recipe.getRecipeCategory();
         this.recipePropertyStorage = recipe.getRecipePropertyStorage().copy();
         if (this.recipePropertyStorage != null) {
             this.recipePropertyStorage.freeze(false);


### PR DESCRIPTION
## Outcome
Fixes `Recipe#trimRecipeOutputs` from logging errors due to a missing recipe category.
