### PR TITLE
Fix ME Hatches Parallel and Voiding or Dupeing

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FluidTankList.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidTankList.java
@@ -21,8 +21,6 @@ public class FluidTankList implements IMultipleTankHandler, INBTSerializable<NBT
     private final MultiFluidTankEntry[] fluidTanks;
     private final boolean allowSameFluidFill;
 
-    private IFluidTankProperties[] fluidTankProperties;
-
     public FluidTankList(boolean allowSameFluidFill, IFluidTank... fluidTanks) {
         ArrayList<MultiFluidTankEntry> list = new ArrayList<>();
         for (IFluidTank tank : fluidTanks) list.add(wrapIntoEntry(tank));
@@ -68,14 +66,11 @@ public class FluidTankList implements IMultipleTankHandler, INBTSerializable<NBT
     @Nonnull
     @Override
     public IFluidTankProperties[] getTankProperties() {
-        if (fluidTankProperties == null) {
-            ArrayList<IFluidTankProperties> propertiesList = new ArrayList<>();
-            for (MultiFluidTankEntry fluidTank : fluidTanks) {
-                Collections.addAll(propertiesList, fluidTank.getTankProperties());
-            }
-            this.fluidTankProperties = propertiesList.toArray(new IFluidTankProperties[0]);
+        ArrayList<IFluidTankProperties> propertiesList = new ArrayList<>();
+        for (MultiFluidTankEntry fluidTank : fluidTanks) {
+            Collections.addAll(propertiesList, fluidTank.getTankProperties());
         }
-        return fluidTankProperties;
+        return propertiesList.toArray(new IFluidTankProperties[0]);
     }
 
     @Override

--- a/src/main/java/gregtech/common/gui/widget/appeng/AEConfigWidget.java
+++ b/src/main/java/gregtech/common/gui/widget/appeng/AEConfigWidget.java
@@ -82,6 +82,7 @@ public abstract class AEConfigWidget<T extends IAEStack<T>> extends AbstractWidg
             if (!areAEStackCountEquals(nConfig, oConfig) || !areAEStackCountEquals(nStock, oStock)) {
                 this.changeMap.put(index, newSlot.copy());
                 this.cached[index] = this.config[index].copy();
+                this.gui.holder.markAsDirty();
             }
         }
         if (!this.changeMap.isEmpty()) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
@@ -35,6 +35,9 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.FluidTankProperties;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -242,7 +245,7 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
         list.addAll(Arrays.asList(this.aeFluidTanks));
     }
 
-    public static class ExportOnlyAEFluid extends ExportOnlyAESlot<IAEFluidStack> implements IFluidTank, INotifiableHandler {
+    public static class ExportOnlyAEFluid extends ExportOnlyAESlot<IAEFluidStack> implements IFluidTank, INotifiableHandler, IFluidHandler {
         private final List<MetaTileEntity> notifiableEntities = new ArrayList<>();
         private MetaTileEntity holder;
 
@@ -322,8 +325,24 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
         }
 
         @Override
+        public IFluidTankProperties[] getTankProperties() {
+            return new IFluidTankProperties[] {
+                    new FluidTankProperties(this.getFluid(), 0)
+            };
+        }
+
+        @Override
         public int fill(FluidStack resource, boolean doFill) {
             return 0;
+        }
+
+        @Nullable
+        @Override
+        public FluidStack drain(FluidStack resource, boolean doDrain) {
+            if (this.getFluid() != null && this.getFluid().isFluidEqual(resource)) {
+                return this.drain(resource.amount, doDrain);
+            }
+            return null;
         }
 
         @Nullable

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
@@ -245,7 +245,7 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
         list.addAll(Arrays.asList(this.aeFluidTanks));
     }
 
-    public static class ExportOnlyAEFluid extends ExportOnlyAESlot<IAEFluidStack> implements IFluidTank, IFluidHandler, INotifiableHandler {
+    public static class ExportOnlyAEFluid extends ExportOnlyAESlot<IAEFluidStack> implements IFluidTank, INotifiableHandler {
         private final List<MetaTileEntity> notifiableEntities = new ArrayList<>();
 
         public ExportOnlyAEFluid(IAEFluidStack config, IAEFluidStack stock, MetaTileEntity mte) {
@@ -323,24 +323,8 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
         }
 
         @Override
-        public IFluidTankProperties[] getTankProperties() {
-            return new IFluidTankProperties[] {
-                    new FluidTankProperties(this.getFluid(), 0)
-            };
-        }
-
-        @Override
         public int fill(FluidStack resource, boolean doFill) {
             return 0;
-        }
-
-        @Nullable
-        @Override
-        public FluidStack drain(FluidStack resource, boolean doDrain) {
-            if (this.getFluid() != null && this.getFluid().isFluidEqual(resource)) {
-                return this.drain(resource.amount, doDrain);
-            }
-            return null;
         }
 
         @Nullable

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
@@ -35,9 +35,6 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
-import net.minecraftforge.fluids.capability.FluidTankProperties;
-import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -67,7 +64,7 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
     protected void initializeInventory() {
         this.aeFluidTanks = new ExportOnlyAEFluid[CONFIG_SIZE];
         for (int i = 0; i < CONFIG_SIZE; i ++) {
-            this.aeFluidTanks[i] = new ExportOnlyAEFluid(null, null, this.getController());
+            this.aeFluidTanks[i] = new ExportOnlyAEFluid(this, null, null, this.getController());
         }
         super.initializeInventory();
     }
@@ -247,9 +244,11 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
 
     public static class ExportOnlyAEFluid extends ExportOnlyAESlot<IAEFluidStack> implements IFluidTank, INotifiableHandler {
         private final List<MetaTileEntity> notifiableEntities = new ArrayList<>();
+        private MetaTileEntity holder;
 
-        public ExportOnlyAEFluid(IAEFluidStack config, IAEFluidStack stock, MetaTileEntity mte) {
+        public ExportOnlyAEFluid(MetaTileEntity holder, IAEFluidStack config, IAEFluidStack stock, MetaTileEntity mte) {
             super(config, stock);
+            this.holder = holder;
             this.notifiableEntities.add(mte);
         }
 
@@ -361,11 +360,15 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart imp
                     this.addToNotifiedList(metaTileEntity, this, false);
                 }
             }
+            if (holder != null) {
+                holder.markDirty();
+            }
         }
 
         @Override
         public ExportOnlyAEFluid copy() {
             return new ExportOnlyAEFluid(
+                    this.holder,
                     this.config == null ? null : this.config.copy(),
                     this.stock == null ? null : this.stock.copy(),
                     null

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputBus.java
@@ -198,7 +198,7 @@ public class MetaTileEntityMEOutputBus extends MetaTileEntityAEHostablePart impl
 
     @Override
     public void registerAbilities(List<IItemHandlerModifiable> abilityList) {
-        abilityList.add(new InaccessibleInfiniteSlot(this.internalBuffer, this.getController()));
+        abilityList.add(new InaccessibleInfiniteSlot(this, this.internalBuffer, this.getController()));
     }
 
     @Override
@@ -212,8 +212,10 @@ public class MetaTileEntityMEOutputBus extends MetaTileEntityAEHostablePart impl
     private static class InaccessibleInfiniteSlot implements IItemHandlerModifiable, INotifiableHandler {
         private final IItemList<IAEItemStack> internalBuffer;
         private final List<MetaTileEntity> notifiableEntities = new ArrayList<>();
+        private final MetaTileEntity holder;
 
-        public InaccessibleInfiniteSlot(IItemList<IAEItemStack> internalBuffer, MetaTileEntity mte) {
+        public InaccessibleInfiniteSlot(MetaTileEntity holder, IItemList<IAEItemStack> internalBuffer, MetaTileEntity mte) {
+            this.holder = holder;
             this.internalBuffer = internalBuffer;
             this.notifiableEntities.add(mte);
         }
@@ -221,6 +223,7 @@ public class MetaTileEntityMEOutputBus extends MetaTileEntityAEHostablePart impl
         @Override
         public void setStackInSlot(int slot, @Nonnull ItemStack stack) {
             this.internalBuffer.add(AEItemStack.fromItemStack(stack));
+            this.holder.markDirty();
             this.trigger();
         }
 
@@ -243,6 +246,7 @@ public class MetaTileEntityMEOutputBus extends MetaTileEntityAEHostablePart impl
             }
             if (!simulate) {
                 this.internalBuffer.add(AEItemStack.fromItemStack(stack));
+                this.holder.markDirty();
             }
             this.trigger();
             return ItemStack.EMPTY;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputHatch.java
@@ -200,7 +200,7 @@ public class MetaTileEntityMEOutputHatch extends MetaTileEntityAEHostablePart im
 
     @Override
     public void registerAbilities(List<IFluidTank> list) {
-        list.add(new InaccessibleInfiniteTank(this.internalBuffer, this.getController()));
+        list.add(new InaccessibleInfiniteTank(this, this.internalBuffer, this.getController()));
     }
 
     @Override
@@ -214,8 +214,10 @@ public class MetaTileEntityMEOutputHatch extends MetaTileEntityAEHostablePart im
     private static class InaccessibleInfiniteTank implements IFluidTank, INotifiableHandler {
         private final IItemList<IAEFluidStack> internalBuffer;
         private final List<MetaTileEntity> notifiableEntities = new ArrayList<>();
+        private final MetaTileEntity holder;
 
-        public InaccessibleInfiniteTank(IItemList<IAEFluidStack> internalBuffer, MetaTileEntity mte) {
+        public InaccessibleInfiniteTank(MetaTileEntity holder, IItemList<IAEFluidStack> internalBuffer, MetaTileEntity mte) {
+            this.holder = holder;
             this.internalBuffer = internalBuffer;
             this.notifiableEntities.add(mte);
         }
@@ -248,6 +250,7 @@ public class MetaTileEntityMEOutputHatch extends MetaTileEntityAEHostablePart im
             }
             if (doFill) {
                 this.internalBuffer.add(AEFluidStack.fromFluidStack(resource));
+                holder.markDirty();
             }
             this.trigger();
             return resource.amount;


### PR DESCRIPTION
## What
Fixes ME Input hatches failing to expose their contents properly to parallel logic due to.. excessive wrapping?
Fixes ME busses/hatches not dirtying the chunk they are in when config or inventories changes happen leading to misconfiguration and potential for voiding or duping their content with proper setup

## Implementation Details
Add calls to markDirty of the TE holding the inventories and containers

## Outcome
Fix PA parallel
Fix items/fluids missing or appearing out of nowhere

## Additional Information
Could be done better in some way