### PR TITLE
fix machine explosions sometimes dropping the block

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -290,7 +290,6 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
         MetaTileEntity metaTileEntity = tileEntities.get() == null ? getMetaTileEntity(world, pos) : tileEntities.get();
         if (metaTileEntity == null) return;
-        if (metaTileEntity.wasExploded()) return;
         if (!metaTileEntity.shouldDropWhenDestroyed()) return;
         ItemStack itemStack = metaTileEntity.getStackForm();
         NBTTagCompound tagCompound = new NBTTagCompound();

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -290,8 +290,8 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     public void getDrops(@Nonnull NonNullList<ItemStack> drops, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull IBlockState state, int fortune) {
         MetaTileEntity metaTileEntity = tileEntities.get() == null ? getMetaTileEntity(world, pos) : tileEntities.get();
         if (metaTileEntity == null) return;
-        if (!metaTileEntity.shouldDropWhenDestroyed())
-            return;
+        if (metaTileEntity.wasExploded()) return;
+        if (!metaTileEntity.shouldDropWhenDestroyed()) return;
         ItemStack itemStack = metaTileEntity.getStackForm();
         NBTTagCompound tagCompound = new NBTTagCompound();
         metaTileEntity.writeItemStackData(tagCompound);

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -118,6 +118,8 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     private int cachedLightValue;
     protected boolean isFragile = false;
 
+    private boolean wasExploded = false;
+
     private final CoverBehavior[] coverBehaviors = new CoverBehavior[6];
     protected List<IItemHandlerModifiable> notifiedItemOutputList = new ArrayList<>();
     protected List<IItemHandlerModifiable> notifiedItemInputList = new ArrayList<>();
@@ -1447,9 +1449,24 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public void doExplosion(float explosionPower) {
+        setExploded();
         getWorld().setBlockToAir(getPos());
         getWorld().createExplosion(null, getPos().getX() + 0.5, getPos().getY() + 0.5, getPos().getZ() + 0.5,
                 explosionPower, ConfigHolder.machines.doesExplosionDamagesTerrain);
+    }
+
+    /**
+     * Mark the MTE as having been blown up by an explosion
+     */
+    protected void setExploded() {
+        this.wasExploded = true;
+    }
+
+    /**
+     * @return if the MTE was blown up by an explosion
+     */
+    public boolean wasExploded() {
+        return this.wasExploded;
     }
 
     public void setOnFire(double additionalFireChance) {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1354,7 +1354,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public boolean shouldDropWhenDestroyed() {
-        return !wasExploded() || !isFragile();
+        return !wasExploded() && !isFragile();
     }
 
     public float getBlockHardness() {
@@ -1458,7 +1458,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     /**
      * Mark the MTE as having been blown up by an explosion
      */
-    protected void setExploded() {
+    protected final void setExploded() {
         this.wasExploded = true;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1354,7 +1354,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public boolean shouldDropWhenDestroyed() {
-        return !isFragile();
+        return !wasExploded() || !isFragile();
     }
 
     public float getBlockHardness() {
@@ -1465,7 +1465,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     /**
      * @return if the MTE was blown up by an explosion
      */
-    public boolean wasExploded() {
+    protected final boolean wasExploded() {
         return this.wasExploded;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/hpca/MetaTileEntityHPCAComponent.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/hpca/MetaTileEntityHPCAComponent.java
@@ -220,7 +220,7 @@ public abstract class MetaTileEntityHPCAComponent extends MetaTileEntityMultiblo
 
     @Override
     public boolean shouldDropWhenDestroyed() {
-        return !(canBeDamaged() && isDamaged());
+        return super.shouldDropWhenDestroyed() && !(canBeDamaged() && isDamaged());
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes machine explosions sometimes dropping the machine on the ground, despite having set the block to air. This is caused by the MTE held in the `ThreadLocal` for block drops not consistently being garbage collected after removal from the `World`.

## Outcome
Fixes machine explosions sometimes dropping the block when it should not.
