### PR TITLE
Fixes Muffler Hatch mechanics

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
@@ -76,7 +76,7 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     public void recoverItemsTable(List<ItemStack> recoveryItems) {
         for (ItemStack recoveryItem : recoveryItems) {
             if (calculateChance()) {
-                GTTransferUtils.insertItem(inventory, recoveryItem, false);
+                GTTransferUtils.insertItem(inventory, recoveryItem.copy(), false);
             }
         }
     }


### PR DESCRIPTION
The original Muffler Hatch recovers items exponentially, and will not recover any item after manual removal, until the next game start.
Now it could recover items linearly, ignoring manual removal as expected.