### PR TITLE
Shortcut method for CT material registry getter

### DIFF
--- a/src/main/java/gregtech/integration/crafttweaker/material/CTMaterialRegistry.java
+++ b/src/main/java/gregtech/integration/crafttweaker/material/CTMaterialRegistry.java
@@ -1,6 +1,7 @@
 package gregtech.integration.crafttweaker.material;
 
 import crafttweaker.annotations.ZenRegister;
+import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.Material;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -15,6 +16,11 @@ public class CTMaterialRegistry {
     @ZenMethod
     public Material get(String modid, String name) {
         return GregTechAPI.materialManager.getRegistry(modid).getObject(name);
+    }
+
+    @ZenMethod
+    public Material get(String name) {
+        return get(GTValues.MODID, name);
     }
 
     @ZenMethod


### PR DESCRIPTION
Default to GT registry if unspecified, fixes compat break from 2.7