### PR TITLE
2.7 clarity touchups

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDataBank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDataBank.java
@@ -14,6 +14,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
@@ -43,6 +44,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MetaTileEntityDataBank extends MultiblockWithDisplayBase implements IControllable {
+
+    private static final int EUT_PER_HATCH = GTValues.VA[GTValues.EV];
+    private static final int EUT_PER_HATCH_CHAINED = GTValues.VA[GTValues.LuV];
 
     private IEnergyContainer energyContainer;
 
@@ -75,8 +79,8 @@ public class MetaTileEntityDataBank extends MultiblockWithDisplayBase implements
         int regulars = getAbilities(MultiblockAbility.DATA_ACCESS_HATCH).size();
 
         int dataHatches = receivers + transmitters + regulars;
-        int tier = receivers > 0 ? GTValues.LuV : GTValues.EV;
-        return GTValues.VA[tier] * dataHatches;
+        int eutPerHatch = receivers > 0 ? EUT_PER_HATCH_CHAINED : EUT_PER_HATCH;
+        return eutPerHatch * dataHatches;
     }
 
     @Override
@@ -237,8 +241,8 @@ public class MetaTileEntityDataBank extends MultiblockWithDisplayBase implements
         tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.1"));
         tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.2"));
         tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.3"));
-        tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.4", GTValues.VA[GTValues.EV]));
-        tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.5", GTValues.VA[GTValues.LuV]));
+        tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.4", TextFormattingUtil.formatNumbers(EUT_PER_HATCH)));
+        tooltip.add(I18n.format("gregtech.machine.data_bank.tooltip.5", TextFormattingUtil.formatNumbers(EUT_PER_HATCH_CHAINED)));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityNetworkSwitch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityNetworkSwitch.java
@@ -14,6 +14,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockComputerCasing;
@@ -40,6 +41,8 @@ import java.util.List;
 import java.util.Set;
 
 public class MetaTileEntityNetworkSwitch extends MetaTileEntityDataBank implements IOpticalComputationProvider {
+
+    private static final int EUT_PER_HATCH = GTValues.VA[GTValues.IV];
 
     private final MultipleComputationHandler computationHandler = new MultipleComputationHandler();
 
@@ -143,6 +146,7 @@ public class MetaTileEntityNetworkSwitch extends MetaTileEntityDataBank implemen
         tooltip.add(I18n.format("gregtech.machine.network_switch.tooltip.1"));
         tooltip.add(I18n.format("gregtech.machine.network_switch.tooltip.2"));
         tooltip.add(I18n.format("gregtech.machine.network_switch.tooltip.3"));
+        tooltip.add(I18n.format("gregtech.machine.network_switch.tooltip.4", TextFormattingUtil.formatNumbers(EUT_PER_HATCH)));
     }
 
     @Override
@@ -181,7 +185,7 @@ public class MetaTileEntityNetworkSwitch extends MetaTileEntityDataBank implemen
             reset();
             this.providers.addAll(providers);
             this.transmitters.addAll(transmitters);
-            this.EUt = (providers.size() + transmitters.size()) * GTValues.VA[GTValues.IV];
+            this.EUt = (providers.size() + transmitters.size()) * EUT_PER_HATCH;
         }
 
         private void reset() {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityLaserHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityLaserHatch.java
@@ -96,7 +96,7 @@ public class MetaTileEntityLaserHatch extends MetaTileEntityMultiblockPart imple
 
     @Override
     public void addInformation(ItemStack stack, @Nullable World world, @NotNull List<String> tooltip, boolean advanced) {
-        tooltip.add(I18n.format("gregtech.machine.laser_hatch.tooltip1"));
+        tooltip.add(I18n.format(isOutput ? "gregtech.machine.laser_hatch.source.tooltip1" : "gregtech.machine.laser_hatch.target.tooltip1"));
         tooltip.add(I18n.format("gregtech.machine.laser_hatch.tooltip2"));
 
         if (isOutput) {

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -96,7 +96,17 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                     Collection<Recipe> possibleRecipes = ((IResearchRecipeMap) RecipeMaps.ASSEMBLY_LINE_RECIPES).getDataStickEntry(researchId);
                     if (possibleRecipes != null) {
                         for (Recipe r : possibleRecipes) {
-                            scannerPossibilities.add(r.getOutputs().get(0));
+                            ItemStack researchItem = r.getOutputs().get(0);
+                            researchItem = researchItem.copy();
+                            researchItem.setCount(1);
+                            boolean didMatch = false;
+                            for (ItemStack stack : scannerPossibilities) {
+                                if (ItemStack.areItemStacksEqual(stack, researchItem)) {
+                                    didMatch = true;
+                                    break;
+                                }
+                            }
+                            if (!didMatch) scannerPossibilities.add(researchItem);
                         }
                     }
                     scannerPossibilities.add(recipeOutputs.get(0));

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -3,6 +3,9 @@ package gregtech.integration.jei.recipe;
 import gregtech.api.GTValues;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.items.metaitem.stats.IDataItem;
+import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
@@ -10,7 +13,9 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.machines.IResearchRecipeMap;
 import gregtech.api.recipes.machines.IScannerRecipeMap;
+import gregtech.api.recipes.recipeproperties.ComputationProperty;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
+import gregtech.api.recipes.recipeproperties.TotalComputationProperty;
 import gregtech.api.util.AssemblyLineManager;
 import gregtech.api.util.ClipboardUtil;
 import gregtech.api.util.GTUtility;
@@ -135,6 +140,21 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         } else if (notConsumed) {
             tooltip.add(TooltipHelper.BLINKING_CYAN + I18n.format("gregtech.recipe.not_consumed"));
         }
+
+        if (!input && this.recipeMap instanceof IScannerRecipeMap && ingredient instanceof ItemStack stack && !stack.isEmpty()) {
+            // check for "normal" data items
+            if (stack.getItem() instanceof IDataItem) return;
+            // check for metaitem data items
+            if (stack.getItem() instanceof MetaItem<?> metaItem) {
+                for (IItemBehaviour behaviour : metaItem.getBehaviours(stack)) {
+                    if (behaviour instanceof IDataItem) {
+                        return;
+                    }
+                }
+            }
+            // If we are here, we know this is not the data item, so add the tooltip
+            tooltip.add(TooltipHelper.BLINKING_CYAN + I18n.format("gregtech.recipe.research_result"));
+        }
     }
 
     public void addFluidTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
@@ -164,7 +184,14 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
         // Default entries
         if (drawTotalEU) {
-            minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", Math.abs((long) recipe.getEUt()) * recipe.getDuration()), 0, yPosition, 0x111111);
+            long eu = Math.abs((long) recipe.getEUt()) * recipe.getDuration();
+            // sadly we still need a custom override here, since computation uses duration and EU/t very differently
+            if (recipe.hasProperty(TotalComputationProperty.getInstance()) && recipe.hasProperty(ComputationProperty.getInstance())) {
+                int minimumCWUt = recipe.getProperty(ComputationProperty.getInstance(), 1);
+                minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.max_eu", eu / minimumCWUt), 0, yPosition, 0x111111);
+            } else {
+                minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", eu), 0, yPosition, 0x111111);
+            }
         }
         if (drawEUt) {
             minecraft.fontRenderer.drawString(I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted", Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]), 0, yPosition += LINE_HEIGHT, 0x111111);

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4672,8 +4672,8 @@ gregtech.machine.data_bank.name=Data Bank
 gregtech.machine.data_bank.tooltip.1=Your Personal NAS
 gregtech.machine.data_bank.tooltip.2=Bulk Data Storage. Transfer with Optical Cables.
 gregtech.machine.data_bank.tooltip.3=Data Banks can be chained together.
-gregtech.machine.data_bank.tooltip.4=Uses §f%s EU/t§7 per Data Hatch normally.
-gregtech.machine.data_bank.tooltip.5=Uses §f%s EU/t§7 per Data Hatch when chained.
+gregtech.machine.data_bank.tooltip.4=Uses §f%s EU/t§7 per Data/Optical Hatch normally.
+gregtech.machine.data_bank.tooltip.5=Uses §f%s EU/t§7 per Data/Optical Hatch when chained.
 gregtech.multiblock.data_bank.description=The Data Bank is a multiblock structure used for sharing Assembly Line Research Data between multiple Assembly Lines. Additionally, it enables Assembly Lines to read more complex research data on Data Modules.
 
 gregtech.machine.power_substation.name=Power Substation
@@ -4705,6 +4705,7 @@ gregtech.machine.network_switch.name=Network Switch
 gregtech.machine.network_switch.tooltip.1=Ethernet Hub
 gregtech.machine.network_switch.tooltip.2=Used to route and distribute §fComputation§7.
 gregtech.machine.network_switch.tooltip.3=Can combine any number of Computation §fReceivers§7 into any number of Computation §fTransmitters§7.
+gregtech.machine.network_switch.tooltip.4=Uses §f%s EU/t§7 per Computation Data Hatch.
 gregtech.multiblock.network_switch.description=The Network Switch is a multiblock structure used for distributing Computation from many sources to many destinations. It can accept any number of Computation Data Reception or Transmission Hatches. It is necessary for Research Data which requires much higher Computation, as the Research Station can only accept one Computation Data Reception Hatch. HPCAs must have a Bridge Component for the Network Switch to be able to access their Computation.
 
 gregtech.machine.high_performance_computing_array.name=High Performance Computing Array

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5079,8 +5079,8 @@ gregtech.machine.laser_hatch.target_4096a.uxv.name=UXV 4096A Laser Target Hatch
 gregtech.machine.laser_hatch.target_4096a.opv.name=OpV 4096A Laser Target Hatch
 gregtech.machine.laser_hatch.target_4096a.max.name=MAX 4096A Laser Target Hatch
 
-
-gregtech.machine.laser_hatch.tooltip1=Receiving power from distance
+gregtech.machine.laser_hatch.source.tooltip1=Transmitting power at distance
+gregtech.machine.laser_hatch.target.tooltip1=Receiving power from distance
 gregtech.machine.laser_hatch.tooltip2=§cLaser Cables must be in a straight line!§7
 
 gregtech.machine.fluid_tank.max_multiblock=Max Multiblock Size: %,dx%,dx%,d

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5152,7 +5152,7 @@ gregtech.recipe.cleanroom=Requires %s
 gregtech.recipe.cleanroom.display_name=Cleanroom
 gregtech.recipe.cleanroom_sterile.display_name=Sterile Cleanroom
 gregtech.recipe.research=Requires Research
-gregtech.recipe.computation_per_tick=Min Computation: %,d CWU/t
+gregtech.recipe.computation_per_tick=Min. Computation: %,d CWU/t
 gregtech.recipe.total_computation=Computation: %,d CWU
 gregtech.recipe.research_result=Research result item, not produced by this recipe directly
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5137,6 +5137,7 @@ gregtech.universal.tooltip.requires_redstone=§4Requires Redstone power
 gregtech.block.tooltip.no_mob_spawning=§bMobs cannot spawn on this block
 
 gregtech.recipe.total=Total: %,d EU
+gregtech.recipe.max_eu=Max. EU: %,d EU
 gregtech.recipe.eu=Usage: %,d EU/t (%s§r)
 gregtech.recipe.eu_inverted=Generation: %,d EU/t
 gregtech.recipe.duration=Duration: %s secs
@@ -5152,7 +5153,8 @@ gregtech.recipe.cleanroom.display_name=Cleanroom
 gregtech.recipe.cleanroom_sterile.display_name=Sterile Cleanroom
 gregtech.recipe.research=Requires Research
 gregtech.recipe.computation_per_tick=Min Computation: %,d CWU/t
-gregtech.recipe.total_computation=Computation: %,d
+gregtech.recipe.total_computation=Computation: %,d CWU
+gregtech.recipe.research_result=Research result item, not produced by this recipe directly
 
 gregtech.fluid.click_to_fill=§7Click with a Fluid Container to §bfill §7the tank (Shift-click for a full stack).
 gregtech.fluid.click_combined=§7Click with a Fluid Container to §cempty §7or §bfill §7the tank (Shift-click for a full stack).


### PR DESCRIPTION
- Add a tooltip to research result items in JEI to clearly note that they are not produced directly by the recipe, and are just there to show that it is the item that this research is for
- Fix `Computation:` line in JEI to have a unit
- Fix `Total EU:` line in JEI for Research Station to be `Max EU:` to better reflect how its energy consumption works

Let me know if there are any other touchups you can think of 