### PR TITLE
use GTValues.LV etc. in all usages of GTValues.V*

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
@@ -58,6 +58,9 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Supplier;
 
+import static gregtech.api.GTValues.LV;
+import static gregtech.api.GTValues.V;
+
 /**
  * Collection of tool related helper methods
  */
@@ -582,7 +585,7 @@ public final class ToolHelper {
                 // Stack lists can be immutable going into Recipe#matches barring no rewrites
                 List<ItemStack> dropAsList = Collections.singletonList(silktouchDrop);
                 // Search for forge hammer recipes from all drops individually (only LV or under)
-                Recipe hammerRecipe = RecipeMaps.FORGE_HAMMER_RECIPES.findRecipe(GTValues.V[1], dropAsList, Collections.emptyList(), false);
+                Recipe hammerRecipe = RecipeMaps.FORGE_HAMMER_RECIPES.findRecipe(V[LV], dropAsList, Collections.emptyList(), false);
                 if (hammerRecipe != null && hammerRecipe.matches(true, dropAsList, Collections.emptyList())) {
                     drops.clear();
                     OrePrefix prefix = OreDictUnifier.getPrefix(silktouchDrop);

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -30,7 +30,7 @@ public class ElementMaterials {
                 .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
                         .enchantability(14).build())
                 .rotorStats(10.0f, 2.0f, 128)
-                .cableProperties(GTValues.V[4], 1, 1)
+                .cableProperties(V[EV], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
                 .blastTemp(1700, GasTier.LOW)
                 .fluidTemp(933)
@@ -171,7 +171,7 @@ public class ElementMaterials {
                 .color(0x5050FA).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FINE_WIRE)
                 .element(Elements.Co)
-                .cableProperties(GTValues.V[1], 2, 2)
+                .cableProperties(V[LV], 2, 2)
                 .itemPipeProperties(2560, 2.0f)
                 .fluidTemp(1768)
                 .build();
@@ -187,7 +187,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, MORTAR_GRINDABLE, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE,
                         GENERATE_DOUBLE_PLATE)
                 .element(Elements.Cu)
-                .cableProperties(GTValues.V[2], 1, 2)
+                .cableProperties(V[MV], 1, 2)
                 .fluidPipeProperties(1696, 6, true)
                 .fluidTemp(1358)
                 .build();
@@ -285,7 +285,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_RING, MORTAR_GRINDABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES,
                         GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE, GENERATE_FOIL, GENERATE_DOUBLE_PLATE)
                 .element(Elements.Au)
-                .cableProperties(GTValues.V[3], 3, 2)
+                .cableProperties(V[HV], 3, 2)
                 .fluidPipeProperties(1671, 25, true, true, false, false)
                 .fluidTemp(1337)
                 .build();
@@ -352,7 +352,7 @@ public class ElementMaterials {
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 256, 2)
                         .enchantability(14).build())
                 .rotorStats(7.0f, 2.5f, 256)
-                .cableProperties(GTValues.V[2], 2, 3)
+                .cableProperties(V[MV], 2, 3)
                 .fluidTemp(1811)
                 .build();
 
@@ -380,7 +380,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL,
                         GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE)
                 .element(Elements.Pb)
-                .cableProperties(GTValues.V[0], 2, 2)
+                .cableProperties(V[ULV], 2, 2)
                 .fluidPipeProperties(1200, 8, true)
                 .fluidTemp(600)
                 .build();
@@ -514,7 +514,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_DOUBLE_PLATE)
                 .element(Elements.Os)
                 .rotorStats(16.0f, 4.0f, 1280)
-                .cableProperties(GTValues.V[6], 4, 2)
+                .cableProperties(V[LuV], 4, 2)
                 .itemPipeProperties(256, 8.0f)
                 .blastTemp(4500, GasTier.HIGH, VA[LuV], 1000)
                 .fluidTemp(3306)
@@ -550,7 +550,7 @@ public class ElementMaterials {
                 .color(0xFFFFC8).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_RING, GENERATE_DOUBLE_PLATE)
                 .element(Elements.Pt)
-                .cableProperties(GTValues.V[5], 2, 1)
+                .cableProperties(V[IV], 2, 1)
                 .itemPipeProperties(512, 4.0f)
                 .fluidTemp(2041)
                 .build();
@@ -676,7 +676,7 @@ public class ElementMaterials {
                 .color(0xDCDCFF).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_DOUBLE_PLATE, MORTAR_GRINDABLE, GENERATE_FINE_WIRE, GENERATE_RING)
                 .element(Elements.Ag)
-                .cableProperties(GTValues.V[3], 1, 1)
+                .cableProperties(V[HV], 1, 1)
                 .fluidTemp(1235)
                 .build();
 
@@ -750,7 +750,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL,
                         GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE)
                 .element(Elements.Sn)
-                .cableProperties(GTValues.V[1], 1, 1)
+                .cableProperties(V[LV], 1, 1)
                 .itemPipeProperties(4096, 0.5f)
                 .fluidTemp(505)
                 .build();
@@ -779,7 +779,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_GEAR, GENERATE_DOUBLE_PLATE)
                 .element(Elements.W)
                 .rotorStats(7.0f, 3.0f, 2560)
-                .cableProperties(GTValues.V[5], 2, 2)
+                .cableProperties(V[IV], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
                 .blastTemp(3600, GasTier.MID, VA[EV], 1800)
                 .fluidTemp(3695)
@@ -845,7 +845,7 @@ public class ElementMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW, GENERATE_DOUBLE_PLATE)
                 .element(Elements.Nq)
                 .rotorStats(6.0f, 4.0f, 1280)
-                .cableProperties(GTValues.V[7], 2, 2)
+                .cableProperties(V[ZPM], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
                 .blastTemp(5000, GasTier.HIGH, VA[IV], 600)
                 .build();
@@ -883,7 +883,7 @@ public class ElementMaterials {
                 .color(0x600000).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .element(Elements.Tr)
-                .cableProperties(GTValues.V[8], 1, 8)
+                .cableProperties(V[UV], 1, 8)
                 .rotorStats(20.0f, 6.0f, 10240)
                 .fluidTemp(25000)
                 .build();
@@ -904,7 +904,7 @@ public class ElementMaterials {
                 .color(0x9973BD).iconSet(SHINY)
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW, GENERATE_GEAR)
                 .element(Elements.Ke)
-                .cableProperties(GTValues.V[7], 6, 4)
+                .cableProperties(V[ZPM], 6, 4)
                 .blastTemp(7200, GasTier.HIGH, VA[LuV], 1500)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -34,7 +34,7 @@ public class FirstDegreeMaterials {
                 .color(0xFF8D3B).iconSet(BRIGHT)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FINE_WIRE)
                 .components(Copper, 1)
-                .cableProperties(GTValues.V[2], 1, 1)
+                .cableProperties(V[MV], 1, 1)
                 .fluidTemp(1358)
                 .build();
         Copper.getProperty(PropertyKey.INGOT).setArcSmeltingInto(AnnealedCopper);
@@ -195,7 +195,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_DOUBLE_PLATE)
                 .components(Copper, 1, Nickel, 1)
                 .itemPipeProperties(2048, 1)
-                .cableProperties(GTValues.V[2], 1, 1)
+                .cableProperties(V[MV], 1, 1)
                 .fluidTemp(1542)
                 .build();
 
@@ -222,7 +222,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FINE_WIRE, GENERATE_RING, GENERATE_DOUBLE_PLATE)
                 .components(Silver, 1, Gold, 1)
                 .itemPipeProperties(1024, 2)
-                .cableProperties(GTValues.V[3], 2, 2)
+                .cableProperties(V[HV], 2, 2)
                 .fluidTemp(1285)
                 .build();
 
@@ -306,7 +306,7 @@ public class FirstDegreeMaterials {
                 .color(0xC2D2DF).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Iron, 1, Aluminium, 1, Chrome, 1)
-                .cableProperties(GTValues.V[3], 4, 3)
+                .cableProperties(V[HV], 4, 3)
                 .blastTemp(1800, GasTier.LOW, VA[HV], 900)
                 .fluidTemp(1708)
                 .build();
@@ -351,7 +351,7 @@ public class FirstDegreeMaterials {
                 .color(0xCDCEF6).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Nickel, 4, Chrome, 1)
-                .cableProperties(GTValues.V[4], 4, 4)
+                .cableProperties(V[EV], 4, 4)
                 .blastTemp(2700, GasTier.LOW, VA[HV], 1300)
                 .fluidTemp(1818)
                 .build();
@@ -361,7 +361,7 @@ public class FirstDegreeMaterials {
                 .color(0x1D291D)
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .components(Niobium, 1, Nitrogen, 1)
-                .cableProperties(GTValues.V[6], 1, 1)
+                .cableProperties(V[LuV], 1, 1)
                 .blastTemp(2846, GasTier.MID)
                 .build();
 
@@ -372,7 +372,7 @@ public class FirstDegreeMaterials {
                         GENERATE_DOUBLE_PLATE)
                 .components(Niobium, 1, Titanium, 1)
                 .fluidPipeProperties(5900, 175, true)
-                .cableProperties(GTValues.V[6], 4, 2)
+                .cableProperties(V[LuV], 4, 2)
                 .blastTemp(4500, GasTier.HIGH, VA[HV], 1500)
                 .fluidTemp(2345)
                 .build();
@@ -600,7 +600,7 @@ public class FirstDegreeMaterials {
                         .enchantability(14).build())
                 .rotorStats(6.0f, 3.0f, 512)
                 .fluidPipeProperties(1855, 75, true)
-                .cableProperties(GTValues.V[4], 2, 2)
+                .cableProperties(V[EV], 2, 2)
                 .blastTemp(1000, null, VA[MV], 800) // no gas tier for steel
                 .fluidTemp(2046)
                 .build();
@@ -676,7 +676,7 @@ public class FirstDegreeMaterials {
                 .color(0x80808C).iconSet(SHINY)
                 .flags(STD_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_SPRING_SMALL)
                 .components(Vanadium, 3, Gallium, 1)
-                .cableProperties(GTValues.V[7], 4, 2)
+                .cableProperties(V[ZPM], 4, 2)
                 .blastTemp(4500, GasTier.HIGH, VA[EV], 1200)
                 .fluidTemp(1712)
                 .build();
@@ -713,7 +713,7 @@ public class FirstDegreeMaterials {
                 .color(0x504046).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .components(Yttrium, 1, Barium, 2, Copper, 3, Oxygen, 7)
-                .cableProperties(GTValues.V[8], 4, 4)
+                .cableProperties(V[UV], 4, 4)
                 .blastTemp(4500, GasTier.HIGH) // todo redo this EBF process
                 .fluidTemp(1799)
                 .build();
@@ -751,7 +751,7 @@ public class FirstDegreeMaterials {
                 .color(0x808080).iconSet(SHINY)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 1)
-                .cableProperties(GTValues.V[5], 1, 1)
+                .cableProperties(V[IV], 1, 1)
                 .build();
 
         TungsticAcid = new Material.Builder(343, gregtechId("tungstic_acid"))

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -88,7 +88,7 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(TungstenSteel, 5, Chrome, 1, Molybdenum, 2, Vanadium, 1)
                 .rotorStats(10.0f, 5.5f, 4000)
-                .cableProperties(GTValues.V[6], 4, 2)
+                .cableProperties(V[LuV], 4, 2)
                 .blastTemp(4200, GasTier.MID, VA[EV], 1300)
                 .build();
 
@@ -97,7 +97,7 @@ public class HigherDegreeMaterials {
                 .color(0xC80000)
                 .flags(STD_METAL, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW, DISABLE_DECOMPOSITION)
                 .components(Copper, 1, Redstone, 4)
-                .cableProperties(GTValues.V[0], 1, 0)
+                .cableProperties(V[ULV], 1, 0)
                 .fluidTemp(1400)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -96,7 +96,7 @@ public class SecondDegreeMaterials {
                 .color(0x646464).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .components(Nickel, 1, BlackBronze, 1, Steel, 3)
-                .cableProperties(GTValues.V[4], 3, 2)
+                .cableProperties(V[EV], 3, 2)
                 .blastTemp(1200, GasTier.LOW)
                 .build();
 
@@ -122,7 +122,7 @@ public class SecondDegreeMaterials {
                         .enchantability(14).build())
                 .rotorStats(8.0f, 4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
-                .cableProperties(GTValues.V[5], 3, 2)
+                .cableProperties(V[IV], 3, 2)
                 .blastTemp(3000, GasTier.MID, GTValues.VA[EV], 1000)
                 .build();
 
@@ -327,7 +327,7 @@ public class SecondDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(40.0F, 12.0F, 3072, 5)
                         .attackSpeed(0.3F).enchantability(33).magnetic().build())
                 .rotorStats(8.0f, 5.0f, 5120)
-                .cableProperties(GTValues.V[8], 2, 4)
+                .cableProperties(V[UV], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, VA[LuV], 1000)
                 .build();
 

--- a/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockMachineCasing.java
@@ -19,6 +19,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Locale;
 
+import static gregtech.api.GTValues.VOLTAGE_NAMES;
+
 @ParametersAreNonnullByDefault
 public class BlockMachineCasing extends VariantBlock<BlockMachineCasing.MachineCasingType> {
 
@@ -49,21 +51,21 @@ public class BlockMachineCasing extends VariantBlock<BlockMachineCasing.MachineC
     public enum MachineCasingType implements IStringSerializable {
 
         //Voltage-tiered casings
-        ULV(makeName(GTValues.VOLTAGE_NAMES[0])),
-        LV(makeName(GTValues.VOLTAGE_NAMES[1])),
-        MV(makeName(GTValues.VOLTAGE_NAMES[2])),
-        HV(makeName(GTValues.VOLTAGE_NAMES[3])),
-        EV(makeName(GTValues.VOLTAGE_NAMES[4])),
-        IV(makeName(GTValues.VOLTAGE_NAMES[5])),
-        LuV(makeName(GTValues.VOLTAGE_NAMES[6])),
-        ZPM(makeName(GTValues.VOLTAGE_NAMES[7])),
-        UV(makeName(GTValues.VOLTAGE_NAMES[8])),
-        UHV(makeName(GTValues.VOLTAGE_NAMES[9])),
-        UEV(makeName(GTValues.VOLTAGE_NAMES[10])),
-        UIV(makeName(GTValues.VOLTAGE_NAMES[11])),
-        UXV(makeName(GTValues.VOLTAGE_NAMES[12])),
-        OpV(makeName(GTValues.VOLTAGE_NAMES[13])),
-        MAX(makeName(GTValues.VOLTAGE_NAMES[14]));
+        ULV(makeName(VOLTAGE_NAMES[GTValues.ULV])),
+        LV(makeName(VOLTAGE_NAMES[GTValues.LV])),
+        MV(makeName(VOLTAGE_NAMES[GTValues.MV])),
+        HV(makeName(VOLTAGE_NAMES[GTValues.HV])),
+        EV(makeName(VOLTAGE_NAMES[GTValues.EV])),
+        IV(makeName(VOLTAGE_NAMES[GTValues.IV])),
+        LuV(makeName(VOLTAGE_NAMES[GTValues.LuV])),
+        ZPM(makeName(VOLTAGE_NAMES[GTValues.ZPM])),
+        UV(makeName(VOLTAGE_NAMES[GTValues.UV])),
+        UHV(makeName(VOLTAGE_NAMES[GTValues.UHV])),
+        UEV(makeName(VOLTAGE_NAMES[GTValues.UEV])),
+        UIV(makeName(VOLTAGE_NAMES[GTValues.UIV])),
+        UXV(makeName(VOLTAGE_NAMES[GTValues.UXV])),
+        OpV(makeName(VOLTAGE_NAMES[GTValues.OpV])),
+        MAX(makeName(VOLTAGE_NAMES[GTValues.MAX]));
 
         private final String name;
 

--- a/src/main/java/gregtech/common/covers/CoverBehaviors.java
+++ b/src/main/java/gregtech/common/covers/CoverBehaviors.java
@@ -23,6 +23,7 @@ import net.minecraft.util.ResourceLocation;
 import javax.annotation.Nonnull;
 import java.util.function.BiFunction;
 
+import static gregtech.api.GTValues.*;
 import static gregtech.api.util.GTUtility.gregtechId;
 
 public class CoverBehaviors {
@@ -55,15 +56,15 @@ public class CoverBehaviors {
         registerBehavior(gregtechId("shutter"), MetaItems.COVER_SHUTTER, CoverShutter::new);
 
         registerBehavior(gregtechId("solar_panel.basic"), MetaItems.COVER_SOLAR_PANEL, (tile, side) -> new CoverSolarPanel(tile, side, 1));
-        registerBehavior(gregtechId("solar_panel.ulv"), MetaItems.COVER_SOLAR_PANEL_ULV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[0]));
-        registerBehavior(gregtechId("solar_panel.lv"), MetaItems.COVER_SOLAR_PANEL_LV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[1]));
-        registerBehavior(gregtechId("solar_panel.mv"), MetaItems.COVER_SOLAR_PANEL_MV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[2]));
-        registerBehavior(gregtechId("solar_panel.hv"), MetaItems.COVER_SOLAR_PANEL_HV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[3]));
-        registerBehavior(gregtechId("solar_panel.ev"), MetaItems.COVER_SOLAR_PANEL_EV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[4]));
-        registerBehavior(gregtechId("solar_panel.iv"), MetaItems.COVER_SOLAR_PANEL_IV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[5]));
-        registerBehavior(gregtechId("solar_panel.luv"), MetaItems.COVER_SOLAR_PANEL_LUV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[6]));
-        registerBehavior(gregtechId("solar_panel.zpm"), MetaItems.COVER_SOLAR_PANEL_ZPM, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[7]));
-        registerBehavior(gregtechId("solar_panel.uv"), MetaItems.COVER_SOLAR_PANEL_UV, (tile, side) -> new CoverSolarPanel(tile, side, GTValues.V[8]));
+        registerBehavior(gregtechId("solar_panel.ulv"), MetaItems.COVER_SOLAR_PANEL_ULV, (tile, side) -> new CoverSolarPanel(tile, side, V[ULV]));
+        registerBehavior(gregtechId("solar_panel.lv"), MetaItems.COVER_SOLAR_PANEL_LV, (tile, side) -> new CoverSolarPanel(tile, side, V[LV]));
+        registerBehavior(gregtechId("solar_panel.mv"), MetaItems.COVER_SOLAR_PANEL_MV, (tile, side) -> new CoverSolarPanel(tile, side, V[MV]));
+        registerBehavior(gregtechId("solar_panel.hv"), MetaItems.COVER_SOLAR_PANEL_HV, (tile, side) -> new CoverSolarPanel(tile, side, V[HV]));
+        registerBehavior(gregtechId("solar_panel.ev"), MetaItems.COVER_SOLAR_PANEL_EV, (tile, side) -> new CoverSolarPanel(tile, side, V[EV]));
+        registerBehavior(gregtechId("solar_panel.iv"), MetaItems.COVER_SOLAR_PANEL_IV, (tile, side) -> new CoverSolarPanel(tile, side, V[IV]));
+        registerBehavior(gregtechId("solar_panel.luv"), MetaItems.COVER_SOLAR_PANEL_LUV, (tile, side) -> new CoverSolarPanel(tile, side, V[LuV]));
+        registerBehavior(gregtechId("solar_panel.zpm"), MetaItems.COVER_SOLAR_PANEL_ZPM, (tile, side) -> new CoverSolarPanel(tile, side, V[ZPM]));
+        registerBehavior(gregtechId("solar_panel.uv"), MetaItems.COVER_SOLAR_PANEL_UV, (tile, side) -> new CoverSolarPanel(tile, side, V[UV]));
 
         registerBehavior(gregtechId("machine_controller"), MetaItems.COVER_MACHINE_CONTROLLER, CoverMachineController::new);
         registerBehavior(gregtechId("smart_filter"), MetaItems.SMART_FILTER, (tile, side) -> new CoverItemFilter(tile, side, "cover.smart_item_filter.title", Textures.SMART_FILTER_FILTER_OVERLAY, new SmartItemFilter()));

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -36,6 +36,8 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
 
+import static gregtech.api.GTValues.MAX;
+import static gregtech.api.GTValues.V;
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_IO_SPEED;
 
 public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEnergyContainer {
@@ -123,7 +125,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements IEne
                 amps = 0;
                 setTier = 0;
             } else {
-                voltage = GTValues.V[14];
+                voltage = V[MAX];
                 amps = Integer.MAX_VALUE;
                 setTier = 14;
             }


### PR DESCRIPTION
code readability++
also static imports, yay

intellij structural replace template to find and fix these:
```xml
<replaceConfiguration name="GTValues.V[int]" text="gregtech.api.GTValues.$a$[$v$]" recursive="false" type="JAVA" pattern_context="default" search_injected="false" reformatAccordingToStyle="false" shortenFQN="false" replacement="GTValues.$a$[GTValues.$v2$]">
  <constraint name="__context__" within="" contains="" />
  <constraint name="v" regexp="[0-9]+" nameOfExprType="int" within="" contains="" />
  <constraint name="a" regexp="V[A-Z_]*" within="" contains="" />
  <variableDefinition name="v2" script="&quot;var VN = [&quot;ULV&quot;, &quot;LV&quot;, &quot;MV&quot;, &quot;HV&quot;, &quot;EV&quot;, &quot;IV&quot;, &quot;LuV&quot;, &quot;ZPM&quot;, &quot;UV&quot;, &quot;UHV&quot;, &quot;UEV&quot;, &quot;UIV&quot;, &quot;UXV&quot;, &quot;OpV&quot;, &quot;MAX&quot;]&#10;return VN[v.value]&quot;" />
</replaceConfiguration>
```