### PR TITLE
Fix tools tab missing search bar

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -78,7 +78,7 @@ public class GregTechAPI {
     public static final BaseCreativeTab TAB_GREGTECH_PIPES =
             new BaseCreativeTab(GTValues.MODID + ".pipes", () -> OreDictUnifier.get(OrePrefix.pipeNormalFluid, Materials.Aluminium), true);
     public static final BaseCreativeTab TAB_GREGTECH_TOOLS =
-            new BaseCreativeTab(GTValues.MODID + ".tools", () -> ToolItems.HARD_HAMMER.get(Materials.Aluminium), false);
+            new BaseCreativeTab(GTValues.MODID + ".tools", () -> ToolItems.HARD_HAMMER.get(Materials.Aluminium), true);
     public static final BaseCreativeTab TAB_GREGTECH_MATERIALS =
             new BaseCreativeTab(GTValues.MODID + ".materials", () -> OreDictUnifier.get(OrePrefix.ingot, Materials.Aluminium), true);
     public static final BaseCreativeTab TAB_GREGTECH_ORES =


### PR DESCRIPTION
This was probably done intentionally, since the tab is relatively small in item count. However, since it is the only GT tab without a search bar, it felt more out of place to be missing it, so I added it back