### PR TITLE
Fix bedrock fluid vein sizes

### DIFF
--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
@@ -28,14 +28,15 @@ public class BedrockFluidVeinHandler {
     public final static LinkedHashMap<BedrockFluidDepositDefinition, Integer> veinList = new LinkedHashMap<>();
     private final static Map<Integer, HashMap<Integer, Integer>> totalWeightMap = new HashMap<>();
     public static HashMap<ChunkPosDimension, FluidVeinWorldEntry> veinCache = new HashMap<>();
-    public static int saveDataVersion;
-
 
     /**
      * 1: Original version
      * <br>
      * 2: Fixed interpretation of coordinates around axes
      */
+    public static int saveDataVersion;
+
+
     public static final int MAX_FLUID_SAVE_DATA_VERSION = 2;
 
     public static final int VEIN_CHUNK_SIZE = 8; // veins are 8x8 chunk squares

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinHandler.java
@@ -28,6 +28,15 @@ public class BedrockFluidVeinHandler {
     public final static LinkedHashMap<BedrockFluidDepositDefinition, Integer> veinList = new LinkedHashMap<>();
     private final static Map<Integer, HashMap<Integer, Integer>> totalWeightMap = new HashMap<>();
     public static HashMap<ChunkPosDimension, FluidVeinWorldEntry> veinCache = new HashMap<>();
+    public static int saveDataVersion;
+
+
+    /**
+     * 1: Original version
+     * <br>
+     * 2: Fixed interpretation of coordinates around axes
+     */
+    public static final int MAX_FLUID_SAVE_DATA_VERSION = 2;
 
     public static final int VEIN_CHUNK_SIZE = 8; // veins are 8x8 chunk squares
 
@@ -46,13 +55,13 @@ public class BedrockFluidVeinHandler {
         if (world.isRemote)
             return null;
 
-        ChunkPosDimension coords = new ChunkPosDimension(world.provider.getDimension(), chunkX / VEIN_CHUNK_SIZE, chunkZ / VEIN_CHUNK_SIZE);
+        ChunkPosDimension coords = new ChunkPosDimension(world.provider.getDimension(), getVeinCoord(chunkX), getVeinCoord(chunkZ));
 
         FluidVeinWorldEntry worldEntry = veinCache.get(coords);
         if (worldEntry == null) {
             BedrockFluidDepositDefinition definition = null;
 
-            int query = world.getChunk(chunkX / VEIN_CHUNK_SIZE, chunkZ / VEIN_CHUNK_SIZE).getRandomWithSeed(90210).nextInt();
+            int query = world.getChunk(getVeinCoord(chunkX), getVeinCoord(chunkZ)).getRandomWithSeed(90210).nextInt();
 
             Biome biome = world.getBiomeForCoordsBody(new BlockPos(chunkX << 4, 64, chunkZ << 4));
             int totalWeight = getTotalWeight(world.provider, biome);
@@ -230,6 +239,13 @@ public class BedrockFluidVeinHandler {
             info.decreaseOperations(definition.getDepletionAmount());
             BedrockFluidVeinSaveData.setDirty();
         }
+    }
+
+    public static int getVeinCoord(int chunkCoord) {
+        if (saveDataVersion >= 2) {
+            return Math.floorDiv(chunkCoord, VEIN_CHUNK_SIZE);
+        }
+        return chunkCoord / VEIN_CHUNK_SIZE;
     }
 
     public static class FluidVeinWorldEntry {

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
@@ -31,6 +31,14 @@ public class BedrockFluidVeinSaveData extends WorldSavedData {
                 BedrockFluidVeinHandler.veinCache.put(coords, info);
             }
         }
+
+        if (nbt.hasKey("version")) {
+            BedrockFluidVeinHandler.saveDataVersion = nbt.getInteger("version");
+        }
+        else {
+            // version number was added to the save data with version 2
+            BedrockFluidVeinHandler.saveDataVersion = 1;
+        }
     }
 
     @Override
@@ -45,6 +53,7 @@ public class BedrockFluidVeinSaveData extends WorldSavedData {
             }
         }
         nbt.setTag("veinInfo", oilList);
+        nbt.setInteger("version", BedrockFluidVeinHandler.saveDataVersion);
 
         return nbt;
     }

--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
@@ -34,8 +34,7 @@ public class BedrockFluidVeinSaveData extends WorldSavedData {
 
         if (nbt.hasKey("version")) {
             BedrockFluidVeinHandler.saveDataVersion = nbt.getInteger("version");
-        }
-        else {
+        } else {
             // version number was added to the save data with version 2
             BedrockFluidVeinHandler.saveDataVersion = 1;
         }

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -278,6 +278,8 @@ public class CoreModule implements IGregTechModule {
                 if (saveData == null) {
                     saveData = new BedrockFluidVeinSaveData(BedrockFluidVeinSaveData.dataName);
                     world.setData(BedrockFluidVeinSaveData.dataName, saveData);
+                    // the save data does not yet exist, use the latest version number
+                    BedrockFluidVeinHandler.saveDataVersion = BedrockFluidVeinHandler.MAX_FLUID_SAVE_DATA_VERSION;
                 }
                 BedrockFluidVeinSaveData.setInstance(saveData);
             }


### PR DESCRIPTION
## What
Makes newly generated bedrock fluid veins use corrected calculations for their size 

## Implementation Details
`Math.floorDiv()`

## Outcome
All new worlds will have 8x8 veins everywhere, worlds where veins have already generated will continue to have the old, broken, vein sizes.

## Potential Compatibility Issues
none
