### PR TITLE
Multi fluid hatch additions and recipe changes

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -120,8 +120,10 @@ public class MetaTileEntities {
     public static final MetaTileEntityItemBus[] ITEM_EXPORT_BUS = new MetaTileEntityItemBus[GTValues.UHV + 1];
     public static final MetaTileEntityFluidHatch[] FLUID_IMPORT_HATCH = new MetaTileEntityFluidHatch[GTValues.UHV + 1];
     public static final MetaTileEntityFluidHatch[] FLUID_EXPORT_HATCH = new MetaTileEntityFluidHatch[GTValues.UHV + 1];
-    public static final MetaTileEntityMultiFluidHatch[] MULTI_FLUID_IMPORT_HATCH = new MetaTileEntityMultiFluidHatch[2];
-    public static final MetaTileEntityMultiFluidHatch[] MULTI_FLUID_EXPORT_HATCH = new MetaTileEntityMultiFluidHatch[2];
+    public static final MetaTileEntityMultiFluidHatch[] QUADRUPLE_IMPORT_HATCH = new MetaTileEntityMultiFluidHatch[6]; // EV-UHV
+    public static final MetaTileEntityMultiFluidHatch[] NONUPLE_IMPORT_HATCH = new MetaTileEntityMultiFluidHatch[6]; // EV-UHV
+    public static final MetaTileEntityMultiFluidHatch[] QUADRUPLE_EXPORT_HATCH = new MetaTileEntityMultiFluidHatch[6]; // EV-UHV
+    public static final MetaTileEntityMultiFluidHatch[] NONUPLE_EXPORT_HATCH = new MetaTileEntityMultiFluidHatch[6]; // EV-UHV
     public static final MetaTileEntityEnergyHatch[] ENERGY_INPUT_HATCH = new MetaTileEntityEnergyHatch[GTValues.V.length];
     public static final MetaTileEntityEnergyHatch[] ENERGY_INPUT_HATCH_4A = new MetaTileEntityEnergyHatch[6]; // EV, IV, LuV, ZPM, UV, UHV
     public static final MetaTileEntityEnergyHatch[] ENERGY_INPUT_HATCH_16A = new MetaTileEntityEnergyHatch[5]; // IV, LuV, ZPM, UV, UHV
@@ -557,11 +559,7 @@ public class MetaTileEntities {
             registerMetaTileEntity(1195 + i, FLUID_EXPORT_HATCH[i]);
         }
 
-        // Multi-Fluid Hatches
-        MULTI_FLUID_IMPORT_HATCH[0] = registerMetaTileEntity(1190, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.import_4x"), 2, false));
-        MULTI_FLUID_IMPORT_HATCH[1] = registerMetaTileEntity(1191, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.import_9x"), 3, false));
-        MULTI_FLUID_EXPORT_HATCH[0] = registerMetaTileEntity(1205, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_4x"), 2, true));
-        MULTI_FLUID_EXPORT_HATCH[1] = registerMetaTileEntity(1206, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_9x"), 3, true));
+        // IDs 1190, 1191, 1205, and 1206 reserved for multi-fluid hatches
 
         // Energy Input/Output Hatches, IDs 1210-1269
         endPos = GregTechAPI.isHighTier() ? ENERGY_INPUT_HATCH.length - 1 : Math.min(ENERGY_INPUT_HATCH.length - 1, GTValues.UV + 2);
@@ -808,6 +806,22 @@ public class MetaTileEntities {
       
         LONG_DIST_ITEM_ENDPOINT = registerMetaTileEntity(1749, new MetaTileEntityLDItemEndpoint(gregtechId("ld_item_endpoint")));
         LONG_DIST_FLUID_ENDPOINT = registerMetaTileEntity(1750, new MetaTileEntityLDFluidEndpoint(gregtechId("ld_fluid_endpoint")));
+
+
+        // Multi-Fluid Hatches, IDs 1190, 1191, 1205, 1206, 1780-1799
+        // EV hatches separate because of old names/IDs
+        QUADRUPLE_IMPORT_HATCH[0] = registerMetaTileEntity(1190, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.import_4x"), GTValues.EV, 4, false));
+        NONUPLE_IMPORT_HATCH[0] = registerMetaTileEntity(1191, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.import_9x"), GTValues.EV, 9, false));
+        QUADRUPLE_EXPORT_HATCH[0] = registerMetaTileEntity(1205, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_4x"), GTValues.EV, 4, true));
+        NONUPLE_EXPORT_HATCH[0] = registerMetaTileEntity(1206, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_9x"), GTValues.EV, 9, true));
+        for (int i = GTValues.IV; i <= GTValues.UHV; i++) {
+            int index = i - GTValues.IV;
+            String tierName = GTValues.VN[i].toLowerCase();
+            QUADRUPLE_IMPORT_HATCH[index + 1] = registerMetaTileEntity(1780 + index, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.import_4x." + tierName), i, 4, false));
+            NONUPLE_IMPORT_HATCH[index + 1] = registerMetaTileEntity(1785 + index, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.import_9x." + tierName), i, 9, false));
+            QUADRUPLE_EXPORT_HATCH[index + 1] = registerMetaTileEntity(1790 + index, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_4x." + tierName), i, 4, true));
+            NONUPLE_EXPORT_HATCH[index + 1] = registerMetaTileEntity(1795 + index, new MetaTileEntityMultiFluidHatch(gregtechId("fluid_hatch.export_9x." + tierName), i, 9, true));
+        }
 
         /*
          * FOR ADDON DEVELOPERS:

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.multi.multiblockpart;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
@@ -49,7 +50,7 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
         this.numSlots = numSlots;
         // Quadruple: 1/4th the capacity of a fluid hatch of this tier
         // Nonuple: 1/8th the capacity of a fluid hatch of this tier
-        this.tankSize = (BASE_TANK_SIZE * (1 << Math.min(9, tier))) / (numSlots == 4 ? 4 : 8);
+        this.tankSize = (BASE_TANK_SIZE * (1 << Math.min(GTValues.UHV, tier))) / (numSlots == 4 ? 4 : 8);
         FluidTank[] fluidsHandlers = new FluidTank[numSlots];
         for (int i = 0; i < fluidsHandlers.length; i++) {
             fluidsHandlers[i] = new NotifiableFluidTank(tankSize, this, isExportHatch);

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -47,7 +47,6 @@ import static gregtech.common.blocks.BlockMetalCasing.MetalCasingType.BRONZE_BRI
 import static gregtech.common.blocks.MetaBlocks.METAL_CASING;
 import static gregtech.common.items.MetaItems.*;
 import static gregtech.common.metatileentities.MetaTileEntities.*;
-import static gregtech.common.metatileentities.MetaTileEntities.NONUPLE_EXPORT_HATCH;
 import static gregtech.loaders.OreDictionaryLoader.OREDICT_BLOCK_FUEL_COKE;
 import static gregtech.loaders.OreDictionaryLoader.OREDICT_FUEL_COKE;
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -47,6 +47,7 @@ import static gregtech.common.blocks.BlockMetalCasing.MetalCasingType.BRONZE_BRI
 import static gregtech.common.blocks.MetaBlocks.METAL_CASING;
 import static gregtech.common.items.MetaItems.*;
 import static gregtech.common.metatileentities.MetaTileEntities.*;
+import static gregtech.common.metatileentities.MetaTileEntities.NONUPLE_EXPORT_HATCH;
 import static gregtech.loaders.OreDictionaryLoader.OREDICT_BLOCK_FUEL_COKE;
 import static gregtech.loaders.OreDictionaryLoader.OREDICT_FUEL_COKE;
 
@@ -1078,13 +1079,21 @@ public class MachineRecipeLoader {
             }
         }
 
-        for (int i = 0; i < MULTI_FLUID_IMPORT_HATCH.length; i++) {
-            if (MULTI_FLUID_IMPORT_HATCH[i] != null && MULTI_FLUID_EXPORT_HATCH[i] != null) {
+        for (int i = 0; i < QUADRUPLE_IMPORT_HATCH.length; i++) {
+            if (QUADRUPLE_IMPORT_HATCH[i] != null && QUADRUPLE_EXPORT_HATCH[i] != null) {
+                ModHandler.addShapedRecipe("quadruple_fluid_hatch_output_to_input_" + QUADRUPLE_IMPORT_HATCH[i].getTier(), QUADRUPLE_IMPORT_HATCH[i].getStackForm(),
+                        "d", "B", 'B', QUADRUPLE_EXPORT_HATCH[i].getStackForm());
+                ModHandler.addShapedRecipe("quadruple_fluid_hatch_input_to_output_" + QUADRUPLE_EXPORT_HATCH[i].getTier(), QUADRUPLE_EXPORT_HATCH[i].getStackForm(),
+                        "d", "B", 'B', QUADRUPLE_IMPORT_HATCH[i].getStackForm());
+            }
+        }
 
-                ModHandler.addShapedRecipe("multi_fluid_hatch_output_to_input_" + MULTI_FLUID_IMPORT_HATCH[i].getTier(), MULTI_FLUID_IMPORT_HATCH[i].getStackForm(),
-                        "d", "B", 'B', MULTI_FLUID_EXPORT_HATCH[i].getStackForm());
-                ModHandler.addShapedRecipe("multi_fluid_hatch_input_to_output_" + MULTI_FLUID_EXPORT_HATCH[i].getTier(), MULTI_FLUID_EXPORT_HATCH[i].getStackForm(),
-                        "d", "B", 'B', MULTI_FLUID_IMPORT_HATCH[i].getStackForm());
+        for (int i = 0; i < NONUPLE_IMPORT_HATCH.length; i++) {
+            if (NONUPLE_IMPORT_HATCH[i] != null && NONUPLE_EXPORT_HATCH[i] != null) {
+                ModHandler.addShapedRecipe("nonuple_fluid_hatch_output_to_input_" + NONUPLE_IMPORT_HATCH[i].getTier(), NONUPLE_IMPORT_HATCH[i].getStackForm(),
+                        "d", "B", 'B', NONUPLE_EXPORT_HATCH[i].getStackForm());
+                ModHandler.addShapedRecipe("nonuple_fluid_hatch_input_to_output_" + NONUPLE_EXPORT_HATCH[i].getTier(), NONUPLE_EXPORT_HATCH[i].getStackForm(),
+                        "d", "B", 'B', NONUPLE_IMPORT_HATCH[i].getStackForm());
             }
         }
 

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityLoader.java
@@ -153,12 +153,6 @@ public class MetaTileEntityLoader {
         ModHandler.addShapelessRecipe("frost_hazard_to_steel_solid_casing", MetaBlocks.METAL_CASING.getItemVariant(STEEL_SOLID), MetaBlocks.WARNING_SIGN.getItemVariant(FROST_HAZARD));
         ModHandler.addShapelessRecipe("noise_hazard_to_steel_solid_casing", MetaBlocks.METAL_CASING.getItemVariant(STEEL_SOLID), MetaBlocks.WARNING_SIGN.getItemVariant(NOISE_HAZARD));
 
-        ModHandler.addShapedRecipe(true, "fluid_import_hatch_4x", MetaTileEntities.MULTI_FLUID_IMPORT_HATCH[0].getStackForm(), "P", "M", 'M', MetaTileEntities.HULL[GTValues.HV].getStackForm(), 'P', new UnificationEntry(OrePrefix.pipeQuadrupleFluid, Materials.Titanium));
-        ModHandler.addShapedRecipe(true, "fluid_import_hatch_9x", MetaTileEntities.MULTI_FLUID_IMPORT_HATCH[1].getStackForm(), "P", "M", 'M', MetaTileEntities.HULL[GTValues.IV].getStackForm(), 'P', new UnificationEntry(OrePrefix.pipeNonupleFluid, Materials.TungstenSteel));
-
-        ModHandler.addShapedRecipe(true, "fluid_export_hatch_4x", MetaTileEntities.MULTI_FLUID_EXPORT_HATCH[0].getStackForm(), "M", "P", 'M', MetaTileEntities.HULL[GTValues.HV].getStackForm(), 'P', new UnificationEntry(OrePrefix.pipeQuadrupleFluid, Materials.Titanium));
-        ModHandler.addShapedRecipe(true, "fluid_export_hatch_9x", MetaTileEntities.MULTI_FLUID_EXPORT_HATCH[1].getStackForm(), "M", "P", 'M', MetaTileEntities.HULL[GTValues.IV].getStackForm(), 'P', new UnificationEntry(OrePrefix.pipeNonupleFluid, Materials.TungstenSteel));
-
         ModHandler.addShapedRecipe(true, "rotor_holder_hv", MetaTileEntities.ROTOR_HOLDER[0].getStackForm(), "SGS", "GHG", "SGS", 'H', MetaTileEntities.HULL[GTValues.HV].getStackForm(), 'G', new UnificationEntry(OrePrefix.gear, Materials.BlackSteel), 'S', new UnificationEntry(OrePrefix.gearSmall, Materials.StainlessSteel));
         ModHandler.addShapedRecipe(true, "rotor_holder_ev", MetaTileEntities.ROTOR_HOLDER[1].getStackForm(), "SGS", "GHG", "SGS", 'H', MetaTileEntities.HULL[GTValues.EV].getStackForm(), 'G', new UnificationEntry(OrePrefix.gear, Materials.Ultimet), 'S', new UnificationEntry(OrePrefix.gearSmall, Materials.Titanium));
         ModHandler.addShapedRecipe(true, "rotor_holder_iv", MetaTileEntities.ROTOR_HOLDER[2].getStackForm(), "SGS", "GHG", "SGS", 'H', MetaTileEntities.HULL[GTValues.IV].getStackForm(), 'G', new UnificationEntry(OrePrefix.gear, Materials.HSSG), 'S', new UnificationEntry(OrePrefix.gearSmall, Materials.TungstenSteel));

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -36,6 +36,202 @@ public class MetaTileEntityMachineRecipeLoader {
         registerHatchBusRecipe(UV, FLUID_IMPORT_HATCH[UV], FLUID_EXPORT_HATCH[UV], QUANTUM_TANK[0].getStackForm());
         registerHatchBusRecipe(UHV, FLUID_IMPORT_HATCH[UHV], FLUID_EXPORT_HATCH[UHV], QUANTUM_TANK[1].getStackForm());
 
+        // Quadruple Fluid Input Hatches
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[EV])
+                .input(pipeQuadrupleFluid, Titanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_IMPORT_HATCH[0])
+                .duration(300).EUt(VA[EV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[IV])
+                .input(pipeQuadrupleFluid, TungstenSteel)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_IMPORT_HATCH[1])
+                .duration(300).EUt(VA[IV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[LuV])
+                .input(pipeQuadrupleFluid, NiobiumTitanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_IMPORT_HATCH[2])
+                .duration(300).EUt(VA[LuV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[ZPM])
+                .input(pipeQuadrupleFluid, Iridium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_IMPORT_HATCH[3])
+                .duration(300).EUt(VA[ZPM]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[UV])
+                .input(pipeQuadrupleFluid, Naquadah)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_IMPORT_HATCH[4])
+                .duration(300).EUt(VA[UV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[UHV])
+                .input(pipeQuadrupleFluid, Neutronium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_IMPORT_HATCH[5])
+                .duration(300).EUt(VA[UV]).buildAndRegister();
+
+        // Nonuple Fluid Input Hatches
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[EV])
+                .input(pipeNonupleFluid, Titanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_IMPORT_HATCH[0])
+                .duration(600).EUt(VA[EV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[IV])
+                .input(pipeNonupleFluid, TungstenSteel)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_IMPORT_HATCH[1])
+                .duration(600).EUt(VA[IV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[LuV])
+                .input(pipeNonupleFluid, NiobiumTitanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_IMPORT_HATCH[2])
+                .duration(600).EUt(VA[LuV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[ZPM])
+                .input(pipeNonupleFluid, Iridium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_IMPORT_HATCH[3])
+                .duration(600).EUt(VA[ZPM]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[UV])
+                .input(pipeNonupleFluid, Naquadah)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_IMPORT_HATCH[4])
+                .duration(600).EUt(VA[UV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_IMPORT_HATCH[UHV])
+                .input(pipeNonupleFluid, Neutronium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_IMPORT_HATCH[5])
+                .duration(600).EUt(VA[UV]).buildAndRegister();
+
+        // Quadruple Fluid Output Hatches
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[EV])
+                .input(pipeQuadrupleFluid, Titanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_EXPORT_HATCH[0])
+                .duration(300).EUt(VA[EV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[IV])
+                .input(pipeQuadrupleFluid, TungstenSteel)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_EXPORT_HATCH[1])
+                .duration(300).EUt(VA[IV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[LuV])
+                .input(pipeQuadrupleFluid, NiobiumTitanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_EXPORT_HATCH[2])
+                .duration(300).EUt(VA[LuV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[ZPM])
+                .input(pipeQuadrupleFluid, Iridium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_EXPORT_HATCH[3])
+                .duration(300).EUt(VA[ZPM]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[UV])
+                .input(pipeQuadrupleFluid, Naquadah)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_EXPORT_HATCH[4])
+                .duration(300).EUt(VA[UV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[UHV])
+                .input(pipeQuadrupleFluid, Neutronium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 4))
+                .circuitMeta(4)
+                .output(QUADRUPLE_EXPORT_HATCH[5])
+                .duration(300).EUt(VA[UV]).buildAndRegister();
+
+        // Nonuple Fluid Output Hatches
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[EV])
+                .input(pipeNonupleFluid, Titanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_EXPORT_HATCH[0])
+                .duration(600).EUt(VA[EV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[IV])
+                .input(pipeNonupleFluid, TungstenSteel)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_EXPORT_HATCH[1])
+                .duration(600).EUt(VA[IV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[LuV])
+                .input(pipeNonupleFluid, NiobiumTitanium)
+                .fluidInputs(Polytetrafluoroethylene.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_EXPORT_HATCH[2])
+                .duration(600).EUt(VA[LuV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[ZPM])
+                .input(pipeNonupleFluid, Iridium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_EXPORT_HATCH[3])
+                .duration(600).EUt(VA[ZPM]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[UV])
+                .input(pipeNonupleFluid, Naquadah)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_EXPORT_HATCH[4])
+                .duration(600).EUt(VA[UV]).buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(FLUID_EXPORT_HATCH[UHV])
+                .input(pipeNonupleFluid, Neutronium)
+                .fluidInputs(Polybenzimidazole.getFluid(L * 9))
+                .circuitMeta(9)
+                .output(NONUPLE_EXPORT_HATCH[5])
+                .duration(600).EUt(VA[UV]).buildAndRegister();
+
         // Item Buses
         registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new ItemStack(Blocks.CHEST));
         registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new ItemStack(Blocks.CHEST));

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4822,10 +4822,33 @@ gregtech.machine.fluid_hatch.import.uhv.name=UHV Input Hatch
 
 gregtech.machine.fluid_hatch.export.tooltip=Fluid Output for Multiblocks
 
-gregtech.machine.fluid_hatch.import_4x.name=Quadruple Input Hatch
-gregtech.machine.fluid_hatch.import_9x.name=Nonuple Input Hatch
-gregtech.machine.fluid_hatch.export_4x.name=Quadruple Output Hatch
-gregtech.machine.fluid_hatch.export_9x.name=Nonuple Output Hatch
+gregtech.machine.fluid_hatch.import_4x.name=EV Quadruple Input Hatch
+gregtech.machine.fluid_hatch.import_4x.iv.name=IV Quadruple Input Hatch
+gregtech.machine.fluid_hatch.import_4x.luv.name=LuV Quadruple Input Hatch
+gregtech.machine.fluid_hatch.import_4x.zpm.name=ZPM Quadruple Input Hatch
+gregtech.machine.fluid_hatch.import_4x.uv.name=UV Quadruple Input Hatch
+gregtech.machine.fluid_hatch.import_4x.uhv.name=UHV Quadruple Input Hatch
+
+gregtech.machine.fluid_hatch.import_9x.name=EV Nonuple Input Hatch
+gregtech.machine.fluid_hatch.import_9x.iv.name=IV Nonuple Input Hatch
+gregtech.machine.fluid_hatch.import_9x.luv.name=LuV Nonuple Input Hatch
+gregtech.machine.fluid_hatch.import_9x.zpm.name=ZPM Nonuple Input Hatch
+gregtech.machine.fluid_hatch.import_9x.uv.name=UV Nonuple Input Hatch
+gregtech.machine.fluid_hatch.import_9x.uhv.name=UHV Nonuple Input Hatch
+
+gregtech.machine.fluid_hatch.export_4x.name=EV Quadruple Output Hatch
+gregtech.machine.fluid_hatch.export_4x.iv.name=IV Quadruple Output Hatch
+gregtech.machine.fluid_hatch.export_4x.luv.name=LuV Quadruple Output Hatch
+gregtech.machine.fluid_hatch.export_4x.zpm.name=ZPM Quadruple Output Hatch
+gregtech.machine.fluid_hatch.export_4x.uv.name=UV Quadruple Output Hatch
+gregtech.machine.fluid_hatch.export_4x.uhv.name=UHV Quadruple Output Hatch
+
+gregtech.machine.fluid_hatch.export_9x.name=EV Nonuple Output Hatch
+gregtech.machine.fluid_hatch.export_9x.iv.name=IV Nonuple Output Hatch
+gregtech.machine.fluid_hatch.export_9x.luv.name=LuV Nonuple Output Hatch
+gregtech.machine.fluid_hatch.export_9x.zpm.name=ZPM Nonuple Output Hatch
+gregtech.machine.fluid_hatch.export_9x.uv.name=UV Nonuple Output Hatch
+gregtech.machine.fluid_hatch.export_9x.uhv.name=UHV Nonuple Output Hatch
 
 gregtech.machine.fluid_hatch.export.ulv.name=ULV Output Hatch
 gregtech.machine.fluid_hatch.export.lv.name=LV Output Hatch


### PR DESCRIPTION
- Added IV-UHV quad/nonuple hatches
- Quad hatch can hold 1/4th of the on-tier hatch's tank size
- Nonuple hatch can hold 1/8th of the on-tier hatch's tank size (because 1/9th is a bad number)
- Recipes adjusted to be in-line with hatch recipe changes in 2.7