### PR TITLE
Fix Large Boiler and Steam Machines giving incorrect info in TheOneProbe/HWYLA

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -204,6 +204,16 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic {
         this.lastTickSteamOutput = lastTickSteamOutput;
     }
 
+    @Override
+    public int getInfoProviderEUt() {
+        return this.lastTickSteamOutput;
+    }
+
+    @Override
+    public boolean consumesEnergy() {
+        return false;
+    }
+
     public void invalidate() {
         progressTime = 0;
         maxProgressTime = 0;

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -5,7 +5,9 @@ import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
+import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaRegistrar;
@@ -58,18 +60,25 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
             if (tag.getBoolean("Working")) {
                 int EUt = tag.getInteger("RecipeEUt");
                 int absEUt = Math.abs(EUt);
+                boolean consumer = EUt > 0;
                 String endText = null;
 
                 if (accessor.getTileEntity() instanceof IGregTechTileEntity gtte) {
-                    if (gtte.getMetaTileEntity() instanceof SteamMetaTileEntity) {
-                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("material.steam");
+                    if (gtte.getMetaTileEntity() instanceof SteamMetaTileEntity || gtte.getMetaTileEntity() instanceof MetaTileEntityLargeBoiler) {
+                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.steam")+ " " + I18n.format(Materials.Steam.getUnlocalizedName());
+                    }
+                    AbstractRecipeLogic arl = gtte.getMetaTileEntity().getRecipeLogic();
+                    if (arl != null) {
+                        consumer = arl.consumesEnergy();
                     }
                 }
                 if (endText == null) {
                     endText = ": " + absEUt + TextFormatting.RESET + " EU/t (" + GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.RESET + ")";
                 }
 
-                if (EUt > 0) {
+                if (EUt == 0) return tooltip;
+
+                if (consumer) {
                     tooltip.add(I18n.format("gregtech.top.energy_consumption") + endText);
                 } else {
                     tooltip.add(I18n.format("gregtech.top.energy_production") + endText);

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -49,7 +49,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 IGregTechTileEntity gtTileEntity = (IGregTechTileEntity) tileEntity;
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
                 if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler) {
-                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t {*gregtech.top.steam*} " + Materials.Steam.getLocalizedName();
+                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t {*gregtech.top.steam*} {*" + Materials.Steam.getUnlocalizedName() + "*}";
                 }
             }
             if (text == null) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -7,7 +7,9 @@ import gregtech.api.capability.impl.PrimitiveRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
+import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
@@ -40,13 +42,14 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             }
             int EUt = capability.getInfoProviderEUt();
             int absEUt = Math.abs(EUt);
+            boolean consumer = capability.consumesEnergy();
             String text = null;
 
             if (tileEntity instanceof IGregTechTileEntity) {
                 IGregTechTileEntity gtTileEntity = (IGregTechTileEntity) tileEntity;
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
-                if (mte instanceof SteamMetaTileEntity) {
-                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t " + "{*material.steam*}";
+                if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler) {
+                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t {*gregtech.top.steam*} " + Materials.Steam.getLocalizedName();
                 }
             }
             if (text == null) {
@@ -54,9 +57,11 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN + " (" + GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.GREEN + ")";
             }
 
-            if (EUt > 0) {
+            if (EUt == 0) return; // idk what to do for 0 eut
+
+            if (consumer) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);
-            } else if (EUt < 0) {
+            } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " + text);
             }
         }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -57,6 +57,7 @@ gregtech.top.working_disabled=Working Disabled
 
 gregtech.top.energy_consumption=Using
 gregtech.top.energy_production=Producing
+gregtech.top.steam=of
 
 gregtech.top.transform_up=Step Up
 gregtech.top.transform_down=Step Down


### PR DESCRIPTION
## What
Makes large boilers (and steam consuming machines) properly display the L/t of their steam generation/usage.
fixes [GCP #96](https://github.com/GregTechCEu/GregTech-Community-Pack/issues/96)

## Implementation Details
Overrides some methods in `BoilerRecipeLogic`
utilize those methods in `RecipeLogicInfoProvider`

## Outcome
large boiler and steam machines are no longer deceitful 

## Additional Information
![image](https://github.com/GregTechCEu/GregTech/assets/44148655/721f9497-c3b6-462a-9aea-8deddf7980e5)

## Potential Compatibility Issues
none afaik
