### PR TITLE
Tile entity sync fixes

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -67,6 +67,7 @@ public class GregtechDataCodes {
     public static final int COVER_REMOVED_PIPE = assignId();
     public static final int PIPE_OPTICAL_ACTIVE = assignId();
     public static final int PIPE_LASER_ACTIVE = assignId();
+    public static final int CABLE_TEMPERATURE = assignId();
 
     // Multiblock implementation update codes
     public static final int SYNC_CONTROLLER = assignId();
@@ -110,7 +111,7 @@ public class GregtechDataCodes {
     public static final int UPDATE_FAKE_GUI_DETECT = assignId();
 
     // Digital Interface
-    public static final int UPDATE_MODE = assignId();
+    public static final int UPDATE_COVER_MODE = assignId();
     public static final int UPDATE_FLUID = assignId();
     public static final int UPDATE_ITEM = assignId();
     public static final int UPDATE_ENERGY = assignId();

--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -1,139 +1,147 @@
 package gregtech.api.capability;
 
+import io.netty.buffer.ByteBuf;
+
 public class GregtechDataCodes {
 
-    // MTE implementation update codes
-    public static final int INITIALIZE_MTE = -1;
-    public static final int UPDATE_FRONT_FACING = -2;
-    public static final int UPDATE_PAINTING_COLOR = -3;
-    public static final int SYNC_MTE_TRAITS = -4;
-    public static final int COVER_ATTACHED_MTE = -5;
-    public static final int COVER_REMOVED_MTE = -6;
-    public static final int UPDATE_COVER_DATA_MTE = -7;
-    public static final int UPDATE_SOUND_MUFFLED = -9;
+    private static int nextId = 0;
 
-    public static final int UPDATE_OUTPUT_FACING = 100;
-    public static final int UPDATE_AUTO_OUTPUT_ITEMS = 101;
-    public static final int UPDATE_AUTO_OUTPUT_FLUIDS = 102;
+    public static int assignId() {
+        return nextId++;
+    }
+
+    // MTE implementation update codes
+    public static final int INITIALIZE_MTE = assignId();
+    public static final int UPDATE_FRONT_FACING = assignId();
+    public static final int UPDATE_PAINTING_COLOR = assignId();
+    public static final int SYNC_MTE_TRAITS = assignId();
+    public static final int COVER_ATTACHED_MTE = assignId();
+    public static final int COVER_REMOVED_MTE = assignId();
+    public static final int UPDATE_COVER_DATA_MTE = assignId();
+    public static final int UPDATE_SOUND_MUFFLED = assignId();
+
+    public static final int UPDATE_OUTPUT_FACING = assignId();
+    public static final int UPDATE_AUTO_OUTPUT_ITEMS = assignId();
+    public static final int UPDATE_AUTO_OUTPUT_FLUIDS = assignId();
 
     // Drum
-    public static final int UPDATE_AUTO_OUTPUT = 560;
+    public static final int UPDATE_AUTO_OUTPUT = assignId();
 
     // Safe
-    public static final int UPDATE_LOCKED_STATE = 8;
-    public static final int UPDATE_CONTENTS_SEED = 9;
+    public static final int UPDATE_LOCKED_STATE = assignId();
+    public static final int UPDATE_CONTENTS_SEED = assignId();
 
     // Steam Machines
-    public static final int NEEDS_VENTING = 2;
-    public static final int VENTING_SIDE = 3;
-    public static final int VENTING_STUCK = 4;
-    public static final int BOILER_HEAT = 15;
-    public static final int BOILER_LAST_TICK_STEAM = 16;
+    public static final int NEEDS_VENTING = assignId();
+    public static final int VENTING_SIDE = assignId();
+    public static final int VENTING_STUCK = assignId();
+    public static final int BOILER_HEAT = assignId();
+    public static final int BOILER_LAST_TICK_STEAM = assignId();
 
     // Misc TEs (Transformer, World Accelerator)
-    public static final int SYNC_TILE_MODE = 500;
+    public static final int SYNC_TILE_MODE = assignId();
 
     // Clipboard
-    public static final int CREATE_FAKE_UI = 1;
-    public static final int MOUSE_POSITION = 2;
-    public static final int INIT_CLIPBOARD_NBT = 3;
+    public static final int CREATE_FAKE_UI = assignId();
+    public static final int MOUSE_POSITION = assignId();
+    public static final int INIT_CLIPBOARD_NBT = assignId();
 
-    public static final int UPDATE_UI = 10; // 10-36
+    public static final int UPDATE_UI = assignId(); // 10-36
     // Pump
-    public static final int PUMP_HEAD_LEVEL = 200;
+    public static final int PUMP_HEAD_LEVEL = assignId();
 
     // Item Collector, Magic Energy Absorber, Large Boiler, Steam Oven
-    public static final int IS_WORKING = 100;
+    public static final int IS_WORKING = assignId();
 
     // Adjustable Transformer, Adjustable Energy Hatch, Diode
-    public static final int AMP_INDEX = 101;
+    public static final int AMP_INDEX = assignId();
 
     // Pipe implementation update codes
-    public static final int UPDATE_INSULATION_COLOR = -1;
-    public static final int UPDATE_CONNECTIONS = -2;
-    public static final int SYNC_COVER_IMPLEMENTATION = -3;
-    public static final int UPDATE_PIPE_TYPE = -4;
-    public static final int UPDATE_PIPE_MATERIAL = -5;
-    public static final int UPDATE_BLOCKED_CONNECTIONS = -6;
-    public static final int UPDATE_FRAME_MATERIAL = -7;
-    public static final int UPDATE_COVER_DATA_PIPE = 0;
-    public static final int COVER_ATTACHED_PIPE = 1;
-    public static final int COVER_REMOVED_PIPE = 2;
-    public static final int PIPE_OPTICAL_ACTIVE = 3;
-    public static final int PIPE_LASER_ACTIVE = 4;
+    public static final int UPDATE_INSULATION_COLOR = assignId();
+    public static final int UPDATE_CONNECTIONS = assignId();
+    public static final int SYNC_COVER_IMPLEMENTATION = assignId();
+    public static final int UPDATE_PIPE_TYPE = assignId();
+    public static final int UPDATE_PIPE_MATERIAL = assignId();
+    public static final int UPDATE_BLOCKED_CONNECTIONS = assignId();
+    public static final int UPDATE_FRAME_MATERIAL = assignId();
+    public static final int UPDATE_COVER_DATA_PIPE = assignId();
+    public static final int COVER_ATTACHED_PIPE = assignId();
+    public static final int COVER_REMOVED_PIPE = assignId();
+    public static final int PIPE_OPTICAL_ACTIVE = assignId();
+    public static final int PIPE_LASER_ACTIVE = assignId();
 
     // Multiblock implementation update codes
-    public static final int SYNC_CONTROLLER = 100;
-    public static final int IS_ROTOR_LOOPING = 200;
-    public static final int FRONT_FACE_FREE = 201;
-    public static final int UPDATE_ROTOR_COLOR = 201;
-    public static final int UPDATE_STRUCTURE_SIZE = 202;
-    public static final int STRUCTURE_FORMED = 400;
-    public static final int VARIANT_RENDER_UPDATE = 410;
-    public static final int IS_TAPED = 550;
-    public static final int STORE_MAINTENANCE = 551;
-    public static final int STORE_TAPED = 552;
-    public static final int RECIPE_MAP_INDEX = 553;
-    public static final int IS_FRONT_FACE_FREE = 554;
-    public static final int MAINTENANCE_MULTIPLIER = 555;
+    public static final int SYNC_CONTROLLER = assignId();
+    public static final int IS_ROTOR_LOOPING = assignId();
+    public static final int FRONT_FACE_FREE = assignId();
+    public static final int UPDATE_ROTOR_COLOR = assignId();
+    public static final int UPDATE_STRUCTURE_SIZE = assignId();
+    public static final int STRUCTURE_FORMED = assignId();
+    public static final int VARIANT_RENDER_UPDATE = assignId();
+    public static final int IS_TAPED = assignId();
+    public static final int STORE_MAINTENANCE = assignId();
+    public static final int STORE_TAPED = assignId();
+    public static final int RECIPE_MAP_INDEX = assignId();
+    public static final int IS_FRONT_FACE_FREE = assignId();
+    public static final int MAINTENANCE_MULTIPLIER = assignId();
 
     // Item Bus Item Stack Auto Collapsing
-    public static final int TOGGLE_COLLAPSE_ITEMS = 600;
+    public static final int TOGGLE_COLLAPSE_ITEMS = assignId();
 
     // Fusion Reactor
-    public static final int UPDATE_COLOR = 371;
+    public static final int UPDATE_COLOR = assignId();
 
     // Assembly Line
-    public static final int UPDATE_PARTICLE = 371;
+    public static final int UPDATE_PARTICLE = assignId();
 
     // Central Monitor
-    public static final int UPDATE_ALL = 1;
-    public static final int UPDATE_COVERS = 2;
-    public static final int UPDATE_HEIGHT = 3;
-    public static final int UPDATE_ACTIVE = 4;
-    public static final int UPDATE_PLUGIN_ITEM = 3;
+    public static final int UPDATE_ALL = assignId();
+    public static final int UPDATE_COVERS = assignId();
+    public static final int UPDATE_HEIGHT = assignId();
+    public static final int UPDATE_ACTIVE = assignId();
+    public static final int UPDATE_PLUGIN_ITEM = assignId();
 
     // Central Monitor Plugin
-    public static final int UPDATE_PLUGIN_DATA = 2;
-    public static final int UPDATE_PLUGIN_CONFIG = 0;
-    public static final int ACTION_PLUGIN_CONFIG = 0;
-    public static final int UPDATE_PLUGIN_CLICK = -2;
-    public static final int UPDATE_ADVANCED_VALID_POS = 1;
-    public static final int UPDATE_FAKE_GUI = 1;
-    public static final int ACTION_FAKE_GUI = 1;
-    public static final int UPDATE_FAKE_GUI_DETECT = -1;
+    public static final int UPDATE_PLUGIN_DATA = assignId();
+    public static final int UPDATE_PLUGIN_CONFIG = assignId();
+    public static final int ACTION_PLUGIN_CONFIG = assignId();
+    public static final int UPDATE_PLUGIN_CLICK = assignId();
+    public static final int UPDATE_ADVANCED_VALID_POS = assignId();
+    public static final int UPDATE_FAKE_GUI = assignId();
+    public static final int ACTION_FAKE_GUI = assignId();
+    public static final int UPDATE_FAKE_GUI_DETECT = assignId();
 
     // Digital Interface
-    public static final int UPDATE_MODE = 1;
-    public static final int UPDATE_FLUID = 2;
-    public static final int UPDATE_ITEM = 3;
-    public static final int UPDATE_ENERGY = 4;
-    public static final int UPDATE_ENERGY_PER = 5;
-    public static final int UPDATE_MACHINE = 6;
+    public static final int UPDATE_MODE = assignId();
+    public static final int UPDATE_FLUID = assignId();
+    public static final int UPDATE_ITEM = assignId();
+    public static final int UPDATE_ENERGY = assignId();
+    public static final int UPDATE_ENERGY_PER = assignId();
+    public static final int UPDATE_MACHINE = assignId();
 
     // Phantom Tanks
-    public static final int REMOVE_PHANTOM_FLUID_TYPE = 10;
-    public static final int CHANGE_PHANTOM_FLUID = 11;
-    public static final int SET_PHANTOM_FLUID = 12;
-    public static final int LOAD_PHANTOM_FLUID_STACK_FROM_NBT = 13;
+    public static final int REMOVE_PHANTOM_FLUID_TYPE = assignId();
+    public static final int CHANGE_PHANTOM_FLUID = assignId();
+    public static final int SET_PHANTOM_FLUID = assignId();
+    public static final int LOAD_PHANTOM_FLUID_STACK_FROM_NBT = assignId();
 
     // Recipe Logic
-    public static final int WORKABLE_ACTIVE = 1;
-    public static final int WORKING_ENABLED = 5;
+    public static final int WORKABLE_ACTIVE = assignId();
+    public static final int WORKING_ENABLED = assignId();
 
     // Creative Energy
-    public static final int UPDATE_IO_SPEED = 1;
+    public static final int UPDATE_IO_SPEED = assignId();
 
     // Quantum Chest/Tank
-    public static final int UPDATE_ITEM_COUNT = 14;
-    public static final int UPDATE_FLUID_AMOUNT = 14;
+    public static final int UPDATE_ITEM_COUNT = assignId();
+    public static final int UPDATE_FLUID_AMOUNT = assignId();
 
     // Detector Covers
-    public static final int UPDATE_INVERTED = 100;
+    public static final int UPDATE_INVERTED = assignId();
 
     // HPCA / Research Station
-    public static final int DAMAGE_STATE = 222;
-    public static final int LOCK_OBJECT_HOLDER = 223;
+    public static final int DAMAGE_STATE = assignId();
+    public static final int LOCK_OBJECT_HOLDER = assignId();
 
     // NBT Keys
 

--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -1,7 +1,5 @@
 package gregtech.api.capability;
 
-import io.netty.buffer.ByteBuf;
-
 public class GregtechDataCodes {
 
     private static int nextId = 0;

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -1,10 +1,9 @@
 package gregtech.api.metatileentity;
 
 import gregtech.api.block.BlockStateTileEntity;
+import gregtech.api.util.PacketDataList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -26,13 +25,13 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
 
     public abstract void receiveCustomData(int discriminator, PacketBuffer buf);
 
-    protected final Int2ObjectMap<byte[]> updates = new Int2ObjectArrayMap<>(5);
+    protected final PacketDataList updates = new PacketDataList();
 
     public void writeCustomData(int discriminator, Consumer<PacketBuffer> dataWriter) {
         ByteBuf backedBuffer = Unpooled.buffer();
         dataWriter.accept(new PacketBuffer(backedBuffer));
         byte[] updateData = Arrays.copyOfRange(backedBuffer.array(), 0, backedBuffer.writerIndex());
-        updates.put(discriminator, updateData);
+        this.updates.add(discriminator, updateData);
         @SuppressWarnings("deprecation")
         IBlockState blockState = getBlockType().getStateFromMeta(getBlockMetadata());
         world.notifyBlockUpdate(getPos(), blockState, blockState, 0);
@@ -44,14 +43,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
             return null;
         }
         NBTTagCompound updateTag = new NBTTagCompound();
-        NBTTagList listTag = new NBTTagList();
-        for (Int2ObjectMap.Entry<byte[]> entry : updates.int2ObjectEntrySet()) {
-            NBTTagCompound entryTag = new NBTTagCompound();
-            entryTag.setByteArray(Integer.toString(entry.getIntKey()), entry.getValue());
-            listTag.appendTag(entryTag);
-        }
-        updateTag.setTag("d", listTag);
-        this.updates.clear();
+        updateTag.setTag("d", this.updates.dumpToNbt());
         return new SPacketUpdateTileEntity(getPos(), 0, updateTag);
     }
 

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -1,7 +1,7 @@
 package gregtech.api.metatileentity;
 
 import gregtech.api.block.BlockStateTileEntity;
-import gregtech.api.util.PacketDataList;
+import gregtech.api.network.PacketDataList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.minecraft.block.state.IBlockState;

--- a/src/main/java/gregtech/api/network/PacketDataList.java
+++ b/src/main/java/gregtech/api/network/PacketDataList.java
@@ -28,7 +28,7 @@ public class PacketDataList {
     private void ensureSize(int s) {
         if (this.discriminators.length < s) {
             int n = this.discriminators.length;
-            int newCapacity = n * (s / n + 1);
+            int newCapacity = Math.max(n + 2, s); // there are rarely more than 2 elements in the list
             int[] temp = new int[newCapacity];
             byte[][] temp2 = new byte[newCapacity][];
             System.arraycopy(this.discriminators, 0, temp, 0, n);

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -59,7 +59,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         this.paintingColor = tileEntity.getPaintingColor();
         this.connections = tileEntity.getConnections();
         if (tileEntity instanceof TileEntityPipeBase pipeBase) {
-            this.updates.putAll(pipeBase.updates);
+            this.updates.addAll(pipeBase.updates);
         }
         tileEntity.getCoverableImplementation().transferDataTo(coverableImplementation);
         setFrameMaterial(tileEntity.getFrameMaterial());
@@ -429,8 +429,6 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         } else if (discriminator == UPDATE_CONNECTIONS) {
             this.connections = buf.readVarInt();
             scheduleChunkForRenderUpdate();
-        } else if (discriminator == SYNC_COVER_IMPLEMENTATION) {
-            this.coverableImplementation.readCustomData(buf.readVarInt(), buf);
         } else if (discriminator == UPDATE_PIPE_TYPE) {
             readPipeProperties(buf);
             scheduleChunkForRenderUpdate();
@@ -446,15 +444,14 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
                 this.frameMaterial = null;
             }
             scheduleChunkForRenderUpdate();
+        } else {
+            this.coverableImplementation.readCustomData(discriminator, buf);
         }
     }
 
     @Override
     public void writeCoverCustomData(int id, Consumer<PacketBuffer> writer) {
-        writeCustomData(SYNC_COVER_IMPLEMENTATION, buffer -> {
-            buffer.writeVarInt(id);
-            writer.accept(buffer);
-        });
+        writeCustomData(id, writer);
     }
 
     @Override

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -58,8 +58,8 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         this.pipeType = tileEntity.getPipeType();
         this.paintingColor = tileEntity.getPaintingColor();
         this.connections = tileEntity.getConnections();
-        if (tileEntity instanceof TileEntityPipeBase pipeBase) {
-            this.updates.addAll(pipeBase.updates);
+        if (tileEntity instanceof SyncedTileEntityBase pipeBase) {
+            addPacketsFrom(pipeBase);
         }
         tileEntity.getCoverableImplementation().transferDataTo(coverableImplementation);
         setFrameMaterial(tileEntity.getFrameMaterial());

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -429,6 +429,8 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         } else if (discriminator == UPDATE_CONNECTIONS) {
             this.connections = buf.readVarInt();
             scheduleChunkForRenderUpdate();
+        } else if (discriminator == SYNC_COVER_IMPLEMENTATION) {
+            this.coverableImplementation.readCustomData(buf.readVarInt(), buf);
         } else if (discriminator == UPDATE_PIPE_TYPE) {
             readPipeProperties(buf);
             scheduleChunkForRenderUpdate();
@@ -444,14 +446,15 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
                 this.frameMaterial = null;
             }
             scheduleChunkForRenderUpdate();
-        } else {
-            this.coverableImplementation.readCustomData(discriminator, buf);
         }
     }
 
     @Override
     public void writeCoverCustomData(int id, Consumer<PacketBuffer> writer) {
-        writeCustomData(id, writer);
+        writeCustomData(SYNC_COVER_IMPLEMENTATION, buffer -> {
+            buffer.writeVarInt(id);
+            writer.accept(buffer);
+        });
     }
 
     @Override

--- a/src/main/java/gregtech/api/util/PacketDataList.java
+++ b/src/main/java/gregtech/api/util/PacketDataList.java
@@ -1,0 +1,73 @@
+package gregtech.api.util;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+
+/**
+ * An optimised data structure backed by two arrays.
+ * This is essentially equivalent to <code>List<Pair<Integer, byte[]>></code>, but more efficient.
+ * {@link it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap} can not be used since it doesn't allow duplicate discriminators.
+ */
+public class PacketDataList {
+
+    private int[] discriminators;
+    private byte[][] data;
+    private int size = 0;
+
+    public PacketDataList() {
+        this.discriminators = new int[4];
+        this.data = new byte[4][];
+    }
+
+    private void ensureSize(int s) {
+        if (this.discriminators.length < s) {
+            int n = this.discriminators.length;
+            int[] temp = new int[n + n];
+            byte[][] temp2 = new byte[n + n][];
+            System.arraycopy(this.discriminators, 0, temp, 0, n);
+            System.arraycopy(this.data, 0, temp2, 0, n);
+            this.discriminators = temp;
+            this.data = temp2;
+        }
+    }
+
+    public void add(int discriminator, byte[] data) {
+        ensureSize(this.size + 1);
+        this.discriminators[this.size] = discriminator;
+        this.data[this.size] = data;
+        this.size++;
+    }
+
+    public void addAll(PacketDataList dataList) {
+        for (int i = 0; i < dataList.size; i++) {
+            add(dataList.discriminators[i], dataList.data[i]);
+        }
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    public void clear() {
+        for (int i = 0; i < this.size; i++) {
+            this.data[i] = null;
+        }
+        this.size = 0;
+    }
+
+    public NBTTagList dumpToNbt() {
+        NBTTagList listTag = new NBTTagList();
+        for (int i = 0; i < this.size; i++) {
+            NBTTagCompound entryTag = new NBTTagCompound();
+            entryTag.setByteArray(Integer.toString(this.discriminators[i]), this.data[i]);
+            listTag.appendTag(entryTag);
+            this.data[i] = null;
+        }
+        this.size = 0;
+        return listTag;
+    }
+}

--- a/src/main/java/gregtech/api/util/PacketDataList.java
+++ b/src/main/java/gregtech/api/util/PacketDataList.java
@@ -44,7 +44,7 @@ public class PacketDataList {
         }
     }
 
-    public int getSize() {
+    public int size() {
         return size;
     }
 

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -6,6 +6,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 import gregtech.api.capability.impl.ItemHandlerDelegate;
@@ -100,7 +101,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
 
     public void setConveyorMode(ConveyorMode conveyorMode) {
         this.conveyorMode = conveyorMode;
-        writeUpdateData(1, buf -> buf.writeEnumValue(conveyorMode));
+        writeUpdateData(GregtechDataCodes.UPDATE_COVER_MODE, buf -> buf.writeEnumValue(conveyorMode));
         coverHolder.markDirty();
     }
 
@@ -521,7 +522,7 @@ public class CoverConveyor extends CoverBehavior implements CoverWithUI, ITickab
     @Override
     public void readUpdateData(int id, PacketBuffer packetBuffer) {
         super.readUpdateData(id, packetBuffer);
-        if (id == 1) {
+        if (id == GregtechDataCodes.UPDATE_COVER_MODE) {
             this.conveyorMode = packetBuffer.readEnumValue(ConveyorMode.class);
             coverHolder.scheduleRenderUpdate();
         }

--- a/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
@@ -126,7 +126,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IFastRenderM
             this.mode = mode;
             this.slot = slot;
             this.spin = spin;
-            writeUpdateData(GregtechDataCodes.UPDATE_MODE, packetBuffer -> {
+            writeUpdateData(GregtechDataCodes.UPDATE_COVER_MODE, packetBuffer -> {
                 packetBuffer.writeByte(mode.ordinal());
                 packetBuffer.writeInt(slot);
                 packetBuffer.writeByte(spin.getIndex());
@@ -778,7 +778,7 @@ public class CoverDigitalInterface extends CoverBehavior implements IFastRenderM
     @Override
     public void readUpdateData(int id, PacketBuffer packetBuffer) {
         super.readUpdateData(id, packetBuffer);
-        if (id == GregtechDataCodes.UPDATE_MODE) { // set mode
+        if (id == GregtechDataCodes.UPDATE_COVER_MODE) { // set mode
             setMode(MODE.VALUES[packetBuffer.readByte()], packetBuffer.readInt(), EnumFacing.byIndex(packetBuffer.readByte()));
         } else if (id == GregtechDataCodes.UPDATE_FLUID) { // sync fluids
             readFluids(packetBuffer);

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -7,6 +7,7 @@ import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Matrix4;
 import com.google.common.math.IntMath;
 import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 import gregtech.api.capability.impl.FluidHandlerDelegate;
@@ -91,7 +92,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
 
     public void setPumpMode(PumpMode pumpMode) {
         this.pumpMode = pumpMode;
-        writeUpdateData(1, buf -> buf.writeEnumValue(pumpMode));
+        writeUpdateData(GregtechDataCodes.UPDATE_COVER_MODE, buf -> buf.writeEnumValue(pumpMode));
         coverHolder.markDirty();
     }
 
@@ -251,7 +252,7 @@ public class CoverPump extends CoverBehavior implements CoverWithUI, ITickable, 
     @Override
     public void readUpdateData(int id, PacketBuffer packetBuffer) {
         super.readUpdateData(id, packetBuffer);
-        if (id == 1) {
+        if (id == GregtechDataCodes.UPDATE_COVER_MODE) {
             this.pumpMode = packetBuffer.readEnumValue(PumpMode.class);
             coverHolder.scheduleRenderUpdate();
         }

--- a/src/main/java/gregtech/common/pipelike/cable/tile/TileEntityCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/tile/TileEntityCable.java
@@ -3,7 +3,6 @@ package gregtech.common.pipelike.cable.tile;
 import codechicken.lib.vec.Cuboid6;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
-import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.IDataInfoProvider;
 import gregtech.api.pipenet.block.BlockPipe;
@@ -37,6 +36,9 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+
+import static gregtech.api.capability.GregtechDataCodes.CABLE_TEMPERATURE;
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_CONNECTIONS;
 
 public class TileEntityCable extends TileEntityMaterialPipeBase<Insulation, WireProperties> implements IDataInfoProvider {
 
@@ -186,7 +188,7 @@ public class TileEntityCable extends TileEntityMaterialPipeBase<Insulation, Wire
         this.temperature = temperature;
         world.checkLight(pos);
         if (!world.isRemote) {
-            writeCustomData(100, buf -> buf.writeVarInt(temperature));
+            writeCustomData(CABLE_TEMPERATURE, buf -> buf.writeVarInt(temperature));
         } else {
             if (temperature <= getDefaultTemp()) {
                 if (isParticleAlive())
@@ -295,11 +297,11 @@ public class TileEntityCable extends TileEntityMaterialPipeBase<Insulation, Wire
 
     @Override
     public void receiveCustomData(int discriminator, PacketBuffer buf) {
-        if (discriminator == 100) {
+        if (discriminator == CABLE_TEMPERATURE) {
             setTemperature(buf.readVarInt());
         } else {
             super.receiveCustomData(discriminator, buf);
-            if (isParticleAlive() && discriminator == GregtechDataCodes.UPDATE_CONNECTIONS) {
+            if (isParticleAlive() && discriminator == UPDATE_CONNECTIONS) {
                 particle.updatePipeBoxes(getPipeBoxes());
             }
         }


### PR DESCRIPTION
## What
This changes the data codes for syncing to be assigned automatically.
This also replaces the array map in `SyncedTileEntityBase` with a custom data structure. The array map does not allow duplicate discriminators, which can cause packets to be lost.

## Implementation Details
The new data structure is backed by 2 arrays. This makes it fast and doesn't require boxing.

## Outcome
Data codes for syncing can now be added without thinking about the number.
Fixes potential issue with packets overwritting each other as seen in #2071.

## Potential Compatibility Issues
All addons MUST check their data codes (if any) and use the new system.
`GregtechDataCodes.assignId()` can be used to get a new discriminator.
