### PR TITLE
Fix Buses not Auto Collapsing

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -360,6 +360,12 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     public void setAutoCollapse(boolean inverted) {
         autoCollapse = inverted;
         if (!getWorld().isRemote) {
+            if (isExportHatch) {
+                addNotifiedOutput(this.getExportItems());
+            }
+            else {
+                addNotifiedInput(this.getImportItems());
+            }
             writeCustomData(GregtechDataCodes.TOGGLE_COLLAPSE_ITEMS, packetBuffer -> packetBuffer.writeBoolean(autoCollapse));
             notifyBlockUpdate();
             markDirty();

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -363,8 +363,7 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
             if (autoCollapse) {
                 if (isExportHatch) {
                     addNotifiedOutput(this.getExportItems());
-                }
-                else {
+                } else {
                     addNotifiedInput(this.getImportItems());
                 }
             }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -360,11 +360,13 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     public void setAutoCollapse(boolean inverted) {
         autoCollapse = inverted;
         if (!getWorld().isRemote) {
-            if (isExportHatch) {
-                addNotifiedOutput(this.getExportItems());
-            }
-            else {
-                addNotifiedInput(this.getImportItems());
+            if (autoCollapse) {
+                if (isExportHatch) {
+                    addNotifiedOutput(this.getExportItems());
+                }
+                else {
+                    addNotifiedInput(this.getImportItems());
+                }
             }
             writeCustomData(GregtechDataCodes.TOGGLE_COLLAPSE_ITEMS, packetBuffer -> packetBuffer.writeBoolean(autoCollapse));
             notifyBlockUpdate();

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -119,7 +119,7 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
             }
             // Only attempt to auto collapse the inventory contents once the bus has been notified
             if (isAutoCollapse()) {
-                // Ghost Circuit Inventory messing with things
+                // Exclude the ghost circuit inventory from the auto collapse, so it does not extract any ghost circuits from the slot
                 IItemHandlerModifiable inventory = (isExportHatch ? this.getExportItems() : super.getImportItems());
                 if (isExportHatch ? this.getNotifiedItemOutputList().contains(inventory) : this.getNotifiedItemInputList().contains(inventory)) {
                     collapseInventorySlotContents(inventory);

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -119,7 +119,8 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
             }
             // Only attempt to auto collapse the inventory contents once the bus has been notified
             if (isAutoCollapse()) {
-                IItemHandlerModifiable inventory = (isExportHatch ? this.getExportItems() : this.getImportItems());
+                // Ghost Circuit Inventory messing with things
+                IItemHandlerModifiable inventory = (isExportHatch ? this.getExportItems() : super.getImportItems());
                 if (isExportHatch ? this.getNotifiedItemOutputList().contains(inventory) : this.getNotifiedItemInputList().contains(inventory)) {
                     collapseInventorySlotContents(inventory);
                 }
@@ -364,7 +365,7 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
                 if (isExportHatch) {
                     addNotifiedOutput(this.getExportItems());
                 } else {
-                    addNotifiedInput(this.getImportItems());
+                    addNotifiedInput(super.getImportItems());
                 }
             }
             writeCustomData(GregtechDataCodes.TOGGLE_COLLAPSE_ITEMS, packetBuffer -> packetBuffer.writeBoolean(autoCollapse));


### PR DESCRIPTION
## What
Fixes buses not auto collapsing by ensuring that the buses are notified when they are auto collapse toggled.

Closes #1971 

## Outcome
Fixes buses not auto collapsing

