### PR TITLE
Add MTE tick time tracker debug TOP provider

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -61,7 +61,8 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
     @SideOnly(Side.CLIENT)
     private GTNameTagParticle nameTagParticle;
 
-    private final int[] timeStatistics = new int[20];
+    public static final int TRACKED_TICKS = 20;
+    private final int[] timeStatistics = new int[TRACKED_TICKS];
     private int timeStatisticsIndex = 0;
     private int lagWarningCount = 0;
     protected static final DecimalFormat tricorderFormat = new DecimalFormat("#.#########");
@@ -231,17 +232,11 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
             }
         }
         if (logLevel > 1) {
-            if (timeStatistics.length > 0) {
-                double averageTickTime = 0;
-                double worstTickTime = 0;
-                for (int tickTime : timeStatistics) {
-                    averageTickTime += tickTime;
-                    if (tickTime > worstTickTime) {
-                        worstTickTime = tickTime;
-                    }
-                    // Uncomment this line to print out tick-by-tick times.
-                    // list.add(new TextComponentTranslation("tickTime " + tickTime));
-                }
+            double[] timeStats = getTimeStatistics();
+            if (timeStats != null) {
+                double averageTickTime = timeStats[0];
+                double worstTickTime = timeStats[1];
+
                 list.add(new TextComponentTranslation("behavior.tricorder.debug_cpu_load",
                         new TextComponentTranslation(TextFormattingUtil.formatNumbers(averageTickTime / timeStatistics.length)).setStyle(new Style().setColor(TextFormatting.YELLOW)),
                         new TextComponentTranslation(TextFormattingUtil.formatNumbers(timeStatistics.length)).setStyle(new Style().setColor(TextFormatting.GREEN)),
@@ -249,6 +244,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
                 ));
                 list.add(new TextComponentTranslation("behavior.tricorder.debug_cpu_load_seconds", tricorderFormat.format(worstTickTime / 1000000000)));
             }
+
             if (lagWarningCount > 0) {
                 list.add(new TextComponentTranslation("behavior.tricorder.debug_lag_count",
                         new TextComponentTranslation(TextFormattingUtil.formatNumbers(lagWarningCount)).setStyle(new Style().setColor(TextFormatting.RED)),
@@ -257,6 +253,25 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
             }
         }
         return list;
+    }
+
+    /**
+     * @return double array of length 2, with index 0 being the average time and index 1 the worst time, in ns.
+     *         If there is no tick time, it will return null.
+     */
+    public double @Nullable [] getTimeStatistics() {
+        if (timeStatistics.length > 0) {
+            double averageTickTime = 0;
+            double worstTickTime = 0;
+            for (int tickTime : timeStatistics) {
+                averageTickTime += tickTime;
+                if (tickTime > worstTickTime) {
+                    worstTickTime = tickTime;
+                }
+            }
+            return new double[] { averageTickTime, worstTickTime };
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -259,7 +259,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
      * @return double array of length 2, with index 0 being the average time and index 1 the worst time, in ns.
      *         If there is no tick time, it will return null.
      */
-    public double @Nullable [] getTimeStatistics() {
+    public double[] getTimeStatistics() {
         if (timeStatistics.length > 0) {
             double averageTickTime = 0;
             double worstTickTime = 0;

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
@@ -4,6 +4,8 @@ import gregtech.api.GTValues;
 import gregtech.api.modules.GregTechModule;
 import gregtech.integration.IntegrationSubmodule;
 import gregtech.integration.theoneprobe.provider.*;
+import gregtech.integration.theoneprobe.provider.debug.DebugPipeNetInfoProvider;
+import gregtech.integration.theoneprobe.provider.debug.DebugTickTimeProvider;
 import gregtech.modules.GregTechModules;
 import mcjty.theoneprobe.TheOneProbe;
 import mcjty.theoneprobe.api.ITheOneProbe;
@@ -25,7 +27,6 @@ public class TheOneProbeModule extends IntegrationSubmodule {
         oneProbe.registerProvider(new ElectricContainerInfoProvider());
         oneProbe.registerProvider(new WorkableInfoProvider());
         oneProbe.registerProvider(new ControllableInfoProvider());
-        oneProbe.registerProvider(new DebugPipeNetInfoProvider());
         oneProbe.registerProvider(new TransformerInfoProvider());
         oneProbe.registerProvider(new DiodeInfoProvider());
         oneProbe.registerProvider(new MultiblockInfoProvider());
@@ -38,5 +39,9 @@ public class TheOneProbeModule extends IntegrationSubmodule {
         oneProbe.registerProvider(new BlockOreInfoProvider());
         oneProbe.registerProvider(new LampInfoProvider());
         oneProbe.registerProvider(new LDPipeProvider());
+
+        // Dev environment debug providers
+        oneProbe.registerProvider(new DebugPipeNetInfoProvider());
+        oneProbe.registerProvider(new DebugTickTimeProvider());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/debug/DebugPipeNetInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/debug/DebugPipeNetInfoProvider.java
@@ -1,4 +1,4 @@
-package gregtech.integration.theoneprobe.provider;
+package gregtech.integration.theoneprobe.provider.debug;
 
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -29,7 +29,7 @@ public class DebugPipeNetInfoProvider implements IProbeInfoProvider {
 
     @Override
     public void addProbeInfo(@Nonnull ProbeMode mode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData data) {
-        if (mode == ProbeMode.DEBUG && ConfigHolder.misc.debug) {
+        if (ConfigHolder.misc.debug) {
             TileEntity tileEntity = world.getTileEntity(data.getPos());
             if (tileEntity instanceof IGregTechTileEntity) {
                 MetaTileEntity metaTileEntity = ((IGregTechTileEntity) tileEntity).getMetaTileEntity();

--- a/src/main/java/gregtech/integration/theoneprobe/provider/debug/DebugTickTimeProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/debug/DebugTickTimeProvider.java
@@ -1,0 +1,39 @@
+package gregtech.integration.theoneprobe.provider.debug;
+
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.util.TextFormattingUtil;
+import gregtech.common.ConfigHolder;
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.IProbeInfoProvider;
+import mcjty.theoneprobe.api.ProbeMode;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public class DebugTickTimeProvider implements IProbeInfoProvider {
+
+    @Override
+    public String getID() {
+        return "gregtech:debug_tick_time_provider";
+    }
+
+    @Override
+    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
+        if (ConfigHolder.misc.debug) {
+            TileEntity tile = world.getTileEntity(data.getPos());
+            if (tile instanceof MetaTileEntityHolder holder) {
+                double[] timeStatistics = holder.getTimeStatistics();
+                if (timeStatistics != null) {
+                    double averageTickTime = timeStatistics[0];
+                    double worstTickTime = timeStatistics[1];
+
+                    // this is for dev environment debug, so don't worry about translating
+                    probeInfo.text("Average: " + TextFormattingUtil.formatNumbers(averageTickTime / MetaTileEntityHolder.TRACKED_TICKS) + "ns");
+                    probeInfo.text("Worst: " + TextFormattingUtil.formatNumbers(worstTickTime) + "ns");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
With debug config option, you can now see the tick time for the MTE you are looking at in TOP. Intended for dev environments and possibly pack authors