### PR TITLE
Fix tool durability issues

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -156,7 +156,8 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         ToolProperty toolProperty = material.getProperty(PropertyKey.TOOL);
 
         // Durability formula we are working with:
-        // Final Durability = (material durability * material durability multiplier) + (tool definition durability * definition durability multiplier)
+        // Final Durability = (material durability * material durability multiplier) + (tool definition durability * definition durability multiplier) - 1
+        // Subtracts 1 internally since Minecraft treats "0" as a valid durability, but we don't want to display this.
 
         int durability = toolProperty.getToolDurability() * toolProperty.getDurabilityMultiplier();
 
@@ -167,7 +168,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
             durability += toolStats.getBaseDurability(stack) * toolStats.getDurabilityMultiplier(stack);
         }
 
-        toolTag.setInteger(MAX_DURABILITY_KEY, durability);
+        toolTag.setInteger(MAX_DURABILITY_KEY, durability - 1);
         toolTag.setInteger(DURABILITY_KEY, 0);
         if (toolProperty.getUnbreakable()) {
             stackCompound.setBoolean(UNBREAKABLE_KEY, true);
@@ -667,12 +668,12 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
 
         // durability info
         if (!tagCompound.getBoolean(UNBREAKABLE_KEY)) {
-            int damageRemaining = tool.getTotalMaxDurability(stack) - stack.getItemDamage();
+            // Plus 1 to match vanilla behavior where tools can still be used once at zero durability. We want to not show this
+            int damageRemaining = tool.getTotalMaxDurability(stack) - stack.getItemDamage() + 1;
             if (toolStats.isSuitableForCrafting(stack)) {
                 tooltip.add(I18n.format("item.gt.tool.tooltip.crafting_uses", TextFormattingUtil.formatNumbers(damageRemaining / Math.max(1, toolStats.getToolDamagePerCraft(stack)))));
             }
 
-            // Plus 1 to match vanilla behavior where tools can still be used once at zero durability
             tooltip.add(I18n.format("item.gt.tool.tooltip.general_uses", TextFormattingUtil.formatNumbers(damageRemaining)));
         }
 


### PR DESCRIPTION
Does two things:
- Subtracts `1` from the total tool durability. This is to account for MC treating 0 durability as not yet broken, effectively giving tools 1 extra durability
- Displays durability with `1` durability added. This makes things seem normal, and will keep tools from showing `0 uses left` or similar.

This fix was done to retain consistency with MC tools internally for better logic, but to fix tools having 1 extra use (detrimental for crafting tools, which are intended to have crafting uses in clean multiples for easily handling stacks) and displaying `0 uses left` when there is actually 1 use left