### PR TITLE
Add Filtering to Pump Machines

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -10,14 +10,11 @@ import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
-import gregtech.api.gui.Widget;
-import gregtech.api.gui.resources.IGuiTexture;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
-import gregtech.api.util.IDirtyNotifiable;
 import gregtech.api.util.Position;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
@@ -48,7 +45,6 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -64,13 +60,13 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
 
     private final Deque<BlockPos> fluidSourceBlocks = new ArrayDeque<>();
     private final Deque<BlockPos> blocksToCheck = new ArrayDeque<>();
-    private FluidFilterContainer fluidFilter;
+    private final FluidFilterContainer fluidFilter;
     private boolean initializedQueue = false;
     private int pumpHeadY;
 
     public MetaTileEntityPump(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
-        fluidFilter = new FluidFilterContainer(getHolder());
+        this.fluidFilter = new FluidFilterContainer(this::markDirty);
     }
 
     @Override
@@ -306,7 +302,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
         this.pumpHeadY = data.getInteger("PumpHeadDepth");
-        this.fluidFilter.deserializeNBT(data);
+        this.fluidFilter.deserializeNBT(data.getCompoundTag("Filter"));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -27,6 +27,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
@@ -45,6 +47,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static gregtech.api.capability.GregtechDataCodes.PUMP_HEAD_LEVEL;
 
@@ -167,10 +170,10 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
         tankDisplay.addWidget(tankWidget);
         tankDisplay.addWidget(new LabelWidget(6, 6, getMetaFullName()));
         tankDisplay.addWidget(new LabelWidget(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF));
-        tankDisplay.addWidget(new DynamicLabelWidget(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF));
-        tankDisplay.addWidget(new DynamicLabelWidget(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF));
+        tankDisplay.addWidget(new AdvancedTextWidget(11, 30, getFluidAmountText(tankWidget), 0xFFFFFF));
+        tankDisplay.addWidget(new AdvancedTextWidget(11, 40, getFluidNameText(tankWidget), 0xFFFFFF));
 
-        return ModularUI.defaultBuilder(/*GuiTextures.BACKGROUND, 176 + 94, 166*/)
+        return ModularUI.defaultBuilder()
                 .widget(tankDisplay)
                 .bindPlayerInventory(entityPlayer.inventory)
                 .build(getHolder(), entityPlayer);
@@ -313,6 +316,44 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
             return;
         }
         this.lockedFluid = null;
+    }
+    private Consumer<List<ITextComponent>> getFluidNameText(TankWidget tankWidget) {
+        return (list) -> {
+            String fluidName = "";
+            // If there is no fluid in the tank
+            if (tankWidget.getFluidLocalizedName().isEmpty()) {
+                // But there is a locked fluid
+                if (this.lockedFluid != null) {
+                    fluidName = this.lockedFluid.getLocalizedName();
+                }
+            } else {
+                fluidName = tankWidget.getFluidLocalizedName();
+            }
+
+            if (!fluidName.isEmpty()) {
+                list.add(new TextComponentString(fluidName));
+
+            }
+        };
+    }
+
+    private Consumer<List<ITextComponent>> getFluidAmountText(TankWidget tankWidget) {
+        return (list) -> {
+            String fluidAmount = "";
+
+            // Nothing in the tank
+            if (tankWidget.getFormattedFluidAmount().equals("0")) {
+                // Display Zero to show information about the locked fluid
+                if (this.lockedFluid != null) {
+                    fluidAmount = "0";
+                }
+            } else {
+                fluidAmount = tankWidget.getFormattedFluidAmount();
+            }
+            if (!fluidAmount.isEmpty()) {
+                list.add(new TextComponentString(fluidAmount));
+            }
+        };
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -281,6 +281,11 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
             }
             FluidStack drainStack = fluidHandler.drain(Integer.MAX_VALUE, false);
             if (drainStack != null && exportFluids.fill(drainStack, false) == drainStack.amount) {
+                if (locked) {
+                    lockedFluid = drainStack.copy();
+                    lockedFluid.amount = 1;
+                }
+
                 if (lockedFluid == null || drainStack.isFluidEqual(lockedFluid)) {
                     exportFluids.fill(drainStack, true);
                     fluidHandler.drain(drainStack.amount, true);

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -148,12 +148,12 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
         tankDisplay.addWidget(new ImageWidget(91, 36, 14, 14, GuiTextures.TANK_ICON));
         tankDisplay.addWidget(new SlotWidget(exportItems, 0, 90, 53, true, false)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY));
-        tankDisplay.addWidget(new ToggleButtonWidget(25, 64, 18, 18,
+        tankDisplay.addWidget(new ToggleButtonWidget(11, 50, 18, 18,
                 GuiTextures.BUTTON_LOCK, this::isLocked, this::setLocked)
                 .setTooltipText("gregtech.gui.fluid_lock.tooltip")
                 .shouldUseBaseBackground());
 
-        TankWidget tankWidget = new PhantomTankWidget(exportFluids.getTankAt(0), 69, 52, 18, 18,
+        TankWidget tankWidget = new PhantomTankWidget(exportFluids.getTankAt(0), 67, 50, 18, 18,
                 () -> this.lockedFluid,
                 fs -> {
                     if (this.exportFluids.getTankAt(0).getFluidAmount() != 0) {
@@ -175,12 +175,9 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
         tankDisplay.addWidget(new DynamicLabelWidget(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF));
         tankDisplay.addWidget(new DynamicLabelWidget(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF));
 
-//        WidgetGroup filterWidget = new WidgetGroup(new Position(102, 6));
-//        fluidFilter.initUI(0, filterWidget::addWidget);
-        return ModularUI.builder(GuiTextures.BACKGROUND, 176 + 94, 166)
+        return ModularUI.defaultBuilder(/*GuiTextures.BACKGROUND, 176 + 94, 166*/)
                 .widget(tankDisplay)
-//                .widget(filterWidget)
-                .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT, 47, 166 - 82)
+                .bindPlayerInventory(entityPlayer.inventory)
                 .build(getHolder(), entityPlayer);
     }
 
@@ -345,6 +342,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
         data.setInteger("PumpHeadDepth", pumpHeadY);
+        data.setBoolean("IsLocked", locked);
         if (locked && lockedFluid != null) {
             data.setTag("LockedFluid", lockedFluid.writeToNBT(new NBTTagCompound()));
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -140,18 +140,18 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
         WidgetGroup tankDisplay = new WidgetGroup();
-        tankDisplay.addWidget(new ImageWidget(7, 16, 81, 55, GuiTextures.DISPLAY));
+        tankDisplay.addWidget(new ImageWidget(7, 16, 81, 46, GuiTextures.DISPLAY));
         tankDisplay.addWidget(new FluidContainerSlotWidget(importItems, 0, 90, 16, false)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY));
-        tankDisplay.addWidget(new ImageWidget(91, 36, 14, 14, GuiTextures.TANK_ICON));
-        tankDisplay.addWidget(new SlotWidget(exportItems, 0, 90, 53, true, false)
+        // tankDisplay.addWidget(new ImageWidget(91, 36, 14, 14, GuiTextures.TANK_ICON));
+        tankDisplay.addWidget(new SlotWidget(exportItems, 0, 90, 44, true, false)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY));
-        tankDisplay.addWidget(new ToggleButtonWidget(11, 50, 18, 18,
+        tankDisplay.addWidget(new ToggleButtonWidget(7, 64, 18, 18,
                 GuiTextures.BUTTON_LOCK, this::isLocked, this::setLocked)
                 .setTooltipText("gregtech.gui.fluid_lock.tooltip")
                 .shouldUseBaseBackground());
 
-        TankWidget tankWidget = new PhantomTankWidget(exportFluids.getTankAt(0), 67, 50, 18, 18,
+        TankWidget tankWidget = new PhantomTankWidget(exportFluids.getTankAt(0), 67, 41, 18, 18,
                 () -> this.lockedFluid,
                 fs -> {
                     if (this.exportFluids.getTankAt(0).getFluidAmount() != 0) {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -60,7 +60,6 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
 
     private final Deque<BlockPos> fluidSourceBlocks = new ArrayDeque<>();
     private final Deque<BlockPos> blocksToCheck = new ArrayDeque<>();
-//    private final FluidFilterContainer fluidFilter;
     private boolean initializedQueue = false;
     private int pumpHeadY;
     @Nullable

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -10,6 +10,7 @@ import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
+import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
@@ -48,6 +49,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static gregtech.api.capability.GregtechDataCodes.PUMP_HEAD_LEVEL;
 
@@ -134,25 +136,28 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
-        // Builder builder = ModularUI.defaultBuilder();
-        Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176 + 64, 166);
-        builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
+        WidgetGroup tankDisplay = new WidgetGroup();
+        tankDisplay.addWidget(new ImageWidget(7, 16, 81, 55, GuiTextures.DISPLAY));
+        tankDisplay.addWidget(new FluidContainerSlotWidget(importItems, 0, 90, 16, false)
+                .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY));
+        tankDisplay.addWidget(new ImageWidget(91, 36, 14, 14, GuiTextures.TANK_ICON));
+        tankDisplay.addWidget(new SlotWidget(exportItems, 0, 90, 53, true, false)
+                .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY));
+
         TankWidget tankWidget = new TankWidget(exportFluids.getTankAt(0), 69, 52, 18, 18)
                 .setHideTooltip(true).setAlwaysShowFull(true);
-        builder.widget(tankWidget);
-        WidgetGroup filterWidget = new WidgetGroup(new Position(108, 6));
+        tankDisplay.addWidget(tankWidget);
+        tankDisplay.addWidget(new LabelWidget(6, 6, getMetaFullName()));
+        tankDisplay.addWidget(new LabelWidget(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF));
+        tankDisplay.addWidget(new DynamicLabelWidget(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF));
+        tankDisplay.addWidget(new DynamicLabelWidget(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF));
+
+        WidgetGroup filterWidget = new WidgetGroup(new Position(102, 6));
         fluidFilter.initUI(0, filterWidget::addWidget);
-        builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
-        builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
-        builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
-        return builder.label(6, 6, getMetaFullName())
-                .widget(new FluidContainerSlotWidget(importItems, 0, 90, 17, false)
-                        .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY))
-                .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
-                .widget(new SlotWidget(exportItems, 0, 90, 54, true, false)
-                        .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY))
+        return ModularUI.builder(GuiTextures.BACKGROUND, 176 + 94, 166)
+                .widget(tankDisplay)
                 .widget(filterWidget)
-                .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT, 32, 166 - 82)
+                .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT, 47, 166 - 82)
                 .build(getHolder(), entityPlayer);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -167,7 +167,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
                         this.lockedFluid = fs.copy();
                         this.lockedFluid.amount = 1;
                     }
-                }).setHideTooltip(true).setAlwaysShowFull(true);
+                }).setDrawHoveringText(false).setAlwaysShowFull(true);
 
         tankDisplay.addWidget(tankWidget);
         tankDisplay.addWidget(new LabelWidget(6, 6, getMetaFullName()));

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -9,17 +9,13 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.ModularUI.Builder;
-import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
-import gregtech.api.util.Position;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
-import gregtech.common.covers.filter.FluidFilterContainer;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
@@ -49,7 +45,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static gregtech.api.capability.GregtechDataCodes.PUMP_HEAD_LEVEL;
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -283,7 +283,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
             }
             FluidStack drainStack = fluidHandler.drain(Integer.MAX_VALUE, false);
             if (drainStack != null && exportFluids.fill(drainStack, false) == drainStack.amount) {
-                if (locked) {
+                if (locked && lockedFluid == null) {
                     lockedFluid = drainStack.copy();
                     lockedFluid.amount = 1;
                 }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -11,12 +11,14 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.gui.Widget;
+import gregtech.api.gui.resources.IGuiTexture;
 import gregtech.api.gui.widgets.*;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.TieredMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.IDirtyNotifiable;
+import gregtech.api.util.Position;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
 import gregtech.common.covers.filter.FluidFilterContainer;
@@ -46,6 +48,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -135,12 +138,14 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
 
     @Override
     protected ModularUI createUI(EntityPlayer entityPlayer) {
-        Builder builder = ModularUI.defaultBuilder();
+        // Builder builder = ModularUI.defaultBuilder();
+        Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176 + 64, 166);
         builder.image(7, 16, 81, 55, GuiTextures.DISPLAY);
         TankWidget tankWidget = new TankWidget(exportFluids.getTankAt(0), 69, 52, 18, 18)
                 .setHideTooltip(true).setAlwaysShowFull(true);
         builder.widget(tankWidget);
-        fluidFilter.initUI(32, builder::widget);
+        WidgetGroup filterWidget = new WidgetGroup(new Position(108, 6));
+        fluidFilter.initUI(0, filterWidget::addWidget);
         builder.label(11, 20, "gregtech.gui.fluid_amount", 0xFFFFFF);
         builder.dynamicLabel(11, 30, tankWidget::getFormattedFluidAmount, 0xFFFFFF);
         builder.dynamicLabel(11, 40, tankWidget::getFluidLocalizedName, 0xFFFFFF);
@@ -150,7 +155,8 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
                 .widget(new ImageWidget(91, 36, 14, 15, GuiTextures.TANK_ICON))
                 .widget(new SlotWidget(exportItems, 0, 90, 54, true, false)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.OUT_SLOT_OVERLAY))
-                .bindPlayerInventory(entityPlayer.inventory)
+                .widget(filterWidget)
+                .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT, 32, 166 - 82)
                 .build(getHolder(), entityPlayer);
     }
 


### PR DESCRIPTION
## What
Allows users to filter what the pump machine can extract from in-world fluids

## Implementation Details
Switches the TankWidget with a PhantomTankWidget, for filtering
Adds a lock button to the pump machine

## Outcome
Users can filter the pump machine

## Additional Information
![image](https://github.com/GregTechCEu/GregTech/assets/44148655/65410a3c-d8f8-40e5-90bf-bd0d0b421322)

## Potential Compatibility Issues
none afaik
