### PR TITLE
slightly better fluid vein version handling

### DIFF
--- a/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
+++ b/src/main/java/gregtech/api/worldgen/bedrockFluids/BedrockFluidVeinSaveData.java
@@ -34,6 +34,9 @@ public class BedrockFluidVeinSaveData extends WorldSavedData {
 
         if (nbt.hasKey("version")) {
             BedrockFluidVeinHandler.saveDataVersion = nbt.getInteger("version");
+        } else if (veinList.isEmpty()) {
+            // there are no veins, so there is no data to be changed or lost by bumping the version
+            BedrockFluidVeinHandler.saveDataVersion = BedrockFluidVeinHandler.MAX_FLUID_SAVE_DATA_VERSION;
         } else {
             // version number was added to the save data with version 2
             BedrockFluidVeinHandler.saveDataVersion = 1;


### PR DESCRIPTION
don't force the old broken vein version if there are no veins when initially generating the version  
i thought about it and this would be better behavior than current, best to get this out in 2.7.3 before every vein cache has a version attached to it