### PR TITLE
Fix method name reobf issue with Battery Data

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/IBatteryData.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IBatteryData.java
@@ -8,5 +8,5 @@ public interface IBatteryData {
 
     long getCapacity();
 
-    @NotNull String getName();
+    @NotNull String getBatteryName();
 }

--- a/src/main/java/gregtech/common/blocks/BlockBatteryPart.java
+++ b/src/main/java/gregtech/common/blocks/BlockBatteryPart.java
@@ -84,10 +84,17 @@ public class BlockBatteryPart extends VariantBlock<BlockBatteryPart.BatteryPartT
             return capacity;
         }
 
+        // must be separately named because of reobf issue
+        @NotNull
+        @Override
+        public String getBatteryName() {
+            return name().toLowerCase();
+        }
+
         @NotNull
         @Override
         public String getName() {
-            return name().toLowerCase();
+            return getBatteryName();
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -274,7 +274,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase imp
             // Allow unfilled batteries in the structure, but do not add them to match context.
             // This lets you use empty batteries as "filler slots" for convenience if desired.
             if (battery.getTier() != -1 && battery.getCapacity() > 0) {
-                String key = PMC_BATTERY_HEADER + battery.getName();
+                String key = PMC_BATTERY_HEADER + battery.getBatteryName();
                 BatteryMatchWrapper wrapper = blockWorldState.getMatchContext().get(key);
                 if (wrapper == null) wrapper = new BatteryMatchWrapper(battery);
                 blockWorldState.getMatchContext().set(key, wrapper.increment());

--- a/src/test/java/gregtech/common/metatileentities/multiblock/PowerSubstationTest.java
+++ b/src/test/java/gregtech/common/metatileentities/multiblock/PowerSubstationTest.java
@@ -408,7 +408,7 @@ public class PowerSubstationTest {
         // not used in this test
         @NotNull
         @Override
-        public String getName() {
+        public String getBatteryName() {
             return "";
         }
     }


### PR DESCRIPTION
Fixes `IBatteryData#getName()` being reobfuscated when used on a type that also implements `IStringSerializable`