### PR TITLE
Add a config for special events

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -2,6 +2,7 @@ package gregtech.api;
 
 import gregtech.GregTechVersion;
 import gregtech.api.util.XSTR;
+import gregtech.common.ConfigHolder;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.oredict.OreDictionary;
@@ -167,11 +168,11 @@ public class GTValues {
 
     public static Supplier<Boolean> FOOLS = () -> {
         String[] yearMonthDay = LocalDate.now().toString().split("-");
-        return yearMonthDay[1].equals("04") && yearMonthDay[2].equals("01");
+        return ConfigHolder.misc.specialEvents && yearMonthDay[1].equals("04") && yearMonthDay[2].equals("01");
     };
 
     public static Supplier<Boolean> XMAS = () -> {
         String[] yearMonthDay = LocalDate.now().toString().split("-");
-        return yearMonthDay[1].equals("12") && (yearMonthDay[2].equals("24") || yearMonthDay[2].equals("25"));
+        return ConfigHolder.misc.specialEvents && yearMonthDay[1].equals("12") && (yearMonthDay[2].equals("24") || yearMonthDay[2].equals("25"));
     };
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -282,6 +282,9 @@ public class ConfigHolder {
         @Config.Comment({"Whether to enable more verbose logging.", "Default: false"})
         public boolean debug = false;
 
+        @Config.Comment({"Whether to enable Special Event features (e.g. Christmas, etc).", "Default: true"})
+        public boolean specialEvents = true;
+
         @Config.Comment({"Setting this to true makes GTCEu ignore error and invalid recipes that would otherwise cause crash.", "Default: true"})
         public boolean ignoreErrorOrInvalidRecipes = true;
 


### PR DESCRIPTION
## What
Adds a Config option for special events, such as Christmas and April Fools. This is partly because the date desync is not yet fixed


## Outcome
Config for special events
