### PR TITLE
Limit PA/APA to at most 4 energy hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -84,7 +84,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                 .where('X', states(getCasingState())
                         .setMinGlobalLimited(tier == 0 ? 11 : 4)
                         .or(autoAbilities(false, true, true, true, true, true, true))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1)) // no energy hatch maximum
+                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(4))
                         .or(abilities(MultiblockAbility.MACHINE_HATCH).setExactLimit(1)))
                 .where('#', air())
                 .build();


### PR DESCRIPTION
In 2.7, we unlocked the energy hatch limit entirely for PA/APA, though thinking about it more, allowing this is overkill imo. Limiting it to at most 4 means that an APA with 64 machines in it can be powered by 4 16A on-tier energy hatches, and more power than this couldn't be utilized by the machine anyway