### PR TITLE
Plasma uses localized key for each instead of gregtech.fluid.plasma.

### DIFF
--- a/src/main/java/gregtech/api/fluids/MaterialFluid.java
+++ b/src/main/java/gregtech/api/fluids/MaterialFluid.java
@@ -41,24 +41,17 @@ public class MaterialFluid extends Fluid {
 
     @Override
     public String getUnlocalizedName() {
-        return material.getUnlocalizedName();
+        return material.getUnlocalizedName() + fluidType.getLocalization();
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public String getLocalizedName(FluidStack stack) {
-        String localizedName;
-        String customTranslationKey = "fluid." + material.getUnlocalizedName();
-
+        String customTranslationKey = "fluid." + material.getUnlocalizedName() + fluidType.getLocalization();
         if (I18n.hasKey(customTranslationKey)) {
-            localizedName = I18n.format(customTranslationKey);
+            return I18n.format(customTranslationKey);
         } else {
-            localizedName = I18n.format(getUnlocalizedName());
+            return I18n.format(material.getUnlocalizedName() + fluidType.getLocalization());
         }
-
-        if (fluidType != null) {
-            return I18n.format(fluidType.getLocalization(), localizedName);
-        }
-        return localizedName;
     }
 }

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidType.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidType.java
@@ -34,7 +34,7 @@ public abstract class FluidType {
         this.name = name;
         this.prefix = prefix;
         this.suffix = suffix;
-        this.localization = localization;
+        this.localization = localization.isEmpty() ? "" : ("." + localization);
         FLUID_TYPES.put(name, this);
     }
 

--- a/src/main/java/gregtech/api/fluids/fluidType/FluidTypes.java
+++ b/src/main/java/gregtech/api/fluids/fluidType/FluidTypes.java
@@ -9,14 +9,14 @@ import stanhebben.zenscript.annotations.ZenProperty;
 public class FluidTypes {
 
     @ZenProperty
-    public static final FluidType LIQUID = new FluidTypeLiquid("liquid", null, null, "gregtech.fluid.generic");
+    public static final FluidType LIQUID = new FluidTypeLiquid("liquid", null, null, "");
 
     @ZenProperty
-    public static final FluidType ACID = new FluidTypeAcid("acid", null, null, "gregtech.fluid.generic");
+    public static final FluidType ACID = new FluidTypeAcid("acid", null, null, "");
 
     @ZenProperty
-    public static final FluidType GAS = new FluidTypeGas("gas", null, null, "gregtech.fluid.generic");
+    public static final FluidType GAS = new FluidTypeGas("gas", null, null, "");
 
     @ZenProperty
-    public static final FluidType PLASMA = new FluidTypePlasma("plasma", "plasma", null, "gregtech.fluid.plasma");
+    public static final FluidType PLASMA = new FluidTypePlasma("plasma", "plasma", null, "plasma");
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2184,6 +2184,14 @@ item.gregtech.material.iridium_metal_residue.dustTiny=Tiny Pile of Iridium Metal
 item.gregtech.material.iridium_metal_residue.dustSmall=Small Pile of Iridium Metal Residue
 item.gregtech.material.iridium_metal_residue.dust=Iridium Metal Residue
 
+# Plasma Names
+gregtech.material.argon.plasma=Argon Plasma
+gregtech.material.helium.plasma=Helium Plasma
+gregtech.material.iron.plasma=Iron Plasma
+gregtech.material.nickel.plasma=Nickel Plasma
+gregtech.material.nitrogen.plasma=Nitrogen Plasma
+gregtech.material.oxygen.plasma=Oxygen Plasma
+
 recipemap.ore_washer.name=Ore Washer
 recipemap.thermal_centrifuge.name=Thermal Centrifuge
 recipemap.extractor.name=Extractor

--- a/src/main/resources/assets/gregtech/lang/ja_jp.lang
+++ b/src/main/resources/assets/gregtech/lang/ja_jp.lang
@@ -1291,7 +1291,7 @@ cover.advanced_fluid_detector.invert_tooltip=赤石ロジックの反転を切�
 cover.advanced_fluid_detector.max=最大液体量:
 cover.advanced_fluid_detector.min=最小液体量:
 cover.advanced_item_detector.label=発展型アイテム検出器
-cover.advanced_item_detector.invert_tooltip=赤石ロジックの反転を切り替え/nデフォルトでは、最小アイテム量を下回った時に信号が停止し、最大アイテム量を上回った時に信号が出力されます。 
+cover.advanced_item_detector.invert_tooltip=赤石ロジックの反転を切り替え/nデフォルトでは、最小アイテム量を下回った時に信号が停止し、最大アイテム量を上回った時に信号が出力されます。
 cover.advanced_item_detector.max=最大アイテム量:
 cover.advanced_item_detector.min=最小アイテム量:
 
@@ -2189,6 +2189,14 @@ item.gregtech.material.platinum_sludge_residue.dust=白金泥残留物の粉
 item.gregtech.material.iridium_metal_residue.dustTiny=極小のイリジウム金属残留物の粉
 item.gregtech.material.iridium_metal_residue.dustSmall=小さなイリジウム金属残留物の粉
 item.gregtech.material.iridium_metal_residue.dust=イリジウム金属残留物の粉
+
+# Plasma Names
+gregtech.material.argon.plasma=アルゴンプラズマ
+gregtech.material.helium.plasma=ヘリウムプラズマ
+gregtech.material.iron.plasma=鉄プラズマ
+gregtech.material.nickel.plasma=ニッケルプラズマ
+gregtech.material.nitrogen.plasma=窒素プラズマ
+gregtech.material.oxygen.plasma=酸素プラズマ
 
 recipemap.ore_washer.name=鉱石洗浄機
 recipemap.thermal_centrifuge.name=熱遠心分離機
@@ -5392,7 +5400,7 @@ gregtech.multiblock.large_boiler.throttle=スロットル: %d
 gregtech.multiblock.large_boiler.throttle.tooltip=ボイラーはより少ない蒸気を生産し、より少ない燃料を消費する。これにより効率が失われることはなく、予熱時間は影響されない。
 gregtech.multiblock.large_boiler.throttle_increment=スロットルを§a+5%%§f上昇§r/n§7ボイラーはより少ない蒸気を生産し、より少ない燃料を消費する。これにより効率が失われることはなく、予熱時間は影響されない。
 gregtech.multiblock.large_boiler.throttle_decrement=スロットを§c-5%%§f低下§r/n§7Bボイラーはより少ない蒸気を生産し、より少ない燃料を消費する。これにより効率が失われることはなく、予熱時間は影響されない。
-gregtech.multiblock.large_boiler.rate_tooltip=§f石炭1つ§7から§f%d L§7の蒸気を生産 
+gregtech.multiblock.large_boiler.rate_tooltip=§f石炭1つ§7から§f%d L§7の蒸気を生産
 gregtech.multiblock.large_boiler.heat_time_tooltip=§7予熱に§f%,d 秒§7必要
 gregtech.multiblock.large_boiler.explosion_tooltip=水がない状態で燃料を入れると爆発する。
 

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -1668,7 +1668,7 @@ gregtech.material.diphenyl_isophthalate=Дифенилизофталат
 gregtech.material.phthalic_acid=Фталевая кислота
 gregtech.material.dimethylbenzene=Диметилбензол
 gregtech.material.diaminobenzidine=3,3-Диаминобензидин
-gregtech.material.dichlorobenzidine=3,3-Дихлорбензидин 
+gregtech.material.dichlorobenzidine=3,3-Дихлорбензидин
 gregtech.material.nitrochlorobenzene=2-Нитрохлорбензол
 gregtech.material.chlorobenzene=Хлорбензол
 gregtech.material.octane=Октан
@@ -2057,6 +2057,15 @@ item.gregtech.material.platinum_sludge_residue.dust=Остаток платин�
 item.gregtech.material.iridium_metal_residue.dust=Металлический остаток иридия
 item.gregtech.material.iridium_metal_residue.dustSmall=Маленькая кучка металлического остатка иридия
 item.gregtech.material.iridium_metal_residue.dustTiny=Крошечная кучка металлического остатка иридия
+
+# Plasma Names
+gregtech.material.argon.plasma=Плазма (Аргон)
+gregtech.material.helium.plasma=Плазма (Гелий)
+gregtech.material.iron.plasma=Плазма (Железо)
+gregtech.material.nickel.plasma=Плазма (Никель)
+gregtech.material.nitrogen.plasma=Плазма (Азот)
+gregtech.material.oxygen.plasma=Плазма (Кислород)
+
 recipemap.ore_washer.name=Рудопромывка
 recipemap.thermal_centrifuge.name=Термальная центрифуга
 recipemap.extractor.name=Экстрактор

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2135,6 +2135,14 @@ item.gregtech.material.iridium_metal_residue.dustTiny=小撮铱金属渣
 item.gregtech.material.iridium_metal_residue.dustSmall=小堆铱金属渣
 item.gregtech.material.iridium_metal_residue.dust=铱金属渣
 
+# Plasma Names
+gregtech.material.argon.plasma=氩等离子体
+gregtech.material.helium.plasma=氦等离子体
+gregtech.material.iron.plasma=铁等离子体
+gregtech.material.nickel.plasma=镍等离子体
+gregtech.material.nitrogen.plasma=氮等离子体
+gregtech.material.oxygen.plasma=氧等离子体
+
 recipemap.ore_washer.name=洗矿厂
 recipemap.thermal_centrifuge.name=热力离心机
 recipemap.extractor.name=提取机
@@ -4567,7 +4575,7 @@ gregtech.machine.coke_oven.tooltip=为炼钢和发电提供更优质的燃料
 gregtech.machine.assembly_line.tooltip=真的不是什么多方块组装机！
 gregtech.machine.fusion_reactor.luv.tooltip=原子级合金熔炼机
 gregtech.machine.fusion_reactor.zpm.tooltip=一 轮 红 日 落 大 地
-gregtech.machine.fusion_reactor.uv.tooltip=化 作 白 矮 星 砸 向 你 
+gregtech.machine.fusion_reactor.uv.tooltip=化 作 白 矮 星 砸 向 你
 gregtech.machine.large_chemical_reactor.tooltip=黑匣子形反应器
 gregtech.machine.steam_oven.tooltip=和多重冶炼炉还是有区别的
 gregtech.machine.steam_grinder.tooltip=多方块研磨机，但是没有副产物


### PR DESCRIPTION
## What
MaterialFluid.getUnlocalizedName() doesn't consider what FluidType the fluid is, so localized name of a plasma in QuantumTank doesn't have Plasma suffix.


## Implementation Details
The problem is that nested localization isn't suitable for getUnlocalizedName, so we must use localized key for each instead of gregtech.fluid.plasma.

## Outcome
FluidType.localization now has a localization suffix(empty or "plasma") instead of gregtech.fluid.general/gregtech.fluid.plasma.
All plasma localizations are added to all lang files.

## Potential Compatibility Issues
FluidType.localization now has a localization suffix(empty or "plasma") instead of gregtech.fluid.general/gregtech.fluid.plasma.
