### PR TITLE
Fix Super/Quantum Tanks voiding incorrect fluid

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -603,7 +603,11 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         @Override
         public int fillInternal(FluidStack resource, boolean doFill) {
             int accepted = super.fillInternal(resource, doFill);
-            if (accepted == 0) return accepted;
+
+            // if "resource" is not the same as the stored fluid, and we couldn't accept "resource"
+            if (!resource.isFluidEqual(getFluid()) && accepted == 0) {
+                return 0;
+            }
 
             if (doFill && locked && lockedFluid == null) {
                 lockedFluid = resource.copy();

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -603,6 +603,8 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         @Override
         public int fillInternal(FluidStack resource, boolean doFill) {
             int accepted = super.fillInternal(resource, doFill);
+            if (accepted == 0) return accepted;
+
             if (doFill && locked && lockedFluid == null) {
                 lockedFluid = resource.copy();
                 lockedFluid.amount = 1;

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -604,8 +604,8 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         public int fillInternal(FluidStack resource, boolean doFill) {
             int accepted = super.fillInternal(resource, doFill);
 
-            // if "resource" is not the same as the stored fluid, and we couldn't accept "resource"
-            if (!resource.isFluidEqual(getFluid()) && accepted == 0) {
+            // if we couldn't accept "resource", and "resource" is not the same as the stored fluid.
+            if (accepted == 0 && !resource.isFluidEqual(getFluid())) {
                 return 0;
             }
 


### PR DESCRIPTION
## What
Fixes #1872. Excess Fluid Voiding was voiding fluid different from the fluid currently stored in the tank.

## Implementation Details
Check if the accepted amount from the `super.fillInternal()` was 0 and return early.

## Outcome
a proper amount of voiding
