### PR TITLE
Allow the jetpack tank to be extracted from

### DIFF
--- a/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
@@ -276,7 +276,6 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDP
         public ICapabilityProvider createProvider(ItemStack itemStack) {
             return new GTFluidHandlerItemStack(itemStack, maxCapacity)
                     .setFilter(JETPACK_FUEL_FILTER)
-                    .setCanDrain(false);
         }
 
         @Override


### PR DESCRIPTION
## What
Allow the fluid jetpack tank to be extracted from

## Implementation Details
remove flag that prevents tank draining

## Outcome
Fixes: #1983 
