### PR TITLE
fix pipe tool click with offhand shield

### DIFF
--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -408,6 +408,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                 return EnumActionResult.SUCCESS;
             }
             entityPlayer.swingArm(hand);
+            return EnumActionResult.SUCCESS;
         }
         return EnumActionResult.PASS;
     }

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -5,6 +5,7 @@ import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.longdist.LongDistanceNetwork;
+import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.CapesRegistry;
 import gregtech.api.util.GTUtility;
@@ -79,9 +80,15 @@ public class EventHandlers {
 
     @SubscribeEvent
     public static void onPlayerInteractionRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getWorld().getTileEntity(event.getPos()) instanceof IGregTechTileEntity) {
+        // fix sneaking with shields not allowing tool interactions with GT machines
+        TileEntity tileEntity = event.getWorld().getTileEntity(event.getPos());
+        if (tileEntity instanceof IGregTechTileEntity) {
             event.setUseBlock(Event.Result.ALLOW);
         }
+        if (tileEntity instanceof IPipeTile<?,?>) {
+            event.setUseBlock(Event.Result.ALLOW);
+        }
+
         ItemStack stack = event.getItemStack();
         if (!stack.isEmpty() && stack.getItem() == Items.FLINT_AND_STEEL) {
             if (!event.getWorld().isRemote

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -84,8 +84,7 @@ public class EventHandlers {
         TileEntity tileEntity = event.getWorld().getTileEntity(event.getPos());
         if (tileEntity instanceof IGregTechTileEntity) {
             event.setUseBlock(Event.Result.ALLOW);
-        }
-        if (tileEntity instanceof IPipeTile<?,?>) {
+        } else if (tileEntity instanceof IPipeTile<?,?>) {
             event.setUseBlock(Event.Result.ALLOW);
         }
 


### PR DESCRIPTION
## Outcome
Fixes pipes restrictors not being applied when holding an offhand shield, and also fixes client-side pipe clicking logic returning divergent results from the server.
