### PR TITLE
Tiny pile removal

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -215,23 +215,23 @@ public class MachineRecipeLoader {
     }
 
     private static void registerPrimitiveBlastFurnaceRecipes() {
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(gem, Coal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(1800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(dust, Coal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(1800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(gem, Charcoal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(1800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(dust, Charcoal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(1800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(OREDICT_FUEL_COKE).output(ingot, Steel).output(dustTiny, Ash).duration(1500).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(dust, Coke).output(ingot, Steel).output(dustTiny, Ash).duration(1500).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(gem, Coal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(1800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(dust, Coal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(1800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(gem, Charcoal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(1800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(dust, Charcoal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(1800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(OREDICT_FUEL_COKE).output(ingot, Steel).chancedOutput(dustSmall, Ash, 5000, 0).duration(1500).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, Iron).input(dust, Coke).output(ingot, Steel).chancedOutput(dustSmall, Ash, 5000, 0).duration(1500).buildAndRegister();
 
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(block, Iron).input(block, Coal, 2).output(block, Steel).output(dust, DarkAsh, 2).duration(16200).buildAndRegister();
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(block, Iron).input(block, Charcoal, 2).output(block, Steel).output(dust, DarkAsh, 2).duration(16200).buildAndRegister();
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(block, Iron).input(OREDICT_BLOCK_FUEL_COKE).output(block, Steel).output(dust, Ash).duration(13500).buildAndRegister();
 
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(gem, Coal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(dust, Coal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(gem, Charcoal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(dust, Charcoal, 2).output(ingot, Steel).output(dustTiny, DarkAsh, 2).duration(800).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(OREDICT_FUEL_COKE).output(ingot, Steel).output(dustTiny, Ash).duration(600).buildAndRegister();
-        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(dust, Coke).output(ingot, Steel).output(dustTiny, Ash).duration(600).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(gem, Coal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(dust, Coal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(gem, Charcoal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(dust, Charcoal, 2).output(ingot, Steel).output(dustSmall, DarkAsh).duration(800).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(OREDICT_FUEL_COKE).output(ingot, Steel).chancedOutput(dustSmall, Ash, 5000, 0).duration(600).buildAndRegister();
+        PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(ingot, WroughtIron).input(dust, Coke).output(ingot, Steel).chancedOutput(dustSmall, Ash, 5000, 0).duration(600).buildAndRegister();
 
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(block, WroughtIron).input(block, Coal, 2).output(block, Steel).output(dust, DarkAsh, 2).duration(7200).buildAndRegister();
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder().input(block, WroughtIron).input(block, Charcoal, 2).output(block, Steel).output(dust, DarkAsh, 2).duration(7200).buildAndRegister();
@@ -709,15 +709,15 @@ public class MachineRecipeLoader {
     }
 
     private static void registerBlastFurnaceRecipes() {
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Ruby).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Ruby).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Ruby).output(nugget, Aluminium, 3).chancedOutput(dustSmall, DarkAsh, 5000, 0).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Ruby).output(nugget, Aluminium, 3).chancedOutput(dustSmall, DarkAsh, 5000, 0).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, GreenSapphire).output(nugget, Aluminium, 3).chancedOutput(dustSmall, DarkAsh, 5000, 0).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).output(nugget, Aluminium, 3).chancedOutput(dustSmall, DarkAsh, 5000, 0).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(800).EUt(VA[HV]).input(dust, Magnesium, 2).fluidInputs(TitaniumTetrachloride.getFluid(1000)).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.Titanium), OreDictUnifier.get(OrePrefix.dust, Materials.MagnesiumChloride, 6)).blastFurnaceTemp(Materials.Titanium.getBlastTemperature() + 200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(VA[MV]).input(ingot, Iron).fluidInputs(Oxygen.getFluid(200)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(300).EUt(VA[MV]).input(ingot, WroughtIron).fluidInputs(Oxygen.getFluid(200)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(500).EUt(VA[MV]).input(ingot, Iron).fluidInputs(Oxygen.getFluid(200)).output(ingot, Steel).chancedOutput(dustSmall, Ash, 5000, 0).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(300).EUt(VA[MV]).input(ingot, WroughtIron).fluidInputs(Oxygen.getFluid(200)).output(ingot, Steel).chancedOutput(dustSmall, Ash, 5000, 0).blastFurnaceTemp(1000).buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder()
                 .input(dust, Ilmenite, 10)
@@ -750,7 +750,7 @@ public class MachineRecipeLoader {
                 .input(dust, Tetrahedrite)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, CupricOxide)
-                .output(dustTiny, AntimonyTrioxide, 3)
+                .chancedOutput(dust, AntimonyTrioxide, 3333, 0)
                 .fluidOutputs(SulfurDioxide.getFluid(2000))
                 .buildAndRegister();
 
@@ -783,7 +783,7 @@ public class MachineRecipeLoader {
                 .input(dust, SiliconDioxide, 3)
                 .input(dust, Carbon, 2)
                 .output(ingotHot, Silicon)
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(2000))
                 .buildAndRegister();
     }
@@ -793,7 +793,7 @@ public class MachineRecipeLoader {
                 .input(dust, inputMaterial)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, outputMaterial)
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(SulfurDioxide.getFluid(sulfurDioxideAmount))
                 .buildAndRegister();
     }
@@ -844,7 +844,7 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder()
                 .input(stone, Endstone)
                 .output(dust, Endstone)
-                .chancedOutput(dustTiny, Tungstate, 1200, 280)
+                .chancedOutput(dustSmall, Tungstate, 533, 280)
                 .buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
@@ -857,7 +857,7 @@ public class MachineRecipeLoader {
             MACERATOR_RECIPES.recipeBuilder()
                     .input(stone, Soapstone)
                     .output(dustImpure, Talc)
-                    .chancedOutput(dustTiny, Chromite, 1000, 280)
+                    .chancedOutput(dust, Chromite, 111, 280)
                     .buildAndRegister();
 
         if (!OreDictionary.getOres("stoneRedrock").isEmpty())
@@ -912,37 +912,37 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.PORKCHOP))
                 .output(dustSmall, Meat, 6)
-                .output(dustTiny, Bone)
+                .chancedOutput(dustSmall, Bone, 5000, 0)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.FISH, 1, GTValues.W))
                 .output(dustSmall, Meat, 6)
-                .output(dustTiny, Bone)
+                .chancedOutput(dustSmall, Bone, 5000, 0)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.CHICKEN))
                 .output(dust, Meat)
-                .output(dustTiny, Bone)
+                .chancedOutput(dustSmall, Bone, 5000, 0)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.BEEF))
                 .output(dustSmall, Meat, 6)
-                .output(dustTiny, Bone)
+                .chancedOutput(dustSmall, Bone, 5000, 0)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.RABBIT))
                 .output(dustSmall, Meat, 6)
-                .output(dustTiny, Bone)
+                .chancedOutput(dustSmall, Bone, 5000, 0)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.MUTTON))
                 .output(dust, Meat)
-                .output(dustTiny, Bone)
+                .chancedOutput(dustSmall, Bone, 5000, 0)
                 .duration(102).buildAndRegister();
 
 

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -123,9 +123,10 @@ public class VanillaStandardRecipes {
                 .output(OrePrefix.dust, Materials.QuartzSand)
                 .duration(30).buildAndRegister();
 
-        ModHandler.addShapelessRecipe("glass_dust_flint", OreDictUnifier.get(OrePrefix.dust, Materials.Glass),
+        ModHandler.addShapelessRecipe("glass_dust_flint", OreDictUnifier.get(OrePrefix.dust, Materials.Glass, 2),
                 new UnificationEntry(OrePrefix.dust, Materials.QuartzSand),
-                new UnificationEntry(OrePrefix.dustTiny, Materials.Flint));
+                new UnificationEntry(OrePrefix.dust, Materials.QuartzSand),
+                new UnificationEntry(OrePrefix.dustSmall, Materials.Flint));
 
         RecipeMaps.MIXER_RECIPES.recipeBuilder().duration(160).EUt(VA[ULV])
                 .input(dustSmall, Materials.Flint)
@@ -365,7 +366,7 @@ public class VanillaStandardRecipes {
         LATHE_RECIPES.recipeBuilder()
                 .input("treeSapling")
                 .outputs(new ItemStack(Items.STICK))
-                .output(dustTiny, Wood)
+                .chancedOutput(dustSmall, Wood, 5000, 0)
                 .duration(16).EUt(VA[ULV])
                 .buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
@@ -164,7 +164,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Krypton.getFluid(1000))
                 .fluidOutputs(Xenon.getFluid(1000))
                 .fluidOutputs(Radon.getFluid(1000))
-                .chancedOutput(dustTiny, EnderPearl, 9000, 0)
+                .chancedOutput(dust, EnderPearl, 1000, 0)
                 .disableDistilleryRecipes()
                 .duration(2000).EUt(VA[IV]).buildAndRegister();
     }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/GrowthMediumRecipes.java
@@ -8,8 +8,7 @@ import net.minecraft.item.ItemStack;
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
-import static gregtech.api.unification.ore.OrePrefix.dust;
-import static gregtech.api.unification.ore.OrePrefix.dustTiny;
+import static gregtech.api.unification.ore.OrePrefix.*;
 import static gregtech.common.items.MetaItems.*;
 
 public class GrowthMediumRecipes {
@@ -54,17 +53,17 @@ public class GrowthMediumRecipes {
                 .cleanroom(CleanroomType.STERILE_CLEANROOM)
                 .buildAndRegister();
 
-        BREWING_RECIPES.recipeBuilder().EUt(4).duration(128)
-                .input(dustTiny, Uranium235)
-                .fluidInputs(BacterialSludge.getFluid(1000))
-                .fluidOutputs(EnrichedBacterialSludge.getFluid(1000))
+        BREWING_RECIPES.recipeBuilder().EUt(4).duration(228)
+                .input(dustSmall, Uranium235)
+                .fluidInputs(BacterialSludge.getFluid(2250))
+                .fluidOutputs(EnrichedBacterialSludge.getFluid(2250))
                 .cleanroom(CleanroomType.STERILE_CLEANROOM)
                 .buildAndRegister();
 
-        BREWING_RECIPES.recipeBuilder().EUt(4).duration(128)
-                .input(dustTiny, Naquadria)
-                .fluidInputs(BacterialSludge.getFluid(1000))
-                .fluidOutputs(EnrichedBacterialSludge.getFluid(2000))
+        BREWING_RECIPES.recipeBuilder().EUt(4).duration(228)
+                .input(dustSmall, Naquadria)
+                .fluidInputs(BacterialSludge.getFluid(2250))
+                .fluidOutputs(EnrichedBacterialSludge.getFluid(2250))
                 .cleanroom(CleanroomType.STERILE_CLEANROOM)
                 .buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PetrochemRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PetrochemRecipes.java
@@ -233,7 +233,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedHeavyFuel.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dustSmall, Carbon, 4444, 0)
                 .fluidOutputs(LightFuel.getFluid(300))
                 .fluidOutputs(Naphtha.getFluid(50))
                 .fluidOutputs(Toluene.getFluid(25))
@@ -249,7 +249,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedHeavyFuel.getFluid(1000))
-                .output(dustTiny, Carbon, 3)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(LightFuel.getFluid(100))
                 .fluidOutputs(Naphtha.getFluid(125))
                 .fluidOutputs(Toluene.getFluid(80))
@@ -285,7 +285,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedLightFuel.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dustSmall, Carbon, 4444, 0)
                 .fluidOutputs(HeavyFuel.getFluid(150))
                 .fluidOutputs(Naphtha.getFluid(400))
                 .fluidOutputs(Toluene.getFluid(40))
@@ -301,7 +301,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedLightFuel.getFluid(1000))
-                .output(dustTiny, Carbon, 3)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(HeavyFuel.getFluid(50))
                 .fluidOutputs(Naphtha.getFluid(100))
                 .fluidOutputs(Toluene.getFluid(30))
@@ -333,7 +333,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedNaphtha.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dustSmall, Carbon, 4444, 0)
                 .fluidOutputs(HeavyFuel.getFluid(75))
                 .fluidOutputs(LightFuel.getFluid(150))
                 .fluidOutputs(Toluene.getFluid(40))
@@ -349,7 +349,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedNaphtha.getFluid(1000))
-                .output(dustTiny, Carbon, 3)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(HeavyFuel.getFluid(25))
                 .fluidOutputs(LightFuel.getFluid(50))
                 .fluidOutputs(Toluene.getFluid(20))
@@ -379,7 +379,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedGas.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dustSmall, Carbon, 4444, 0)
                 .fluidOutputs(Propene.getFluid(45))
                 .fluidOutputs(Ethane.getFluid(8))
                 .fluidOutputs(Ethylene.getFluid(85))
@@ -389,7 +389,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedGas.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(Propene.getFluid(8))
                 .fluidOutputs(Ethane.getFluid(45))
                 .fluidOutputs(Ethylene.getFluid(92))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -180,36 +180,36 @@ public class PolymerRecipes {
     private static void epoxyProcess() {
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .input(dustTiny, SodiumHydroxide)
-                .fluidInputs(SeedOil.getFluid(6000))
-                .fluidInputs(Methanol.getFluid(1000))
-                .fluidOutputs(Glycerol.getFluid(1000))
-                .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(VA[LV]).buildAndRegister();
+                .input(dustSmall, SodiumHydroxide)
+                .fluidInputs(SeedOil.getFluid(13500))
+                .fluidInputs(Methanol.getFluid(2250))
+                .fluidOutputs(Glycerol.getFluid(2250))
+                .fluidOutputs(BioDiesel.getFluid(13500))
+                .duration(1350).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .input(dustTiny, SodiumHydroxide)
-                .fluidInputs(SeedOil.getFluid(6000))
-                .fluidInputs(Ethanol.getFluid(1000))
-                .fluidOutputs(Glycerol.getFluid(1000))
-                .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(VA[LV]).buildAndRegister();
+                .input(dustSmall, SodiumHydroxide)
+                .fluidInputs(SeedOil.getFluid(13500))
+                .fluidInputs(Ethanol.getFluid(2250))
+                .fluidOutputs(Glycerol.getFluid(2250))
+                .fluidOutputs(BioDiesel.getFluid(13500))
+                .duration(1350).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .input(dustTiny, SodiumHydroxide)
-                .fluidInputs(FishOil.getFluid(6000))
-                .fluidInputs(Methanol.getFluid(1000))
-                .fluidOutputs(Glycerol.getFluid(1000))
-                .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(VA[LV]).buildAndRegister();
+                .input(dustSmall, SodiumHydroxide)
+                .fluidInputs(FishOil.getFluid(13500))
+                .fluidInputs(Methanol.getFluid(2250))
+                .fluidOutputs(Glycerol.getFluid(2250))
+                .fluidOutputs(BioDiesel.getFluid(13500))
+                .duration(1350).EUt(VA[LV]).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
-                .input(dustTiny, SodiumHydroxide)
-                .fluidInputs(FishOil.getFluid(6000))
-                .fluidInputs(Ethanol.getFluid(1000))
-                .fluidOutputs(Glycerol.getFluid(1000))
-                .fluidOutputs(BioDiesel.getFluid(6000))
-                .duration(600).EUt(VA[LV]).buildAndRegister();
+                .input(dustSmall, SodiumHydroxide)
+                .fluidInputs(FishOil.getFluid(13500))
+                .fluidInputs(Ethanol.getFluid(2250))
+                .fluidOutputs(Glycerol.getFluid(2250))
+                .fluidOutputs(BioDiesel.getFluid(13500))
+                .duration(1350).EUt(VA[LV]).buildAndRegister();
 
         LARGE_CHEMICAL_RECIPES.recipeBuilder()
                 .input(dust, SodiumHydroxide)
@@ -379,13 +379,6 @@ public class PolymerRecipes {
                 .fluidOutputs(HydrochloricAcid.getFluid(2000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(200)
-                .input(dustTiny, Copper)
-                .fluidInputs(Nitrochlorobenzene.getFluid(2000))
-                .fluidInputs(Hydrogen.getFluid(2000))
-                .fluidOutputs(Dichlorobenzidine.getFluid(1000))
-                .buildAndRegister();
-
         LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(1800)
                 .input(dust, Copper)
                 .fluidInputs(Nitrochlorobenzene.getFluid(18000))
@@ -417,28 +410,12 @@ public class PolymerRecipes {
                 .fluidOutputs(DilutedSulfuricAcid.getFluid(1000))
                 .buildAndRegister();
 
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(100)
-                .input(dustTiny, PotassiumDichromate)
-                .fluidInputs(Dimethylbenzene.getFluid(1000))
-                .fluidInputs(Oxygen.getFluid(2000))
-                .fluidOutputs(PhthalicAcid.getFluid(1000))
-                .fluidOutputs(Water.getFluid(2000))
-                .buildAndRegister();
-
         LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(900)
                 .input(dust, PotassiumDichromate)
                 .fluidInputs(Dimethylbenzene.getFluid(9000))
                 .fluidInputs(Oxygen.getFluid(18000))
                 .fluidOutputs(PhthalicAcid.getFluid(9000))
                 .fluidOutputs(Water.getFluid(18000))
-                .buildAndRegister();
-
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(125)
-                .fluidInputs(Naphthalene.getFluid(2000))
-                .fluidInputs(SulfuricAcid.getFluid(1000))
-                .input(dustTiny, Potassium)
-                .fluidOutputs(PhthalicAcid.getFluid(2500))
-                .fluidOutputs(HydrogenSulfide.getFluid(1000))
                 .buildAndRegister();
 
         LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[LV]).duration(1125)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -366,7 +366,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .input(gem, Charcoal)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -374,7 +374,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .input(gem, Coal)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -382,7 +382,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .input(dust, Charcoal)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -391,7 +391,7 @@ public class ReactorRecipes {
                 .input(dust, Coal)
                 .circuitMeta(1)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .outputs(OreDictUnifier.get(dustTiny, Ash))
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .buildAndRegister();
 
@@ -436,7 +436,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(gem, Charcoal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -444,7 +444,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(gem, Coal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0))
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -452,7 +452,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(dust, Charcoal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -460,7 +460,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(dust, Coal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dustSmall, Ash, 5000, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -652,8 +652,8 @@ public class ReactorRecipes {
         CHEMICAL_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.GHAST_TEAR))
                 .fluidInputs(Water.getFluid(1000))
-                .output(dustTiny, Potassium)
-                .output(dustTiny, Lithium)
+                .chancedOutput(dustSmall, Potassium, 4444, 0)
+                .chancedOutput(dustSmall, Lithium, 4444, 0)
                 .fluidOutputs(SaltWater.getFluid(1000))
                 .duration(400).EUt(VA[LV]).buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -129,14 +129,14 @@ public class SeparationRecipes {
                 .inputs(new ItemStack(Blocks.DIRT, 1, GTValues.W))
                 .chancedOutput(PLANT_BALL, 1250, 700)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
-                .chancedOutput(dustTiny, Clay, 4000, 900)
+                .chancedOutput(dustSmall, Clay, 1777, 400)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.GRASS))
                 .chancedOutput(MetaItems.PLANT_BALL.getStackForm(), 3000, 1200)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
-                .chancedOutput(dustTiny, Clay, 5000, 900)
+                .chancedOutput(dustSmall, Clay, 2222, 400)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(650).EUt(VA[LV])
@@ -144,7 +144,7 @@ public class SeparationRecipes {
                 .chancedOutput(new ItemStack(Blocks.RED_MUSHROOM), 2500, 900)
                 .chancedOutput(new ItemStack(Blocks.BROWN_MUSHROOM), 2500, 900)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
-                .chancedOutput(dustTiny, Clay, 5000, 900)
+                .chancedOutput(dustSmall, Clay, 2222, 400)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(240).EUt(VA[LV])
@@ -152,9 +152,9 @@ public class SeparationRecipes {
                 .chancedOutput(dustSmall, Quicklime, 2, 9900, 0)
                 .chancedOutput(dustSmall, Potash, 6400, 0)
                 .chancedOutput(dustSmall, Magnesia, 6000, 0)
-                .chancedOutput(dustTiny, PhosphorusPentoxide, 500, 0)
-                .chancedOutput(dustTiny, SodaAsh, 5000, 0)
-                .chancedOutput(dustTiny, BandedIron, 2500, 0)
+                .chancedOutput(dustSmall, PhosphorusPentoxide, 222, 0)
+                .chancedOutput(dustSmall, SodaAsh, 2222, 0)
+                .chancedOutput(dustSmall, BandedIron, 1111, 0)
                 .buildAndRegister();
 
 
@@ -177,13 +177,13 @@ public class SeparationRecipes {
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(800).EUt(320)
                 .input(dust, Uranium238)
-                .chancedOutput(dustTiny, Plutonium239, 200, 80)
-                .chancedOutput(dustTiny, Uranium235, 2000, 350)
+                .chancedOutput(dustSmall, Plutonium239, 88, 15)
+                .chancedOutput(dustSmall, Uranium235, 888, 68)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(1600).EUt(320)
                 .input(dust, Plutonium239)
-                .chancedOutput(dustTiny, Uranium238, 3000, 450)
+                .chancedOutput(dustSmall, Uranium238, 1333, 88)
                 .chancedOutput(dust, Plutonium241, 2000, 300)
                 .buildAndRegister();
 
@@ -191,23 +191,23 @@ public class SeparationRecipes {
                 .input(dust, Endstone)
                 .chancedOutput(new ItemStack(Blocks.SAND), 9000, 300)
                 .chancedOutput(dustSmall, Tungstate, 1250, 450)
-                .chancedOutput(dustTiny, Platinum, 625, 150)
+                .chancedOutput(dustSmall, Platinum, 277, 29)
                 .fluidOutputs(Helium.getFluid(120))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(160).EUt(20)
                 .input(dust, Netherrack)
-                .chancedOutput(dustTiny, Redstone, 5625, 850)
-                .chancedOutput(dustTiny, Gold, 625, 120)
+                .chancedOutput(dustSmall, Redstone, 2500, 377)
+                .chancedOutput(dustSmall, Gold, 277, 53)
                 .chancedOutput(dustSmall, Sulfur, 9900, 100)
-                .chancedOutput(dustTiny, Coal, 5625, 850)
+                .chancedOutput(dustSmall, Coal, 2500, 377)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(80)
                 .inputs(new ItemStack(Blocks.SOUL_SAND))
                 .chancedOutput(new ItemStack(Blocks.SAND), 9000, 130)
                 .chancedOutput(dustSmall, Saltpeter, 8000, 480)
-                .chancedOutput(dustTiny, Coal, 2000, 340)
+                .chancedOutput(dustSmall, Coal, 888, 151)
                 .fluidOutputs(Oil.getFluid(80))
                 .buildAndRegister();
 
@@ -234,7 +234,7 @@ public class SeparationRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder().duration(50).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.SAND, 1, 1))
                 .chancedOutput(dust, Iron, 5000, 500)
-                .chancedOutput(dustTiny, Diamond, 100, 100)
+                .chancedOutput(dust, Diamond, 11, 11)
                 .chancedOutput(new ItemStack(Blocks.SAND, 1, 0), 5000, 5000)
                 .buildAndRegister();
 
@@ -276,20 +276,20 @@ public class SeparationRecipes {
                 .input(dust, Stone)
                 .output(dustSmall, Quartzite)
                 .output(dustSmall, PotassiumFeldspar)
-                .output(dustTiny, Marble, 2)
-                .output(dustTiny, Biotite)
-                .chancedOutput(dustTiny, MetalMixture, 7500, 750)
-                .chancedOutput(dustTiny, Sodalite, 5000, 500)
+                .output(dustSmall, Marble)
+                .chancedOutput(dustSmall, Biotite, 4444, 0)
+                .chancedOutput(dustSmall, MetalMixture, 3333, 333)
+                .chancedOutput(dustSmall, Sodalite, 2222, 222)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(1000).EUt(900)
                 .input(dust, MetalMixture)
                 .output(dustSmall, BandedIron)
                 .output(dustSmall, Bauxite)
-                .output(dustTiny, Pyrolusite, 2)
-                .output(dustTiny, Barite)
-                .chancedOutput(dustTiny, Chromite, 7500, 750)
-                .chancedOutput(dustTiny, Ilmenite, 5000, 500)
+                .output(dustSmall, Pyrolusite)
+                .chancedOutput(dustSmall, Barite, 4444, 0)
+                .chancedOutput(dustSmall, Chromite, 3333, 750)
+                .chancedOutput(dustSmall, Ilmenite, 2222, 500)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(60).EUt(VA[LV])


### PR DESCRIPTION
## What
Recipes resulting in 2 tiny dark ash dusts were changed to create 1 small dark ash dust. Recipes outputting 1 tiny ash dust were changed to have a 50% chance to output 1 small dark ash dust. Alternatively, I could change it to have a 44% chance which would be closer to the original ratio. Let me know if I should change this.

The recipe that resulted in 3 tiny antimony trioxide dusts was changed to have a 33% chance to output a full dust.

The meat maceration recipes were changed to have a 50% chance for a small bone dust.

Tungstate from endstone processing was changed from a 12% chance of getting a tiny dust to a 5.33% chance of getting a small dust.

Macerating soapstone was changed from a 10% chance of a tiny chromite dust to a 1.11% chance of getting a full chromite dust.

The flint and quartz sand recipe creating glass dust was changed to use 2 quartz sand dusts and 1 small flint dust to output 2 glass dust.

Lathing a tree sapling was changed to have a 50% chance of resulting in a small dust.

The ender air distillation recipe was changed from a 90% chance of a tiny ender pearl dust to a 10% chance of a full dust

The bacterial sludge recipe was changed to use a small uranium235/naquadria dust as input and 2250 mb (instead of 1000) of bacterial sludge to output 2250 mb of enriched bacterial sludge. The ratios stay the same and the duration was changed accordingly.

The lightly steam cracked heavy fuel now has a 44.44% chance of giving a small carbon dust.
The severely steam cracked heavy fuel now outputs a full carbon dust with a 33.33% chance.

The biodiesel recipes were multiplied by 2.25 so they could use a small dust instead of a tiny dust of sodium hydroxide. Alternatively these could use a full dust.

The phtalic acid recipe using tiny dusts was just removed in favor of using a full dust, same with dichlorobenzidine.

The ghast tear processing recipe now has a 44.4% chance of a small dust of lithium.

The dirt centrifuging recipe now has a 17.77% chance of a small clay dust instead of a 40% chance of a tiny dust.

A bunch of chanced seperation recipes were also changed to output small dusts instead of tiny dusts.

## Implementation Details
1 small dust = 2.25 tiny dusts.

## Outcome
Removes tiny dusts from recipes. Does not touch ore processing or recycling.

## Additional Information

## Potential Compatibility Issues
