### PR TITLE
Allow material blocks to be burned

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -378,7 +378,7 @@ public class UnknownCompositionMaterials {
         Wood = new Material.Builder(1617, gregtechId("wood"))
                 .wood()
                 .color(0x896727).iconSet(WOOD)
-                .flags(GENERATE_PLATE, GENERATE_ROD, GENERATE_BOLT_SCREW, GENERATE_LONG_ROD, FLAMMABLE, GENERATE_GEAR, GENERATE_FRAME)
+                .flags(GENERATE_PLATE, GENERATE_ROD, GENERATE_BOLT_SCREW, GENERATE_LONG_ROD, GENERATE_GEAR, GENERATE_FRAME)
                 .fluidPipeProperties(340, 5, false)
                 .build();
 
@@ -486,7 +486,7 @@ public class UnknownCompositionMaterials {
         TreatedWood = new Material.Builder(1648, gregtechId("treated_wood"))
                 .wood()
                 .color(0x674A28).iconSet(WOOD)
-                .flags(GENERATE_PLATE, FLAMMABLE, GENERATE_ROD, GENERATE_FRAME)
+                .flags(GENERATE_PLATE, GENERATE_ROD, GENERATE_FRAME)
                 .fluidPipeProperties(340, 10, false)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/properties/WoodProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/WoodProperty.java
@@ -1,5 +1,6 @@
 package gregtech.api.unification.material.properties;
 
+import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.unification.ore.OrePrefix;
 
 public class WoodProperty implements IMaterialProperty {
@@ -7,6 +8,7 @@ public class WoodProperty implements IMaterialProperty {
     @Override
     public void verifyProperty(MaterialProperties properties) {
         properties.ensureSet(PropertyKey.DUST);
+        properties.getMaterial().addFlags(MaterialFlags.FLAMMABLE);
 
         if (properties.hasProperty(PropertyKey.FLUID_PIPE)) {
             OrePrefix.pipeTinyFluid.setIgnored(properties.getMaterial());

--- a/src/main/java/gregtech/common/blocks/BlockMaterialBase.java
+++ b/src/main/java/gregtech/common/blocks/BlockMaterialBase.java
@@ -1,8 +1,8 @@
 package gregtech.common.blocks;
 
-import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.properties.PropertyMaterial;
 import net.minecraft.block.Block;
@@ -97,7 +97,7 @@ public abstract class BlockMaterialBase extends Block {
     @Override
     public int getFlammability(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
         Material material = getGtMaterial(world.getBlockState(pos));
-        if (ModHandler.isMaterialWood(material)) {
+        if (material.hasFlag(MaterialFlags.FLAMMABLE)) {
             return 20; // flammability of things like Wood Planks
         }
         return super.getFlammability(world, pos, face);

--- a/src/main/java/gregtech/common/blocks/BlockMaterialBase.java
+++ b/src/main/java/gregtech/common/blocks/BlockMaterialBase.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks;
 
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
@@ -10,6 +11,7 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -90,5 +92,14 @@ public abstract class BlockMaterialBase extends Block {
     @SuppressWarnings("deprecation")
     public MapColor getMapColor(@Nonnull IBlockState state, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos) {
         return getMaterial(state).getMaterialMapColor();
+    }
+
+    @Override
+    public int getFlammability(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+        Material material = getGtMaterial(world.getBlockState(pos));
+        if (ModHandler.isMaterialWood(material)) {
+            return 20; // flammability of things like Wood Planks
+        }
+        return super.getFlammability(world, pos, face);
     }
 }

--- a/src/main/java/gregtech/common/blocks/BlockMaterialBase.java
+++ b/src/main/java/gregtech/common/blocks/BlockMaterialBase.java
@@ -102,4 +102,13 @@ public abstract class BlockMaterialBase extends Block {
         }
         return super.getFlammability(world, pos, face);
     }
+
+    @Override
+    public int getFireSpreadSpeed(@Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing face) {
+        Material material = getGtMaterial(world.getBlockState(pos));
+        if (material.hasFlag(MaterialFlags.FLAMMABLE)) {
+            return 5; // encouragement of things like Wood Planks
+        }
+        return super.getFireSpreadSpeed(world, pos, face);
+    }
 }


### PR DESCRIPTION
Allow Wooden material blocks to be burned, like Wood Frames. Generalized in `BlockMaterialBase` so any material block with a `WoodProperty` material can be burned. Used the internal burn value of vanilla Planks.