### PR TITLE
Move syncing functionality into ISyncedTileEntity

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -967,13 +967,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     @Override
-    public void writeInitialData(@Nonnull PacketBuffer buf) {
+    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
         buf.writeBoolean(this.isActive);
         buf.writeBoolean(this.workingEnabled);
     }
 
     @Override
-    public void receiveInitialData(@Nonnull PacketBuffer buf) {
+    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
         this.isActive = buf.readBoolean();
         this.workingEnabled = buf.readBoolean();
     }

--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -257,15 +257,15 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    public void writeInitialData(@Nonnull PacketBuffer buf) {
-        super.writeInitialData(buf);
+    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
+        super.writeInitialSyncData(buf);
         buf.writeVarInt(currentHeat);
         buf.writeVarInt(lastTickSteamOutput);
     }
 
     @Override
-    public void receiveInitialData(@Nonnull PacketBuffer buf) {
-        super.receiveInitialData(buf);
+    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
+        super.receiveInitialSyncData(buf);
         this.currentHeat = buf.readVarInt();
         this.lastTickSteamOutput = buf.readVarInt();
     }

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -107,16 +107,16 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    public void writeInitialData(@Nonnull PacketBuffer buf) {
-        super.writeInitialData(buf);
+    public void writeInitialSyncData(@Nonnull PacketBuffer buf) {
+        super.writeInitialSyncData(buf);
         buf.writeByte(getVentingSide().getIndex());
         buf.writeBoolean(needsVenting);
         buf.writeBoolean(ventingStuck);
     }
 
     @Override
-    public void receiveInitialData(@Nonnull PacketBuffer buf) {
-        super.receiveInitialData(buf);
+    public void receiveInitialSyncData(@Nonnull PacketBuffer buf) {
+        super.receiveInitialSyncData(buf);
         this.ventingSide = EnumFacing.VALUES[buf.readByte()];
         this.needsVenting = buf.readBoolean();
         this.ventingStuck = buf.readBoolean();

--- a/src/main/java/gregtech/api/metatileentity/MTETrait.java
+++ b/src/main/java/gregtech/api/metatileentity/MTETrait.java
@@ -79,9 +79,7 @@ public abstract class MTETrait implements ISyncedTileEntity {
     }
 
     @Override
-    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
-        writeInitialData(buf);
-    }
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {}
 
     /**
      * Deprecated since 2.7 and will be removed in 2.8.
@@ -90,12 +88,12 @@ public abstract class MTETrait implements ISyncedTileEntity {
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2.8")
     @Deprecated
-    public void writeInitialData(@NotNull PacketBuffer buffer) {}
+    public void writeInitialData(@NotNull PacketBuffer buffer) {
+        writeInitialSyncData(buffer);
+    }
 
     @Override
-    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
-        receiveInitialData(buf);
-    }
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {}
 
     /**
      * Deprecated since 2.7 and will be removed in 2.8.
@@ -104,7 +102,9 @@ public abstract class MTETrait implements ISyncedTileEntity {
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2.8")
     @Deprecated
-    public void receiveInitialData(@NotNull PacketBuffer buffer) {}
+    public void receiveInitialData(@NotNull PacketBuffer buffer) {
+        receiveInitialSyncData(buffer);
+    }
 
     @Override
     public void receiveCustomData(int discriminator, @NotNull PacketBuffer buf) {}

--- a/src/main/java/gregtech/api/metatileentity/MTETrait.java
+++ b/src/main/java/gregtech/api/metatileentity/MTETrait.java
@@ -82,11 +82,11 @@ public abstract class MTETrait implements ISyncedTileEntity {
     public void writeInitialSyncData(@NotNull PacketBuffer buf) {}
 
     /**
-     * Deprecated since 2.7 and will be removed in 2.8.
+     * Deprecated since 2.8 and will be removed in 2.9.
      *
      * @deprecated Use {@link #writeInitialSyncData(PacketBuffer)}
      */
-    @ApiStatus.ScheduledForRemoval(inVersion = "2.8")
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     @Deprecated
     public void writeInitialData(@NotNull PacketBuffer buffer) {
         writeInitialSyncData(buffer);
@@ -96,11 +96,11 @@ public abstract class MTETrait implements ISyncedTileEntity {
     public void receiveInitialSyncData(@NotNull PacketBuffer buf) {}
 
     /**
-     * Deprecated since 2.7 and will be removed in 2.8.
+     * Deprecated since 2.8 and will be removed in 2.9.
      *
      * @deprecated use {@link #receiveInitialSyncData(PacketBuffer)}
      */
-    @ApiStatus.ScheduledForRemoval(inVersion = "2.8")
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     @Deprecated
     public void receiveInitialData(@NotNull PacketBuffer buffer) {
         receiveInitialSyncData(buffer);

--- a/src/main/java/gregtech/api/metatileentity/MTETrait.java
+++ b/src/main/java/gregtech/api/metatileentity/MTETrait.java
@@ -102,6 +102,7 @@ public abstract class MTETrait implements ISyncedTileEntity {
      *
      * @deprecated use {@link #receiveInitialSyncData(PacketBuffer)}
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.8")
     @Deprecated
     public void receiveInitialData(@NotNull PacketBuffer buffer) {}
 

--- a/src/main/java/gregtech/api/metatileentity/MTETrait.java
+++ b/src/main/java/gregtech/api/metatileentity/MTETrait.java
@@ -1,21 +1,23 @@
 package gregtech.api.metatileentity;
 
+import gregtech.api.metatileentity.interfaces.ISyncedTileEntity;
 import it.unimi.dsi.fastutil.objects.Object2IntFunction;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
-public abstract class MTETrait {
+public abstract class MTETrait implements ISyncedTileEntity {
 
     private static final Object2IntFunction<String> traitIds = new Object2IntOpenHashMap<>();
-    private static int rollingNetworkId = 0;
-
     private static final int NO_NETWORK_ID = -1;
+
+    private static int rollingNetworkId = 0;
 
     static {
         traitIds.defaultReturnValue(NO_NETWORK_ID);
@@ -29,7 +31,7 @@ public abstract class MTETrait {
      *
      * @param metaTileEntity the MTE to reference, and add the trait to
      */
-    public MTETrait(@Nonnull MetaTileEntity metaTileEntity) {
+    public MTETrait(@NotNull MetaTileEntity metaTileEntity) {
         this.metaTileEntity = metaTileEntity;
 
         final String traitName = getName();
@@ -42,7 +44,7 @@ public abstract class MTETrait {
         metaTileEntity.addMetaTileEntityTrait(this);
     }
 
-    @Nonnull
+    @NotNull
     public MetaTileEntity getMetaTileEntity() {
         return metaTileEntity;
     }
@@ -50,7 +52,7 @@ public abstract class MTETrait {
     /**
      * @return the name of the MTE Trait
      */
-    @Nonnull
+    @NotNull
     public abstract String getName();
 
     /**
@@ -68,25 +70,47 @@ public abstract class MTETrait {
     public void update() {
     }
 
-    @Nonnull
+    @NotNull
     public NBTTagCompound serializeNBT() {
         return new NBTTagCompound();
     }
 
-    public void deserializeNBT(@Nonnull NBTTagCompound compound) {
+    public void deserializeNBT(@NotNull NBTTagCompound compound) {
     }
 
-    public void writeInitialData(@Nonnull PacketBuffer buffer) {
+    @Override
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
+        writeInitialData(buf);
     }
 
-    public void receiveInitialData(@Nonnull PacketBuffer buffer) {
+    /**
+     * Deprecated since 2.7 and will be removed in 2.8.
+     *
+     * @deprecated Use {@link #writeInitialSyncData(PacketBuffer)}
+     */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.8")
+    @Deprecated
+    public void writeInitialData(@NotNull PacketBuffer buffer) {}
+
+    @Override
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
+        receiveInitialData(buf);
     }
 
-    public void receiveCustomData(int id, @Nonnull PacketBuffer buffer) {
-    }
+    /**
+     * Deprecated since 2.7 and will be removed in 2.8.
+     *
+     * @deprecated use {@link #receiveInitialSyncData(PacketBuffer)}
+     */
+    @Deprecated
+    public void receiveInitialData(@NotNull PacketBuffer buffer) {}
 
-    public final void writeCustomData(int id, @Nonnull Consumer<PacketBuffer> writer) {
-        metaTileEntity.writeTraitData(this, id, writer);
+    @Override
+    public void receiveCustomData(int discriminator, @NotNull PacketBuffer buf) {}
+
+    @Override
+    public final void writeCustomData(int discriminator, @NotNull Consumer<@NotNull PacketBuffer> dataWriter) {
+        metaTileEntity.writeTraitData(this, discriminator, dataWriter);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -29,6 +29,7 @@ import gregtech.api.items.itemhandlers.GTItemStackHandler;
 import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.items.toolitem.ToolHelper;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.interfaces.ISyncedTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTTransferUtils;
@@ -74,6 +75,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nonnull;
@@ -87,7 +89,7 @@ import java.util.function.Consumer;
 
 import static gregtech.api.capability.GregtechDataCodes.*;
 
-public abstract class MetaTileEntity implements ICoverable, IVoidable {
+public abstract class MetaTileEntity implements ISyncedTileEntity, ICoverable, IVoidable {
 
     public static final IndexedCuboid6 FULL_CUBE_COLLISION = new IndexedCuboid6(null, Cuboid6.full);
     public static final String TAG_KEY_PAINTING_COLOR = "PaintingColor";
@@ -177,7 +179,8 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return holder == null ? 0L : holder.getOffsetTimer();
     }
 
-    public void writeCustomData(int discriminator, Consumer<PacketBuffer> dataWriter) {
+    @Override
+    public final void writeCustomData(int discriminator, @NotNull Consumer<@NotNull PacketBuffer> dataWriter) {
         if (holder != null) {
             holder.writeCustomData(discriminator, dataWriter);
         }
@@ -886,13 +889,14 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return 1;
     }
 
-    public void writeInitialSyncData(PacketBuffer buf) {
+    @Override
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
         buf.writeByte(this.frontFacing.getIndex());
         buf.writeInt(this.paintingColor);
         buf.writeShort(this.mteTraitByNetworkId.size());
         for (Int2ObjectMap.Entry<MTETrait> entry : mteTraitByNetworkId.int2ObjectEntrySet()) {
             buf.writeVarInt(entry.getIntKey());
-            entry.getValue().writeInitialData(buf);
+            entry.getValue().writeInitialSyncData(buf);
         }
         CoverIO.writeCoverSyncData(buf, this);
         buf.writeBoolean(muffled);
@@ -902,7 +906,8 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return this.paintingColor != -1;
     }
 
-    public void receiveInitialSyncData(PacketBuffer buf) {
+    @Override
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
         this.frontFacing = EnumFacing.VALUES[buf.readByte()];
         this.paintingColor = buf.readInt();
         int amountOfTraits = buf.readShort();
@@ -933,7 +938,8 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         });
     }
 
-    public void receiveCustomData(int dataId, PacketBuffer buf) {
+    @Override
+    public void receiveCustomData(int dataId, @NotNull PacketBuffer buf) {
         if (dataId == UPDATE_FRONT_FACING) {
             this.frontFacing = EnumFacing.VALUES[buf.readByte()];
             scheduleRenderUpdate();

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -916,7 +916,7 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, ICoverable, I
             MTETrait trait = mteTraitByNetworkId.get(traitNetworkId);
             if (trait == null) {
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
-            } else trait.receiveInitialData(buf);
+            } else trait.receiveInitialSyncData(buf);
         }
         CoverIO.receiveCoverSyncData(buf, this, (side, cover) -> this.coverBehaviors[side.getIndex()] = cover);
         this.muffled = buf.readBoolean();

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -896,7 +896,7 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, ICoverable, I
         buf.writeShort(this.mteTraitByNetworkId.size());
         for (Int2ObjectMap.Entry<MTETrait> entry : mteTraitByNetworkId.int2ObjectEntrySet()) {
             buf.writeVarInt(entry.getIntKey());
-            entry.getValue().writeInitialSyncData(buf);
+            entry.getValue().writeInitialData(buf);
         }
         CoverIO.writeCoverSyncData(buf, this);
         buf.writeBoolean(muffled);
@@ -916,7 +916,7 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, ICoverable, I
             MTETrait trait = mteTraitByNetworkId.get(traitNetworkId);
             if (trait == null) {
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
-            } else trait.receiveInitialSyncData(buf);
+            } else trait.receiveInitialData(buf);
         }
         CoverIO.receiveCoverSyncData(buf, this, (side, cover) -> this.coverBehaviors[side.getIndex()] = cover);
         this.muffled = buf.readBoolean();

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -41,6 +41,7 @@ import net.minecraftforge.fml.common.Optional.InterfaceList;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -275,7 +276,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
-    public void writeInitialSyncData(PacketBuffer buf) {
+    public void writeInitialSyncData(@NotNull PacketBuffer buf) {
         buf.writeString(getName());
         if (metaTileEntity != null) {
             buf.writeBoolean(true);
@@ -285,7 +286,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
-    public void receiveInitialSyncData(PacketBuffer buf) {
+    public void receiveInitialSyncData(@NotNull PacketBuffer buf) {
         setCustomName(buf.readString(Short.MAX_VALUE));
         if (buf.readBoolean()) {
             receiveMTEInitializationData(buf);
@@ -293,7 +294,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     }
 
     @Override
-    public void receiveCustomData(int discriminator, PacketBuffer buffer) {
+    public void receiveCustomData(int discriminator, @NotNull PacketBuffer buffer) {
         if (discriminator == INITIALIZE_MTE) {
             receiveMTEInitializationData(buffer);
         } else if (metaTileEntity != null) {
@@ -306,7 +307,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
      *
      * @param buf the buffer to read data from
      */
-    private void receiveMTEInitializationData(@Nonnull PacketBuffer buf) {
+    private void receiveMTEInitializationData(@NotNull PacketBuffer buf) {
         int metaTileEntityId = buf.readVarInt();
         setMetaTileEntity(GregTechAPI.MTE_REGISTRY.getObjectById(metaTileEntityId));
         this.metaTileEntity.onPlacement();

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -1,6 +1,7 @@
 package gregtech.api.metatileentity;
 
 import gregtech.api.block.BlockStateTileEntity;
+import gregtech.api.metatileentity.interfaces.ISyncedTileEntity;
 import gregtech.api.network.PacketDataList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -12,22 +13,18 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraftforge.common.util.Constants;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
-public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
-
-    public abstract void writeInitialSyncData(PacketBuffer buf);
-
-    public abstract void receiveInitialSyncData(PacketBuffer buf);
-
-    public abstract void receiveCustomData(int discriminator, PacketBuffer buf);
+public abstract class SyncedTileEntityBase extends BlockStateTileEntity implements ISyncedTileEntity {
 
     private final PacketDataList updates = new PacketDataList();
 
-    public void writeCustomData(int discriminator, Consumer<PacketBuffer> dataWriter) {
+    @Override
+    public final void writeCustomData(int discriminator, @NotNull Consumer<@NotNull PacketBuffer> dataWriter) {
         ByteBuf backedBuffer = Unpooled.buffer();
         dataWriter.accept(new PacketBuffer(backedBuffer));
         byte[] updateData = Arrays.copyOfRange(backedBuffer.array(), 0, backedBuffer.writerIndex());
@@ -55,7 +52,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     }
 
     @Override
-    public SPacketUpdateTileEntity getUpdatePacket() {
+    public final @Nullable SPacketUpdateTileEntity getUpdatePacket() {
         if (this.updates.isEmpty()) {
             return null;
         }
@@ -65,7 +62,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     }
 
     @Override
-    public void onDataPacket(@Nonnull NetworkManager net, SPacketUpdateTileEntity pkt) {
+    public final void onDataPacket(@NotNull NetworkManager net, @NotNull SPacketUpdateTileEntity pkt) {
         NBTTagCompound updateTag = pkt.getNbtCompound();
         NBTTagList listTag = updateTag.getTagList("d", Constants.NBT.TAG_COMPOUND);
         for (NBTBase entryBase : listTag) {
@@ -77,9 +74,8 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
         }
     }
 
-    @Nonnull
     @Override
-    public NBTTagCompound getUpdateTag() {
+    public final @NotNull NBTTagCompound getUpdateTag() {
         NBTTagCompound updateTag = super.getUpdateTag();
         ByteBuf backedBuffer = Unpooled.buffer();
         writeInitialSyncData(new PacketBuffer(backedBuffer));
@@ -89,11 +85,10 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     }
 
     @Override
-    public void handleUpdateTag(@Nonnull NBTTagCompound tag) {
+    public final void handleUpdateTag(@NotNull NBTTagCompound tag) {
         super.readFromNBT(tag); // deserializes Forge data and capabilities
         byte[] updateData = tag.getByteArray("d");
         ByteBuf backedBuffer = Unpooled.copiedBuffer(updateData);
         receiveInitialSyncData(new PacketBuffer(backedBuffer));
     }
-
 }

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
@@ -2,23 +2,18 @@ package gregtech.api.metatileentity.interfaces;
 
 import gregtech.api.gui.IUIHolder;
 import gregtech.api.metatileentity.MetaTileEntity;
-import net.minecraft.network.PacketBuffer;
-
-import java.util.function.Consumer;
 
 /**
  * A simple compound Interface for all my TileEntities.
  * <p/>
- * Also delivers most of the Informations about TileEntities.
+ * Also delivers most of the Information about TileEntities.
  * <p/>
  */
-public interface IGregTechTileEntity extends IHasWorldObjectAndCoords, IUIHolder {
+public interface IGregTechTileEntity extends IHasWorldObjectAndCoords, ISyncedTileEntity, IUIHolder {
 
     MetaTileEntity getMetaTileEntity();
 
     MetaTileEntity setMetaTileEntity(MetaTileEntity metaTileEntity);
-
-    void writeCustomData(int discriminator, Consumer<PacketBuffer> dataWriter);
 
     long getOffsetTimer(); // todo might not keep this one
 

--- a/src/main/java/gregtech/api/metatileentity/interfaces/ISyncedTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/ISyncedTileEntity.java
@@ -1,0 +1,89 @@
+package gregtech.api.metatileentity.interfaces;
+
+import net.minecraft.network.PacketBuffer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Functions which sync data between the Server and Client sides in a TileEntity.
+ */
+public interface ISyncedTileEntity {
+
+    /**
+     * Used to sync data from Server -> Client.
+     * Called during initial loading of the chunk or when many blocks change at once.
+     * <p>
+     * Data is received in {@link #receiveInitialSyncData(PacketBuffer)}.
+     * <p>
+     * Typically used to send server side data to the client on initial chunk loading.
+     * <p>
+     * <em>Should be called automatically</em>.
+     * <p>
+     * This method is called <strong>Server-Side</strong>.
+     * <p>
+     * Equivalent to {@link net.minecraft.tileentity.TileEntity#getUpdateTag}.
+     *
+     * @param buf the buffer to write data to
+     */
+    void writeInitialSyncData(@NotNull PacketBuffer buf);
+
+    /**
+     * Used to receive Server -> Client sync data.
+     * Called during initial loading of the chunk or when many blocks change at once.
+     * <p>
+     * Data sent is from {@link #writeInitialSyncData(PacketBuffer)}.
+     * <p>
+     * Typically used to receive server side data on initial chunk loading.
+     * <p>
+     * <em>Should be called automatically</em>.
+     * <p>
+     * This method is called <strong>Client-Side</strong>.
+     * <p>
+     * Equivalent to {@link net.minecraft.tileentity.TileEntity#handleUpdateTag}.
+     *
+     * @param buf the buffer to read data from
+     */
+    void receiveInitialSyncData(@NotNull PacketBuffer buf);
+
+    /**
+     * Used to send an anonymous Server -> Client packet.
+     * Call to build up the packet to send to the client when it is re-synced.
+     * <p>
+     * Data is received in {@link #receiveCustomData(int, PacketBuffer)};
+     * <p>
+     * Typically used to signal to the client that a rendering update is needed
+     * when sending a server-side state update.
+     * <p>
+     * <em>Should be called manually</em>.
+     * <p>
+     * This method is called <strong>Server-Side</strong>.
+     * <p>
+     * Equivalent to {@link net.minecraft.tileentity.TileEntity#getUpdatePacket}
+     *
+     * @param discriminator the discriminator determining the packet sent.
+     * @param dataWriter    a consumer which writes packet data to a buffer.
+     * @see gregtech.api.capability.GregtechDataCodes
+     */
+    void writeCustomData(int discriminator, @NotNull Consumer<@NotNull PacketBuffer> dataWriter);
+
+    /**
+     * Used to receive an anonymous Server -> Client packet.
+     * Called when receiving a packet for the location this TileEntity is currently in.
+     * <p>
+     * Data is sent with {@link #writeCustomData(int, Consumer)}.
+     * <p>
+     * Typically used to perform a rendering update when receiving server-side state changes.
+     * <p>
+     * <em>Should be called automatically</em>.
+     * <p>
+     * This method is called <strong>Client-Side</strong>.
+     * <p>
+     * Equivalent to {@link net.minecraft.tileentity.TileEntity#onDataPacket}
+     *
+     * @param discriminator the discriminator determining the packet sent.
+     * @param buf           the buffer containing the packet data.
+     * @see gregtech.api.capability.GregtechDataCodes
+     */
+    void receiveCustomData(int discriminator, @NotNull PacketBuffer buf);
+}


### PR DESCRIPTION
## What
Moves tile entity syncing into a new interface: `ISyncedTileEntity`. This allows the three duplicate instances of these methods to be unified under one interface, and share javadocs between them. This PR also adds documentation for what these sync methods do and how they function.

## Outcome
Moves syncing functionality into `ISyncedTileEntity`.
