### PR TITLE
Fix fluid pipes from vanilla materials

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -72,7 +72,7 @@ public class PipeRecipeHandler {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
 
         // Some pipes like wood do not have an ingot
-        if (!OrePrefix.ingot.isIgnored(material)) {
+        if (material.hasProperty(PropertyKey.INGOT)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material, 1)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_TINY)
@@ -114,7 +114,7 @@ public class PipeRecipeHandler {
     private static void processPipeSmall(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
 
-        if (!OrePrefix.ingot.isIgnored(material)) {
+        if (material.hasProperty(PropertyKey.INGOT)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material, 1)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_SMALL)
@@ -156,7 +156,7 @@ public class PipeRecipeHandler {
     private static void processPipeNormal(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
 
-        if (!OrePrefix.ingot.isIgnored(material)) {
+        if (material.hasProperty(PropertyKey.INGOT)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material, 3)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_NORMAL)
@@ -198,7 +198,7 @@ public class PipeRecipeHandler {
     private static void processPipeLarge(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
 
-        if (!OrePrefix.ingot.isIgnored(material)) {
+        if (material.hasProperty(PropertyKey.INGOT)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material, 6)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_LARGE)
@@ -240,7 +240,7 @@ public class PipeRecipeHandler {
     private static void processPipeHuge(OrePrefix pipePrefix, Material material, IMaterialProperty property) {
         ItemStack pipeStack = OreDictUnifier.get(pipePrefix, material);
 
-        if (!OrePrefix.ingot.isIgnored(material)) {
+        if (material.hasProperty(PropertyKey.INGOT)) {
             RecipeMaps.EXTRUDER_RECIPES.recipeBuilder()
                     .input(OrePrefix.ingot, material, 12)
                     .notConsumable(MetaItems.SHAPE_EXTRUDER_PIPE_HUGE)


### PR DESCRIPTION
## What
Fixes fluid pipe extruder recipes from vanilla materials.

Vanilla materials with ingots have the ingot prefix set ignored, so we don't generate two of the same ingots. This means that pipes made from these materials would not get extruder recipes. 

Changes the check to check if the material has the ingot property. This will still exclude wood, as intended, but keep the extruder recipes for those vanilla materials.


## Outcome
Fix pipe extruder recipes for vanilla materials.
