### PR TITLE
Rename getId() in IGTTool to restore SpongeForge Compability

### DIFF
--- a/src/main/java/gregtech/api/damagesources/DamageSources.java
+++ b/src/main/java/gregtech/api/damagesources/DamageSources.java
@@ -54,7 +54,7 @@ public class DamageSources {
         ItemStack stack = source != null ? source.getHeldItemMainhand() : ItemStack.EMPTY;
         if (!stack.isEmpty() && stack.getItem() instanceof IGTTool) {
             IGTTool tool = (IGTTool) stack.getItem();
-            return new DamageSourceTool("player", source, String.format("death.attack.%s", tool.getId()));
+            return new DamageSourceTool("player", source, String.format("death.attack.%s", tool.getToolId()));
         }
         return new EntityDamageSource("player", source);
     }
@@ -65,7 +65,7 @@ public class DamageSources {
         ItemStack stack = source != null ? source.getItemStackFromSlot(EntityEquipmentSlot.MAINHAND) : ItemStack.EMPTY;
         if (!stack.isEmpty() && stack.getItem() instanceof IGTTool) {
             IGTTool tool = (IGTTool) stack.getItem();
-            return new DamageSourceTool("mob", source, String.format("death.attack.%s", tool.getId()));
+            return new DamageSourceTool("mob", source, String.format("death.attack.%s", tool.getToolId()));
         }
         return new EntityDamageSource("mob", source);
     }

--- a/src/main/java/gregtech/api/items/toolitem/IGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/IGTTool.java
@@ -100,7 +100,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
     /**
      * @return the name of the tool
      */
-    String getId();
+    String getToolId();
 
     boolean isElectric();
 
@@ -721,7 +721,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
         toolStats.getBehaviors().forEach(behavior -> behavior.addInformation(stack, world, tooltip, flag));
 
         // unique tooltip
-        String uniqueTooltip = "item.gt.tool." + getId() + ".tooltip";
+        String uniqueTooltip = "item.gt.tool." + getToolId() + ".tooltip";
         if (I18n.hasKey(uniqueTooltip)) {
             tooltip.add("");
             tooltip.add(I18n.format(uniqueTooltip));
@@ -820,7 +820,7 @@ public interface IGTTool extends ItemUIFactory, IAEWrench, IToolWrench, IToolHam
 
     @SideOnly(Side.CLIENT)
     default String getModelPath() {
-        return getDomain() + ":" + "tools/" + getId();
+        return getDomain() + ":" + "tools/" + getToolId();
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTAxe.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTAxe.java
@@ -66,7 +66,7 @@ public class ItemGTAxe extends ItemAxe implements IGTTool {
     }
 
     @Override
-    public String getId() {
+    public String getToolId() {
         return id;
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTHoe.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTHoe.java
@@ -66,7 +66,7 @@ public class ItemGTHoe extends ItemHoe implements IGTTool {
     }
 
     @Override
-    public String getId() {
+    public String getToolId() {
         return id;
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTSword.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTSword.java
@@ -70,7 +70,7 @@ public class ItemGTSword extends ItemSword implements IGTTool {
     }
 
     @Override
-    public String getId() {
+    public String getToolId() {
         return id;
     }
 

--- a/src/main/java/gregtech/api/items/toolitem/ItemGTTool.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTTool.java
@@ -72,7 +72,7 @@ public class ItemGTTool extends ItemTool implements IGTTool {
     }
 
     @Override
-    public String getId() {
+    public String getToolId() {
         return id;
     }
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/ToolRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/ToolRecipeHandler.java
@@ -16,7 +16,6 @@ import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.properties.ToolProperty;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
-import gregtech.common.ConfigHolder;
 import gregtech.common.crafting.ToolHeadReplaceRecipe;
 import gregtech.common.items.MetaItems;
 import gregtech.common.items.ToolItems;
@@ -296,7 +295,7 @@ public class ToolRecipeHandler {
             ItemStack powerUnitStack = powerUnitItems.get(tier).getStackForm();
             IElectricItem powerUnit = powerUnitStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null);
             ItemStack tool = toolItem.get(material, 0, powerUnit.getMaxCharge());
-            ModHandler.addShapedEnergyTransferRecipe(String.format("%s_%s", toolItem.getId(), material),
+            ModHandler.addShapedEnergyTransferRecipe(String.format("%s_%s", toolItem.getToolId(), material),
                     tool,
                     Ingredient.fromStacks(powerUnitStack), true, true,
                     "wHd", " U ",
@@ -307,10 +306,10 @@ public class ToolRecipeHandler {
 
     public static void addToolRecipe(@Nonnull Material material, @Nonnull IGTTool tool, boolean mirrored, Object... recipe) {
         if (mirrored) {
-            ModHandler.addMirroredShapedRecipe(String.format("%s_%s", tool.getId(), material),
+            ModHandler.addMirroredShapedRecipe(String.format("%s_%s", tool.getToolId(), material),
                     tool.get(material), recipe);
         } else {
-            ModHandler.addShapedRecipe(String.format("%s_%s", tool.getId(), material),
+            ModHandler.addShapedRecipe(String.format("%s_%s", tool.getToolId(), material),
                     tool.get(material), recipe);
         }
     }


### PR DESCRIPTION
## What
Fixes  #1531 and restores compatibility with SpongeForge

## Implementation Details
Renamed `getId()` to `getToolId()` in `gregtech.api.items.toolitem.IGTTool `, since Sponge already implements a method with the same name in their mixins. 

## Outcome
Fixes: #1531

## Potential Compatibility Issues
Addons using the method will break