### PR TITLE
Allow LCR to accept any coil

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
@@ -56,7 +56,7 @@ public class MetaTileEntityLargeChemicalReactor extends RecipeMapMultiblockContr
                 .where('S', selfPredicate())
                 .where('X', casing.or(abilities))
                 .where('P', states(getPipeCasingState()))
-                .where('C', states(MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.CUPRONICKEL)).setMinGlobalLimited(1).setMaxGlobalLimited(1)
+                .where('C', heatingCoils().setMinGlobalLimited(1).setMaxGlobalLimited(1)
                         .or(abilities)
                         .or(casing))
                 .build();


### PR DESCRIPTION
Allows the LCR to accept any coil block. No additional benefit, but just allows for using whatever coil you have on-hand instead of forcing only Cupronickel