### PR TITLE
Cleanup and fix loot table injection

### DIFF
--- a/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
+++ b/src/main/java/gregtech/loaders/dungeon/ChestGenHooks.java
@@ -138,7 +138,7 @@ public final class ChestGenHooks {
             }
 
             if (minAmount == maxAmount) {
-                itemStack.setCount(1);
+                itemStack.setCount(minAmount);
                 return itemStack;
             }
 


### PR DESCRIPTION
## What
Cleans up and fixes issues with loot table injection.

Due to an insufficient generated name for loot entries, entries would often be marked as duplicate and would not be added. This PR fixes this by incorporating all relevant values in the unique name. 

Some examples of when this would previously fail:
1. The same item injected to the same loot table twice, but with different weights and/or quantities.
2. The same item injected into the same loot table twice, but once with an NBT Tag and another time without.

This PR also improves logging for failed loot table injections to allow easier debugging in the future.

## Outcome
Cleans up and fixes failed loot table injections.

## Potential Compatibility Issues
No compatibility issues are expected. Nothing publicly-facing has changed on a method signature or class level.
