### PR TITLE
fix info provider inaccuracy with boosted EUt

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -148,6 +148,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         return metaTileEntity.getExportFluids();
     }
 
+    /**
+     * @return true if energy is consumed by this Recipe Logic, otherwise false
+     */
+    public boolean consumesEnergy() {
+        return true;
+    }
+
     @Nonnull
     @Override
     public final String getName() {
@@ -803,6 +810,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      */
     public int getRecipeEUt() {
         return recipeEUt;
+    }
+
+    /**
+     * @return the current recipe's EU/t for TOP/Waila/Tricorder
+     */
+    public int getInfoProviderEUt() {
+        return getRecipeEUt();
     }
 
     /**

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -22,6 +22,11 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
     }
 
     @Override
+    public boolean consumesEnergy() {
+        return false;
+    }
+
+    @Override
     protected boolean hasEnoughPower(@Nonnull int[] resultOverclock) {
         // generators always have enough power to run recipes
         return true;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -76,6 +76,13 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         return Integer.MAX_VALUE;
     }
 
+    /**
+     * Boost the energy production.
+     * Should not change the state of the workable logic. Only read current values.
+     *
+     * @param production the energy amount to boost
+     * @return the boosted energy amount
+     */
     protected long boostProduction(long production) {
         return production;
     }
@@ -88,6 +95,16 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
             if (!simulate) getEnergyContainer().changeEnergy(-euToDraw);
             return true;
         } else return false;
+    }
+
+    @Override
+    public int getInfoProviderEUt() {
+        return (int) boostProduction(super.getInfoProviderEUt());
+    }
+
+    @Override
+    public boolean consumesEnergy() {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
@@ -163,15 +163,15 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity 
                 ));
             }
             // multi amp recipes: change 0 ? 0 : 1 to 0 ? 0 : amperage
-            if (workable.getRecipeEUt() > 0) {
+            if (workable.consumesEnergy()) {
                 list.add(new TextComponentTranslation("behavior.tricorder.workable_consumption",
-                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getRecipeEUt())).setStyle(new Style().setColor(TextFormatting.RED)),
-                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getRecipeEUt() == 0 ? 0 : 1)).setStyle(new Style().setColor(TextFormatting.RED))
+                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getInfoProviderEUt())).setStyle(new Style().setColor(TextFormatting.RED)),
+                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getInfoProviderEUt() == 0 ? 0 : 1)).setStyle(new Style().setColor(TextFormatting.RED))
                 ));
             } else {
                 list.add(new TextComponentTranslation("behavior.tricorder.workable_production",
-                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getRecipeEUt() * -1)).setStyle(new Style().setColor(TextFormatting.RED)),
-                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getRecipeEUt() == 0 ? 0 : 1)).setStyle(new Style().setColor(TextFormatting.RED))
+                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getInfoProviderEUt())).setStyle(new Style().setColor(TextFormatting.RED)),
+                        new TextComponentTranslation(TextFormattingUtil.formatNumbers(workable.getInfoProviderEUt() == 0 ? 0 : 1)).setStyle(new Style().setColor(TextFormatting.RED))
                 ));
             }
         }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -113,17 +113,17 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
                 new TextComponentTranslation(TextFormattingUtil.formatNumbers(energyContainer.getEnergyCapacity())).setStyle(new Style().setColor(TextFormatting.YELLOW))
         ));
 
-        if (recipeMapWorkable.getRecipeEUt() < 0) {
+        if (!recipeMapWorkable.consumesEnergy()) {
             list.add(new TextComponentTranslation("behavior.tricorder.workable_production",
-                    new TextComponentTranslation(TextFormattingUtil.formatNumbers(recipeMapWorkable.getRecipeEUt() * -1)).setStyle(new Style().setColor(TextFormatting.RED)),
-                    new TextComponentTranslation(TextFormattingUtil.formatNumbers(recipeMapWorkable.getRecipeEUt() == 0 ? 0 : 1)).setStyle(new Style().setColor(TextFormatting.RED))
+                    new TextComponentTranslation(TextFormattingUtil.formatNumbers(Math.abs(recipeMapWorkable.getInfoProviderEUt()))).setStyle(new Style().setColor(TextFormatting.RED)),
+                    new TextComponentTranslation(TextFormattingUtil.formatNumbers(recipeMapWorkable.getInfoProviderEUt() == 0 ? 0 : 1)).setStyle(new Style().setColor(TextFormatting.RED))
+            ));
+
+            list.add(new TextComponentTranslation("behavior.tricorder.multiblock_energy_output",
+                    new TextComponentTranslation(TextFormattingUtil.formatNumbers(energyContainer.getOutputVoltage())).setStyle(new Style().setColor(TextFormatting.YELLOW)),
+                    new TextComponentTranslation(GTValues.VN[GTUtility.getTierByVoltage(energyContainer.getOutputVoltage())]).setStyle(new Style().setColor(TextFormatting.YELLOW))
             ));
         }
-
-        list.add(new TextComponentTranslation("behavior.tricorder.multiblock_energy_output",
-                new TextComponentTranslation(TextFormattingUtil.formatNumbers(energyContainer.getOutputVoltage())).setStyle(new Style().setColor(TextFormatting.YELLOW)),
-                new TextComponentTranslation(GTValues.VN[GTUtility.getTierByVoltage(energyContainer.getOutputVoltage())]).setStyle(new Style().setColor(TextFormatting.YELLOW))
-        ));
 
         if (ConfigHolder.machines.enableMaintenance && hasMaintenanceMechanics()) {
             list.add(new TextComponentTranslation("behavior.tricorder.multiblock_maintenance",

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -40,7 +40,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
         NBTTagCompound subTag = new NBTTagCompound();
         subTag.setBoolean("Working", capability.isWorking());
         if (capability.isWorking()) {
-            subTag.setInteger("RecipeEUt", capability.getRecipeEUt());
+            subTag.setInteger("RecipeEUt", capability.getInfoProviderEUt());
         }
         tag.setTag("gregtech.AbstractRecipeLogic", subTag);
         return tag;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -38,7 +38,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             if (capability instanceof PrimitiveRecipeLogic) {
                 return; // do not show info for primitive machines, as they are supposed to appear powerless
             }
-            int EUt = capability.getRecipeEUt();
+            int EUt = capability.getInfoProviderEUt();
             int absEUt = Math.abs(EUt);
             String text = null;
 


### PR DESCRIPTION
## Outcome
Fixes TOP, Waila, and the Tricorder displaying incorrect EUt values for generators which boost their production.
