### PR TITLE
Add steam boiler production to top/waila

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -268,7 +268,9 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
 
                 steamFluidTank.drain(4000, true);
             }
-        } else this.hasNoWater = false;
+        } else {
+            this.hasNoWater = waterFluidTank.getFluidAmount() == 0;
+        }
     }
 
     public boolean isBurning() {

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -233,6 +233,10 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
         return (int) (getBaseSteamOutput() * (currentTemperature / (getMaxTemperate() * 1.0)) / 2);
     }
 
+    public boolean hasWater() {
+        return !hasNoWater;
+    }
+
     private void generateSteam() {
         if (currentTemperature >= 100) {
             int fillAmount = getTotalSteamOutput();

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -227,9 +227,15 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
 
     protected abstract int getBaseSteamOutput();
 
+    /** Returns the current total steam output every 10 ticks. */
+    public int getTotalSteamOutput() {
+        if (currentTemperature < 100) return 0;
+        return (int) (getBaseSteamOutput() * (currentTemperature / (getMaxTemperate() * 1.0)) / 2);
+    }
+
     private void generateSteam() {
         if (currentTemperature >= 100) {
-            int fillAmount = (int) (getBaseSteamOutput() * (currentTemperature / (getMaxTemperate() * 1.0)) / 2);
+            int fillAmount = getTotalSteamOutput();
             boolean hasDrainedWater = waterFluidTank.drain(1, true) != null;
             int filledSteam = 0;
             if (hasDrainedWater) {

--- a/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
+++ b/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
@@ -33,6 +33,7 @@ public class HWYLAModule extends IntegrationSubmodule implements IWailaPlugin {
         MultiRecipeMapDataProvider.INSTANCE.register(registrar);
         ConverterDataProvider.INSTANCE.register(registrar);
         RecipeLogicDataProvider.INSTANCE.register(registrar);
+        SteamBoilerDataProvider.INSTANCE.register(registrar);
         PrimitivePumpDataProvider.INSTANCE.register(registrar);
         // one day, if cover provider is ported to waila, register it right here
         BlockOreDataProvider.INSTANCE.register(registrar);

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -68,7 +68,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                 if (accessor.getTileEntity() instanceof IGregTechTileEntity gtte) {
                     MetaTileEntity mte = gtte.getMetaTileEntity();
                     if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler || mte instanceof RecipeMapSteamMultiblockController) {
-                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format("gregtech.top.of") + " " + I18n.format(Materials.Steam.getUnlocalizedName());
+                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " + I18n.format(Materials.Steam.getUnlocalizedName());
                     }
                     AbstractRecipeLogic arl = mte.getRecipeLogic();
                     if (arl != null) {

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -57,14 +57,21 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
             NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.SteamBoiler");
             if (tag.getBoolean("IsBurning")) {
                 int steamRate = tag.getInteger("SteamRate");
-                if (steamRate > 0) {
-                    if (tag.getBoolean("HasWater")) {
-                        tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + (steamRate / 10) + " L/t " + I18n.format(Materials.Steam.getUnlocalizedName()));
-                    } else {
-                        tooltip.add(I18n.format("gregtech.top.steam_no_water"));
-                    }
-                } else {
+                boolean hasWater = tag.getBoolean("HasWater");
+
+                // Creating steam
+                if (steamRate > 0 && hasWater) {
+                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + (steamRate / 10) + " L/t " + I18n.format(Materials.Steam.getUnlocalizedName()));
+                }
+
+                // Initial heat-up
+                if (steamRate <= 0) {
                     tooltip.add(I18n.format("gregtech.top.steam_heating_up"));
+                }
+
+                // No water
+                if (!hasWater) {
+                    tooltip.add(I18n.format("gregtech.top.steam_no_water"));
                 }
             }
         }

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -1,0 +1,68 @@
+package gregtech.integration.hwyla.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.unification.material.Materials;
+import gregtech.common.metatileentities.steam.boiler.SteamBoiler;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.IWailaRegistrar;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class SteamBoilerDataProvider implements IWailaDataProvider {
+
+    public static final SteamBoilerDataProvider INSTANCE = new SteamBoilerDataProvider();
+
+    public void register(@NotNull IWailaRegistrar registrar) {
+        registrar.registerBodyProvider(this, IGregTechTileEntity.class);
+        registrar.registerNBTProvider(this, IGregTechTileEntity.class);
+        registrar.addConfig(GTValues.MODID, "gregtech.steam_boiler");
+    }
+
+    @NotNull
+    @Override
+    public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world, BlockPos pos) {
+        if (te instanceof IGregTechTileEntity gtte) {
+            if (gtte.getMetaTileEntity() instanceof SteamBoiler boiler) {
+                NBTTagCompound subTag = new NBTTagCompound();
+                subTag.setBoolean("IsBurning", boiler.isBurning());
+                subTag.setInteger("SteamRate", boiler.getTotalSteamOutput());
+                tag.setTag("gregtech.SteamBoiler", subTag);
+            }
+        }
+        return tag;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getWailaBody(ItemStack itemStack, List<String> tooltip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
+        if (!config.getConfig("gregtech.steam_boiler")
+                || !(accessor.getTileEntity() instanceof IGregTechTileEntity gtte)
+                || !(gtte.getMetaTileEntity() instanceof SteamBoiler)) {
+            return tooltip;
+        }
+
+        if (accessor.getNBTData().hasKey("gregtech.SteamBoiler")) {
+            NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.SteamBoiler");
+            if (tag.getBoolean("IsBurning")) {
+                int steamRate = tag.getInteger("SteamRate");
+                if (steamRate > 0) {
+                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + (steamRate / 10) + " L/t " + I18n.format(Materials.Steam.getUnlocalizedName()));
+                } else {
+                    tooltip.add(I18n.format("gregtech.top.steam_heating_up"));
+                }
+            }
+        }
+        return tooltip;
+    }
+}

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -36,6 +36,7 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
             if (gtte.getMetaTileEntity() instanceof SteamBoiler boiler) {
                 NBTTagCompound subTag = new NBTTagCompound();
                 subTag.setBoolean("IsBurning", boiler.isBurning());
+                subTag.setBoolean("HasWater", boiler.hasWater());
                 subTag.setInteger("SteamRate", boiler.getTotalSteamOutput());
                 tag.setTag("gregtech.SteamBoiler", subTag);
             }
@@ -57,7 +58,11 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
             if (tag.getBoolean("IsBurning")) {
                 int steamRate = tag.getInteger("SteamRate");
                 if (steamRate > 0) {
-                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + (steamRate / 10) + " L/t " + I18n.format(Materials.Steam.getUnlocalizedName()));
+                    if (tag.getBoolean("HasWater")) {
+                        tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + (steamRate / 10) + " L/t " + I18n.format(Materials.Steam.getUnlocalizedName()));
+                    } else {
+                        tooltip.add(I18n.format("gregtech.top.steam_no_water"));
+                    }
                 } else {
                     tooltip.add(I18n.format("gregtech.top.steam_heating_up"));
                 }

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
@@ -34,6 +34,7 @@ public class TheOneProbeModule extends IntegrationSubmodule {
         oneProbe.registerProvider(new MultiRecipeMapInfoProvider());
         oneProbe.registerProvider(new ConverterInfoProvider());
         oneProbe.registerProvider(new RecipeLogicInfoProvider());
+        oneProbe.registerProvider(new SteamBoilerInfoProvider());
         oneProbe.registerProvider(new PrimitivePumpInfoProvider());
         oneProbe.registerProvider(new CoverInfoProvider());
         oneProbe.registerProvider(new BlockOreInfoProvider());

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -49,7 +49,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 IGregTechTileEntity gtTileEntity = (IGregTechTileEntity) tileEntity;
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
                 if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler || mte instanceof RecipeMapSteamMultiblockController) {
-                    text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " L/t {*gregtech.top.of*} {*" + Materials.Steam.getUnlocalizedName() + "*}";
+                    text = TextFormatting.AQUA.toString() + absEUt + TextStyleClass.INFO + " L/t {*" + Materials.Steam.getUnlocalizedName() + "*}";
                 }
             }
             if (text == null) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
@@ -29,20 +29,24 @@ public class SteamBoilerInfoProvider implements IProbeInfoProvider {
                     if (boiler.isBurning()) {
                         // Boiler is active
                         int steamOutput = boiler.getTotalSteamOutput();
-                        if (steamOutput > 0) {
-                            if (boiler.hasWater()) {
-                                // creating steam
-                                probeInfo.text(TextStyleClass.INFO
-                                        + "{*gregtech.top.energy_production*} "
-                                        + TextFormatting.AQUA + (steamOutput / 10)
-                                        + TextStyleClass.INFO + " L/t"
-                                        + " {*" + Materials.Steam.getUnlocalizedName() + "*}");
-                            } else {
-                                probeInfo.text(TextStyleClass.WARNING + "{*gregtech.top.steam_no_water*}");
-                            }
-                        } else {
-                            // still doing initial heat-up
+
+                        // Creating steam
+                        if (steamOutput > 0 && boiler.hasWater()) {
+                            probeInfo.text(TextStyleClass.INFO
+                                    + "{*gregtech.top.energy_production*} "
+                                    + TextFormatting.AQUA + (steamOutput / 10)
+                                    + TextStyleClass.INFO + " L/t"
+                                    + " {*" + Materials.Steam.getUnlocalizedName() + "*}");
+                        }
+
+                        // Initial heat-up
+                        if (steamOutput <= 0) {
                             probeInfo.text(TextStyleClass.INFO.toString() + TextFormatting.RED + "{*gregtech.top.steam_heating_up*}");
+                        }
+
+                        // No water
+                        if (!boiler.hasWater()) {
+                            probeInfo.text(TextStyleClass.WARNING + "{*gregtech.top.steam_no_water*}");
                         }
                     }
                 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
@@ -1,0 +1,48 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.unification.material.Materials;
+import gregtech.common.metatileentities.steam.boiler.SteamBoiler;
+import mcjty.theoneprobe.api.*;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+
+public class SteamBoilerInfoProvider implements IProbeInfoProvider {
+
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":steam_boiler_provider";
+    }
+
+    @Override
+    public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState state, IProbeHitData data) {
+        if (state.getBlock().hasTileEntity(state)) {
+            TileEntity te = world.getTileEntity(data.getPos());
+            if (te instanceof IGregTechTileEntity igtte) {
+                MetaTileEntity mte = igtte.getMetaTileEntity();
+                if (mte instanceof SteamBoiler boiler) {
+                    if (boiler.isBurning()) {
+                        // Boiler is active
+                        int steamOutput = boiler.getTotalSteamOutput();
+                        if (steamOutput > 0) {
+                            // creating steam
+                            probeInfo.text(TextStyleClass.INFO
+                                    + "{*gregtech.top.energy_production*} "
+                                    + TextFormatting.AQUA + (steamOutput / 10)
+                                    + TextStyleClass.INFO + " L/t"
+                                    + " {*" + Materials.Steam.getUnlocalizedName() + "*}");
+                        } else {
+                            // still doing initial heat-up
+                            probeInfo.text(TextStyleClass.INFO.toString() + TextFormatting.RED + "{*gregtech.top.steam_heating_up*}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
@@ -30,12 +30,16 @@ public class SteamBoilerInfoProvider implements IProbeInfoProvider {
                         // Boiler is active
                         int steamOutput = boiler.getTotalSteamOutput();
                         if (steamOutput > 0) {
-                            // creating steam
-                            probeInfo.text(TextStyleClass.INFO
-                                    + "{*gregtech.top.energy_production*} "
-                                    + TextFormatting.AQUA + (steamOutput / 10)
-                                    + TextStyleClass.INFO + " L/t"
-                                    + " {*" + Materials.Steam.getUnlocalizedName() + "*}");
+                            if (boiler.hasWater()) {
+                                // creating steam
+                                probeInfo.text(TextStyleClass.INFO
+                                        + "{*gregtech.top.energy_production*} "
+                                        + TextFormatting.AQUA + (steamOutput / 10)
+                                        + TextStyleClass.INFO + " L/t"
+                                        + " {*" + Materials.Steam.getUnlocalizedName() + "*}");
+                            } else {
+                                probeInfo.text(TextStyleClass.WARNING + "{*gregtech.top.steam_no_water*}");
+                            }
                         } else {
                             // still doing initial heat-up
                             probeInfo.text(TextStyleClass.INFO.toString() + TextFormatting.RED + "{*gregtech.top.steam_heating_up*}");

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -57,12 +57,12 @@ gregtech.top.working_disabled=Working Disabled
 
 gregtech.top.energy_consumption=Using
 gregtech.top.energy_production=Producing
-gregtech.top.of=of
 
 gregtech.top.transform_up=Step Up
 gregtech.top.transform_down=Step Down
 gregtech.top.transform_input=Input:
 gregtech.top.transform_output=Output:
+gregtech.top.steam_heating_up=Heating up
 
 gregtech.top.convert_eu=Converting §eEU§r -> §cFE§r
 gregtech.top.convert_fe=Converting §cFE§r -> §eEU§r

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -63,6 +63,7 @@ gregtech.top.transform_down=Step Down
 gregtech.top.transform_input=Input:
 gregtech.top.transform_output=Output:
 gregtech.top.steam_heating_up=Heating up
+gregtech.top.steam_no_water=No Water
 
 gregtech.top.convert_eu=Converting §eEU§r -> §cFE§r
 gregtech.top.convert_fe=Converting §cFE§r -> §eEU§r


### PR DESCRIPTION
Fills in a missing gap in top/waila production/consumption text for steam boilers, since they do not use normal recipe logic unlike others. Will say "Heating up" if the boiler is working but not hot enough to actually produce any steam