### PR TITLE
Allow recipe properties to individually hide default tooltips

### DIFF
--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -587,6 +587,10 @@ public class Recipe {
         return recipePropertyStorage.getRecipePropertyKeys();
     }
 
+    public Set<RecipeProperty<?>> getPropertyTypes() {
+        return recipePropertyStorage.getPropertyTypes();
+    }
+
     public boolean hasProperty(RecipeProperty<?> property) {
         return recipePropertyStorage.hasRecipeProperty(property);
     }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/EmptyRecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/EmptyRecipePropertyStorage.java
@@ -58,6 +58,11 @@ public final class EmptyRecipePropertyStorage implements IRecipePropertyStorage 
     }
 
     @Override
+    public Set<RecipeProperty<?>> getPropertyTypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
     public Object getRawRecipePropertyValue(String key) {
         return null;
     }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/IRecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/IRecipePropertyStorage.java
@@ -50,6 +50,8 @@ public interface IRecipePropertyStorage {
 
     Set<String> getRecipePropertyKeys();
 
+    Set<RecipeProperty<?>> getPropertyTypes();
+
     /**
      * Provides un-casted value for one specific {@link RecipeProperty} searched by key
      *

--- a/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
@@ -26,12 +26,12 @@ public class PrimitiveProperty extends RecipeProperty<Boolean> {
     }
 
     @Override
-    public boolean showTotalEU() {
-        return false;
+    public boolean hideTotalEU() {
+        return true;
     }
 
     @Override
-    public boolean showEUt() {
-        return false;
+    public boolean hideEUt() {
+        return true;
     }
 }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
@@ -24,4 +24,14 @@ public class PrimitiveProperty extends RecipeProperty<Boolean> {
     @Override
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
     }
+
+    @Override
+    public boolean showTotalEU() {
+        return false;
+    }
+
+    @Override
+    public boolean showEUt() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -54,24 +54,24 @@ public abstract class RecipeProperty<T> {
     }
 
     /**
-     * Whether to show the Total EU tooltip for the recipe in JEI.
+     * Whether to hide the Total EU tooltip for the recipe in JEI.
      */
-    public boolean showTotalEU() {
-        return true;
+    public boolean hideTotalEU() {
+        return false;
     }
 
     /**
-     * Whether to show the EU/t tooltip for the recipe in JEI.
+     * Whether to hide the EU/t tooltip for the recipe in JEI.
      */
-    public boolean showEUt() {
-        return true;
+    public boolean hideEUt() {
+        return false;
     }
 
     /**
-     * Whether to show the Duration tooltip for the recipe in JEI.
+     * Whether to hide the Duration tooltip for the recipe in JEI.
      */
-    public boolean showDuration() {
-        return true;
+    public boolean hideDuration() {
+        return false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -53,6 +53,27 @@ public abstract class RecipeProperty<T> {
         return false;
     }
 
+    /**
+     * Whether to show the Total EU tooltip for the recipe in JEI.
+     */
+    public boolean showTotalEU() {
+        return true;
+    }
+
+    /**
+     * Whether to show the EU/t tooltip for the recipe in JEI.
+     */
+    public boolean showEUt() {
+        return true;
+    }
+
+    /**
+     * Whether to show the Duration tooltip for the recipe in JEI.
+     */
+    public boolean showDuration() {
+        return true;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipePropertyStorage.java
@@ -109,6 +109,11 @@ public class RecipePropertyStorage implements IRecipePropertyStorage {
     }
 
     @Override
+    public Set<RecipeProperty<?>> getPropertyTypes() {
+        return recipeProperties.keySet();
+    }
+
+    @Override
     public Object getRawRecipePropertyValue(String key) {
         RecipeProperty<?> recipeProperty = getRecipePropertyValue(key);
         if (recipeProperty != null) {

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -154,13 +154,13 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
         // Default entries
         var properties = recipe.getPropertyTypes();
-        if (properties.isEmpty() || properties.stream().allMatch(RecipeProperty::showTotalEU)) {
+        if (properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideTotalEU)) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
         } else yPosition -= LINE_HEIGHT;
-        if (properties.isEmpty() || properties.stream().allMatch(RecipeProperty::showEUt)) {
+        if (properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideEUt)) {
             minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);
         } else yPosition -= LINE_HEIGHT;
-        if (properties.isEmpty() || properties.stream().allMatch(RecipeProperty::showDuration)) {
+        if (properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideDuration)) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", TextFormattingUtil.formatNumbers(recipe.getDuration() / 20d)), 0, yPosition += LINE_HEIGHT, 0x111111);
         } else yPosition -= LINE_HEIGHT;
 

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -10,7 +10,6 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.machines.IResearchRecipeMap;
 import gregtech.api.recipes.machines.IScannerRecipeMap;
-import gregtech.api.recipes.recipeproperties.PrimitiveProperty;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.util.AssemblyLineManager;
 import gregtech.api.util.ClipboardUtil;
@@ -152,11 +151,20 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         super.drawInfo(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
         int yPosition = recipeHeight - recipeMap.getPropertyListHeight(recipe);
-        if (!recipe.hasProperty(PrimitiveProperty.getInstance())) {
+
+        // Default entries
+        var properties = recipe.getPropertyTypes();
+        if (properties.isEmpty() || properties.stream().allMatch(RecipeProperty::showTotalEU)) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
+        } else yPosition -= LINE_HEIGHT;
+        if (properties.isEmpty() || properties.stream().allMatch(RecipeProperty::showEUt)) {
             minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);
-        } else yPosition -= LINE_HEIGHT * 2;
-        minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", TextFormattingUtil.formatNumbers(recipe.getDuration() / 20d)), 0, yPosition += LINE_HEIGHT, 0x111111);
+        } else yPosition -= LINE_HEIGHT;
+        if (properties.isEmpty() || properties.stream().allMatch(RecipeProperty::showDuration)) {
+            minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", TextFormattingUtil.formatNumbers(recipe.getDuration() / 20d)), 0, yPosition += LINE_HEIGHT, 0x111111);
+        } else yPosition -= LINE_HEIGHT;
+
+        // Property custom entries
         for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getPropertyValues()) {
             if (!propertyEntry.getKey().isHidden()) {
                 RecipeProperty<?> property = propertyEntry.getKey();


### PR DESCRIPTION
Removes the need for special case hacks in GTRecipeWrapper when a recipe property needs to hide Total EU, EU/t, or Duration default recipe tooltips. No API breaks, as the IRecipeProperty methods have the same defaults as previously