### PR TITLE
Faster markDirty implementation for saving

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -367,12 +367,6 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         }
     }
 
-    @Override
-    public int getComparatorInputOverride(@Nonnull IBlockState blockState, @Nonnull World worldIn, @Nonnull BlockPos pos) {
-        MetaTileEntity metaTileEntity = getMetaTileEntity(worldIn, pos);
-        return metaTileEntity == null ? 0 : metaTileEntity.getComparatorValue();
-    }
-
     protected final ThreadLocal<MetaTileEntity> tileEntities = new ThreadLocal<>();
 
     @Override
@@ -380,11 +374,6 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         tileEntities.set(te == null ? tileEntities.get() : ((IGregTechTileEntity) te).getMetaTileEntity());
         super.harvestBlock(worldIn, player, pos, state, te, stack);
         tileEntities.set(null);
-    }
-
-    @Override
-    public boolean hasComparatorInputOverride(@Nonnull IBlockState state) {
-        return true;
     }
 
     @Nullable

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -74,6 +74,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -114,7 +115,6 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
 
     private final int[] sidedRedstoneOutput = new int[6];
     private final int[] sidedRedstoneInput = new int[6];
-    private int cachedComparatorValue;
     private int cachedLightValue;
     protected boolean isFragile = false;
 
@@ -159,6 +159,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return holder == null ? null : holder.pos();
     }
 
+    @Override
     public void markDirty() {
         if (holder != null) {
             holder.markAsDirty();
@@ -668,7 +669,6 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     }
 
     public void onLoad() {
-        this.cachedComparatorValue = getActualComparatorValue();
         for (EnumFacing side : EnumFacing.VALUES) {
             this.sidedRedstoneInput[side.getIndex()] = GTUtility.getRedstonePower(getWorld(), getPos(), side);
         }
@@ -729,6 +729,11 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         }
     }
 
+    /**
+     * @deprecated Will be removed in 2.9. Comparators no longer supported for MetaTileEntities, as cover are interactions favored.
+     */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+    @Deprecated
     public int getActualComparatorValue() {
         return 0;
     }
@@ -737,22 +742,17 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         return 0;
     }
 
+    /**
+     * @deprecated Will be removed in 2.9.
+     */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+    @Deprecated
     public final int getComparatorValue() {
-        return cachedComparatorValue;
+        return 0;
     }
 
     public final int getLightValue() {
         return cachedLightValue;
-    }
-
-    private void updateComparatorValue() {
-        int newComparatorValue = getActualComparatorValue();
-        if (cachedComparatorValue != newComparatorValue) {
-            this.cachedComparatorValue = newComparatorValue;
-            if (getWorld() != null && !getWorld().isRemote) {
-                notifyBlockUpdate();
-            }
-        }
     }
 
     private void updateLightValue() {
@@ -776,9 +776,6 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
                 if (coverBehavior instanceof ITickable) {
                     ((ITickable) coverBehavior).update();
                 }
-            }
-            if (getOffsetTimer() % 5 == 0L) {
-                updateComparatorValue();
             }
         } else {
             updateSound();
@@ -1130,7 +1127,6 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
         this.sidedRedstoneOutput[side.getIndex()] = strength;
         if (getWorld() != null && !getWorld().isRemote && getCoverAtSide(side) == null) {
             notifyBlockUpdate();
-            markDirty();
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -320,7 +320,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         return getPos();
     }
 
-    @SuppressWarnings("all") // yes it CAN actually be null
+    @SuppressWarnings("ConstantConditions") // yes this CAN actually be null
     @Override
     public void markAsDirty() {
         if (getWorld() != null && getPos() != null) {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -322,7 +322,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
 
     @Override
     public void markAsDirty() {
-        markDirty();
+        getWorld().markChunkDirty(getPos(), this);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -320,9 +320,12 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
         return getPos();
     }
 
+    @SuppressWarnings("all") // yes it CAN actually be null
     @Override
     public void markAsDirty() {
-        getWorld().markChunkDirty(getPos(), this);
+        if (getWorld() != null && getPos() != null) {
+            getWorld().markChunkDirty(getPos(), this);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/TieredMetaTileEntity.java
@@ -16,7 +16,6 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -45,14 +44,6 @@ public abstract class TieredMetaTileEntity extends MetaTileEntity implements IEn
                     tierVoltage * 64L, tierVoltage, getMaxInputOutputAmperage());
         } else this.energyContainer = EnergyContainerHandler.receiverContainer(this,
                 tierVoltage * 64L, tierVoltage, getMaxInputOutputAmperage());
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        long energyStored = energyContainer.getEnergyStored();
-        long energyCapacity = energyContainer.getEnergyCapacity();
-        float f = energyCapacity == 0L ? 0.0f : energyStored / (energyCapacity * 1.0f);
-        return MathHelper.floor(f * 14.0f) + (energyStored > 0 ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -98,7 +98,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         return getPos();
     }
 
-    @SuppressWarnings("all") // yes this CAN actually be null
+    @SuppressWarnings("ConstantConditions") // yes this CAN actually be null
     @Override
     public void markDirty() {
         if (getWorld() != null && getPos() != null) {

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -98,6 +98,14 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         return getPos();
     }
 
+    @SuppressWarnings("all") // yes this CAN actually be null
+    @Override
+    public void markDirty() {
+        if (getWorld() != null && getPos() != null) {
+            getWorld().markChunkDirty(getPos(), this);
+        }
+    }
+
     @Override
     public PipeCoverableImplementation getCoverableImplementation() {
         return coverableImplementation;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -24,7 +24,6 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
@@ -51,14 +50,6 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityDiode(metaTileEntityId, getTier());
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        long energyStored = energyContainer.getEnergyStored();
-        long energyCapacity = energyContainer.getEnergyCapacity();
-        float f = energyCapacity == 0L ? 0.0f : energyStored / (energyCapacity * 1.0f);
-        return MathHelper.floor(f * 14.0f) + (energyStored > 0 ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityHull.java
@@ -3,7 +3,6 @@ package gregtech.common.metatileentities.electric;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEPartLocation;
 import appeng.me.helpers.AENetworkProxy;
-import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
@@ -23,9 +22,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Optional;
@@ -53,14 +50,6 @@ public class MetaTileEntityHull extends MetaTileEntityMultiblockPart implements 
         long tierVoltage = GTValues.V[getTier()];
         this.energyContainer = new EnergyContainerHandler(this, tierVoltage * 16L, tierVoltage, 1L, tierVoltage, 1L);
         ((EnergyContainerHandler) this.energyContainer).setSideOutputCondition(s -> s == getFrontFacing());
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        long energyStored = energyContainer.getEnergyStored();
-        long energyCapacity = energyContainer.getEnergyCapacity();
-        float f = energyCapacity == 0L ? 0.0f : energyStored / (energyCapacity * 1.0f);
-        return MathHelper.floor(f * 14.0f) + (energyStored > 0 ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
@@ -24,7 +24,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -69,11 +68,6 @@ public class MetaTileEntityCrate extends MetaTileEntity {
         super.initializeInventory();
         this.inventory = new ItemStackHandler(inventorySize);
         this.itemInventory = inventory;
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        return ItemHandlerHelper.calcRedstoneFromInventory(inventory);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -29,7 +29,6 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -72,15 +71,6 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     @Override
     public int getLightOpacity() {
         return 1;
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        FluidTank fluidTank = this.fluidTank;
-        int fluidAmount = fluidTank.getFluidAmount();
-        int maxCapacity = fluidTank.getCapacity();
-        float f = fluidAmount / (maxCapacity * 1.0f);
-        return MathHelper.floor(f * 14.0f) + (fluidAmount > 0 ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -35,7 +35,6 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -114,12 +113,6 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     @Override
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[tier].getParticleSprite(), getPaintingColorForRendering());
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        float f = itemsStoredInside / (maxStoredItems * 1.0f);
-        return MathHelper.floor(f * 14.0f) + (itemsStoredInside > 0 ? 1 : 0);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -36,7 +36,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -100,15 +99,6 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         this.importFluids = new FluidTankList(false, fluidTank);
         this.exportFluids = new FluidTankList(false, fluidTank);
         this.outputFluidInventory = new FluidHandlerProxy(new FluidTankList(false), exportFluids);
-    }
-
-    @Override
-    public int getActualComparatorValue() {
-        FluidTank fluidTank = this.fluidTank;
-        int fluidAmount = fluidTank.getFluidAmount();
-        int maxCapacity = fluidTank.getCapacity();
-        float f = fluidAmount / (maxCapacity * 1.0f);
-        return MathHelper.floor(f * 14.0f) + (fluidAmount > 0 ? 1 : 0);
     }
 
     @Override


### PR DESCRIPTION
Removes all comparator interactions for MTEs, in favor of various detector covers. Calls World#markChunkDirty() directly instead of TileEntity#markDirty to avoid unnecessary comparator recalculations and neighbor updates