### PR TITLE
Allow fusion glass to replace output buses/energy hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -105,14 +105,14 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
                 .aisle("######ICI######", "####GGAAAGG####", "######ICI######")
                 .aisle("###############", "######OSO######", "###############")
                 .where('S', selfPredicate())
-                .where('G', states(MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.FUSION_GLASS)).or(states(getCasingState())))
-                .where('E', states(getCasingState()).or(metaTileEntities(Arrays.stream(MetaTileEntities.ENERGY_INPUT_HATCH)
+                .where('G', states(getCasingState(), getGlassState()))
+                .where('E', states(getCasingState(), getGlassState()).or(metaTileEntities(Arrays.stream(MetaTileEntities.ENERGY_INPUT_HATCH)
                         .filter(mte -> mte != null && tier <= mte.getTier() && mte.getTier() <= GTValues.UV)
                         .toArray(MetaTileEntity[]::new))
                         .setMinGlobalLimited(1).setPreviewCount(16)))
                 .where('C', states(getCasingState()))
                 .where('K', states(getCoilState()))
-                .where('O', states(getCasingState()).or(abilities(MultiblockAbility.EXPORT_FLUIDS)))
+                .where('O', states(getCasingState(), getGlassState()).or(abilities(MultiblockAbility.EXPORT_FLUIDS)))
                 .where('A', air())
                 .where('I', states(getCasingState()).or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(2)))
                 .where('#', any())
@@ -172,6 +172,10 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController i
         } else {
             return Textures.FUSION_TEXTURE;
         }
+    }
+
+    private IBlockState getGlassState() {
+        return MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.FUSION_GLASS);
     }
 
     private IBlockState getCasingState() {


### PR DESCRIPTION
Allows for any casing/hatch block in the middle ring to be glass, where previously the spots for multiblock parts still only allowed casings. Lets you have a more complete view of the fusion ring effect