### PR TITLE
fix server crash with groovyscript multiblocks

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -215,6 +215,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
         getBaseTexture(null).render(renderState, translation, ArrayUtils.add(pipeline, new ColourMultiplier(GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()))));
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(getBaseTexture(null).getParticleSprite(), getPaintingColorForRendering());


### PR DESCRIPTION
## What
Fixes this the client-side only method `getParticleTexture()` being loaded on the server when GroovyScript classes extend `RecipeMapMultiblockController`. This is caused by the `@SideOnly` annotation not being inherited automatically for method overrides, as the super method does have correctly have the annotation.

## Outcome
Fixes GregTechCEu/GregTech-Community-Pack#92.
