### PR TITLE
Autogenerate Wood Pipe recipes

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/CraftingRecipeLoader.java
@@ -40,14 +40,6 @@ public class CraftingRecipeLoader {
         ToolRecipeHandler.registerPowerUnitRecipes();
         ToolRecipeHandler.registerCustomToolRecipes();
 
-        ModHandler.addShapedRecipe("small_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeSmallFluid, Materials.Wood), "sWr", 'W', new UnificationEntry(OrePrefix.plank, Materials.Wood));
-        ModHandler.addShapedRecipe("normal_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeNormalFluid, Materials.Wood), "WWW", "s r", 'W', new UnificationEntry(OrePrefix.plank, Materials.Wood));
-        ModHandler.addShapedRecipe("large_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeLargeFluid, Materials.Wood), "WWW", "s r", "WWW", 'W', new UnificationEntry(OrePrefix.plank, Materials.Wood));
-
-        ModHandler.addShapedRecipe("small_treated_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeSmallFluid, Materials.TreatedWood), "sWr", 'W', new UnificationEntry(OrePrefix.plank, Materials.TreatedWood));
-        ModHandler.addShapedRecipe("normal_treated_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeNormalFluid, Materials.TreatedWood), "WWW", "s r", 'W', new UnificationEntry(OrePrefix.plank, Materials.TreatedWood));
-        ModHandler.addShapedRecipe("large_treated_wooden_pipe", OreDictUnifier.get(OrePrefix.pipeLargeFluid, Materials.TreatedWood), "WWW", "s r", "WWW", 'W', new UnificationEntry(OrePrefix.plank, Materials.TreatedWood));
-
         ModHandler.addShapelessRecipe("integrated_circuit", IntCircuitIngredient.getIntegratedCircuit(0), new UnificationEntry(OrePrefix.circuit, Tier.LV));
 
         ModHandler.addShapedRecipe("item_filter", ITEM_FILTER.getStackForm(), "XXX", "XYX", "XXX", 'X', new UnificationEntry(OrePrefix.foil, Materials.Zinc), 'Y', new UnificationEntry(OrePrefix.plate, Materials.Steel));

--- a/src/main/java/gregtech/loaders/recipe/chemistry/AssemblerRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/AssemblerRecipeLoader.java
@@ -125,50 +125,6 @@ public class AssemblerRecipeLoader {
                 .output(TOOL_MATCHES, 4)
                 .duration(64).EUt(16).buildAndRegister();
 
-        // Wood Pipes
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
-                .input(plate, Wood)
-                .circuitMeta(12)
-                .fluidInputs(Glue.getFluid(50))
-                .output(pipeSmallFluid, Wood)
-                .buildAndRegister();
-
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
-                .input(plate, Wood, 3)
-                .circuitMeta(6)
-                .fluidInputs(Glue.getFluid(20))
-                .output(pipeNormalFluid, Wood)
-                .buildAndRegister();
-
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
-                .input(plate, Wood, 6)
-                .circuitMeta(2)
-                .fluidInputs(Glue.getFluid(10))
-                .output(pipeLargeFluid, Wood)
-                .buildAndRegister();
-				
-        // Treated Wood Pipes
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
-                .input(plate, TreatedWood)
-                .circuitMeta(12)
-                .fluidInputs(Glue.getFluid(50))
-                .output(pipeSmallFluid, TreatedWood)
-                .buildAndRegister();
-
-        ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
-                .input(plate, TreatedWood, 3)
-                .circuitMeta(6)
-                .fluidInputs(Glue.getFluid(20))
-                .output(pipeNormalFluid, TreatedWood)
-                .buildAndRegister();
-
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
-                .input(plate, TreatedWood, 6)
-                .circuitMeta(2)
-                .fluidInputs(Glue.getFluid(10))
-                .output(pipeLargeFluid, TreatedWood)
-                .buildAndRegister();
-
         // Voltage Coils
         ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[ULV])
                 .input(stick, IronMagnetic)

--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -100,7 +100,7 @@ public class PipeRecipeHandler {
                         .input(plate, material)
                         .circuitMeta(18)
                         .fluidInputs(Glue.getFluid(50))
-                        .output(pipePrefix, material)
+                        .output(pipePrefix, material, 2)
                         .buildAndRegister();
             }
             else {

--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -66,13 +66,17 @@ public class PipeRecipeHandler {
 
     private static void processPipeTiny(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material, 1)
-                .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_TINY)
-                .outputs(GTUtility.copy(2, pipeStack))
-                .duration((int) (material.getMass()))
-                .EUt(6 * getVoltageMultiplier(material))
-                .buildAndRegister();
+
+        // Some pipes like wood do not have an ingot
+        if (!OrePrefix.ingot.isIgnored(material)) {
+            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.ingot, material, 1)
+                    .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_TINY)
+                    .outputs(GTUtility.copy(2, pipeStack))
+                    .duration((int) (material.getMass()))
+                    .EUt(6 * getVoltageMultiplier(material))
+                    .buildAndRegister();
+        }
 
         if (material.hasFlag(NO_SMASHING)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
@@ -83,21 +87,31 @@ public class PipeRecipeHandler {
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
-            ModHandler.addShapedRecipe(String.format("tiny_%s_pipe", material),
-                    GTUtility.copy(2, pipeStack), " s ", "hXw",
-                    'X', new UnificationEntry(OrePrefix.plate, material));
+            if (ModHandler.isMaterialWood(material)) {
+                ModHandler.addShapedRecipe(String.format("tiny_%s_pipe", material),
+                        GTUtility.copy(2, pipeStack), " s ", "rXw",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            }
+            else {
+                ModHandler.addShapedRecipe(String.format("tiny_%s_pipe", material),
+                        GTUtility.copy(2, pipeStack), " s ", "hXw",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            }
         }
     }
 
     private static void processPipeSmall(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material, 1)
-                .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_SMALL)
-                .outputs(pipeStack)
-                .duration((int) (material.getMass()))
-                .EUt(6 * getVoltageMultiplier(material))
-                .buildAndRegister();
+
+        if (!OrePrefix.ingot.isIgnored(material)) {
+            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.ingot, material, 1)
+                    .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_SMALL)
+                    .outputs(pipeStack)
+                    .duration((int) (material.getMass()))
+                    .EUt(6 * getVoltageMultiplier(material))
+                    .buildAndRegister();
+        }
 
         if (material.hasFlag(NO_SMASHING)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
@@ -108,21 +122,31 @@ public class PipeRecipeHandler {
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
-            ModHandler.addShapedRecipe(String.format("small_%s_pipe", material),
-                    pipeStack, "wXh",
-                    'X', new UnificationEntry(OrePrefix.plate, material));
+            if (ModHandler.isMaterialWood(material)) {
+                ModHandler.addShapedRecipe(String.format("small_%s_pipe", material),
+                        pipeStack, "wXr",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+
+            } else {
+                ModHandler.addShapedRecipe(String.format("small_%s_pipe", material),
+                        pipeStack, "wXh",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            }
         }
     }
 
     private static void processPipeNormal(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material, 3)
-                .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_NORMAL)
-                .outputs(pipeStack)
-                .duration((int) material.getMass() * 3)
-                .EUt(6 * getVoltageMultiplier(material))
-                .buildAndRegister();
+
+        if (!OrePrefix.ingot.isIgnored(material)) {
+            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.ingot, material, 3)
+                    .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_NORMAL)
+                    .outputs(pipeStack)
+                    .duration((int) material.getMass() * 3)
+                    .EUt(6 * getVoltageMultiplier(material))
+                    .buildAndRegister();
+        }
 
         if (material.hasFlag(NO_SMASHING)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
@@ -133,21 +157,30 @@ public class PipeRecipeHandler {
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
-            ModHandler.addShapedRecipe(String.format("medium_%s_pipe", material),
-                    pipeStack, "XXX", "w h",
-                    'X', new UnificationEntry(OrePrefix.plate, material));
+            if (ModHandler.isMaterialWood(material)) {
+                ModHandler.addShapedRecipe(String.format("medium_%s_pipe", material),
+                        pipeStack, "XXX", "w r",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            } else {
+                ModHandler.addShapedRecipe(String.format("medium_%s_pipe", material),
+                        pipeStack, "XXX", "w h",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            }
         }
     }
 
     private static void processPipeLarge(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material, 6)
-                .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_LARGE)
-                .outputs(pipeStack)
-                .duration((int) material.getMass() * 6)
-                .EUt(6 * getVoltageMultiplier(material))
-                .buildAndRegister();
+
+        if (!OrePrefix.ingot.isIgnored(material)) {
+            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.ingot, material, 6)
+                    .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_LARGE)
+                    .outputs(pipeStack)
+                    .duration((int) material.getMass() * 6)
+                    .EUt(6 * getVoltageMultiplier(material))
+                    .buildAndRegister();
+        }
 
         if (material.hasFlag(NO_SMASHING)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
@@ -158,21 +191,31 @@ public class PipeRecipeHandler {
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else {
-            ModHandler.addShapedRecipe(String.format("large_%s_pipe", material),
-                    pipeStack, "XXX", "w h", "XXX",
-                    'X', new UnificationEntry(OrePrefix.plate, material));
+            if (ModHandler.isMaterialWood(material)) {
+                ModHandler.addShapedRecipe(String.format("large_%s_pipe", material),
+                        pipeStack, "XXX", "w r", "XXX",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            }
+            else {
+                ModHandler.addShapedRecipe(String.format("large_%s_pipe", material),
+                        pipeStack, "XXX", "w h", "XXX",
+                        'X', new UnificationEntry(OrePrefix.plate, material));
+            }
         }
     }
 
     private static void processPipeHuge(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
-        RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material, 12)
-                .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_HUGE)
-                .outputs(pipeStack)
-                .duration((int) material.getMass() * 24)
-                .EUt(6 * getVoltageMultiplier(material))
-                .buildAndRegister();
+
+        if (!OrePrefix.ingot.isIgnored(material)) {
+            RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.ingot, material, 12)
+                    .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_HUGE)
+                    .outputs(pipeStack)
+                    .duration((int) material.getMass() * 24)
+                    .EUt(6 * getVoltageMultiplier(material))
+                    .buildAndRegister();
+        }
 
         if (material.hasFlag(NO_SMASHING)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
@@ -183,9 +226,16 @@ public class PipeRecipeHandler {
                     .EUt(6 * getVoltageMultiplier(material))
                     .buildAndRegister();
         } else if (OrePrefix.plateDouble.doGenerateItem(material)) {
-            ModHandler.addShapedRecipe(String.format("huge_%s_pipe", material),
-                    pipeStack, "XXX", "w h", "XXX",
-                    'X', new UnificationEntry(OrePrefix.plateDouble, material));
+            if (ModHandler.isMaterialWood(material)) {
+                ModHandler.addShapedRecipe(String.format("huge_%s_pipe", material),
+                        pipeStack, "XXX", "w r", "XXX",
+                        'X', new UnificationEntry(OrePrefix.plateDouble, material));
+            }
+            else {
+                ModHandler.addShapedRecipe(String.format("huge_%s_pipe", material),
+                        pipeStack, "XXX", "w h", "XXX",
+                        'X', new UnificationEntry(OrePrefix.plateDouble, material));
+            }
         }
     }
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -99,7 +99,7 @@ public class PipeRecipeHandler {
                 ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                         .input(plate, material)
                         .circuitMeta(18)
-                        .fluidInputs(Glue.getFluid(50))
+                        .fluidInputs(Glue.getFluid(10))
                         .output(pipePrefix, material, 2)
                         .buildAndRegister();
             }
@@ -141,7 +141,7 @@ public class PipeRecipeHandler {
                 ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
                         .input(plate, material)
                         .circuitMeta(12)
-                        .fluidInputs(Glue.getFluid(50))
+                        .fluidInputs(Glue.getFluid(10))
                         .output(pipePrefix, material)
                         .buildAndRegister();
 
@@ -225,7 +225,7 @@ public class PipeRecipeHandler {
                 ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                         .input(plate, material, 6)
                         .circuitMeta(2)
-                        .fluidInputs(Glue.getFluid(10))
+                        .fluidInputs(Glue.getFluid(50))
                         .output(pipePrefix, material)
                         .buildAndRegister();
             }
@@ -267,7 +267,7 @@ public class PipeRecipeHandler {
                 ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
                         .input(plateDouble, material, 6)
                         .circuitMeta(24)
-                        .fluidInputs(Glue.getFluid(10))
+                        .fluidInputs(Glue.getFluid(100))
                         .output(pipePrefix, material)
                         .buildAndRegister();
             }

--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -17,7 +17,11 @@ import gregtech.common.items.MetaItems;
 import net.minecraft.item.ItemStack;
 
 import static gregtech.api.GTValues.*;
+import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
+import static gregtech.api.unification.material.Materials.Glue;
 import static gregtech.api.unification.material.info.MaterialFlags.NO_SMASHING;
+import static gregtech.api.unification.ore.OrePrefix.plate;
+import static gregtech.api.unification.ore.OrePrefix.plateDouble;
 
 public class PipeRecipeHandler {
 
@@ -91,6 +95,13 @@ public class PipeRecipeHandler {
                 ModHandler.addShapedRecipe(String.format("tiny_%s_pipe", material),
                         GTUtility.copy(2, pipeStack), " s ", "rXw",
                         'X', new UnificationEntry(OrePrefix.plate, material));
+
+                ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
+                        .input(plate, material)
+                        .circuitMeta(18)
+                        .fluidInputs(Glue.getFluid(50))
+                        .output(pipePrefix, material)
+                        .buildAndRegister();
             }
             else {
                 ModHandler.addShapedRecipe(String.format("tiny_%s_pipe", material),
@@ -127,6 +138,13 @@ public class PipeRecipeHandler {
                         pipeStack, "wXr",
                         'X', new UnificationEntry(OrePrefix.plate, material));
 
+                ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
+                        .input(plate, material)
+                        .circuitMeta(12)
+                        .fluidInputs(Glue.getFluid(50))
+                        .output(pipePrefix, material)
+                        .buildAndRegister();
+
             } else {
                 ModHandler.addShapedRecipe(String.format("small_%s_pipe", material),
                         pipeStack, "wXh",
@@ -161,6 +179,14 @@ public class PipeRecipeHandler {
                 ModHandler.addShapedRecipe(String.format("medium_%s_pipe", material),
                         pipeStack, "XXX", "w r",
                         'X', new UnificationEntry(OrePrefix.plate, material));
+
+                ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
+                        .input(plate, material, 3)
+                        .circuitMeta(6)
+                        .fluidInputs(Glue.getFluid(20))
+                        .output(pipePrefix, material)
+                        .buildAndRegister();
+
             } else {
                 ModHandler.addShapedRecipe(String.format("medium_%s_pipe", material),
                         pipeStack, "XXX", "w h",
@@ -195,6 +221,13 @@ public class PipeRecipeHandler {
                 ModHandler.addShapedRecipe(String.format("large_%s_pipe", material),
                         pipeStack, "XXX", "w r", "XXX",
                         'X', new UnificationEntry(OrePrefix.plate, material));
+
+                ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
+                        .input(plate, material, 6)
+                        .circuitMeta(2)
+                        .fluidInputs(Glue.getFluid(10))
+                        .output(pipePrefix, material)
+                        .buildAndRegister();
             }
             else {
                 ModHandler.addShapedRecipe(String.format("large_%s_pipe", material),
@@ -230,6 +263,13 @@ public class PipeRecipeHandler {
                 ModHandler.addShapedRecipe(String.format("huge_%s_pipe", material),
                         pipeStack, "XXX", "w r", "XXX",
                         'X', new UnificationEntry(OrePrefix.plateDouble, material));
+
+                ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
+                        .input(plateDouble, material, 6)
+                        .circuitMeta(24)
+                        .fluidInputs(Glue.getFluid(10))
+                        .output(pipePrefix, material)
+                        .buildAndRegister();
             }
             else {
                 ModHandler.addShapedRecipe(String.format("huge_%s_pipe", material),


### PR DESCRIPTION
## What
Moves Wood pipe recipes to be auto generated, with the correct tool, and removes the manually added recipes. The recipes have been auto generating since #1792, so we can take advantage of that now.


## Outcome
Fix duplicate wood pipe recipes, stop manually generating
