### PR TITLE
top addons fluid compat

### DIFF
--- a/src/api/java/io/github/drmanganese/topaddons/reference/Colors.java
+++ b/src/api/java/io/github/drmanganese/topaddons/reference/Colors.java
@@ -1,0 +1,12 @@
+package io.github.drmanganese.topaddons.reference;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/DrManganese/TOPAddons/blob/1.12/src/main/java/io/github/drmanganese/topaddons/reference/Colors.java">Colors.java</a>
+ */
+public final class Colors {
+
+    public static final Map<String, Integer> FLUID_NAME_COLOR_MAP = new HashMap<>();
+}

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -145,7 +145,8 @@ public class GTValues {
             MODID_VOXELMAP = "voxelmap",
             MODID_XAERO_MINIMAP = "xaerominimap",
             MODID_HWYLA = "hwyla",
-            MODID_BAUBLES = "baubles";
+            MODID_BAUBLES = "baubles",
+            MODID_TOP_ADDONS = "topaddons";
 
     private static Boolean isClient;
 

--- a/src/main/java/gregtech/api/fluids/MetaFluids.java
+++ b/src/main/java/gregtech/api/fluids/MetaFluids.java
@@ -19,6 +19,7 @@ import gregtech.api.util.FluidTooltipUtil;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.LocalizationUtils;
 import gregtech.common.blocks.MetaBlocks;
+import io.github.drmanganese.topaddons.reference.Colors;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -27,6 +28,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.BlockFluidBase;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fml.common.Loader;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -237,6 +239,7 @@ public class MetaFluids {
             if (material.hasFluidColor()) {
                 fluid.setColor(GTUtility.convertRGBtoOpaqueRGBA_MC(material.getMaterialRGB()));
             } else {
+                // set color to 0xFFFFFFFF to preserve fluid texture
                 fluid.setColor(0xFFFFFFFF);
             }
 
@@ -244,6 +247,8 @@ public class MetaFluids {
             FluidType.setFluidProperties(fluidType, fluid);
 
             if (material.hasFlag(MaterialFlags.STICKY)) fluid.setViscosity(2000);
+
+            registerFluidModCompat(fluidName, material, fluid);
 
             ((MaterialFluid) fluid).registerFluidTooltip();
             FluidRegistry.registerFluid(fluid);
@@ -265,6 +270,12 @@ public class MetaFluids {
 
         fluidToMaterialMappings.put(fluid.getName(), material);
         return fluid;
+    }
+
+    private static void registerFluidModCompat(@Nonnull String fluidName, @Nonnull Material material, @Nonnull Fluid fluid) {
+        if (!material.hasFluidColor() && Loader.isModLoaded(GTValues.MODID_TOP_ADDONS)) {
+            Colors.FLUID_NAME_COLOR_MAP.put(fluidName, GTUtility.convertRGBtoARGB(material.getMaterialRGB()));
+        }
     }
 
     /**

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -94,6 +94,16 @@ public class GTUtility {
         return opacity << 24 | colorValue;
     }
 
+    public static int convertRGBtoARGB(int colorValue) {
+        return convertRGBtoARGB(colorValue, 0xFF);
+    }
+
+    public static int convertRGBtoARGB(int colorValue, int opacity) {
+        // preserve existing opacity if present
+        if (((colorValue >> 24) & 0xFF) != 0) return colorValue;
+        return opacity << 24 | colorValue;
+    }
+
     /**
      * Attempts to merge given ItemStack with ItemStacks in slot list supplied
      * If it's not possible to merge it fully, it will attempt to insert it into first empty slots


### PR DESCRIPTION
## What
Adds compat with TOP Addons for GT fluids. This will make fluids using custom textures no longer show as gray in the TOP display, and will use their base material colors instead.

## Outcome
Adds compat with TOP Addons for GT fluids. 
