### PR TITLE
Add a proper harvest tool and level to power substation batteries

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockBatteryPart.java
+++ b/src/main/java/gregtech/common/blocks/BlockBatteryPart.java
@@ -2,6 +2,7 @@ package gregtech.common.blocks;
 
 import gregtech.api.GTValues;
 import gregtech.api.block.VariantBlock;
+import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.metatileentity.multiblock.IBatteryData;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -27,6 +28,7 @@ public class BlockBatteryPart extends VariantBlock<BlockBatteryPart.BatteryPartT
         setHardness(5.0f);
         setResistance(10.0f);
         setSoundType(SoundType.METAL);
+        setHarvestLevel(ToolClasses.WRENCH, 3); // Diamond level, can be mined by a steel wrench or better
         setDefaultState(getState(BatteryPartType.EMPTY_TIER_I));
     }
 


### PR DESCRIPTION
## What
Add a proper harvest tool and level to power substation batteries

## Implementation Details
It uses the wrench and a diamond harvest level, which can be mined by a steel wrench or better. This could be feasably changed to ultimet though.

## Outcome
Adds a proper harvest tool and level to the power substation batteries, instead of using the default of a pick.

## Additional Information
![image](https://github.com/GregTechCEu/GregTech/assets/46023024/7af0c781-2129-4832-86ac-6bfdec1f4de0)

## Potential Compatibility Issues
none that i can think of