### PR TITLE
Fix MultiRecipeMap localize on TOP

### DIFF
--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -35,7 +35,7 @@ public class MultiRecipeMapInfoProvider extends CapabilityInfoProvider<IMultiple
             if (recipeMap.equals(iMultipleRecipeMaps.getCurrentRecipeMap())) {
                 iProbeInfo.text("   " + TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");
             } else {
-                iProbeInfo.text("   " + TextStyleClass.LABEL + recipeMap.getLocalizedName());
+                iProbeInfo.text("   " + TextStyleClass.LABEL + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*}");
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -33,9 +33,9 @@ public class MultiRecipeMapInfoProvider extends CapabilityInfoProvider<IMultiple
         iProbeInfo.text(TextStyleClass.INFO + IProbeInfo.STARTLOC + "gregtech.multiblock.multiple_recipemaps.header" + IProbeInfo.ENDLOC);
         for (RecipeMap<?> recipeMap : iMultipleRecipeMaps.getAvailableRecipeMaps()) {
             if (recipeMap.equals(iMultipleRecipeMaps.getCurrentRecipeMap())) {
-                iProbeInfo.text("   " + TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");
+                iProbeInfo.text("   " + TextStyleClass.INFOIMP + "{*" + recipeMap.getTranslationKey() + "*} {*<*}");
             } else {
-                iProbeInfo.text("   " + TextStyleClass.LABEL + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*}");
+                iProbeInfo.text("   " + TextStyleClass.LABEL + "{*" + recipeMap.getTranslationKey() + "*}");
             }
         }
     }


### PR DESCRIPTION
## What
Fixed the bug that Inactive machine mode text for machines with MultiRecipeMap(ex. Large Material Press) on TOP was server-localized.

## Outcome
MultiRecipeMapInfoProvider.addProbeInfo() no longer uses getLocalizedName(), it now uses getUnlocalizedName().
