### PR TITLE
Prevent merging electric tools in anvil

### DIFF
--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -165,14 +165,18 @@ public class ToolEventHandlers {
     }
 
     /**
-     * Prevents anvil repairing if tools do not have the same material
+     * Prevents anvil repairing if tools do not have the same material, or if either are electric.
+     * Electric tools can still be repaired with ingots in the anvil, but electric tools cannot
+     * be combined with other GT tools, electric or otherwise.
      */
     @SubscribeEvent
     public static void onAnvilUpdateEvent(AnvilUpdateEvent event) {
         ItemStack left = event.getLeft(), right = event.getRight();
-        if (left.getItem() instanceof IGTTool && right.getItem() instanceof IGTTool) {
-            IGTTool leftTool = (IGTTool) left.getItem(), rightTool = (IGTTool) right.getItem();
+        if (left.getItem() instanceof IGTTool leftTool && right.getItem() instanceof IGTTool rightTool) {
             if (leftTool.getToolMaterial(left) != rightTool.getToolMaterial(right)) {
+                event.setCanceled(true);
+            }
+            if (leftTool.isElectric() || rightTool.isElectric()) {
                 event.setCanceled(true);
             }
         }


### PR DESCRIPTION
Closes #1779 

Prevents electric GT tools from merging with other tools in an anvil. Electric tools can still be repaired with Ingots or other suitable repair items like other tools