### PR TITLE
Fix TextFieldWidget2 not focusing the gui

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
+++ b/src/main/java/gregtech/api/gui/widgets/TextFieldWidget2.java
@@ -217,6 +217,7 @@ public class TextFieldWidget2 extends Widget {
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
         if (isMouseOverElement(mouseX, mouseY)) {
             focused = true;
+            gui.getModularUIGui().setFocused(true);
             if (onFocus != null) {
                 onFocus.accept(this);
             }
@@ -438,6 +439,7 @@ public class TextFieldWidget2 extends Widget {
         setText(t);
         setter.accept(t);
         focused = false;
+        gui.getModularUIGui().setFocused(false);
         writeClientAction(-1, buf -> buf.writeString(t));
     }
 


### PR DESCRIPTION
## What
In order for other mods to not trigger keybinds in gui, one must call `GuiScreen#setFocused()`. That was not being done in `TextFieldWidget2`.

## Outcome
Closes #2063 

## Additional Information
Not tested, but i assume it works.
This is a temporary fix as ModularUI also fixes this issue.

## Potential Compatibility Issues
None
