### PR TITLE
Update groovyscript to 0.6.0 in dependencies.gradle

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     implementation "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684"
     implementation rfg.deobf("curse.maven:ctm-267602:2915363") // CTM 1.0.2.31
-    implementation rfg.deobf("curse.maven:groovyscript-687577:4610037") // GRS 0.5.1
+    implementation rfg.deobf("curse.maven:groovyscript-687577:4687204") // GRS 0.6.0
     implementation rfg.deobf("curse.maven:ae2-extended-life-570458:4402048") // AE2UEL 0.55.6
 
     compileOnlyApi rfg.deobf("curse.maven:opencomputers-223008:4526246") // OpenComputers 1.8.0+9833087


### PR DESCRIPTION
Update groovyscript to 0.6.0 in dependencies.gradle to according to https://github.com/GregTechCEu/GregTech/pull/2040.
groovyscript 0.6.1 is broken.