### PR TITLE
Stricter Optical/Laser cable connections

### DIFF
--- a/src/main/java/gregtech/api/pipenet/tile/IPipeTile.java
+++ b/src/main/java/gregtech/api/pipenet/tile/IPipeTile.java
@@ -36,6 +36,8 @@ public interface IPipeTile<PipeType extends Enum<PipeType> & IPipeType<NodeDataT
 
     int getConnections();
 
+    int getNumConnections();
+
     boolean isConnected(EnumFacing side);
 
     void setConnection(EnumFacing side, boolean connected, boolean fromNeighbor);

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -144,6 +144,17 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     }
 
     @Override
+    public int getNumConnections() {
+        int count = 0;
+        int connections = getConnections();
+        while (connections > 0) {
+            count++;
+            connections = connections & (connections - 1);
+        }
+        return count;
+    }
+
+    @Override
     public int getBlockedConnections() {
         return canHaveBlockedFaces() ? blockedConnections : 0;
     }

--- a/src/main/java/gregtech/common/pipelike/laser/tile/TileEntityLaserPipe.java
+++ b/src/main/java/gregtech/common/pipelike/laser/tile/TileEntityLaserPipe.java
@@ -13,6 +13,7 @@ import gregtech.common.pipelike.laser.net.LaserPipeNet;
 import gregtech.common.pipelike.laser.net.WorldLaserPipeNet;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants;
@@ -116,6 +117,27 @@ public class TileEntityLaserPipe extends TileEntityPipeBase<LaserPipeType, Laser
             // create new handlers
             initHandlers();
         }
+    }
+
+    @Override
+    public void setConnection(EnumFacing side, boolean connected, boolean fromNeighbor) {
+        if (!getWorld().isRemote && connected && !fromNeighbor) {
+            int connections = getConnections();
+            // block connection if any side other than the requested side and its opposite side are already connected.
+            connections &= ~(1 << side.getIndex());
+            connections &= ~(1 << side.getOpposite().getIndex());
+            if (connections != 0) return;
+
+            // check the same for the targeted pipe
+            TileEntity tile = getWorld().getTileEntity(getPos().offset(side));
+            if (tile instanceof IPipeTile<?,?> pipeTile && pipeTile.getPipeType().getClass() == this.getPipeType().getClass()) {
+                connections = pipeTile.getConnections();
+                connections &= ~(1 << side.getIndex());
+                connections &= ~(1 << side.getOpposite().getIndex());
+                if (connections != 0) return;
+            }
+        }
+        super.setConnection(side, connected, fromNeighbor);
     }
 
     public boolean isActive() {

--- a/src/main/java/gregtech/common/pipelike/optical/tile/TileEntityOpticalPipe.java
+++ b/src/main/java/gregtech/common/pipelike/optical/tile/TileEntityOpticalPipe.java
@@ -14,6 +14,7 @@ import gregtech.common.pipelike.optical.net.OpticalNetHandler;
 import gregtech.common.pipelike.optical.net.OpticalPipeNet;
 import gregtech.common.pipelike.optical.net.WorldOpticalPipeNet;
 import net.minecraft.network.PacketBuffer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 
@@ -123,6 +124,21 @@ public class TileEntityOpticalPipe extends TileEntityPipeBase<OpticalPipeType, O
             // create new handlers
             initHandlers();
         }
+    }
+
+    @Override
+    public void setConnection(EnumFacing side, boolean connected, boolean fromNeighbor) {
+        if (!getWorld().isRemote && connected && !fromNeighbor) {
+            // never allow more than two connections total
+            if (getNumConnections() >= 2) return;
+
+            // also check the other pipe
+            TileEntity tile = getWorld().getTileEntity(getPos().offset(side));
+            if (tile instanceof IPipeTile<?,?> pipeTile && pipeTile.getPipeType().getClass() == this.getPipeType().getClass()) {
+                if (pipeTile.getNumConnections() >= 2) return;
+            }
+        }
+        super.setConnection(side, connected, fromNeighbor);
     }
 
     public boolean isActive() {


### PR DESCRIPTION
- Never allow laser cables to form connections that aren't in straight lines
- Never allow optical cables to form more than two total connections

This is only checked on connecting, not disconnecting, so there should be no issues with existing setups misconnecting these cables. It also is only checked on the source pipe not the neighbor check, as if the connection is from the neighbor it can be assumed to be correct.

Both of these should make it very clear what is and is not allowed with these cables.

Forgive the bitwise code but I do what must be done