### PR TITLE
Add method to modify material amount for OrePrefixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ modGroup = gregtech
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 2.7.2-beta
+modVersion = 2.7.3-beta
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = true

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -366,6 +366,18 @@ public class OrePrefix {
 
         dustSmall.setIgnored(Materials.Lapotron);
         dustTiny.setIgnored(Materials.Lapotron);
+
+        block.modifyMaterialAmount(Materials.Glowstone,4);
+        block.modifyMaterialAmount(Materials.NetherQuartz, 4);
+        block.modifyMaterialAmount(Materials.Brick, 4);
+        block.modifyMaterialAmount(Materials.Clay, 4);
+        block.modifyMaterialAmount(Materials.Glass, 1);
+        block.modifyMaterialAmount(Materials.Ice, 1);
+        block.modifyMaterialAmount(Materials.Obsidian, 1);
+        block.modifyMaterialAmount(Materials.Concrete, 1);
+
+        stick.modifyMaterialAmount(Materials.Blaze, 4);
+        stick.modifyMaterialAmount(Materials.Bone, 5);
     }
 
     private static void excludeAllGems(Material material) {
@@ -405,6 +417,7 @@ public class OrePrefix {
     private final List<IOreRegistrationHandler> oreProcessingHandlers = new ArrayList<>();
     private final Set<Material> ignoredMaterials = new HashSet<>();
     private final Set<Material> generatedMaterials = new HashSet<>();
+    private final Map<Material, Integer> materialAmounts = new HashMap<>();
     private boolean isMarkerPrefix = false;
 
     public byte maxStackSize = 64;
@@ -453,25 +466,8 @@ public class OrePrefix {
         if (material == null) {
             return this.materialAmount;
         }
-
-        if (this == block) {
-            //glowstone and nether quartz blocks use 4 gems (dusts)
-            if (material == Materials.Glowstone ||
-                    material == Materials.NetherQuartz ||
-                    material == Materials.Brick ||
-                    material == Materials.Clay)
-                return M * 4;
-                //glass, ice and obsidian gain only one dust
-            else if (material == Materials.Glass ||
-                    material == Materials.Ice ||
-                    material == Materials.Obsidian ||
-                    material == Materials.Concrete)
-                return M;
-        } else if (this == stick) {
-            if (material == Materials.Blaze)
-                return M * 4;
-            else if (material == Materials.Bone)
-                return M * 5;
+        if (isAmountModified(material)) {
+            return M * materialAmounts.get(material);
         }
         return materialAmount;
     }
@@ -587,6 +583,14 @@ public class OrePrefix {
     @ZenMethod
     public void removeIgnored(@Nonnull Material material) {
         ignoredMaterials.remove(material);
+    }
+
+    public boolean isAmountModified(Material material) {
+        return materialAmounts.containsKey(material);
+    }
+    @ZenMethod
+    public void modifyMaterialAmount(@Nonnull Material material, @Nonnull int amount) {
+        materialAmounts.put(material, amount);
     }
 
     public boolean isMarkerPrefix() {

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -588,6 +588,7 @@ public class OrePrefix {
     public boolean isAmountModified(Material material) {
         return materialAmounts.containsKey(material);
     }
+
     @ZenMethod
     public void modifyMaterialAmount(@Nonnull Material material, @Nonnull int amount) {
         materialAmounts.put(material, amount);

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -14,15 +14,13 @@ import gregtech.api.util.function.TriConsumer;
 import gregtech.common.ConfigHolder;
 import it.unimi.dsi.fastutil.objects.Object2FloatMap;
 import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.client.resources.I18n;
 import org.apache.commons.lang3.Validate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -371,7 +369,7 @@ public class OrePrefix {
         dustSmall.setIgnored(Materials.Lapotron);
         dustTiny.setIgnored(Materials.Lapotron);
 
-        block.modifyMaterialAmount(Materials.Glowstone,4);
+        block.modifyMaterialAmount(Materials.Glowstone, 4);
         block.modifyMaterialAmount(Materials.NetherQuartz, 4);
         block.modifyMaterialAmount(Materials.Brick, 4);
         block.modifyMaterialAmount(Materials.Clay, 4);
@@ -421,7 +419,7 @@ public class OrePrefix {
     private final List<IOreRegistrationHandler> oreProcessingHandlers = new ArrayList<>();
     private final Set<Material> ignoredMaterials = new HashSet<>();
     private final Set<Material> generatedMaterials = new HashSet<>();
-    private final Object2IntMap<Material> materialAmounts = new Object2IntOpenHashMap<>();
+    private final Object2FloatMap<Material> materialAmounts = new Object2FloatOpenHashMap<>();
     private boolean isMarkerPrefix = false;
 
     public byte maxStackSize = 64;
@@ -466,14 +464,10 @@ public class OrePrefix {
     }
 
     public long getMaterialAmount(@Nullable Material material) {
-
-        if (material == null) {
+        if (material == null || !isAmountModified(material)) {
             return this.materialAmount;
         }
-        if (isAmountModified(material)) {
-            return (long) (M * materialAmounts.get(material));
-        }
-        return materialAmount;
+        return (long) (M * materialAmounts.getFloat(material));
     }
 
     @ZenMethod
@@ -554,7 +548,7 @@ public class OrePrefix {
     }
 
     // todo clean this up
-    public String getLocalNameForItem(@Nonnull Material material) {
+    public String getLocalNameForItem(@NotNull Material material) {
         String specifiedUnlocalized = "item." + material.getUnlocalizedName() + "." + this.name;
         if (LocalizationUtils.hasKey(specifiedUnlocalized)) return LocalizationUtils.format(specifiedUnlocalized);
         String unlocalized = findUnlocalizedName(material);
@@ -563,7 +557,7 @@ public class OrePrefix {
         return formatted.equals(unlocalized) ? matLocalized : formatted;
     }
 
-    private String findUnlocalizedName(@Nonnull Material material) {
+    private String findUnlocalizedName(@NotNull Material material) {
         if (material.hasProperty(PropertyKey.POLYMER)) {
             String localizationKey = String.format("item.material.oreprefix.polymer.%s", this.name);
             // Not every polymer ore prefix gets a special name
@@ -585,7 +579,7 @@ public class OrePrefix {
     }
 
     @ZenMethod
-    public void removeIgnored(@Nonnull Material material) {
+    public void removeIgnored(@NotNull Material material) {
         ignoredMaterials.remove(material);
     }
 
@@ -594,7 +588,7 @@ public class OrePrefix {
     }
 
     @ZenMethod
-    public void modifyMaterialAmount(@Nonnull Material material, @Nonnull int amount) {
+    public void modifyMaterialAmount(@NotNull Material material, float amount) {
         materialAmounts.put(material, amount);
     }
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -12,6 +12,10 @@ import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.function.TriConsumer;
 import gregtech.common.ConfigHolder;
+import it.unimi.dsi.fastutil.objects.Object2FloatMap;
+import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.client.resources.I18n;
 import org.apache.commons.lang3.Validate;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -417,7 +421,7 @@ public class OrePrefix {
     private final List<IOreRegistrationHandler> oreProcessingHandlers = new ArrayList<>();
     private final Set<Material> ignoredMaterials = new HashSet<>();
     private final Set<Material> generatedMaterials = new HashSet<>();
-    private final Map<Material, Integer> materialAmounts = new HashMap<>();
+    private final Object2IntMap<Material> materialAmounts = new Object2IntOpenHashMap<>();
     private boolean isMarkerPrefix = false;
 
     public byte maxStackSize = 64;
@@ -467,7 +471,7 @@ public class OrePrefix {
             return this.materialAmount;
         }
         if (isAmountModified(material)) {
-            return M * materialAmounts.get(material);
+            return (long) (M * materialAmounts.get(material));
         }
         return materialAmount;
     }


### PR DESCRIPTION
## What
Allows addons and scripting mods to modify material amounts for an OrePrefix. 


## Outcome
Adds method to modify material amount for OrePrefixes.

## Additional Information
Inspired by #2050 
