### PR TITLE
separate MarkerMaterial from OreDictUnifier

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -16,6 +16,7 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.registry.IMaterialRegistryManager;
+import gregtech.api.unification.material.registry.MarkerMaterialRegistry;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.ore.StoneType;
 import gregtech.api.util.BaseCreativeTab;
@@ -55,6 +56,8 @@ public class GregTechAPI {
     public static ISoundManager soundManager;
     /** Will be available at the Construction stage */
     public static IMaterialRegistryManager materialManager;
+    /** Will be available at the Pre-Initialization stage */
+    public static MarkerMaterialRegistry markerMaterialRegistry;
 
     /** Will be available at the Pre-Initialization stage */
     private static boolean highTier;

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
-import gregtech.api.unification.material.MarkerMaterial;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.registry.MaterialRegistry;
@@ -38,8 +37,6 @@ public class OreDictUnifier {
 
     private OreDictUnifier() {}
 
-    //simple version of material registry for marker materials
-    private static final Map<String, MarkerMaterial> markerMaterialRegistry = new Object2ObjectOpenHashMap<>();
     private static final Map<ItemAndMetadata, ItemMaterialInfo> materialUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<ItemAndMetadata, UnificationEntry> stackUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<UnificationEntry, ArrayList<ItemAndMetadata>> stackUnificationItems = new Object2ObjectOpenHashMap<>();
@@ -66,13 +63,6 @@ public class OreDictUnifier {
     public static Comparator<ItemStack> getItemStackComparator() {
         Comparator<ItemAndMetadata> comparator = getSimpleItemStackComparator();
         return (first, second) -> comparator.compare(new ItemAndMetadata(first), new ItemAndMetadata(second));
-    }
-
-    public static void registerMarkerMaterial(MarkerMaterial markerMaterial) {
-        if (markerMaterialRegistry.containsKey(markerMaterial.toString())) {
-            throw new IllegalArgumentException(("Marker material with id " + markerMaterial + " is already registered!"));
-        }
-        markerMaterialRegistry.put(markerMaterial.toString(), markerMaterial);
     }
 
     public static void registerOre(ItemStack itemStack, ItemMaterialInfo materialInfo) {
@@ -149,8 +139,8 @@ public class OreDictUnifier {
                     String underscoreName = GTUtility.toLowerCaseUnderscore(possibleMaterialName); //basaltic_mineral_sand
                     Material possibleMaterial = registry.getObject(underscoreName); //Materials.BasalticSand
                     if (possibleMaterial == null) {
-                        //if we didn't found real material, try using marker material registry
-                        possibleMaterial = markerMaterialRegistry.get(underscoreName);
+                        //if we didn't find real material, try using marker material registry
+                        possibleMaterial = GregTechAPI.markerMaterialRegistry.getMarkerMaterial(underscoreName);
                     }
                     if (maybePrefix != null && possibleMaterial != null) {
                         orePrefix = maybePrefix;

--- a/src/main/java/gregtech/api/unification/material/MarkerMaterial.java
+++ b/src/main/java/gregtech/api/unification/material/MarkerMaterial.java
@@ -1,7 +1,8 @@
 package gregtech.api.unification.material;
 
-import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.GregTechAPI;
 import gregtech.api.util.GTUtility;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 
@@ -13,9 +14,19 @@ import javax.annotation.Nonnull;
  */
 public final class MarkerMaterial extends Material {
 
-    public MarkerMaterial(@Nonnull String name) {
+    private MarkerMaterial(@Nonnull String name) {
         super(GTUtility.gregtechId(name));
-        OreDictUnifier.registerMarkerMaterial(this);
+    }
+
+    /**
+     * Create a new MarkerMaterial
+     *
+     * @param name the name of the MarkerMaterial
+     * @return the new MarkerMaterial
+     */
+    public static @NotNull MarkerMaterial create(@NotNull String name) {
+        MarkerMaterial markerMaterial = new MarkerMaterial(name);
+        return GregTechAPI.markerMaterialRegistry.registerMarkerMaterial(markerMaterial);
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/material/MarkerMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/MarkerMaterials.java
@@ -16,7 +16,7 @@ public class MarkerMaterials {
     /**
      * Marker materials without category
      */
-    public static final MarkerMaterial Empty = new MarkerMaterial("empty");
+    public static final MarkerMaterial Empty = MarkerMaterial.create("empty");
 
     /**
      * Color materials
@@ -28,29 +28,29 @@ public class MarkerMaterials {
          * Means absence of color on OrePrefix
          * Often a default value for color prefixes
          */
-        public static final MarkerMaterial Colorless = new MarkerMaterial("colorless");
+        public static final MarkerMaterial Colorless = MarkerMaterial.create("colorless");
 
-        public static final MarkerMaterial White = new MarkerMaterial("white");
-        public static final MarkerMaterial Orange = new MarkerMaterial("orange");
-        public static final MarkerMaterial Magenta = new MarkerMaterial("magenta");
-        public static final MarkerMaterial LightBlue = new MarkerMaterial("light_blue");
-        public static final MarkerMaterial Yellow = new MarkerMaterial("yellow");
-        public static final MarkerMaterial Lime = new MarkerMaterial("lime");
-        public static final MarkerMaterial Pink = new MarkerMaterial("pink");
-        public static final MarkerMaterial Gray = new MarkerMaterial("gray");
-        public static final MarkerMaterial LightGray = new MarkerMaterial("light_gray");
-        public static final MarkerMaterial Cyan = new MarkerMaterial("cyan");
-        public static final MarkerMaterial Purple = new MarkerMaterial("purple");
-        public static final MarkerMaterial Blue = new MarkerMaterial("blue");
-        public static final MarkerMaterial Brown = new MarkerMaterial("brown");
-        public static final MarkerMaterial Green = new MarkerMaterial("green");
-        public static final MarkerMaterial Red = new MarkerMaterial("red");
-        public static final MarkerMaterial Black = new MarkerMaterial("black");
+        public static final MarkerMaterial White = MarkerMaterial.create("white");
+        public static final MarkerMaterial Orange = MarkerMaterial.create("orange");
+        public static final MarkerMaterial Magenta = MarkerMaterial.create("magenta");
+        public static final MarkerMaterial LightBlue = MarkerMaterial.create("light_blue");
+        public static final MarkerMaterial Yellow = MarkerMaterial.create("yellow");
+        public static final MarkerMaterial Lime = MarkerMaterial.create("lime");
+        public static final MarkerMaterial Pink = MarkerMaterial.create("pink");
+        public static final MarkerMaterial Gray = MarkerMaterial.create("gray");
+        public static final MarkerMaterial LightGray = MarkerMaterial.create("light_gray");
+        public static final MarkerMaterial Cyan = MarkerMaterial.create("cyan");
+        public static final MarkerMaterial Purple = MarkerMaterial.create("purple");
+        public static final MarkerMaterial Blue = MarkerMaterial.create("blue");
+        public static final MarkerMaterial Brown = MarkerMaterial.create("brown");
+        public static final MarkerMaterial Green = MarkerMaterial.create("green");
+        public static final MarkerMaterial Red = MarkerMaterial.create("red");
+        public static final MarkerMaterial Black = MarkerMaterial.create("black");
 
         /**
          * Arrays containing all possible color values (without Colorless!)
          */
-        public static final MarkerMaterial[] VALUES = new MarkerMaterial[]{
+        public static final MarkerMaterial[] VALUES = {
                 White, Orange, Magenta, LightBlue, Yellow, Lime, Pink, Gray, LightGray, Cyan, Purple, Blue, Brown, Green, Red, Black
         };
 
@@ -84,30 +84,30 @@ public class MarkerMaterials {
      * Circuitry, batteries and other technical things
      */
     public static class Tier {
-        public static final Material ULV = new MarkerMaterial(GTValues.VN[GTValues.ULV].toLowerCase());
-        public static final Material LV = new MarkerMaterial(GTValues.VN[GTValues.LV].toLowerCase());
-        public static final Material MV = new MarkerMaterial(GTValues.VN[GTValues.MV].toLowerCase());
-        public static final Material HV = new MarkerMaterial(GTValues.VN[GTValues.HV].toLowerCase());
-        public static final Material EV = new MarkerMaterial(GTValues.VN[GTValues.EV].toLowerCase());
-        public static final Material IV = new MarkerMaterial(GTValues.VN[GTValues.IV].toLowerCase());
-        public static final Material LuV = new MarkerMaterial(GTValues.VN[GTValues.LuV].toLowerCase());
-        public static final Material ZPM = new MarkerMaterial(GTValues.VN[GTValues.ZPM].toLowerCase());
-        public static final Material UV = new MarkerMaterial(GTValues.VN[GTValues.UV].toLowerCase());
-        public static final Material UHV = new MarkerMaterial(GTValues.VN[GTValues.UHV].toLowerCase());
+        public static final Material ULV = MarkerMaterial.create(GTValues.VN[GTValues.ULV].toLowerCase());
+        public static final Material LV = MarkerMaterial.create(GTValues.VN[GTValues.LV].toLowerCase());
+        public static final Material MV = MarkerMaterial.create(GTValues.VN[GTValues.MV].toLowerCase());
+        public static final Material HV = MarkerMaterial.create(GTValues.VN[GTValues.HV].toLowerCase());
+        public static final Material EV = MarkerMaterial.create(GTValues.VN[GTValues.EV].toLowerCase());
+        public static final Material IV = MarkerMaterial.create(GTValues.VN[GTValues.IV].toLowerCase());
+        public static final Material LuV = MarkerMaterial.create(GTValues.VN[GTValues.LuV].toLowerCase());
+        public static final Material ZPM = MarkerMaterial.create(GTValues.VN[GTValues.ZPM].toLowerCase());
+        public static final Material UV = MarkerMaterial.create(GTValues.VN[GTValues.UV].toLowerCase());
+        public static final Material UHV = MarkerMaterial.create(GTValues.VN[GTValues.UHV].toLowerCase());
 
-        public static final Material UEV = new MarkerMaterial(GTValues.VN[GTValues.UEV].toLowerCase());
-        public static final Material UIV = new MarkerMaterial(GTValues.VN[GTValues.UIV].toLowerCase());
-        public static final Material UXV = new MarkerMaterial(GTValues.VN[GTValues.UXV].toLowerCase());
-        public static final Material OpV = new MarkerMaterial(GTValues.VN[GTValues.OpV].toLowerCase());
-        public static final Material MAX = new MarkerMaterial(GTValues.VN[GTValues.MAX].toLowerCase());
+        public static final Material UEV = MarkerMaterial.create(GTValues.VN[GTValues.UEV].toLowerCase());
+        public static final Material UIV = MarkerMaterial.create(GTValues.VN[GTValues.UIV].toLowerCase());
+        public static final Material UXV = MarkerMaterial.create(GTValues.VN[GTValues.UXV].toLowerCase());
+        public static final Material OpV = MarkerMaterial.create(GTValues.VN[GTValues.OpV].toLowerCase());
+        public static final Material MAX = MarkerMaterial.create(GTValues.VN[GTValues.MAX].toLowerCase());
     }
 
     public static class Component {
-        public static final Material Resistor = new MarkerMaterial("resistor");
-        public static final Material Transistor = new MarkerMaterial("transistor");
-        public static final Material Capacitor = new MarkerMaterial("capacitor");
-        public static final Material Diode = new MarkerMaterial("diode");
-        public static final Material Inductor = new MarkerMaterial("inductor");
+        public static final Material Resistor = MarkerMaterial.create("resistor");
+        public static final Material Transistor = MarkerMaterial.create("transistor");
+        public static final Material Capacitor = MarkerMaterial.create("capacitor");
+        public static final Material Diode = MarkerMaterial.create("diode");
+        public static final Material Inductor = MarkerMaterial.create("inductor");
     }
 
 }

--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -127,7 +127,7 @@ public class Materials {
         EXT2_METAL.addAll(Arrays.asList(GENERATE_LONG_ROD, GENERATE_BOLT_SCREW));
     }
 
-    public static final MarkerMaterial NULL = new MarkerMaterial("null");
+    public static final MarkerMaterial NULL = MarkerMaterial.create("null");
 
     /**
      * Direct Elements

--- a/src/main/java/gregtech/api/unification/material/registry/MarkerMaterialRegistry.java
+++ b/src/main/java/gregtech/api/unification/material/registry/MarkerMaterialRegistry.java
@@ -1,0 +1,43 @@
+package gregtech.api.unification.material.registry;
+
+import gregtech.api.unification.material.MarkerMaterial;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public class MarkerMaterialRegistry {
+
+    private final Map<String, MarkerMaterial> map = new Object2ObjectOpenHashMap<>();
+
+    /**
+     * @param markerMaterial the MarkerMaterial to register
+     * @return the registered MarkerMaterial
+     */
+    public @NotNull MarkerMaterial registerMarkerMaterial(@NotNull MarkerMaterial markerMaterial) {
+        MarkerMaterial existing = map.get(markerMaterial.getName());
+        if (existing != null) return existing;
+
+        map.put(markerMaterial.getName(), markerMaterial);
+        return markerMaterial;
+    }
+
+    /**
+     * @param name the name of the MarkerMaterial
+     * @return the MarkerMaterial associated with the name
+     */
+    public @Nullable MarkerMaterial getMarkerMaterial(@NotNull String name) {
+        return map.get(name);
+    }
+
+    /**
+     * @return all registered marker materials
+     */
+    public @NotNull @UnmodifiableView Collection<@NotNull MarkerMaterial> getAll() {
+        return Collections.unmodifiableCollection(map.values());
+    }
+}

--- a/src/main/java/gregtech/api/unification/material/registry/MarkerMaterialRegistry.java
+++ b/src/main/java/gregtech/api/unification/material/registry/MarkerMaterialRegistry.java
@@ -10,9 +10,20 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-public class MarkerMaterialRegistry {
+public final class MarkerMaterialRegistry {
+
+    private static MarkerMaterialRegistry INSTANCE;
 
     private final Map<String, MarkerMaterial> map = new Object2ObjectOpenHashMap<>();
+
+    private MarkerMaterialRegistry() {}
+
+    public static MarkerMaterialRegistry getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new MarkerMaterialRegistry();
+        }
+        return INSTANCE;
+    }
 
     /**
      * @param markerMaterial the MarkerMaterial to register

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -23,6 +23,7 @@ import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.event.MaterialEvent;
 import gregtech.api.unification.material.event.MaterialRegistryEvent;
 import gregtech.api.unification.material.event.PostMaterialEvent;
+import gregtech.api.unification.material.registry.MarkerMaterialRegistry;
 import gregtech.api.util.CapesRegistry;
 import gregtech.api.util.VirtualTankRegistry;
 import gregtech.api.util.input.KeyBind;
@@ -122,6 +123,8 @@ public class CoreModule implements IGregTechModule {
         SimpleCapabilityManager.init();
 
         /* Start Material Registration */
+
+        GregTechAPI.markerMaterialRegistry = new MarkerMaterialRegistry();
 
         // First, register other mods' Registries
         MaterialRegistryManager managerInternal = (MaterialRegistryManager) GregTechAPI.materialManager;

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -13,9 +13,8 @@ import gregtech.api.items.gui.PlayerInventoryUIFactory;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
 import gregtech.api.modules.GregTechModule;
 import gregtech.api.modules.IGregTechModule;
-import gregtech.api.pipenet.longdist.LongDistanceNetwork;
-import gregtech.api.recipes.ModHandler;
 import gregtech.api.pipenet.longdist.LongDistancePipeType;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 import gregtech.api.unification.OreDictUnifier;
@@ -124,7 +123,7 @@ public class CoreModule implements IGregTechModule {
 
         /* Start Material Registration */
 
-        GregTechAPI.markerMaterialRegistry = new MarkerMaterialRegistry();
+        GregTechAPI.markerMaterialRegistry = MarkerMaterialRegistry.getInstance();
 
         // First, register other mods' Registries
         MaterialRegistryManager managerInternal = (MaterialRegistryManager) GregTechAPI.materialManager;

--- a/src/test/java/gregtech/Bootstrap.java
+++ b/src/test/java/gregtech/Bootstrap.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.fluids.MetaFluids;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.material.registry.MarkerMaterialRegistry;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.items.MetaItems;
 import gregtech.core.unification.material.internal.MaterialRegistryManager;
@@ -62,6 +63,7 @@ public final class Bootstrap {
 
         MaterialRegistryManager managerInternal = MaterialRegistryManager.getInstance();
         GregTechAPI.materialManager = managerInternal;
+        GregTechAPI.markerMaterialRegistry = MarkerMaterialRegistry.getInstance();
         managerInternal.unfreezeRegistries();
         Materials.register();
         managerInternal.closeRegistries();


### PR DESCRIPTION
## What
Refactors MarkerMaterials into a new registry independent of `OreDictUnifier`. This refactor also allows for multiple mods registering a MarkerMaterial with the same name, which would previously hard crash.

## Outcome
Separates `MarkerMaterial` registration from `OreDictUnifier`.

## Potential Compatibility Issues
MarkerMaterials must now be created using `MarkerMaterial.create()`.
Registration of MarkerMaterials is now automatic, and the methods to do so in OreDictUnifier have been removed.
