### PR TITLE
Fix fluid veins being lost when switching OS

### DIFF
--- a/src/main/java/gregtech/api/util/FileUtility.java
+++ b/src/main/java/gregtech/api/util/FileUtility.java
@@ -146,11 +146,9 @@ public class FileUtility {
      * @return A String of the File name at the end of the file path
      */
     public static String trimFileName(String name) {
-        FileSystem fs = FileSystems.getDefault();
-        String separator = fs.getSeparator();
 
         //Remove the leading "folderName\"
-        String[] tempName = name.split(Matcher.quoteReplacement(separator));
+        String[] tempName = name.split(Matcher.quoteReplacement("/"));
         //Take the last entry in case of nested folders
         String newName = tempName[tempName.length - 1];
         //Remove the ".json"

--- a/src/main/java/gregtech/api/util/FileUtility.java
+++ b/src/main/java/gregtech/api/util/FileUtility.java
@@ -146,9 +146,11 @@ public class FileUtility {
      * @return A String of the File name at the end of the file path
      */
     public static String trimFileName(String name) {
+        // this method is passed deposit names, which need to be converted first
+        name = slashToNativeSep(name);
 
         //Remove the leading "folderName\"
-        String[] tempName = name.split(Matcher.quoteReplacement("/"));
+        String[] tempName = name.split(Matcher.quoteReplacement(File.separator));
         //Take the last entry in case of nested folders
         String newName = tempName[tempName.length - 1];
         //Remove the ".json"
@@ -161,5 +163,23 @@ public class FileUtility {
         newName = newName.substring(0, 1).toUpperCase() + newName.substring(1);
 
         return newName;
+    }
+
+    /**
+     * Converts a path string from using the filesystem's native path separator to /
+     * <br>
+     * Useful for converting paths to consistent strings across operating systems
+     */
+    public static String nativeSepToSlash(String path) {
+        return path.replace(File.separatorChar, '/');
+    }
+
+    /**
+     * Converts a path string from using / to the filesystem's native path separator
+     * <br>
+     * Useful for allowing paths converted with {@link FileUtility#nativeSepToSlash(String)} to be used for file i/o
+     */
+    public static String slashToNativeSep(String path) {
+        return path.replace('/', File.separatorChar);
     }
 }

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -286,7 +287,7 @@ public class BedrockFluidVeinHandler {
             if (tag.hasKey("vein")) {
                 String s = tag.getString("vein");
                 for (BedrockFluidDepositDefinition definition : veinList.keySet()) {
-                    if (s.equalsIgnoreCase(definition.getDepositName()))
+                    if (s.replace(File.separatorChar, '/').equalsIgnoreCase(definition.getDepositName()))
                         info.vein = definition;
                 }
             }

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
@@ -2,10 +2,11 @@ package gregtech.api.worldgen.bedrockFluids;
 
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
-import gregtech.core.network.packets.PacketFluidVeinList;
+import gregtech.api.util.FileUtility;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.XSTR;
 import gregtech.api.worldgen.config.BedrockFluidDepositDefinition;
+import gregtech.core.network.packets.PacketFluidVeinList;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -17,7 +18,6 @@ import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -287,7 +287,8 @@ public class BedrockFluidVeinHandler {
             if (tag.hasKey("vein")) {
                 String s = tag.getString("vein");
                 for (BedrockFluidDepositDefinition definition : veinList.keySet()) {
-                    if (s.replace(File.separatorChar, '/').equalsIgnoreCase(definition.getDepositName()))
+                    // old save data can have deposit names with native separators, get rid of those
+                    if (FileUtility.nativeSepToSlash(s).equalsIgnoreCase(definition.getDepositName()))
                         info.vein = definition;
                 }
             }

--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -77,7 +77,10 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition {
         return true;
     }
 
-    //This is the file name
+    /**
+     * Must be converted using {@link gregtech.api.util.FileUtility#slashToNativeSep(String)}
+     * before it can be used as a file path
+     */
     @Override
     public String getDepositName() {
         return depositName;

--- a/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/IWorldgenDefinition.java
@@ -7,6 +7,10 @@ import javax.annotation.Nonnull;
 public interface IWorldgenDefinition {
 
     //This is the file name
+    /**
+     * Must be converted using {@link gregtech.api.util.FileUtility#slashToNativeSep(String)}
+     * before it can be used as a file path
+     */
     String getDepositName();
 
     boolean initializeFromConfig(@Nonnull JsonObject configRoot);

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -85,7 +85,10 @@ public class OreDepositDefinition implements IWorldgenDefinition {
         return true;
     }
 
-    //This is the file name
+    /**
+     * Must be converted using {@link gregtech.api.util.FileUtility#slashToNativeSep(String)}
+     * before it can be used as a file path
+     */
     @Override
     public String getDepositName() {
         return depositName;

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -29,7 +29,6 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.io.IOUtils;
 
 import javax.annotation.Nonnull;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -249,8 +248,8 @@ public class WorldGenRegistry {
                 break;
             }
 
-            // Finds the file name to create the Definition with
-            String depositName = veinPath.relativize(worldgenDefinition).toString().replace(File.separatorChar, '/');
+            // Finds the file name to create the Definition with, using a consistent separator character
+            String depositName = FileUtility.nativeSepToSlash(veinPath.relativize(worldgenDefinition).toString());
 
             try {
                 // Creates the deposit definition and initializes various components based on the json entries in the file
@@ -280,8 +279,8 @@ public class WorldGenRegistry {
                 break;
             }
 
-            // Finds the file name to create the Definition with
-            String depositName = bedrockVeinPath.relativize(worldgenDefinition).toString().replace(File.separatorChar, '/');
+            // Finds the file name to create the Definition with, using a consistent separator character
+            String depositName = FileUtility.nativeSepToSlash(bedrockVeinPath.relativize(worldgenDefinition).toString());
 
             try {
                 // Creates the deposit definition and initializes various components based on the json entries in the file
@@ -424,7 +423,7 @@ public class WorldGenRegistry {
 
     private static void removeExistingFiles(Path root, @Nonnull List<? extends IWorldgenDefinition> definitions) {
         for (IWorldgenDefinition definition : definitions) {
-            Path filePath = root.resolve(Paths.get(definition.getDepositName().replace('/', File.separatorChar)));
+            Path filePath = root.resolve(Paths.get(FileUtility.slashToNativeSep(definition.getDepositName())));
 
             try {
                 if (Files.exists(filePath)) {
@@ -442,7 +441,7 @@ public class WorldGenRegistry {
         while (it.hasNext()) {
             T definition = it.next();
 
-            JsonObject element = FileUtility.tryExtractFromFile(root.resolve(definition.getDepositName().replace('/', File.separatorChar)));
+            JsonObject element = FileUtility.tryExtractFromFile(root.resolve(FileUtility.slashToNativeSep(definition.getDepositName())));
 
             if (element == null) {
                 GTLog.logger.error("Addon mod tried to register bad ore definition at {}", definition.getDepositName());

--- a/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
+++ b/src/main/java/gregtech/api/worldgen/config/WorldGenRegistry.java
@@ -29,6 +29,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.io.IOUtils;
 
 import javax.annotation.Nonnull;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -249,7 +250,7 @@ public class WorldGenRegistry {
             }
 
             // Finds the file name to create the Definition with
-            String depositName = veinPath.relativize(worldgenDefinition).toString();
+            String depositName = veinPath.relativize(worldgenDefinition).toString().replace(File.separatorChar, '/');
 
             try {
                 // Creates the deposit definition and initializes various components based on the json entries in the file
@@ -280,7 +281,7 @@ public class WorldGenRegistry {
             }
 
             // Finds the file name to create the Definition with
-            String depositName = bedrockVeinPath.relativize(worldgenDefinition).toString();
+            String depositName = bedrockVeinPath.relativize(worldgenDefinition).toString().replace(File.separatorChar, '/');
 
             try {
                 // Creates the deposit definition and initializes various components based on the json entries in the file
@@ -423,7 +424,7 @@ public class WorldGenRegistry {
 
     private static void removeExistingFiles(Path root, @Nonnull List<? extends IWorldgenDefinition> definitions) {
         for (IWorldgenDefinition definition : definitions) {
-            Path filePath = root.resolve(Paths.get(definition.getDepositName()));
+            Path filePath = root.resolve(Paths.get(definition.getDepositName().replace('/', File.separatorChar)));
 
             try {
                 if (Files.exists(filePath)) {
@@ -441,7 +442,7 @@ public class WorldGenRegistry {
         while (it.hasNext()) {
             T definition = it.next();
 
-            JsonObject element = FileUtility.tryExtractFromFile(root.resolve(definition.getDepositName()));
+            JsonObject element = FileUtility.tryExtractFromFile(root.resolve(definition.getDepositName().replace('/', File.separatorChar)));
 
             if (element == null) {
                 GTLog.logger.error("Addon mod tried to register bad ore definition at {}", definition.getDepositName());


### PR DESCRIPTION
## What
Makes ore and fluid vein definitions use the same strings for their names on all operating systems.

## Implementation Details
hacky string replacements

## Outcome
Hopefully fixes #1555 

## Potential Compatibility Issues
Should be none, existing save data with non-normalized names will be automatically normalized when read
Do note this was not tested, I do not have easy access to a Windows machine
