### PR TITLE
fix double slabs not dropping items

### DIFF
--- a/src/main/java/gregtech/common/blocks/wood/BlockGregWoodSlab.java
+++ b/src/main/java/gregtech/common/blocks/wood/BlockGregWoodSlab.java
@@ -2,6 +2,7 @@ package gregtech.common.blocks.wood;
 
 import gregtech.api.GregTechAPI;
 import gregtech.api.items.toolitem.ToolClasses;
+import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.BlockSlab;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -10,6 +11,7 @@ import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
@@ -17,6 +19,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
 import javax.annotation.Nonnull;
+import java.util.Random;
 
 public abstract class BlockGregWoodSlab extends BlockSlab {
 
@@ -42,6 +45,12 @@ public abstract class BlockGregWoodSlab extends BlockSlab {
     @Override
     public int damageDropped(IBlockState state) {
         return state.getValue(VARIANT).ordinal();
+    }
+
+    @Nonnull
+    @Override
+    public Item getItemDropped(@Nonnull IBlockState state, @Nonnull Random rand, int fortune) {
+        return Item.getItemFromBlock(MetaBlocks.WOOD_SLAB);
     }
 
     @Nonnull


### PR DESCRIPTION
## What
Fixes double slabs not dropping items when destroyed.

## Outcome
Fixes #1970.