### PR TITLE
Fix fluid name on tank GUI depending on server locale

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/PhantomTankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomTankWidget.java
@@ -190,4 +190,13 @@ public class PhantomTankWidget extends TankWidget implements IGhostIngredientTar
         FluidStack fluid = phantomFluidGetter.get();
         return fluid == null ? "" : fluid.getLocalizedName();
     }
+
+    @Override
+    public String getFluidUnlocalizedName() {
+        if (lastFluidInTank != null) {
+            return lastFluidInTank.getUnlocalizedName();
+        }
+        FluidStack fluid = phantomFluidGetter.get();
+        return fluid == null ? "" : fluid.getUnlocalizedName();
+    }
 }

--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -114,6 +114,10 @@ public class TankWidget extends Widget implements IIngredientSlot {
         return lastFluidInTank == null ? "" : lastFluidInTank.getLocalizedName();
     }
 
+    public String getFluidUnlocalizedName() {
+        return lastFluidInTank == null ? "" : lastFluidInTank.getUnlocalizedName();
+    }
+
     @Override
     public void drawInBackground(int mouseX, int mouseY, float partialTicks, IRenderContext context) {
         Position pos = getPosition();

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -29,6 +29,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
@@ -320,18 +321,17 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
         return (list) -> {
             String fluidName = "";
             // If there is no fluid in the tank
-            if (tankWidget.getFluidLocalizedName().isEmpty()) {
+            if (tankWidget.getFluidUnlocalizedName().isEmpty()) {
                 // But there is a locked fluid
                 if (this.lockedFluid != null) {
-                    fluidName = this.lockedFluid.getLocalizedName();
+                    fluidName = this.lockedFluid.getUnlocalizedName();
                 }
             } else {
-                fluidName = tankWidget.getFluidLocalizedName();
+                fluidName = tankWidget.getFluidUnlocalizedName();
             }
 
             if (!fluidName.isEmpty()) {
-                list.add(new TextComponentString(fluidName));
-
+                list.add(new TextComponentTranslation(fluidName));
             }
         };
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -27,6 +27,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
@@ -255,17 +256,17 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         return (list) -> {
             String fluidName = "";
             // If there is no fluid in the tank
-            if (tankWidget.getFluidLocalizedName().isEmpty()) {
+            if (tankWidget.getFluidUnlocalizedName().isEmpty()) {
                 // But there is a locked fluid
                 if (this.lockedFluid != null) {
-                    fluidName = this.lockedFluid.getLocalizedName();
+                    fluidName = this.lockedFluid.getUnlocalizedName();
                 }
             } else {
-                fluidName = tankWidget.getFluidLocalizedName();
+                fluidName = tankWidget.getFluidUnlocalizedName();
             }
 
             if (!fluidName.isEmpty()) {
-                list.add(new TextComponentString(fluidName));
+                list.add(new TextComponentTranslation(fluidName));
             }
         };
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -335,18 +335,17 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         return (list) -> {
             String fluidName = "";
             // If there is no fluid in the tank
-            if (tankWidget.getFluidLocalizedName().isEmpty()) {
+            if (tankWidget.getFluidUnlocalizedName().isEmpty()) {
                 // But there is a locked fluid
                 if (this.lockedFluid != null) {
-                    fluidName = this.lockedFluid.getLocalizedName();
+                    fluidName = this.lockedFluid.getUnlocalizedName();
                 }
             } else {
-                fluidName = tankWidget.getFluidLocalizedName();
+                fluidName = tankWidget.getFluidUnlocalizedName();
             }
 
             if (!fluidName.isEmpty()) {
-                list.add(new TextComponentString(fluidName));
-
+                list.add(new TextComponentTranslation(fluidName));
             }
         };
     }


### PR DESCRIPTION
## What
Currently having different locale setting on client and server makes client render fluid name on some tank GUIs with server locale. This PR fixes that.

## Implementation Details
Currently `getFluidNameText` syncs already translated text. I changed them to send unlocalized name with `TextComponentTranslation`, so that client can translate text with its own locale setting.

## Outcome
Fix bug.