### PR TITLE
Fix perfect OC getting stuck at 2 or 3 ticks

### DIFF
--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -32,6 +32,9 @@ public class OverclockingLogic {
         double resultVoltage = recipeEUt;
 
         for (; numberOfOCs > 0; numberOfOCs--) {
+            // make sure that duration is not already as low as it can do
+            if (resultDuration == 1) break;
+
             // it is important to do voltage first,
             // so overclocking voltage does not go above the limit before changing duration
 
@@ -41,7 +44,7 @@ public class OverclockingLogic {
 
             double potentialDuration = resultDuration / durationDivisor;
             // do not allow duration to go below one tick
-            if (potentialDuration < 1) break;
+            if (potentialDuration < 1) potentialDuration = 1;
             // update the duration for the next iteration
             resultDuration = potentialDuration;
 


### PR DESCRIPTION
Closes #1967 

The overclocking logic checked if the `currentDuration / durationDivisor` was less than 1 to ensure it doesn't accidentally set the duration to 0 ticks or overclock too many times. However, in cases where `currentDuration` is either 2 or 3, and the divisor is 4 (perfect OC), it would not overclock because it would have made it 0 ticks