### PR TITLE
Research station logic improvement

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.IOpticalComputationReceiver;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.recipeproperties.ComputationProperty;
+import gregtech.api.recipes.recipeproperties.TotalComputationProperty;
 import net.minecraft.nbt.NBTTagCompound;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,14 +23,13 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
      * to draw as much CWU/t as possible to try and accelerate the computation process, and CWU/t is treated as a
      * minimum value instead of a static cost.
      */
-    private final boolean isDurationTotalCWU;
+    private boolean isDurationTotalCWU;
     private int recipeCWUt;
     private boolean hasNotEnoughComputation;
 
-    public ComputationRecipeLogic(RecipeMapMultiblockController metaTileEntity, ComputationType type, boolean isDurationTotalCWU) {
+    public ComputationRecipeLogic(RecipeMapMultiblockController metaTileEntity, ComputationType type) {
         super(metaTileEntity);
         this.type = type;
-        this.isDurationTotalCWU = isDurationTotalCWU;
         if (!(metaTileEntity instanceof IOpticalComputationReceiver)) {
             throw new IllegalArgumentException("MetaTileEntity must be instanceof IOpticalComputationReceiver");
         }
@@ -58,6 +58,7 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
     protected void setupRecipe(Recipe recipe) {
         super.setupRecipe(recipe);
         this.recipeCWUt = recipe.getProperty(ComputationProperty.getInstance(), 0);
+        this.isDurationTotalCWU = recipe.hasProperty(TotalComputationProperty.getInstance());
     }
 
     @Override
@@ -107,6 +108,7 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
     protected void completeRecipe() {
         super.completeRecipe();
         this.recipeCWUt = 0;
+        this.isDurationTotalCWU = false;
         this.hasNotEnoughComputation = false;
     }
 

--- a/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
@@ -26,6 +26,7 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
     private boolean isDurationTotalCWU;
     private int recipeCWUt;
     private boolean hasNotEnoughComputation;
+    private int currentDrawnCWUt;
 
     public ComputationRecipeLogic(RecipeMapMultiblockController metaTileEntity, ComputationType type) {
         super(metaTileEntity);
@@ -78,8 +79,8 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
                 this.hasNotEnoughComputation = false;
                 if (isDurationTotalCWU) {
                     // draw as much CWU as possible, and increase progress by this amount
-                    int drawnCWU = provider.requestCWUt(availableCWUt, false);
-                    progressTime += drawnCWU;
+                    currentDrawnCWUt = provider.requestCWUt(availableCWUt, false);
+                    progressTime += currentDrawnCWUt;
                 } else {
                     // draw only the recipe CWU/t, and increase progress by 1
                     provider.requestCWUt(recipeCWUt, false);
@@ -89,6 +90,7 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
                     completeRecipe();
                 }
             } else {
+                currentDrawnCWUt = 0;
                 this.hasNotEnoughComputation = true;
                 // only decrement progress for low CWU/t if we need a steady supply
                 if (type == ComputationType.STEADY) {
@@ -110,10 +112,15 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
         this.recipeCWUt = 0;
         this.isDurationTotalCWU = false;
         this.hasNotEnoughComputation = false;
+        this.currentDrawnCWUt = 0;
     }
 
     public int getRecipeCWUt() {
         return recipeCWUt;
+    }
+
+    public int getCurrentDrawnCWUt() {
+        return isDurationTotalCWU ? currentDrawnCWUt : recipeCWUt;
     }
 
     public boolean isHasNotEnoughComputation() {

--- a/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
@@ -126,6 +126,7 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
         NBTTagCompound compound = super.serializeNBT();
         if (this.progressTime > 0) {
             compound.setInteger("RecipeCWUt", recipeCWUt);
+            compound.setBoolean("IsDurationTotalCWU", isDurationTotalCWU);
         }
         return compound;
     }
@@ -135,7 +136,16 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
         super.deserializeNBT(compound);
         if (this.progressTime > 0) {
             recipeCWUt = compound.getInteger("RecipeCWUt");
+            isDurationTotalCWU = compound.getBoolean("IsDurationTotalCWU");
         }
+    }
+
+
+    /**
+     * @return Whether TOP / WAILA should show the recipe progress as duration or as total computation.
+     */
+    public boolean shouldShowDuration() {
+        return !isDurationTotalCWU;
     }
 
     public enum ComputationType {

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -926,9 +926,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     /**
      * This height is used to determine Y position to start drawing info on JEI.
+     * @deprecated remove overrides, this method is no longer used in any way.
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     public int getPropertyListHeight(Recipe recipe) {
-        return (recipe.getUnhiddenPropertyCount() + 3) * 10 - 3; // GTRecipeWrapper#LINE_HEIGHT
+        return 0;
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/builders/ComputationRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ComputationRecipeBuilder.java
@@ -4,6 +4,7 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.ComputationProperty;
+import gregtech.api.recipes.recipeproperties.TotalComputationProperty;
 import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import org.jetbrains.annotations.NotNull;
@@ -31,6 +32,10 @@ public class ComputationRecipeBuilder extends RecipeBuilder<ComputationRecipeBui
             this.CWUt(((Number) value).intValue());
             return true;
         }
+        if (key.equals(TotalComputationProperty.KEY)) {
+            this.totalCWU(((Number) value).intValue());
+            return true;
+        }
         return super.applyProperty(key, value);
     }
 
@@ -41,5 +46,17 @@ public class ComputationRecipeBuilder extends RecipeBuilder<ComputationRecipeBui
         }
         this.applyProperty(ComputationProperty.getInstance(), cwut);
         return this;
+    }
+
+    /**
+     * The total computation for this recipe. If desired, this should be used instead of a call to duration().
+     */
+    public ComputationRecipeBuilder totalCWU(int totalCWU) {
+        if (totalCWU < 0) {
+            GTLog.logger.error("Total CWU cannot be less than 0", new IllegalArgumentException());
+            recipeStatus = EnumValidationResult.INVALID;
+        }
+        this.applyProperty(TotalComputationProperty.getInstance(), totalCWU);
+        return duration(totalCWU);
     }
 }

--- a/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
@@ -1,0 +1,152 @@
+package gregtech.api.recipes.builders;
+
+import gregtech.api.GTValues;
+import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.items.metaitem.stats.IDataItem;
+import gregtech.api.items.metaitem.stats.IItemBehaviour;
+import gregtech.api.util.AssemblyLineManager;
+import gregtech.api.util.GTStringUtils;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+
+public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> {
+
+    protected ItemStack researchStack;
+    protected ItemStack dataStack;
+    protected String researchId;
+    protected int eut;
+
+    public T researchStack(@Nonnull ItemStack researchStack) {
+        if (!researchStack.isEmpty()) {
+            this.researchStack = researchStack;
+        }
+        return (T) this;
+    }
+
+    public T dataStack(@Nonnull ItemStack dataStack) {
+        if (!dataStack.isEmpty()) {
+            this.dataStack = dataStack;
+        }
+        return (T) this;
+    }
+
+    public T researchId(String researchId) {
+        this.researchId = researchId;
+        return (T) this;
+    }
+
+    public T EUt(int eut) {
+        this.eut = eut;
+        return (T) this;
+    }
+
+    protected void validateResearchItem() {
+        if (researchStack == null) {
+            throw new IllegalArgumentException("Research stack cannot be null or empty!");
+        }
+
+        if (researchId == null) {
+            researchId = GTStringUtils.itemStackToString(researchStack);
+        }
+
+        if (dataStack == null) {
+            dataStack = getDefaultDataItem();
+        }
+
+        boolean foundBehavior = false;
+        if (dataStack.getItem() instanceof MetaItem<?> metaItem) {
+            for (IItemBehaviour behaviour : metaItem.getBehaviours(dataStack)) {
+                if (behaviour instanceof IDataItem) {
+                    foundBehavior = true;
+                    dataStack = dataStack.copy();
+                    dataStack.setCount(1);
+                    break;
+                }
+            }
+        }
+        if (!foundBehavior) {
+            throw new IllegalArgumentException("Data ItemStack must have the IDataItem behavior");
+        }
+    }
+
+    protected abstract ItemStack getDefaultDataItem();
+
+    protected abstract AssemblyLineRecipeBuilder.ResearchRecipeEntry build();
+
+    public static class ScannerRecipeBuilder extends ResearchRecipeBuilder<ScannerRecipeBuilder> {
+
+        public static final int DEFAULT_SCANNER_DURATION = 1200; // 60 secs
+        public static final int DEFAULT_SCANNER_EUT = GTValues.VA[GTValues.HV];
+
+        private int duration;
+
+        ScannerRecipeBuilder() {/**/}
+
+        public ScannerRecipeBuilder duration(int duration) {
+            this.duration = duration;
+            return this;
+        }
+
+        @Override
+        protected ItemStack getDefaultDataItem() {
+            return AssemblyLineManager.getDefaultScannerItem();
+        }
+
+        @Override
+        protected AssemblyLineRecipeBuilder.ResearchRecipeEntry build() {
+            validateResearchItem();
+            if (duration <= 0) duration = DEFAULT_SCANNER_DURATION;
+            if (eut <= 0) eut = DEFAULT_SCANNER_EUT;
+            return new AssemblyLineRecipeBuilder.ResearchRecipeEntry(researchId, researchStack, dataStack, duration, eut, 0);
+        }
+    }
+
+    public static class StationRecipeBuilder extends ResearchRecipeBuilder<StationRecipeBuilder> {
+
+        public static final int DEFAULT_STATION_EUT = GTValues.VA[GTValues.LuV];
+        // By default, the total CWU needed will be 200 seconds if exactly enough CWU/t is provided.
+        // Providing more CWU/t will allow it to take less time.
+        public static final int DEFAULT_STATION_TOTAL_CWUT = 4000;
+
+        private int cwut;
+        private int totalCWU;
+
+        StationRecipeBuilder() {/**/}
+
+        public StationRecipeBuilder CWUt(int cwut) {
+            this.cwut = cwut;
+            this.totalCWU = cwut * DEFAULT_STATION_TOTAL_CWUT;
+            return this;
+        }
+
+        public StationRecipeBuilder CWUt(int cwut, int totalCWU) {
+            this.cwut = cwut;
+            this.totalCWU = totalCWU;
+            return this;
+        }
+
+        @Override
+        protected ItemStack getDefaultDataItem() {
+            return AssemblyLineManager.getDefaultResearchStationItem(cwut);
+        }
+
+        @Override
+        protected AssemblyLineRecipeBuilder.ResearchRecipeEntry build() {
+            validateResearchItem();
+            if (cwut <= 0 || totalCWU <= 0) {
+                throw new IllegalArgumentException("CWU/t and total CWU must both be set, and non-zero!");
+            }
+            if (cwut > totalCWU) {
+                throw new IllegalArgumentException("Total CWU cannot be greater than CWU/t!");
+            }
+
+            // "duration" is the total CWU/t.
+            // Not called duration in API because logic does not treat it like normal duration.
+            int duration = totalCWU;
+            if (eut <= 0) eut = DEFAULT_STATION_EUT;
+
+            return new AssemblyLineRecipeBuilder.ResearchRecipeEntry(researchId, researchStack, dataStack, duration, eut, cwut);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapCokeOven.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -24,10 +23,5 @@ public class RecipeMapCokeOven<R extends RecipeBuilder<R>> extends RecipeMap<R> 
         addSlot(builder, 106, 10, 0, exportItems, null, false, true);
         addSlot(builder, 106, 28, 0, null, exportFluids, true, true);
         return builder;
-    }
-
-    @Override
-    public int getPropertyListHeight(Recipe recipe) {
-        return 4;
     }
 }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/TotalComputationProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/TotalComputationProperty.java
@@ -1,0 +1,32 @@
+package gregtech.api.recipes.recipeproperties;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+
+public class TotalComputationProperty extends RecipeProperty<Integer> {
+
+    public static final String KEY = "total_computation";
+
+    private static TotalComputationProperty INSTANCE;
+
+    protected TotalComputationProperty() {
+        super(KEY, Integer.class);
+    }
+
+    public static TotalComputationProperty getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TotalComputationProperty();
+        }
+        return INSTANCE;
+    }
+
+    @Override
+    public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
+        minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total_computation", castValue(value)), x, y, color);
+    }
+
+    @Override
+    public boolean hideDuration() {
+        return true;
+    }
+}

--- a/src/main/java/gregtech/api/util/AssemblyLineManager.java
+++ b/src/main/java/gregtech/api/util/AssemblyLineManager.java
@@ -119,9 +119,9 @@ public final class AssemblyLineManager {
                     .inputNBT(dataItem.getItem(), 1, dataItem.getMetadata(), NBTMatcher.ANY, NBTCondition.ANY)
                     .inputs(researchItem)
                     .outputs(dataItem)
-                    .duration(duration)
                     .EUt(EUt)
                     .CWUt(CWUt)
+                    .totalCWU(duration)
                     .buildAndRegister();
         } else {
             RecipeMaps.SCANNER_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
@@ -238,7 +238,7 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
     private static class ResearchStationRecipeLogic extends ComputationRecipeLogic {
 
         public ResearchStationRecipeLogic(MetaTileEntityResearchStation metaTileEntity) {
-            super(metaTileEntity, ComputationType.SPORADIC, true);
+            super(metaTileEntity, ComputationType.SPORADIC);
         }
 
         @NotNull

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
@@ -211,6 +211,7 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
         tooltip.add(I18n.format("gregtech.machine.research_station.tooltip.1"));
         tooltip.add(I18n.format("gregtech.machine.research_station.tooltip.2"));
         tooltip.add(I18n.format("gregtech.machine.research_station.tooltip.3"));
+        tooltip.add(I18n.format("gregtech.machine.research_station.tooltip.4"));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
@@ -238,7 +238,7 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
     private static class ResearchStationRecipeLogic extends ComputationRecipeLogic {
 
         public ResearchStationRecipeLogic(MetaTileEntityResearchStation metaTileEntity) {
-            super(metaTileEntity, ComputationType.SPORADIC);
+            super(metaTileEntity, ComputationType.SPORADIC, true);
         }
 
         @NotNull

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
@@ -218,7 +218,7 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
         super.addDisplayText(textList);
         if (isStructureFormed() && isActive()) {
             var recipeLogic = getRecipeMapWorkable();
-            textList.add(new TextComponentTranslation("gregtech.multiblock.computation.usage", recipeLogic.getRecipeCWUt()));
+            textList.add(new TextComponentTranslation("gregtech.multiblock.computation.usage", recipeLogic.getCurrentDrawnCWUt()));
             if (recipeLogic.isHasNotEnoughComputation()) {
                 textList.add(new TextComponentTranslation("gregtech.multiblock.computation.not_enough_computation")
                         .setStyle(new Style().setColor(TextFormatting.RED)));

--- a/src/main/java/gregtech/integration/hwyla/provider/WorkableDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/WorkableDataProvider.java
@@ -3,6 +3,7 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
+import gregtech.api.capability.impl.ComputationRecipeLogic;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaRegistrar;
@@ -36,6 +37,7 @@ public class WorkableDataProvider extends CapabilityDataProvider<IWorkable> {
         NBTTagCompound subTag = new NBTTagCompound();
         subTag.setBoolean("Active", capability.isActive());
         if (capability.isActive()) {
+            subTag.setBoolean("ShowAsComputation", capability instanceof ComputationRecipeLogic logic && !logic.shouldShowDuration());
             subTag.setInteger("Progress", capability.getProgress());
             subTag.setInteger("MaxProgress", capability.getMaxProgress());
         }
@@ -56,6 +58,10 @@ public class WorkableDataProvider extends CapabilityDataProvider<IWorkable> {
             if (active) {
                 int progress = tag.getInteger("Progress");
                 int maxProgress = tag.getInteger("MaxProgress");
+
+                if (tag.getBoolean("ShowAsComputation")) {
+                    tooltip.add(I18n.format("gregtech.waila.progress_computation", progress, maxProgress));
+                }
 
                 if (maxProgress == 0) {
                     tooltip.add(I18n.format("gregtech.waila.progress_idle"));

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -150,19 +150,28 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     @Override
     public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
         super.drawInfo(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
-        int yPosition = recipeHeight - recipeMap.getPropertyListHeight(recipe);
+        var properties = recipe.getPropertyTypes();
+        boolean drawTotalEU = properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideTotalEU);
+        boolean drawEUt = properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideEUt);
+        boolean drawDuration = properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideDuration);
+
+        int defaultLines = 0;
+        if (drawTotalEU) defaultLines++;
+        if (drawEUt) defaultLines++;
+        if (drawDuration) defaultLines++;
+
+        int yPosition = recipeHeight - ((recipe.getUnhiddenPropertyCount() + defaultLines) * 10 - 3);
 
         // Default entries
-        var properties = recipe.getPropertyTypes();
-        if (properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideTotalEU)) {
+        if (drawTotalEU) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
-        } else yPosition -= LINE_HEIGHT;
-        if (properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideEUt)) {
+        }
+        if (drawEUt) {
             minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);
-        } else yPosition -= LINE_HEIGHT;
-        if (properties.isEmpty() || properties.stream().noneMatch(RecipeProperty::hideDuration)) {
+        }
+        if (drawDuration) {
             minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.duration", TextFormattingUtil.formatNumbers(recipe.getDuration() / 20d)), 0, yPosition += LINE_HEIGHT, 0x111111);
-        } else yPosition -= LINE_HEIGHT;
+        }
 
         // Property custom entries
         for (Map.Entry<RecipeProperty<?>, Object> propertyEntry : recipe.getPropertyValues()) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
@@ -3,6 +3,7 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
+import gregtech.api.capability.impl.ComputationRecipeLogic;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import net.minecraft.entity.player.EntityPlayer;
@@ -30,8 +31,19 @@ public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {
 
         int currentProgress = capability.getProgress();
         int maxProgress = capability.getMaxProgress();
-        String text;
 
+        if (capability instanceof ComputationRecipeLogic logic && !logic.shouldShowDuration()) {
+            // show as total computation instead
+            int color = capability.isWorkingEnabled() ? 0xFF00D4CE : 0xFFBB1C28;
+            probeInfo.progress(currentProgress, maxProgress, probeInfo.defaultProgressStyle()
+                    .suffix(" / " + maxProgress + " CWU")
+                    .filledColor(color)
+                    .alternateFilledColor(color)
+                    .borderColor(0xFF555555));
+            return;
+        }
+
+        String text;
         if (maxProgress < 20) {
             text = " / " + maxProgress + " t";
         } else {

--- a/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
@@ -28,7 +28,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(NiobiumTitanium.getFluid(L * 8))
                 .outputs(FUSION_REACTOR[0].getStackForm())
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(OreDictUnifier.get(wireGtSingle, IndiumTinBariumTitaniumCuprate))
                         .duration(1200)
                         .EUt(VA[IV]))
@@ -46,7 +46,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(VanadiumGallium.getFluid(L * 8))
                 .outputs(FUSION_REACTOR[1].getStackForm())
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(FUSION_REACTOR[0].getStackForm())
                         .CWUt(16)
                         .EUt(VA[ZPM]))
@@ -64,7 +64,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(YttriumBariumCuprate.getFluid(L * 8))
                 .outputs(FUSION_REACTOR[2].getStackForm())
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(FUSION_REACTOR[1].getStackForm())
                         .CWUt(96)
                         .EUt(VA[UV]))

--- a/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
@@ -349,7 +349,7 @@ public class BatteryRecipes {
                 .input(bolt, Naquadah, 16)
                 .fluidInputs(SolderingAlloy.getFluid(L * 5))
                 .output(ENERGY_LAPOTRONIC_ORB_CLUSTER)
-                .research(ENERGY_LAPOTRONIC_ORB.getStackForm())
+                .scannerResearch(ENERGY_LAPOTRONIC_ORB.getStackForm())
                 .buildAndRegister();
 
         // Energy Module
@@ -369,7 +369,7 @@ public class BatteryRecipes {
                 .input(bolt, Trinium, 16)
                 .fluidInputs(SolderingAlloy.getFluid(L * 10))
                 .output(ENERGY_MODULE)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_LAPOTRONIC_ORB_CLUSTER.getStackForm())
                         .CWUt(16))
                 .buildAndRegister();
@@ -392,7 +392,7 @@ public class BatteryRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 20))
                 .fluidInputs(Polybenzimidazole.getFluid(L * 4))
                 .output(ENERGY_CLUSTER)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_MODULE.getStackForm())
                         .CWUt(96)
                         .EUt(VA[ZPM]))
@@ -417,7 +417,7 @@ public class BatteryRecipes {
                 .fluidInputs(Polybenzimidazole.getFluid(2304))
                 .fluidInputs(Naquadria.getFluid(L * 18))
                 .output(ULTIMATE_BATTERY)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_CLUSTER.getStackForm())
                         .CWUt(144)
                         .EUt(VA[UHV]))

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -1365,7 +1365,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_DIODE, 8)
                 .fluidInputs(SolderingAlloy.getFluid(L * 10))
                 .output(CRYSTAL_MAINFRAME_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(CRYSTAL_COMPUTER_ZPM.getStackForm())
                         .CWUt(16))
                 .buildAndRegister();
@@ -1432,7 +1432,7 @@ public class CircuitRecipes {
                 .input(plate, Europium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(1152))
                 .output(WETWARE_SUPER_COMPUTER_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(WETWARE_PROCESSOR_ASSEMBLY_ZPM.getStackForm())
                         .CWUt(16))
                 .buildAndRegister();
@@ -1453,7 +1453,7 @@ public class CircuitRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 20))
                 .fluidInputs(Polybenzimidazole.getFluid(L * 8))
                 .output(WETWARE_MAINFRAME_UHV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(WETWARE_SUPER_COMPUTER_UV.getStackForm())
                         .CWUt(96)
                         .EUt(VA[UV]))

--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -86,7 +86,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ELECTRIC_MOTOR_LuV)
-                .research(ELECTRIC_MOTOR_IV.getStackForm())
+                .scannerResearch(ELECTRIC_MOTOR_IV.getStackForm())
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -100,7 +100,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ELECTRIC_MOTOR_ZPM)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ELECTRIC_MOTOR_LuV.getStackForm())
                         .duration(1200)
                         .EUt(VA[IV]))
@@ -118,7 +118,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(1000))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ELECTRIC_MOTOR_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ELECTRIC_MOTOR_ZPM.getStackForm())
                         .CWUt(32)
                         .EUt(VA[ZPM]))
@@ -256,7 +256,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(250))
                 .fluidInputs(StyreneButadieneRubber.getFluid(L * 8))
                 .output(CONVEYOR_MODULE_LuV)
-                .research(CONVEYOR_MODULE_IV.getStackForm())
+                .scannerResearch(CONVEYOR_MODULE_IV.getStackForm())
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -270,7 +270,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(500))
                 .fluidInputs(StyreneButadieneRubber.getFluid(L * 16))
                 .output(CONVEYOR_MODULE_ZPM)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(CONVEYOR_MODULE_LuV.getStackForm())
                         .duration(1200)
                         .EUt(VA[IV]))
@@ -288,7 +288,7 @@ public class ComponentRecipes {
                 .fluidInputs(StyreneButadieneRubber.getFluid(L * 24))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(CONVEYOR_MODULE_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(CONVEYOR_MODULE_ZPM.getStackForm())
                         .CWUt(32)
                         .EUt(VA[ZPM]))
@@ -305,7 +305,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ELECTRIC_PUMP_LuV)
-                .research(ELECTRIC_PUMP_IV.getStackForm())
+                .scannerResearch(ELECTRIC_PUMP_IV.getStackForm())
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -319,7 +319,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ELECTRIC_PUMP_ZPM)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ELECTRIC_PUMP_LuV.getStackForm())
                         .duration(1200)
                         .EUt(VA[IV]))
@@ -337,7 +337,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(1000))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ELECTRIC_PUMP_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ELECTRIC_PUMP_ZPM.getStackForm())
                         .CWUt(32)
                         .EUt(VA[ZPM]))
@@ -521,7 +521,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ELECTRIC_PISTON_LUV)
-                .research(ELECTRIC_PISTON_IV.getStackForm())
+                .scannerResearch(ELECTRIC_PISTON_IV.getStackForm())
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -536,7 +536,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ELECTRIC_PISTON_ZPM)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ELECTRIC_PISTON_LUV.getStackForm())
                         .duration(1200)
                         .EUt(VA[IV]))
@@ -555,7 +555,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(1000))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ELECTRIC_PISTON_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ELECTRIC_PISTON_ZPM.getStackForm())
                         .CWUt(32)
                         .EUt(VA[ZPM]))
@@ -628,7 +628,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ROBOT_ARM_LuV)
-                .research(ROBOT_ARM_IV.getStackForm())
+                .scannerResearch(ROBOT_ARM_IV.getStackForm())
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -644,7 +644,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ROBOT_ARM_ZPM)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ROBOT_ARM_LuV.getStackForm())
                         .duration(1200)
                         .EUt(VA[IV]))
@@ -664,7 +664,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(1000))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ROBOT_ARM_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ROBOT_ARM_ZPM.getStackForm())
                         .CWUt(32)
                         .EUt(VA[ZPM]))
@@ -730,7 +730,7 @@ public class ComponentRecipes {
                 .input(cableGtSingle, NiobiumTitanium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .output(FIELD_GENERATOR_LuV)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(FIELD_GENERATOR_IV.getStackForm())
                         .duration(2400))
                 .duration(600).EUt(6000).buildAndRegister();
@@ -746,7 +746,7 @@ public class ComponentRecipes {
                 .input(cableGtSingle, VanadiumGallium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .output(FIELD_GENERATOR_ZPM)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(FIELD_GENERATOR_LuV.getStackForm())
                         .CWUt(4))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -763,7 +763,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 12))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(FIELD_GENERATOR_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(FIELD_GENERATOR_ZPM.getStackForm())
                         .CWUt(48)
                         .EUt(VA[ZPM]))
@@ -829,7 +829,7 @@ public class ComponentRecipes {
                 .input(cableGtSingle, NiobiumTitanium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .output(SENSOR_LuV)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(SENSOR_IV.getStackForm())
                         .duration(2400))
                 .duration(600).EUt(6000).buildAndRegister();
@@ -845,7 +845,7 @@ public class ComponentRecipes {
                 .input(cableGtSingle, VanadiumGallium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .output(SENSOR_ZPM)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(SENSOR_LuV.getStackForm())
                         .CWUt(4))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -862,7 +862,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(SENSOR_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(SENSOR_ZPM.getStackForm())
                         .CWUt(48)
                         .EUt(VA[ZPM]))
@@ -932,7 +932,7 @@ public class ComponentRecipes {
                 .input(cableGtSingle, NiobiumTitanium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .output(EMITTER_LuV)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(EMITTER_IV.getStackForm())
                         .duration(2400))
                 .duration(600).EUt(6000).buildAndRegister();
@@ -948,7 +948,7 @@ public class ComponentRecipes {
                 .input(cableGtSingle, VanadiumGallium, 4)
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .output(EMITTER_ZPM)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(EMITTER_LuV.getStackForm())
                         .CWUt(8))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -965,7 +965,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(EMITTER_UV)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(EMITTER_ZPM.getStackForm())
                         .CWUt(48)
                         .EUt(VA[ZPM]))

--- a/src/main/java/gregtech/loaders/recipe/ComputerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComputerRecipes.java
@@ -37,7 +37,7 @@ public class ComputerRecipes {
                 .output(ADVANCED_DATA_ACCESS_HATCH)
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .fluidInputs(Polybenzimidazole.getFluid(L * 4))
-                .research(b -> b.researchStack(DATA_BANK.getStackForm()).CWUt(4))
+                .stationResearch(b -> b.researchStack(DATA_BANK.getStackForm()).CWUt(4))
                 .duration(400).EUt(6000).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -98,7 +98,7 @@ public class ComputerRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(DATA_BANK)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(DATA_ACCESS_HATCH.getStackForm())
                         .duration(2400)
                         .EUt(VA[EV]))
@@ -116,7 +116,7 @@ public class ComputerRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .fluidInputs(VanadiumGallium.getFluid(L * 8))
                 .output(RESEARCH_STATION)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(SCANNER[LuV].getStackForm())
                         .duration(2400)
                         .EUt(VA[IV]))
@@ -133,7 +133,7 @@ public class ComputerRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .fluidInputs(Polybenzimidazole.getFluid(L * 2))
                 .output(OBJECT_HOLDER)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ITEM_IMPORT_BUS[ZPM].getStackForm())
                         .duration(2400)
                         .EUt(VA[IV]))
@@ -151,7 +151,7 @@ public class ComputerRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .fluidInputs(Polybenzimidazole.getFluid(L * 4))
                 .output(NETWORK_SWITCH)
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(new ItemStack(OPTICAL_PIPES[0]))
                         .CWUt(32)
                         .EUt(VA[ZPM]))
@@ -169,7 +169,7 @@ public class ComputerRecipes {
                 .fluidInputs(VanadiumGallium.getFluid(L * 8))
                 .fluidInputs(PCBCoolant.getFluid(4000))
                 .output(HIGH_PERFORMANCE_COMPUTING_ARRAY)
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(COVER_SCREEN.getStackForm())
                         .duration(2400)
                         .EUt(VA[IV]))

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -131,7 +131,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(6000))
                 .fluidInputs(SolderingAlloy.getFluid(720))
                 .output(ENERGY_OUTPUT_HATCH[LuV])
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ENERGY_OUTPUT_HATCH[IV].getStackForm())
                         .EUt(VA[EV]))
                 .duration(400).EUt(VA[LuV]).buildAndRegister();
@@ -145,7 +145,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(8000))
                 .fluidInputs(SolderingAlloy.getFluid(1440))
                 .output(ENERGY_OUTPUT_HATCH[ZPM])
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_OUTPUT_HATCH[LuV].getStackForm())
                         .CWUt(8))
                 .duration(600).EUt(VA[ZPM]).buildAndRegister();
@@ -159,7 +159,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(10000))
                 .fluidInputs(SolderingAlloy.getFluid(2880))
                 .output(ENERGY_OUTPUT_HATCH[UV])
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_OUTPUT_HATCH[ZPM].getStackForm())
                         .CWUt(64)
                         .EUt(VA[ZPM]))
@@ -174,7 +174,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(12000))
                 .fluidInputs(SolderingAlloy.getFluid(5760))
                 .output(ENERGY_OUTPUT_HATCH[UHV])
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_OUTPUT_HATCH[UV].getStackForm())
                         .CWUt(128)
                         .EUt(VA[UV]))
@@ -259,7 +259,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(6000))
                 .fluidInputs(SolderingAlloy.getFluid(720))
                 .output(ENERGY_INPUT_HATCH[LuV])
-                .research(b -> b
+                .scannerResearch(b -> b
                         .researchStack(ENERGY_INPUT_HATCH[IV].getStackForm())
                         .EUt(VA[EV]))
                 .duration(400).EUt(VA[LuV]).buildAndRegister();
@@ -273,7 +273,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(8000))
                 .fluidInputs(SolderingAlloy.getFluid(1440))
                 .output(ENERGY_INPUT_HATCH[ZPM])
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_INPUT_HATCH[LuV].getStackForm())
                         .CWUt(8))
                 .duration(600).EUt(VA[ZPM]).buildAndRegister();
@@ -287,7 +287,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(10000))
                 .fluidInputs(SolderingAlloy.getFluid(2880))
                 .output(ENERGY_INPUT_HATCH[UV])
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_INPUT_HATCH[ZPM].getStackForm())
                         .CWUt(64)
                         .EUt(VA[ZPM]))
@@ -302,7 +302,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SodiumPotassium.getFluid(12000))
                 .fluidInputs(SolderingAlloy.getFluid(5760))
                 .output(ENERGY_INPUT_HATCH[UHV])
-                .research(b -> b
+                .stationResearch(b -> b
                         .researchStack(ENERGY_INPUT_HATCH[UV].getStackForm())
                         .CWUt(128)
                         .EUt(VA[UV]))

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -251,7 +251,7 @@ public class MiscRecipeLoader {
                 .inputs(ELECTRIC_MOTOR_LuV.getStackForm(2))
                 .input(screw, HSSS, 8)
                 .outputs(QUANTUM_CHESTPLATE_ADVANCED.getStackForm())
-                .research(GRAVITATION_ENGINE.getStackForm())
+                .scannerResearch(GRAVITATION_ENGINE.getStackForm())
                 .buildAndRegister();
 
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5149,7 +5149,8 @@ gregtech.recipe.cleanroom=Requires %s
 gregtech.recipe.cleanroom.display_name=Cleanroom
 gregtech.recipe.cleanroom_sterile.display_name=Sterile Cleanroom
 gregtech.recipe.research=Requires Research
-gregtech.recipe.computation_per_tick=Computation: %,d CWU/t
+gregtech.recipe.computation_per_tick=Min Computation: %,d CWU/t
+gregtech.recipe.total_computation=Computation: %,d
 
 gregtech.fluid.click_to_fill=§7Click with a Fluid Container to §bfill §7the tank (Shift-click for a full stack).
 gregtech.fluid.click_combined=§7Click with a Fluid Container to §cempty §7or §bfill §7the tank (Shift-click for a full stack).

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4696,8 +4696,9 @@ gregtech.machine.active_transformer.routing=Routing.
 
 gregtech.machine.research_station.name=Research Station
 gregtech.machine.research_station.tooltip.1=More than just a Multiblock Scanner
-gregtech.machine.research_station.tooltip.2=Used to scan onto §fData Orbs§7 or §fData Modules§7.
+gregtech.machine.research_station.tooltip.2=Used to scan onto §fData Orbs§7 and §fData Modules§7.
 gregtech.machine.research_station.tooltip.3=Requires §fComputation§7 to work.
+gregtech.machine.research_station.tooltip.4=Providing more Computation allows the recipe to run faster.
 gregtech.multiblock.research_station.description=The Research Station is a multiblock structure used for researching much more complex Assembly Line Research Data. Any Research requiring a Data Orb or Data Module must be scanned in the Research Station. Requires Compute Work Units (CWU/t) to research recipes, which is supplied by High Performance Computing Arrays (HPCAs).
 
 gregtech.machine.network_switch.name=Network Switch

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -107,6 +107,7 @@ gregtech.waila.energy_stored=Energy: %d EU / %d EU
 gregtech.waila.progress_idle=Idle
 gregtech.waila.progress_tick=Progress: %d t / %d t
 gregtech.waila.progress_sec=Progress: %d s / %d s
+gregtech.waila.progress_computation=Computation: %s / %s
 
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.


### PR DESCRIPTION
### Old Logic
Research station used a fixed CWU/t, and had a fixed duration. Would never draw more, had no way of going any faster.

### New Logic
Research station has a minimum CWU/t, with a maximum CWU needed. Will draw as much CWU/t as possible to complete the recipe as fast as it can. The "duration" is the total computation needed, and is incremented by as much CWU as is drawn each tick