### PR TITLE
Fix incorrect packet reading

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -6,6 +6,7 @@ import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.nbt.NBTTagByteArray;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.PacketBuffer;
@@ -53,9 +54,9 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
     @Override
     public void onDataPacket(@Nonnull NetworkManager net, SPacketUpdateTileEntity pkt) {
         for (var entry : pkt.getNbtCompound().tagMap.entrySet()) {
-            if (entry.getValue() instanceof NBTTagCompound compound) {
+            if (entry.getValue() instanceof NBTTagByteArray compound) {
                 String key = entry.getKey();
-                ByteBuf buf = Unpooled.wrappedBuffer(compound.getByteArray(key)).asReadOnly();
+                ByteBuf buf = Unpooled.wrappedBuffer(compound.getByteArray()).asReadOnly();
                 receiveCustomData(Integer.parseInt(key), new PacketBuffer(buf));
             }
         }


### PR DESCRIPTION
## What
Attempts to fix incorrect packet reading that was introduced in #1883 

## Implementation Details
When reading the data packet, parsing the packet depended on if the `entry` in the tag compound was an NBTTagCompound, however, the data here was written as a NBTTagByteArray instead, so the packets were not getting processed.

See

https://github.com/GregTechCEu/GregTech/blob/7408addee4f482232f09517ffb410bcc72340080/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java#L46

which set the data in the provided TagCompound as a ByteArray.

In
https://github.com/GregTechCEu/GregTech/blob/7408addee4f482232f09517ffb410bcc72340080/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java#L55-L56

the code was looking for a TagCompound to continue processing the packet, however, the TagCompound was already unwrapped on the first line, leaving `entry` as a NBTTagByteArray, therefore packets were not getting processed


