### PR TITLE
Include Steam Grinder/Smelter for TOP/HWYLA changes

### DIFF
--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -3,8 +3,10 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
+import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
@@ -64,8 +66,9 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                 String endText = null;
 
                 if (accessor.getTileEntity() instanceof IGregTechTileEntity gtte) {
-                    if (gtte.getMetaTileEntity() instanceof SteamMetaTileEntity || gtte.getMetaTileEntity() instanceof MetaTileEntityLargeBoiler) {
-                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.steam")+ " " + I18n.format(Materials.Steam.getUnlocalizedName());
+                    MetaTileEntity mte = gtte.getMetaTileEntity();
+                    if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler || mte instanceof RecipeMapSteamMultiblockController) {
+                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.of") + I18n.format(Materials.Steam.getUnlocalizedName());
                     }
                     AbstractRecipeLogic arl = gtte.getMetaTileEntity().getRecipeLogic();
                     if (arl != null) {

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -68,7 +68,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                 if (accessor.getTileEntity() instanceof IGregTechTileEntity gtte) {
                     MetaTileEntity mte = gtte.getMetaTileEntity();
                     if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler || mte instanceof RecipeMapSteamMultiblockController) {
-                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.of") + I18n.format(Materials.Steam.getUnlocalizedName());
+                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.of") + " " + I18n.format(Materials.Steam.getUnlocalizedName());
                     }
                     AbstractRecipeLogic arl = mte.getRecipeLogic();
                     if (arl != null) {

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -70,7 +70,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                     if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler || mte instanceof RecipeMapSteamMultiblockController) {
                         endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.of") + I18n.format(Materials.Steam.getUnlocalizedName());
                     }
-                    AbstractRecipeLogic arl = gtte.getMetaTileEntity().getRecipeLogic();
+                    AbstractRecipeLogic arl = mte.getRecipeLogic();
                     if (arl != null) {
                         consumer = arl.consumesEnergy();
                     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -7,6 +7,7 @@ import gregtech.api.capability.impl.PrimitiveRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
@@ -42,14 +43,13 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             }
             int EUt = capability.getInfoProviderEUt();
             int absEUt = Math.abs(EUt);
-            boolean consumer = capability.consumesEnergy();
             String text = null;
 
             if (tileEntity instanceof IGregTechTileEntity) {
                 IGregTechTileEntity gtTileEntity = (IGregTechTileEntity) tileEntity;
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
-                if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler) {
-                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t {*gregtech.top.steam*} {*" + Materials.Steam.getUnlocalizedName() + "*}";
+                if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler || mte instanceof RecipeMapSteamMultiblockController) {
+                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t {*gregtech.top.of*} {*" + Materials.Steam.getUnlocalizedName() + "*}";
                 }
             }
             if (text == null) {
@@ -59,7 +59,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
 
             if (EUt == 0) return; // idk what to do for 0 eut
 
-            if (consumer) {
+            if (capability.consumesEnergy()) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);
             } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " + text);

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -57,7 +57,7 @@ gregtech.top.working_disabled=Working Disabled
 
 gregtech.top.energy_consumption=Using
 gregtech.top.energy_production=Producing
-gregtech.top.steam=of
+gregtech.top.of=of
 
 gregtech.top.transform_up=Step Up
 gregtech.top.transform_down=Step Down


### PR DESCRIPTION
## What
Includes the steam grinder and smelter with the changes by #2001. Also changes the `gregtech.top.steam` lang key to `gregtech.top.of`.

## Implementation Details
I really want to remove `gregtech.top.of`, but i don't know of a better solution

## Outcome
steam grinder and smelter use L/t instead of EU/t
