### PR TITLE
Fix Turbines crashing with Quad/Nonuple Hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -123,7 +123,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
         FuelMultiblockController controller = (FuelMultiblockController) this.metaTileEntity;
         List<IFluidHandler> tanks = controller.getNotifiedFluidInputList();
         for (IFluidTank tank : controller.getAbilities(MultiblockAbility.IMPORT_FLUIDS)) {
-            tanks.add((FluidTank) tank);
+            tanks.add((IFluidHandler) tank);
         }
     }
 }


### PR DESCRIPTION
## What
fixes #1908.

## Implementation Details
fix cast exception by casting to `IFluidHandler` instead of `FluidTank`

## Outcome
game does not die when using turbines with multi-tank hatches

## Potential Compatibility Issues
none afaik
