### PR TITLE
Fix Miner Logic not resetting when finished

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -689,7 +689,7 @@ public class MinerLogic {
             this.isWorkingEnabled = isWorkingEnabled;
             metaTileEntity.markDirty();
             if (metaTileEntity.getWorld() != null && !metaTileEntity.getWorld().isRemote) {
-                if (!isWorkingEnabled && checkCanMine()) resetArea();
+                if (!isWorkingEnabled) resetArea();
 
                 this.metaTileEntity.writeCustomData(GregtechDataCodes.WORKING_ENABLED, buf -> buf.writeBoolean(isWorkingEnabled));
             }


### PR DESCRIPTION
## What
Fix Miner Logic not being resettable when the miner is finished mining all ores

## Implementation Details
Removes `checkCanMine()` from the if check for resetting the area to mine

## Outcome
Large Miners (and single-block miners) will reset their mining area if they finished working and there are more blocks to mine

## Potential Compatibility Issues
none
