### PR TITLE
Improve and fix GTRecipeHandler#removeAllRecipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/GTRecipeHandler.java
+++ b/src/main/java/gregtech/api/recipes/GTRecipeHandler.java
@@ -85,13 +85,9 @@ public class GTRecipeHandler {
      * @param map The RecipeMap to clear all recipes from.
      */
     public static <R extends RecipeBuilder<R>> void removeAllRecipes(RecipeMap<R> map) {
-
-        List<Recipe> recipes = new ArrayList<>(map.getRecipeList());
-
-        for (Recipe r : recipes)
-            map.removeRecipe(r);
-
-        if(ConfigHolder.misc.debug)
+        map.removeAllRecipes();
+        if (ConfigHolder.misc.debug) {
             GTLog.logger.info("Removed all recipes for Recipe Map: {}", map.unlocalizedName);
+        }
     }
 }

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -44,6 +44,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.oredict.OreDictionary;
+import org.jetbrains.annotations.ApiStatus;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.*;
 
@@ -332,6 +333,18 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Removes all recipes.
+     *
+     * @see GTRecipeHandler#removeAllRecipes(RecipeMap)
+     */
+    @ApiStatus.Internal
+    void removeAllRecipes() {
+        this.lookup.getRecipes(false).forEach(this.virtualizedRecipeMap::addBackup);
+        this.lookup.getNodes().clear();
+        this.lookup.getSpecialNodes().clear();
     }
 
     /**


### PR DESCRIPTION
## What
Fixes `GTRecipeHandler#removeAllRecipes` not removing hidden recipes.

Improves the removal performance by using bulk `clear()` operations instead of iterating the recipe list and recursing for each removal.

## Outcome
Fixes and improves `GTRecipeHandler#removeAllRecipes`.
