### PR TITLE
Fix Converter Capabilty returning Null in certain situations

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
@@ -78,6 +78,7 @@ public class MetaTileEntityConverter extends TieredMetaTileEntity {
                     FeCompat.toFe(converterTrait.getVoltage() * converterTrait.getBaseAmps(), FeCompat.ratio(true)),
                     converterTrait.getBaseAmps(), converterTrait.getVoltage()));
         }
+        notifyBlockUpdate();
         return true;
     }
 
@@ -166,7 +167,7 @@ public class MetaTileEntityConverter extends TieredMetaTileEntity {
     @Override
     public <T> T getCapability(Capability<T> capability, EnumFacing side) {
         if (capability == GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER) {
-            return converterTrait.isFeToEu() == (side == frontFacing) ?
+            return side != (!converterTrait.isFeToEu() ? frontFacing : null) ?
                     GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER.cast(converterTrait.getEnergyEUContainer()) : null;
         }
         if (capability == CapabilityEnergy.ENERGY) {

--- a/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
@@ -78,7 +78,6 @@ public class MetaTileEntityConverter extends TieredMetaTileEntity {
                     FeCompat.toFe(converterTrait.getVoltage() * converterTrait.getBaseAmps(), FeCompat.ratio(true)),
                     converterTrait.getBaseAmps(), converterTrait.getVoltage()));
         }
-        notifyBlockUpdate();
         return true;
     }
 


### PR DESCRIPTION
## What
Fixes #1614. 

## Implementation Details
`getCapability()` was returning null in certain circumstances when trying to get `GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER` when the EnergyNetWalker was traversing. 

This fixes that issue by copying what was done for getting `CapabilityEnergy.ENERGY` and adjusting it for the EU container

## Outcome
Fixes #1614.

## Potential Compatibility Issues
none
