### PR TITLE
Fix Magnetic Tools ignoring Void Satchels

### DIFF
--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -17,6 +17,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.block.BlockPipe;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.pipenet.tile.TileEntityPipeBase;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TaskScheduler;
 import net.minecraft.block.Block;
@@ -26,6 +27,7 @@ import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -43,6 +45,8 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.DrawBlockHighlightEvent;
 import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
@@ -54,6 +58,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 import javax.annotation.Nonnull;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -159,7 +164,17 @@ public class ToolEventHandlers {
                 }
             }
             if (behaviorTag.getBoolean(ToolHelper.RELOCATE_MINED_BLOCKS_KEY)) {
-                event.getDrops().removeIf(player::addItemStackToInventory);
+
+                Iterator<ItemStack> dropItr = event.getDrops().iterator();
+                while (dropItr.hasNext()) {
+                    ItemStack dropStack = dropItr.next();
+                    EntityItem drop = new EntityItem(event.getWorld());
+                    drop.setItem(dropStack);
+
+                    if (ForgeEventFactory.onItemPickup(drop, player) == -1 || player.addItemStackToInventory(dropStack)) {
+                        dropItr.remove();
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## What
Fixes GT tools with the magnetic property ignoring the void satchel from Thermal Expansion.

## Implementation Details
Fires the `EntityItemPickupEvent` event so that TE's logic has a chance to be called.

## Outcome
GT Tools with the magnetic property properly respect the void satchel when it's enabled

## Potential Compatibility Issues
none afaik
