### PR TITLE
Baubles compat, rewrite Item Magnet logic

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -46,6 +46,7 @@ dependencies {
     compileOnlyApi "curse.maven:voxelmap-225179:3029445" // VoxelMap 1.9.28
     compileOnlyApi "curse.maven:xaeros-263420:4516832" // Xaero's Minimap 23.4.1
     compileOnlyApi rfg.deobf("curse.maven:hwyla-253449:2568751") // HWYLA 1.8.26-B41
+    compileOnlyApi rfg.deobf("curse.maven:baubles-227083:2518667") // Baubles 1.5.2
 }
 
 minecraft {

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -143,7 +143,8 @@ public class GTValues {
             MODID_JOURNEYMAP = "journeymap",
             MODID_VOXELMAP = "voxelmap",
             MODID_XAERO_MINIMAP = "xaerominimap",
-            MODID_HWYLA = "hwyla";
+            MODID_HWYLA = "hwyla",
+            MODID_BAUBLES = "baubles";
 
     private static Boolean isClient;
 

--- a/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
+++ b/src/main/java/gregtech/api/items/metaitem/ElectricStats.java
@@ -1,6 +1,5 @@
 package gregtech.api.items.metaitem;
 
-import baubles.api.BaublesApi;
 import gregtech.api.GTValues;
 import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
@@ -13,7 +12,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -31,7 +29,6 @@ import net.minecraftforge.fml.common.Loader;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.function.Function;
 
 public class ElectricStats implements IItemComponent, IItemCapabilityProvider, IItemMaxStackSizeProvider, IItemBehaviour, ISubItemHandler {
 
@@ -91,7 +88,8 @@ public class ElectricStats implements IItemComponent, IItemCapabilityProvider, I
                         transferLimit -= chargedAmount;
                         if (transferLimit == 0L) break;
                     }
-                } else if(ConfigHolder.compat.energy.nativeEUToFE && feEnergyItem != null) {
+                }
+                else if(ConfigHolder.compat.energy.nativeEUToFE && feEnergyItem != null) {
                     if(feEnergyItem.getEnergyStored() < feEnergyItem.getMaxEnergyStored()) {
                        int energyMissing = feEnergyItem.getMaxEnergyStored() - feEnergyItem.getEnergyStored();
                        long euToCharge = FeCompat.toEu(energyMissing, ConfigHolder.compat.energy.feToEuRatio);

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -688,11 +688,11 @@ public class MetaItem1 extends StandardMetaItem {
                 .setMaxStackSize(1)
                 .setCreativeTabs(GregTechAPI.TAB_GREGTECH_TOOLS);
         ITEM_MAGNET_LV = addItem(471, "item_magnet.lv")
-                .addComponents(ElectricStats.createElectricItem(100_000L, GTValues.LV), new ItemMagnetBehavior(6, 0.04F))
+                .addComponents(ElectricStats.createElectricItem(100_000L, GTValues.LV), new ItemMagnetBehavior(8))
                 .setMaxStackSize(1)
                 .setCreativeTabs(GregTechAPI.TAB_GREGTECH_TOOLS);
         ITEM_MAGNET_HV = addItem(472, "item_magnet.hv")
-                .addComponents(ElectricStats.createElectricItem(1_600_000L, GTValues.HV), new ItemMagnetBehavior(16, 0.065F))
+                .addComponents(ElectricStats.createElectricItem(1_600_000L, GTValues.HV), new ItemMagnetBehavior(32))
                 .setMaxStackSize(1)
                 .setCreativeTabs(GregTechAPI.TAB_GREGTECH_TOOLS);
 

--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -77,6 +77,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     @Override
     public void onUpdate(ItemStack stack, Entity entity) {
         // Adapted logic from Draconic Evolution
+        // https://github.com/Draconic-Inc/Draconic-Evolution/blob/1.12.2/src/main/java/com/brandon3055/draconicevolution/items/tools/Magnet.java
         if (!entity.isSneaking() && entity.ticksExisted % 10 == 0 && isActive(stack) && entity instanceof EntityPlayer player) {
             World world = entity.getEntityWorld();
             if (!drainEnergy(true, stack, energyDraw)) {
@@ -115,7 +116,9 @@ public class ItemMagnetBehavior implements IItemBehaviour {
                 }
             }
 
-            world.playSound(null, entity.posX, entity.posY, entity.posZ, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.PLAYERS, 0.1F, 0.5F * ((world.rand.nextFloat() - world.rand.nextFloat()) * 0.7F + 2F));
+            if (didMoveEntity) {
+                world.playSound(null, entity.posX, entity.posY, entity.posZ, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.PLAYERS, 0.1F, 0.5F * ((world.rand.nextFloat() - world.rand.nextFloat()) * 0.7F + 2F));
+            }
 
             List<EntityXPOrb> xp = world.getEntitiesWithinAABB(EntityXPOrb.class, new AxisAlignedBB(entity.posX, entity.posY, entity.posZ, entity.posX, entity.posY, entity.posZ).grow(4, 4, 4));
 

--- a/src/main/java/gregtech/integration/baubles/BaubleBehavior.java
+++ b/src/main/java/gregtech/integration/baubles/BaubleBehavior.java
@@ -1,0 +1,52 @@
+package gregtech.integration.baubles;
+
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
+import baubles.api.cap.BaublesCapabilities;
+import gregtech.api.items.metaitem.stats.IItemCapabilityProvider;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BaubleBehavior implements IItemCapabilityProvider, ICapabilityProvider, IBauble {
+
+    private final BaubleType baubleType;
+
+    public BaubleBehavior(BaubleType baubleType) {
+        this.baubleType = baubleType;
+    }
+
+    @Override
+    public BaubleType getBaubleType(ItemStack stack) {
+        return baubleType;
+    }
+
+    @Override
+    public void onWornTick(ItemStack stack, EntityLivingBase player) {
+        if (stack != null && stack != ItemStack.EMPTY && player != null) {
+            stack.getItem().onUpdate(stack, player.getEntityWorld(), player, 0, false);
+        }
+    }
+
+    @Override
+    public ICapabilityProvider createProvider(ItemStack stack) {
+        return this;
+    }
+
+    @Override
+    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
+        return capability == BaublesCapabilities.CAPABILITY_ITEM_BAUBLE;
+    }
+
+    @Override
+    public <T> @Nullable T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
+        if (capability == BaublesCapabilities.CAPABILITY_ITEM_BAUBLE) {
+            return BaublesCapabilities.CAPABILITY_ITEM_BAUBLE.cast(this);
+        }
+        return null;
+    }
+}

--- a/src/main/java/gregtech/integration/baubles/BaublesModule.java
+++ b/src/main/java/gregtech/integration/baubles/BaublesModule.java
@@ -1,0 +1,69 @@
+package gregtech.integration.baubles;
+
+import baubles.api.BaubleType;
+import baubles.api.BaublesApi;
+import baubles.api.cap.IBaublesItemHandler;
+import gregtech.api.GTValues;
+import gregtech.api.modules.GregTechModule;
+import gregtech.common.items.MetaItems;
+import gregtech.integration.IntegrationSubmodule;
+import gregtech.modules.GregTechModules;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+@GregTechModule(
+        moduleID = GregTechModules.MODULE_BAUBLES,
+        containerID = GTValues.MODID,
+        modDependencies = GTValues.MODID_BAUBLES,
+        name = "GregTech Baubles Integration",
+        descriptionKey = "gregtech.modules.baubles_integration.description"
+)
+public class BaublesModule extends IntegrationSubmodule {
+
+    @NotNull
+    @Override
+    public List<Class<?>> getEventBusSubscribers() {
+        return Collections.singletonList(BaublesModule.class);
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void registerItems(RegistryEvent.Register<Item> event) {
+        MetaItems.ITEM_MAGNET_LV.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.ITEM_MAGNET_HV.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+
+        MetaItems.BATTERY_ULV_TANTALUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_LV_CADMIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_LV_LITHIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_LV_SODIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_MV_CADMIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_MV_LITHIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_MV_SODIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_HV_CADMIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_HV_LITHIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_HV_SODIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.ENERGIUM_CRYSTAL.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.LAPOTRON_CRYSTAL.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_EV_VANADIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_IV_VANADIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_LUV_VANADIUM.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_ZPM_NAQUADRIA.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.BATTERY_UV_NAQUADRIA.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.ENERGY_LAPOTRONIC_ORB.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.ENERGY_LAPOTRONIC_ORB_CLUSTER.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.ZERO_POINT_MODULE.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+        MetaItems.ULTIMATE_BATTERY.addComponents(new BaubleBehavior(BaubleType.TRINKET));
+    }
+
+    public static IInventory getBaublesWrappedInventory(@NotNull EntityPlayer player) {
+        IBaublesItemHandler handler = BaublesApi.getBaublesHandler(player);
+        return new BaublesWrappedInventory(handler, player);
+    }
+}

--- a/src/main/java/gregtech/integration/baubles/BaublesWrappedInventory.java
+++ b/src/main/java/gregtech/integration/baubles/BaublesWrappedInventory.java
@@ -1,0 +1,133 @@
+package gregtech.integration.baubles;
+
+import baubles.api.cap.IBaublesItemHandler;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import org.jetbrains.annotations.NotNull;
+
+/** Wrapped player inventory and Baubles inventory. */
+public class BaublesWrappedInventory implements IInventory {
+
+    private final IBaublesItemHandler handler;
+    private final EntityPlayer player;
+
+    public BaublesWrappedInventory(IBaublesItemHandler handler, EntityPlayer player) {
+        this.handler = handler;
+        this.player = player;
+    }
+
+    // wrap everything to check the baubles first, then the player inventory
+
+    @Override
+    public int getSizeInventory() {
+        return handler.getSlots() + player.inventory.getSizeInventory();
+    }
+
+    @Override
+    public @NotNull ItemStack getStackInSlot(int index) {
+        if (index < handler.getSlots()) {
+            return handler.getStackInSlot(index);
+        }
+        return player.inventory.getStackInSlot(index);
+    }
+
+    @Override
+    public @NotNull ItemStack decrStackSize(int index, int count) {
+        if (index < handler.getSlots()) {
+            return handler.extractItem(index, count, false);
+        }
+        return player.inventory.decrStackSize(index, count);
+    }
+
+    @Override
+    public @NotNull ItemStack removeStackFromSlot(int index) {
+        if (index < handler.getSlots()) {
+            ItemStack out = handler.getStackInSlot(index);
+            handler.setStackInSlot(index, ItemStack.EMPTY);
+            return out;
+        }
+        return player.inventory.removeStackFromSlot(index);
+    }
+
+    @Override
+    public void setInventorySlotContents(int index, @NotNull ItemStack stack) {
+        if (index < handler.getSlots()) {
+            handler.setStackInSlot(index, stack);
+        } else {
+            player.inventory.setInventorySlotContents(index, stack);
+        }
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int index, @NotNull ItemStack stack) {
+        if (index < handler.getSlots()) {
+            return handler.isItemValidForSlot(index, stack, player);
+        }
+        return player.inventory.isItemValidForSlot(index, stack);
+    }
+
+    // less important overrides
+
+    @Override
+    public int getInventoryStackLimit() {
+        return 64;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public void markDirty() {
+    }
+
+    @Override
+    public boolean isUsableByPlayer(@NotNull EntityPlayer player) {
+        return true;
+    }
+
+    @Override
+    public void openInventory(@NotNull EntityPlayer player) {
+    }
+
+    @Override
+    public void closeInventory(@NotNull EntityPlayer player) {
+    }
+
+    @Override
+    public int getField(int id) {
+        return 0;
+    }
+
+    @Override
+    public void setField(int id, int value) {
+    }
+
+    @Override
+    public int getFieldCount() {
+        return 0;
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "GTWrappedBaublesInventory";
+    }
+
+    @Override
+    public boolean hasCustomName() {
+        return false;
+    }
+
+    @Override
+    public @NotNull ITextComponent getDisplayName() {
+        return new TextComponentString(getName());
+    }
+}

--- a/src/main/java/gregtech/modules/GregTechModules.java
+++ b/src/main/java/gregtech/modules/GregTechModules.java
@@ -15,6 +15,7 @@ public class GregTechModules implements IModuleContainer {
     public static final String MODULE_GRS = "grs_integration";
     public static final String MODULE_OC  = "oc_integration";
     public static final String MODULE_HWYLA = "hwyla_integration";
+    public static final String MODULE_BAUBLES = "baubles_integration";
 
     @Override
     public String getID() {

--- a/src/main/resources/gregtech_at.cfg
+++ b/src/main/resources/gregtech_at.cfg
@@ -78,3 +78,6 @@ public net.minecraft.creativetab.CreativeTabs field_78034_o # tabLabel
 # EntityBoat
 protected net.minecraft.entity.item.EntityBoat field_184469_aF # status
 protected net.minecraft.entity.item.EntityBoat field_184473_aH # lastYd
+
+# EntityItem
+public net.minecraft.entity.item.EntityItem field_145804_b # pickupDelay


### PR DESCRIPTION
Adds Baubles compatibility for GT Item Magnets and Batteries. Also rewrites the Item Magnet logic, using logic adapted from Draconic Evolution. Done on this branch because this behavior also needed to check Bauble slots for item pickup delay checks.