### PR TITLE
Fix TextFieldWidget server-side classloading issue

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/TextFieldWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TextFieldWidget.java
@@ -3,11 +3,11 @@ package gregtech.api.gui.widgets;
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.gui.resources.IGuiTexture;
+import gregtech.api.util.MCGuiUtil;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.GuiPageButtonList;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.network.PacketBuffer;
@@ -45,7 +45,7 @@ public class TextFieldWidget extends Widget {
             this.textField.setCanLoseFocus(true);
             this.textField.setEnableBackgroundDrawing(enableBackground);
             this.textField.setMaxStringLength(this.maxStringLength);
-            this.textField.setGuiResponder(new Responder());
+            this.textField.setGuiResponder(MCGuiUtil.createTextFieldResponder(this::onTextChanged));
         }
         this.textSupplier = textSupplier;
         this.textResponder = textResponder;
@@ -64,7 +64,7 @@ public class TextFieldWidget extends Widget {
             this.textField.setEnableBackgroundDrawing(enableBackground);
             this.textField.setMaxStringLength(maxStringLength);
             this.maxStringLength = maxStringLength;
-            this.textField.setGuiResponder(new Responder());
+            this.textField.setGuiResponder(MCGuiUtil.createTextFieldResponder(this::onTextChanged));
         }
         this.textSupplier = textSupplier;
         this.textResponder = textResponder;
@@ -79,7 +79,7 @@ public class TextFieldWidget extends Widget {
             this.textField.setCanLoseFocus(true);
             this.textField.setEnableBackgroundDrawing(false);
             this.textField.setMaxStringLength(maxStringLength);
-            this.textField.setGuiResponder(new Responder());
+            this.textField.setGuiResponder(MCGuiUtil.createTextFieldResponder(this::onTextChanged));
         }
         this.background = background;
         this.textSupplier = textSupplier;
@@ -236,19 +236,5 @@ public class TextFieldWidget extends Widget {
             this.textField.setValidator(validator::test);
         }
         return this;
-    }
-
-    private class Responder implements GuiPageButtonList.GuiResponder {
-
-        @Override
-        public void setEntryValue(int id, boolean value) {}
-
-        @Override
-        public void setEntryValue(int id, float value) {}
-
-        @Override
-        public void setEntryValue(int id, String value) {
-            onTextChanged(value);
-        }
     }
 }

--- a/src/main/java/gregtech/api/util/MCGuiUtil.java
+++ b/src/main/java/gregtech/api/util/MCGuiUtil.java
@@ -1,0 +1,28 @@
+package gregtech.api.util;
+
+import net.minecraft.client.gui.GuiPageButtonList.GuiResponder;
+
+import javax.annotation.Nonnull;
+import java.util.function.Consumer;
+
+public class MCGuiUtil {
+
+    public static GuiResponder createTextFieldResponder(Consumer<String> onChanged) {
+        return new GuiResponder() {
+            @Override
+            public void setEntryValue(int id, boolean value) {
+            }
+
+            @Override
+            public void setEntryValue(int id, float value) {
+            }
+
+            @Override
+            public void setEntryValue(int id, @Nonnull String value) {
+                onChanged.accept(value);
+            }
+        };
+    }
+
+
+}

--- a/src/main/java/gregtech/api/util/MCGuiUtil.java
+++ b/src/main/java/gregtech/api/util/MCGuiUtil.java
@@ -5,6 +5,10 @@ import net.minecraft.client.gui.GuiPageButtonList.GuiResponder;
 import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
+/**
+ * This class exists to avoid java always trying to load client classes when loading {@link gregtech.api.gui.widgets.TextFieldWidget}.
+ * Do not remove
+ */
 public class MCGuiUtil {
 
     public static GuiResponder createTextFieldResponder(Consumer<String> onChanged) {


### PR DESCRIPTION
## What
Fixes #1981 by partially reverting #1712 

## Outcome
Ender fluid link guis can be opened on servers again

## Additional Information
classloading :waaaahhhh:
No, making it its own method in `TextFieldWidget` does not work. It has to be a separate class. Is there a better place to put this?