### PR TITLE
Recipe chart app fix

### DIFF
--- a/src/main/java/gregtech/common/terminal/app/recipechart/FluidStackHelper.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/FluidStackHelper.java
@@ -1,0 +1,59 @@
+package gregtech.common.terminal.app.recipechart;
+
+import gregtech.api.gui.Widget;
+import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.terminal.os.TerminalTheme;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTank;
+
+public class FluidStackHelper implements IngredientHelper<FluidStack> {
+
+    public static final FluidStackHelper INSTANCE = new FluidStackHelper();
+
+    @Override
+    public byte getTypeId() {
+        return 2;
+    }
+
+    @Override
+    public int getAmount(FluidStack fluidStack) {
+        return fluidStack.amount;
+    }
+
+    @Override
+    public void setAmount(FluidStack fluidStack, int amount) {
+        fluidStack.amount = amount;
+    }
+
+    @Override
+    public boolean areEqual(FluidStack t1, FluidStack t2) {
+        return t1 != null && t1.isFluidEqual(t2);
+    }
+
+    @Override
+    public boolean isEmpty(FluidStack fluidStack) {
+        return fluidStack.getFluid() == null || fluidStack.amount <= 0;
+    }
+
+    @Override
+    public String getDisplayName(FluidStack fluidStack) {
+        return fluidStack.getLocalizedName();
+    }
+
+    @Override
+    public Widget createWidget(FluidStack fluidStack) {
+        FluidTank tank = new FluidTank(fluidStack, Integer.MAX_VALUE);
+        return new TankWidget(tank, 0, 0, 18, 18).setAlwaysShowFull(true).setBackgroundTexture(TerminalTheme.COLOR_B_2).setClient();
+    }
+
+    @Override
+    public FluidStack deserialize(NBTTagCompound nbt) {
+        return FluidStack.loadFluidStackFromNBT(nbt);
+    }
+
+    @Override
+    public NBTTagCompound serialize(FluidStack fluidStack) {
+        return fluidStack.writeToNBT(new NBTTagCompound());
+    }
+}

--- a/src/main/java/gregtech/common/terminal/app/recipechart/IngredientHelper.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/IngredientHelper.java
@@ -1,0 +1,48 @@
+package gregtech.common.terminal.app.recipechart;
+
+import gregtech.api.gui.Widget;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.Objects;
+
+public interface IngredientHelper<T> {
+
+    static <T> IngredientHelper<T> getFor(Object o) {
+        Objects.requireNonNull(o);
+        if (o.getClass() == ItemStack.class) {
+            return (IngredientHelper<T>) ItemStackHelper.INSTANCE;
+        }
+        if (o.getClass() == FluidStack.class) {
+            return (IngredientHelper<T>) FluidStackHelper.INSTANCE;
+        }
+        throw new IllegalArgumentException();
+    }
+
+    static IngredientHelper<?> getForTypeId(int type) {
+        return switch (type) {
+            case 1 -> ItemStackHelper.INSTANCE;
+            case 2 -> FluidStackHelper.INSTANCE;
+            default -> throw new IllegalArgumentException();
+        };
+    }
+
+    byte getTypeId();
+
+    int getAmount(T t);
+
+    void setAmount(T t, int amount);
+
+    boolean areEqual(T t1, T t2);
+
+    boolean isEmpty(T t);
+
+    String getDisplayName(T t);
+
+    Widget createWidget(T t);
+
+    T deserialize(NBTTagCompound nbt);
+
+    NBTTagCompound serialize(T t);
+}

--- a/src/main/java/gregtech/common/terminal/app/recipechart/ItemStackHelper.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/ItemStackHelper.java
@@ -1,0 +1,61 @@
+package gregtech.common.terminal.app.recipechart;
+
+import gregtech.api.gui.Widget;
+import gregtech.api.gui.widgets.SlotWidget;
+import gregtech.api.terminal.os.TerminalTheme;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
+
+public class ItemStackHelper implements IngredientHelper<ItemStack> {
+
+    public static final ItemStackHelper INSTANCE = new ItemStackHelper();
+
+    @Override
+    public byte getTypeId() {
+        return 1;
+    }
+
+    @Override
+    public int getAmount(ItemStack t) {
+        return t.getCount();
+    }
+
+    @Override
+    public void setAmount(ItemStack t, int amount) {
+        t.setCount(amount);
+    }
+
+    @Override
+    public boolean areEqual(ItemStack t1, ItemStack t2) {
+        return ItemHandlerHelper.canItemStacksStack(t1, t2);
+    }
+
+    @Override
+    public boolean isEmpty(ItemStack stack) {
+        return stack.isEmpty();
+    }
+
+    @Override
+    public String getDisplayName(ItemStack stack) {
+        return stack.getDisplayName();
+    }
+
+    @Override
+    public Widget createWidget(ItemStack stack) {
+        ItemStackHandler handler = new ItemStackHandler(1);
+        handler.setStackInSlot(0, stack);
+        return new SlotWidget(handler, 0, 0, 0, false, false).setBackgroundTexture(TerminalTheme.COLOR_B_2);
+    }
+
+    @Override
+    public ItemStack deserialize(NBTTagCompound nbt) {
+        return new ItemStack(nbt);
+    }
+
+    @Override
+    public NBTTagCompound serialize(ItemStack stack) {
+        return stack.serializeNBT();
+    }
+}

--- a/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
@@ -424,7 +424,7 @@ public class RGNode extends WidgetGroup implements IDraggable {
         Iterator<Widget> iterator = children.keySet().iterator();
         for (NBTBase nbtBase : childrenTag) {
             int[] nbt = ((NBTTagIntArray) nbtBase).getIntArray();
-            children.get(iterator.next()).addAll(Arrays.stream(nbt).mapToObj(it -> container.nodes.get(it)).toList());
+            children.get(iterator.next()).addAll(Arrays.stream(nbt).mapToObj(it -> container.nodes.get(it)).collect(Collectors.toList()));
         }
     }
 

--- a/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 
 public class RGNode extends WidgetGroup implements IDraggable {
     protected Object head;
-    protected int recipePer;
+    protected int recipePer = 1;
     protected ItemStack catalyst;
     private boolean isSelected;
     private WidgetGroup toolGroup;
@@ -435,7 +435,7 @@ public class RGNode extends WidgetGroup implements IDraggable {
                     }
                 }
             }
-            setRecipe(itemInputs, fluidInputs, catalyst, recipePer);
+            setRecipe(itemInputs, fluidInputs, catalyst, Math.max(1, this.recipePer));
             return true;
         }
         return false;

--- a/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
+++ b/src/main/java/gregtech/common/terminal/app/recipechart/widget/RGNode.java
@@ -17,6 +17,7 @@ import gregtech.api.terminal.os.TerminalDialogWidget;
 import gregtech.api.terminal.os.TerminalTheme;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.Position;
+import gregtech.common.terminal.app.recipechart.IngredientHelper;
 import gregtech.integration.jei.JustEnoughItemsModule;
 import gregtech.integration.jei.recipe.GTRecipeWrapper;
 import mezz.jei.api.gui.IRecipeLayout;
@@ -45,6 +46,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class RGNode extends WidgetGroup implements IDraggable {
+
+    private IngredientHelper<Object> headHelper;
     protected Object head;
     protected int recipePer = 1;
     protected ItemStack catalyst;
@@ -60,9 +63,13 @@ public class RGNode extends WidgetGroup implements IDraggable {
         super(x, y, 18, 18);
         init(container);
         this.head = head;
+        if (head != null) {
+            this.headHelper = IngredientHelper.getFor(head);
+        }
         if (isPhantom) {
             PhantomWidget phantom = new PhantomWidget(0, 0, head).setChangeListener(object -> {
                 RGNode.this.head = object;
+                RGNode.this.headHelper = object != null ? IngredientHelper.getFor(object) : null;
                 // Reset any children nodes, now that the parent has changed
                 for (Set<RGNode> childs : children.values()) {
                     for (RGNode child : childs) {
@@ -121,27 +128,13 @@ public class RGNode extends WidgetGroup implements IDraggable {
                                 }
                             }).setClientSide().open()));
         } else {
-            if (head instanceof ItemStack) {
-                ItemStackHandler handler = new ItemStackHandler(1);
-                handler.setStackInSlot(0, (ItemStack) head);
-                this.addWidget(new SlotWidget(handler, 0, 0, 0, false, false).setBackgroundTexture(TerminalTheme.COLOR_B_2));
-            } else if (head instanceof FluidStack) {
-                FluidTank tank = new FluidTank((FluidStack) head, Integer.MAX_VALUE);
-                this.addWidget(new TankWidget(tank, 0, 0, 18, 18).setAlwaysShowFull(true).setBackgroundTexture(TerminalTheme.COLOR_B_2).setClient());
-            }
+            addWidget(this.headHelper.createWidget(head));
         }
     }
 
     private void init(RGContainer container) {
         this.container = container;
-        textWidget = new SimpleTextWidget(9, -5, "", -1, () -> {
-            if (head instanceof ItemStack) {
-                return ((ItemStack) head).getDisplayName();
-            } else if (head instanceof FluidStack) {
-                return ((FluidStack) head).getLocalizedName();
-            }
-            return "terminal.recipe_chart.drag";
-        }, true).setShadow(true);
+        textWidget = new SimpleTextWidget(9, -5, "", -1, () -> this.head != null ? this.headHelper.getDisplayName(this.head) : "terminal.recipe_chart.drag", true).setShadow(true);
         textWidget.setVisible(false);
         textWidget.setActive(false);
         this.addWidget(textWidget);
@@ -167,7 +160,7 @@ public class RGNode extends WidgetGroup implements IDraggable {
                 .setIcon(GuiTextures.ICON_LOCATION)
                 .setHoverText("terminal.recipe_chart.jei")
                 .setClickListener(cd -> {
-                    if (JustEnoughItemsModule.jeiRuntime != null && head != null && !(head instanceof ItemStack && ((ItemStack) head).isEmpty())) {
+                    if (JustEnoughItemsModule.jeiRuntime != null && head != null && !this.headHelper.isEmpty(head)) {
                         JustEnoughItemsModule.jeiRuntime.getRecipesGui().show(new Focus<>(IFocus.Mode.OUTPUT, head));
                     }
                 }));
@@ -180,12 +173,7 @@ public class RGNode extends WidgetGroup implements IDraggable {
     }
 
     public int getHeadDemand() {
-        if (head instanceof ItemStack) {
-            return ((ItemStack) head).getCount();
-        } else if (head instanceof FluidStack) {
-            return ((FluidStack) head).amount;
-        }
-        return 0;
+        return this.headHelper.getAmount(this.head);
     }
 
     public int getChildDemand(RGNode child) {
@@ -205,9 +193,7 @@ public class RGNode extends WidgetGroup implements IDraggable {
     }
 
     public boolean canMerge(RGNode node) {
-        if (this.head instanceof ItemStack && node.head instanceof ItemStack && ((ItemStack) this.head).isItemEqual((ItemStack) node.head)) {
-            return checkMergeAvailable(node);
-        } else if (this.head instanceof FluidStack && node.head instanceof FluidStack && ((FluidStack) this.head).isFluidEqual((FluidStack) node.head)) {
+        if (this.headHelper == node.headHelper && this.headHelper.areEqual(this.head, node.head)) {
             return checkMergeAvailable(node);
         }
         return false;
@@ -288,11 +274,7 @@ public class RGNode extends WidgetGroup implements IDraggable {
     private void dfsUpdateDemand(int demand, Stack<RGNode> updated) {
         if (updated.contains(this)) return;
         updated.push(this);
-        if (head instanceof ItemStack) {
-            ((ItemStack) head).setCount(demand);
-        } else if (head instanceof FluidStack) {
-            ((FluidStack) head).amount = demand;
-        }
+        this.headHelper.setAmount(this.head, demand);
         for (Set<RGNode> children : children.values()) {
             for (RGNode child : children) {
                 child.parentNodes.put(this, this.getChildDemand(child));
@@ -343,15 +325,8 @@ public class RGNode extends WidgetGroup implements IDraggable {
     public boolean transferRecipe(ModularUIContainer x, IRecipeLayout recipeLayout, EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
         if (isSelected) {
             Object obj = recipeLayout.getFocus() == null ? null : recipeLayout.getFocus().getValue();
-            if (head instanceof ItemStack && obj instanceof ItemStack) {
-                if (!((ItemStack) head).isItemEqual((ItemStack) obj)) {
-                    return false;
-                }
-            } else if (head instanceof FluidStack && obj instanceof FluidStack) {
-                if (!((FluidStack) head).isFluidEqual((FluidStack) obj)) {
-                    return false;
-                }
-            } else {
+            IngredientHelper<?> otherHelper = IngredientHelper.getFor(obj);
+            if (this.headHelper != otherHelper || !this.headHelper.areEqual(this.head, obj)) {
                 return false;
             }
             if (!doTransfer) return true;
@@ -449,27 +424,19 @@ public class RGNode extends WidgetGroup implements IDraggable {
         Iterator<Widget> iterator = children.keySet().iterator();
         for (NBTBase nbtBase : childrenTag) {
             int[] nbt = ((NBTTagIntArray) nbtBase).getIntArray();
-            children.get(iterator.next()).addAll(Arrays.stream(nbt).mapToObj(it -> container.nodes.get(it)).collect(Collectors.toList()));
+            children.get(iterator.next()).addAll(Arrays.stream(nbt).mapToObj(it -> container.nodes.get(it)).toList());
         }
     }
 
     public static RGNode deserializeNodeNBT(NBTTagCompound nodeTag, RGContainer container) {
         byte type = nodeTag.getByte("type"); // 0-null 1-itemstack 2-fluidstack
         Object head = null;
-        if (type == 1) {
-            head = new ItemStack(nodeTag.getCompoundTag("nbt"));
-            ((ItemStack) head).setCount(nodeTag.getInteger("count"));
-        } else if (type == 2) {
-            head = FluidStack.loadFluidStackFromNBT(nodeTag.getCompoundTag("nbt"));
-            assert head != null;
-            ((FluidStack) head).amount = nodeTag.getInteger("count");
+        if (type != 0) {
+            IngredientHelper<Object> headHelper = (IngredientHelper<Object>) IngredientHelper.getForTypeId(type);
+            head = headHelper.deserialize(nodeTag.getCompoundTag("nbt"));
+            headHelper.setAmount(head, nodeTag.getInteger("count"));
         }
-        RGNode node;
-        if (nodeTag.getBoolean("phantom")) {
-            node = new RGNode(nodeTag.getInteger("x"), nodeTag.getInteger("y"), container, head, true);
-        } else {
-            node = new RGNode(nodeTag.getInteger("x"), nodeTag.getInteger("y"), container, head, false);
-        }
+        RGNode node = new RGNode(nodeTag.getInteger("x"), nodeTag.getInteger("y"), container, head, nodeTag.getBoolean("phantom"));
         NBTTagList itemsList = nodeTag.getTagList("items", Constants.NBT.TAG_COMPOUND);
         NBTTagList fluidsList = nodeTag.getTagList("fluids", Constants.NBT.TAG_COMPOUND);
         List<ItemStack> itemInputs = new LinkedList<>();
@@ -498,13 +465,10 @@ public class RGNode extends WidgetGroup implements IDraggable {
         NBTTagCompound nbt = new NBTTagCompound();
         nbt.setInteger("x", getSelfPosition().x + container.getScrollXOffset());
         nbt.setInteger("y", getSelfPosition().y + container.getScrollYOffset());
-        nbt.setByte("type", head instanceof ItemStack ? (byte) 1 : head instanceof FluidStack ? (byte) 2 : 0);
-        if (head instanceof ItemStack) {
-            nbt.setTag("nbt", ((ItemStack) head).serializeNBT());
-            nbt.setInteger("count", ((ItemStack) head).getCount());
-        } else if (head instanceof FluidStack) {
-            nbt.setTag("nbt", ((FluidStack) head).writeToNBT(new NBTTagCompound()));
-            nbt.setInteger("count", ((FluidStack) head).amount);
+        nbt.setByte("type", this.head == null ? 0 : this.headHelper.getTypeId());
+        if (this.head != null) {
+            nbt.setTag("nbt", this.headHelper.serialize(this.head));
+            nbt.setInteger("count", this.headHelper.getAmount(this.head));
         }
         nbt.setBoolean("phantom", widgets.stream().anyMatch(it -> it instanceof PhantomWidget));
         // recipe + children

--- a/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
+++ b/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
@@ -41,7 +41,6 @@ import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
-import mezz.jei.api.recipe.wrapper.ICraftingRecipeWrapper;
 import mezz.jei.config.Constants;
 import mezz.jei.input.IShowsRecipeFocuses;
 import mezz.jei.input.InputHandler;
@@ -49,7 +48,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -127,9 +125,11 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
         // register transfer handler for all categories, but not for the crafting station
         ModularUIGuiHandler modularUIGuiHandler = new ModularUIGuiHandler(jeiHelpers.recipeTransferHandlerHelper());
         modularUIGuiHandler.setValidHandlers(widget -> !(widget instanceof CraftingSlotWidget));
-        if (Loader.isModLoaded(GTValues.MODID_JEI)) {
-            modularUIGuiHandler.setValidHandlers(widget -> !(widget instanceof CraftingSlotWidget) && widget instanceof ICraftingRecipeWrapper);
-        }
+        modularUIGuiHandler.blacklistCategory(
+                IntCircuitCategory.UID,
+                GTValues.MODID + ":material_tree",
+                VanillaRecipeCategoryUid.INFORMATION,
+                VanillaRecipeCategoryUid.FUEL);
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(modularUIGuiHandler, Constants.UNIVERSAL_RECIPE_TRANSFER_UID);
 
         registry.addAdvancedGuiHandlers(modularUIGuiHandler);

--- a/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
+++ b/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
@@ -163,8 +163,7 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
             if (metaTileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_CONTROLLABLE, null) != null) {
                 IControllable workableCapability = metaTileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_CONTROLLABLE, null);
 
-                if (workableCapability instanceof AbstractRecipeLogic) {
-                    AbstractRecipeLogic logic = (AbstractRecipeLogic) workableCapability;
+                if (workableCapability instanceof AbstractRecipeLogic logic) {
                     if (metaTileEntity instanceof IMultipleRecipeMaps) {
                         for (RecipeMap<?> recipeMap : ((IMultipleRecipeMaps) metaTileEntity).getAvailableRecipeMaps()) {
                             registerRecipeMapCatalyst(registry, recipeMap, metaTileEntity);

--- a/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
+++ b/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
@@ -50,7 +50,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
 
     @Nullable
     @Override
-    public IRecipeTransferError transferRecipe(ModularUIContainer container, @Nonnull IRecipeLayout recipeLayout, @Nonnull EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
+    public IRecipeTransferError transferRecipe(@Nonnull ModularUIContainer container, @Nonnull IRecipeLayout recipeLayout, @Nonnull EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
         if (this.recipeTransferCategoryBlacklist.contains(recipeLayout.getRecipeCategory().getUid())) {
             return this.transferHelper.createInternalError();
         }
@@ -60,7 +60,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
                 .map(it -> (IRecipeTransferHandlerWidget) it)
                 .filter(validHandlers)
                 .findFirst();
-        if (!transferHandler.isPresent()) {
+        if (transferHandler.isEmpty()) {
             return transferHelper.createInternalError();
         }
         String errorTooltip = transferHandler.get().transferRecipe(container, recipeLayout, player, maxTransfer, doTransfer);
@@ -95,8 +95,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
         Collection<Widget> widgets = gui.getModularUI().guiWidgets.values();
         List<Target<I>> targets = new ArrayList<>();
         for (Widget widget : widgets) {
-            if (widget instanceof IGhostIngredientTarget) {
-                IGhostIngredientTarget ghostTarget = (IGhostIngredientTarget) widget;
+            if (widget instanceof IGhostIngredientTarget ghostTarget) {
                 List<Target<?>> widgetTargets = ghostTarget.getPhantomTargets(ingredient);
                 //noinspection unchecked
                 targets.addAll((List<Target<I>>) (Object) widgetTargets);

--- a/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
+++ b/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
@@ -60,7 +60,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
                 .map(it -> (IRecipeTransferHandlerWidget) it)
                 .filter(validHandlers)
                 .findFirst();
-        if (transferHandler.isEmpty()) {
+        if (!transferHandler.isPresent()) {
             return transferHelper.createInternalError();
         }
         String errorTooltip = transferHandler.get().transferRecipe(container, recipeLayout, player, maxTransfer, doTransfer);

--- a/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
+++ b/src/main/java/gregtech/integration/jei/utils/ModularUIGuiHandler.java
@@ -6,6 +6,7 @@ import gregtech.api.gui.impl.ModularUIGui;
 import gregtech.api.gui.ingredient.IGhostIngredientTarget;
 import gregtech.api.gui.ingredient.IIngredientSlot;
 import gregtech.api.gui.ingredient.IRecipeTransferHandlerWidget;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import mezz.jei.api.gui.IAdvancedGuiHandler;
 import mezz.jei.api.gui.IGhostIngredientHandler;
 import mezz.jei.api.gui.IRecipeLayout;
@@ -25,6 +26,7 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
 
     private final IRecipeTransferHandlerHelper transferHelper;
     private Predicate<IRecipeTransferHandlerWidget> validHandlers = widget -> true;
+    private final Set<String> recipeTransferCategoryBlacklist = new ObjectOpenHashSet<>();
 
     public ModularUIGuiHandler(IRecipeTransferHandlerHelper transferHelper) {
         this.transferHelper = transferHelper;
@@ -49,6 +51,9 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
     @Nullable
     @Override
     public IRecipeTransferError transferRecipe(ModularUIContainer container, @Nonnull IRecipeLayout recipeLayout, @Nonnull EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
+        if (this.recipeTransferCategoryBlacklist.contains(recipeLayout.getRecipeCategory().getUid())) {
+            return this.transferHelper.createInternalError();
+        }
         Optional<IRecipeTransferHandlerWidget> transferHandler = container.getModularUI()
                 .getFlatVisibleWidgetCollection().stream()
                 .filter(it -> it instanceof IRecipeTransferHandlerWidget)
@@ -63,6 +68,10 @@ public class ModularUIGuiHandler implements IAdvancedGuiHandler<ModularUIGui>, I
             return null;
         }
         return transferHelper.createUserErrorWithTooltip(errorTooltip);
+    }
+
+    public void blacklistCategory(String... category) {
+        Collections.addAll(this.recipeTransferCategoryBlacklist, category);
     }
 
     @Nullable


### PR DESCRIPTION
## What
#1638 introduced a bug where only crafting recipes can be applied in the recipe chart. That PR was supposed to fix #1595.
That bug happened because of `0.0f / 0.0f = infinity` causing a int overflow which causes the item to be empty.
This pr fixes that by never dividing by anything less than 1. I also added a blacklist to jei to prevent certain jei categories to be applied to the recipe chart (like material tree or JEI info page).
I also cleaned the code a little bit up in `RGNode`.

## Implementation Details
Terminal magic

## Outcome
Undo #1638 and fix #1595 properly.
Closes #2007

## Additional Information
No

## Potential Compatibility Issues
Probably none
