### PR TITLE
fix iron door recipes and recycling

### DIFF
--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -2,7 +2,6 @@ package gregtech.loaders;
 
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.common.ConfigHolder;
@@ -200,10 +199,10 @@ public class MaterialInfoLoader {
                 new ItemMaterialInfo(new MaterialStack(Bronze, M * 6 * 2 / 64), // 2 large pipe / 64
                         new MaterialStack(Steel, M * 8 / 64))); // 8 steel plate / 64
 
-        if (ConfigHolder.recipes.hardIronRecipes) {
+        if (ConfigHolder.recipes.hardAdvancedIronRecipes) {
             OreDictUnifier.registerOre(new ItemStack(Items.IRON_DOOR, 1), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Iron, (37 * M) / 9), // dust tiny
-                    new MaterialStack(Materials.Steel, M / 9))); // dust tiny
+                    new MaterialStack(Materials.Iron, M * 4 + (M * 3 / 16)), // 4 iron plates + 1 iron bars
+                    new MaterialStack(Materials.Steel, M / 9))); // tiny steel dust
         } else {
             OreDictUnifier.registerOre(new ItemStack(Items.IRON_DOOR, 1), new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
         }

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -437,6 +437,12 @@ public class VanillaOverrideRecipes {
                 'R', new UnificationEntry(OrePrefix.ring, Materials.Steel),
                 'S', new UnificationEntry(OrePrefix.screw, Materials.Steel)
         );
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.plate, Materials.Iron, 4)
+                .inputs(new ItemStack(Blocks.IRON_BARS))
+                .fluidInputs(Materials.Steel.getFluid(L / 9))
+                .outputs(new ItemStack(Items.IRON_DOOR))
+                .duration(400).EUt(VA[ULV]).buildAndRegister();
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:anvil"));
         ModHandler.addShapedRecipe("anvil", new ItemStack(Blocks.ANVIL), "BBB", "SBS", "PBP",

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -845,11 +845,13 @@ public class VanillaStandardRecipes {
                 .outputs(new ItemStack(Blocks.IRON_TRAPDOOR))
                 .duration(100).EUt(16).buildAndRegister();
 
-        RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
-                .input(OrePrefix.plate, Materials.Iron, 6)
-                .circuitMeta(6)
-                .outputs(new ItemStack(Items.IRON_DOOR))
-                .duration(100).EUt(16).buildAndRegister();
+        if (!ConfigHolder.recipes.hardAdvancedIronRecipes) {
+            RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.plate, Materials.Iron, 6)
+                    .circuitMeta(6)
+                    .outputs(new ItemStack(Items.IRON_DOOR, 3))
+                    .duration(100).EUt(16).buildAndRegister();
+        }
     }
 
     /**


### PR DESCRIPTION
## What
Fixes issues with iron door related recipes.

1. Fixes the standard assembler recipe for iron doors outputting 1 instead of 3.
2. Adds an assembler recipe for `hardAdvancedIronRecipes` to replace the standard one for iron doors.
3. Fixes the iron door recycling data containing steel when `hardIronRecipes` is enabled, instead of when `hardAdvancedIronRecipes` is enabled.

## Outcome
Fixes #1993.
