### PR TITLE
track missing textures for sided renderers

### DIFF
--- a/src/main/java/gregtech/client/renderer/texture/cube/OrientedOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/OrientedOverlayRenderer.java
@@ -21,8 +21,9 @@ import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -62,12 +63,12 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
         private final TextureAtlasSprite activeSpriteEmissive;
         private final TextureAtlasSprite pausedSpriteEmissive;
 
-        public ActivePredicate(TextureAtlasSprite normalSprite,
-                               TextureAtlasSprite activeSprite,
-                               TextureAtlasSprite pausedSprite,
-                               TextureAtlasSprite normalSpriteEmissive,
-                               TextureAtlasSprite activeSpriteEmissive,
-                               TextureAtlasSprite pausedSpriteEmissive) {
+        public ActivePredicate(@NotNull TextureAtlasSprite normalSprite,
+                               @NotNull TextureAtlasSprite activeSprite,
+                               @Nullable TextureAtlasSprite pausedSprite,
+                               @Nullable TextureAtlasSprite normalSpriteEmissive,
+                               @Nullable TextureAtlasSprite activeSpriteEmissive,
+                               @Nullable TextureAtlasSprite pausedSpriteEmissive) {
 
             this.normalSprite = normalSprite;
             this.activeSprite = activeSprite;
@@ -77,7 +78,7 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
             this.pausedSpriteEmissive = pausedSpriteEmissive;
         }
 
-        public TextureAtlasSprite getSprite(boolean active, boolean workingEnabled) {
+        public @Nullable TextureAtlasSprite getSprite(boolean active, boolean workingEnabled) {
             if (active) {
                 if (workingEnabled) {
                     return activeSprite;
@@ -88,7 +89,7 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
             return normalSprite;
         }
 
-        public TextureAtlasSprite getEmissiveSprite(boolean active, boolean workingEnabled) {
+        public @Nullable TextureAtlasSprite getEmissiveSprite(boolean active, boolean workingEnabled) {
             if (active) {
                 if (workingEnabled) {
                     return activeSpriteEmissive;
@@ -100,7 +101,7 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
         }
     }
 
-    public OrientedOverlayRenderer(@Nonnull String basePath) {
+    public OrientedOverlayRenderer(@NotNull String basePath) {
         this.basePath = basePath;
         Textures.CUBE_RENDERER_REGISTRY.put(basePath, this);
         Textures.iconRegisters.add(this);
@@ -134,6 +135,11 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
 
             final String active = String.format("%s_active", overlayPath);
             TextureAtlasSprite activeSprite = ICubeRenderer.getResource(textureMap, modID, active);
+
+            if (activeSprite == null) {
+                FMLClientHandler.instance().trackMissingTexture(new ResourceLocation(modID, "blocks/" + basePath + "/overlay_OVERLAY_FACE_active"));
+                continue;
+            }
 
             final String paused = String.format("%s_paused", overlayPath);
             TextureAtlasSprite pausedSprite = ICubeRenderer.getResource(textureMap, modID, paused);

--- a/src/main/java/gregtech/client/renderer/texture/cube/OrientedOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/OrientedOverlayRenderer.java
@@ -137,7 +137,7 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
             TextureAtlasSprite activeSprite = ICubeRenderer.getResource(textureMap, modID, active);
 
             if (activeSprite == null) {
-                FMLClientHandler.instance().trackMissingTexture(new ResourceLocation(modID, "blocks/" + basePath + "/overlay_OVERLAY_FACE_active"));
+                FMLClientHandler.instance().trackMissingTexture(new ResourceLocation(modID, "blocks/" + basePath + "/overlay_" + overlayFace.toString().toLowerCase() + "_active"));
                 continue;
             }
 

--- a/src/main/java/gregtech/client/renderer/texture/cube/OrientedOverlayRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/OrientedOverlayRenderer.java
@@ -16,6 +16,8 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
@@ -116,6 +118,7 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
             basePath = split[1];
         }
 
+        boolean foundTexture = false;
         for (OverlayFace overlayFace : OverlayFace.VALUES) {
             final String faceName = overlayFace.name().toLowerCase();
             final String overlayPath = String.format("blocks/%s/overlay_%s", basePath, faceName);
@@ -124,6 +127,8 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
             TextureAtlasSprite normalSprite = ICubeRenderer.getResource(textureMap, modID, overlayPath);
             // require the normal texture to get the rest
             if (normalSprite == null) continue;
+
+            foundTexture = true;
 
             // normal
 
@@ -143,6 +148,10 @@ public class OrientedOverlayRenderer implements ICubeRenderer {
 
             sprites.put(overlayFace, new ActivePredicate(normalSprite, activeSprite, pausedSprite,
                     normalSpriteEmissive, activeSpriteEmissive, pausedSpriteEmissive));
+        }
+
+        if (!foundTexture) {
+            FMLClientHandler.instance().trackMissingTexture(new ResourceLocation(modID, "blocks/" + basePath + "/overlay_OVERLAY_FACE"));
         }
     }
 

--- a/src/main/java/gregtech/client/renderer/texture/cube/SidedCubeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/cube/SidedCubeRenderer.java
@@ -15,6 +15,8 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.ArrayUtils;
@@ -53,6 +55,7 @@ public class SidedCubeRenderer implements ICubeRenderer {
         this.sprites = new EnumMap<>(OverlayFace.class);
         this.spritesEmissive = new EnumMap<>(OverlayFace.class);
 
+        boolean foundTexture = false;
         for (OverlayFace overlayFace : OverlayFace.VALUES) {
             final String faceName = overlayFace.name().toLowerCase();
             final String overlayPath = String.format(BASE_DIR, basePath, faceName);
@@ -61,9 +64,15 @@ public class SidedCubeRenderer implements ICubeRenderer {
             // require the normal texture to get the rest
             if (normalSprite == null) continue;
 
+            foundTexture = true;
+
             sprites.put(overlayFace, normalSprite);
 
             spritesEmissive.put(overlayFace, ICubeRenderer.getResource(textureMap, modID, overlayPath + EMISSIVE));
+        }
+
+        if (!foundTexture) {
+            FMLClientHandler.instance().trackMissingTexture(new ResourceLocation(modID, "blocks/" + basePath + "/OVERLAY_FACE"));
         }
     }
 


### PR DESCRIPTION
## What
Tracks missing textures for sided renderers. This means forge will log a warning stating which textures cannot be found, in the event a sided renderer did not find a texture for any side. This is useful for debugging why a renderer does not display anything, since this warning will output the location being searched for textures.

## Implementation Details
The other renderers do not have a case where no location is registered to a texture atlas, so they do not need changes. Registering a texture to the texture atlas will automatically track it in case it is not found.

## Outcome
Improves ease of debugging texture location issues for sided renderers.
