### PR TITLE
fix PropertyMaterial value parsing failure

### DIFF
--- a/src/main/java/gregtech/common/blocks/properties/PropertyMaterial.java
+++ b/src/main/java/gregtech/common/blocks/properties/PropertyMaterial.java
@@ -37,8 +37,8 @@ public class PropertyMaterial extends PropertyHelper<Material> {
     @Nonnull
     @Override
     public Optional<Material> parseValue(@Nonnull String value) {
-        int index = value.indexOf(':');
-        String materialName = index < 0 ? value : value.substring(0, index) + '_' + value.substring(index + 1);
+        int index = value.indexOf("__");
+        String materialName = index < 0 ? value : value.substring(0, index) + ':' + value.substring(index + 2);
         Material material = GregTechAPI.materialManager.getMaterial(materialName);
         if (material != null && this.allowedValues.contains(material)) {
             return Optional.of(material);
@@ -49,7 +49,8 @@ public class PropertyMaterial extends PropertyHelper<Material> {
     @Nonnull
     @Override
     public String getName(@Nonnull Material material) {
-        return material.getModid() + '_' + material.getName();
+        // Use double underscore to prevent ${modid}_${material_name} being ambiguous with ${material_name} when parsing
+        return material.getModid() + "__" + material.getName();
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes parsing PropertyMaterial values from a string. There were two bugs at play in this case. The first was a parsing failure for cases where the modid is omitted from the string. The second was not submitting the correct string for the Material Manager to retrieve materials with.

## Implementation Details
Double underscore is used to separate the modid from the material name to avoid ambiguity in parsing. It cannot be known if a modid is being split, or the material name itself is being split unless a more unique separator is used. Double underscore was chosen here due to the restrictions in allowed values on MC's end.

## Outcome
Fixes #2112.

## Additional Information
Test CT script:
```zs
import mods.gregtech.blocks.HeatingCoils;

HeatingCoils.add(<blockstate:gregtech:meta_block_compressed_62:variant=gregtech__polyvinyl_chloride>, "polyvinyl_chloride", 24000, 2, 4, 3, <material:polyvinyl_chloride>);
```
The issue can be reproduced in 2.7.3 using the above with `_` instead of `__`.
