### PR TITLE
Fix Super/Qauntum Tanks losing Locked status

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -188,6 +188,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         }
 
         this.lockedFluid = FluidStack.loadFluidStackFromNBT(tag.getCompoundTag("LockedFluid"));
+        this.locked = this.lockedFluid != null;
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes super/quantum tanks from losing their locked status when loading stack nbt (placing a locked qtank down)

## Implementation Details
sets locked state to true if lockedFluid is not null.

## Outcome
Placing configured qtanks don't lose their locked state.

