### PR TITLE
Allow multiblock controllers to determine weather resistance of multiblock parts

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -428,4 +428,12 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
         }
         doExplosion(explosionPower);
     }
+
+    /**
+     * @param part the part to check
+     * @return if the multiblock part is terrain and weather resistant
+     */
+    public boolean isMultiblockPartWeatherResistant(@Nonnull IMultiblockPart part) {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart.java
@@ -171,4 +171,11 @@ public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity implem
     public int getDefaultPaintingColor() {
         return !isAttachedToMultiBlock() && hatchTexture == null ? super.getDefaultPaintingColor() : 0xFFFFFF;
     }
+
+    @Override
+    public boolean getIsWeatherOrTerrainResistant() {
+        MultiblockControllerBase controllerBase = getController();
+        if (controllerBase == null) return super.getIsWeatherOrTerrainResistant();
+        return controllerBase.isMultiblockPartWeatherResistant(this);
+    }
 }


### PR DESCRIPTION
## What
Allows multiblock controllers to determine the weather resistance of their parts. This is useful for multiblocks that must be outside with exposure to the sky, but also have energy hatches which would otherwise explode in the rain, for example.

## Outcome
Closes #2079.
