### PR TITLE
Add missing hard recipe config recipes

### DIFF
--- a/src/main/java/gregtech/api/items/OreDictNames.java
+++ b/src/main/java/gregtech/api/items/OreDictNames.java
@@ -6,9 +6,11 @@ public enum OreDictNames {
     string,
     chestWood,
     chestEnder,
+    fenceWood,
 
     cobblestone, // For just cobblestone.
     stoneCobble, // For any kind of cobblestone (e.g. mossy cobblestone).
+    stoneBricks, // For any kind of stone bricks
 
     craftingAnvil,
     craftingFurnace,

--- a/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
@@ -94,6 +94,11 @@ public class MaterialFlags {
             .requireProps(PropertyKey.INGOT)
             .build();
 
+    public static final MaterialFlag GENERATE_DENSE = new MaterialFlag.Builder("generate_dense")
+            .requireFlags(GENERATE_PLATE)
+            .requireProps(PropertyKey.DUST)
+            .build();
+
     public static final MaterialFlag GENERATE_ROD = new MaterialFlag.Builder("generate_rod")
             .requireProps(PropertyKey.DUST)
             .build();
@@ -231,11 +236,6 @@ public class MaterialFlags {
 
     public static final MaterialFlag GENERATE_ROTOR = new MaterialFlag.Builder("generate_rotor")
             .requireFlags(GENERATE_BOLT_SCREW, GENERATE_RING, GENERATE_PLATE)
-            .requireProps(PropertyKey.INGOT)
-            .build();
-
-    public static final MaterialFlag GENERATE_DENSE = new MaterialFlag.Builder("generate_dense")
-            .requireFlags(GENERATE_PLATE)
             .requireProps(PropertyKey.INGOT)
             .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -380,7 +380,7 @@ public class FirstDegreeMaterials {
         Obsidian = new Material.Builder(297, gregtechId("obsidian"))
                 .dust(3)
                 .color(0x503264)
-                .flags(NO_SMASHING, EXCLUDE_BLOCK_CRAFTING_RECIPES, GENERATE_PLATE)
+                .flags(NO_SMASHING, EXCLUDE_BLOCK_CRAFTING_RECIPES, GENERATE_PLATE, GENERATE_DENSE)
                 .components(Magnesium, 1, Iron, 1, Silicon, 2, Oxygen, 4)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -25,7 +25,7 @@ public class HigherDegreeMaterials {
         EnderEye = new Material.Builder(2508, gregtechId("ender_eye"))
                 .gem(1)
                 .color(0x66FF66)
-                .flags(NO_SMASHING, NO_SMELTING, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(GENERATE_PLATE, NO_SMASHING, NO_SMELTING, DECOMPOSITION_BY_CENTRIFUGING)
                 .build();
 
         Diatomite = new Material.Builder(2509, gregtechId("diatomite"))

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -101,7 +101,7 @@ public class OrePrefix {
     public static final OrePrefix nugget = new OrePrefix("nugget", M / 9, null, MaterialIconType.nugget, ENABLE_UNIFICATION, hasIngotProperty);
 
     // 9 Plates combined in one Item.
-    public static final OrePrefix plateDense = new OrePrefix("plateDense", M * 9, null, MaterialIconType.plateDense, ENABLE_UNIFICATION, mat -> mat.hasFlag(GENERATE_DENSE) && !mat.hasFlag(NO_SMASHING));
+    public static final OrePrefix plateDense = new OrePrefix("plateDense", M * 9, null, MaterialIconType.plateDense, ENABLE_UNIFICATION, mat -> mat.hasFlag(GENERATE_DENSE));
     // 2 Plates combined in one Item
     public static final OrePrefix plateDouble = new OrePrefix("plateDouble", M * 2, null, MaterialIconType.plateDouble, ENABLE_UNIFICATION, hasIngotProperty.and(mat -> mat.hasFlags(GENERATE_PLATE, GENERATE_DOUBLE_PLATE) && !mat.hasFlag(NO_SMASHING)));
     // Regular Plate made of one Ingot/Dust. Introduced by Calclavia

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -238,7 +238,7 @@ public class ConfigHolder {
         @Config.Comment({"Whether to remove Vanilla Block Recipes from the Crafting Table.", "Default: false"})
         public boolean removeVanillaBlockRecipes = false;
 
-        @Config.Comment({"Whether to make crafting recipes for Bricks, Firebricks, and Coke Bricks harder.", "Default: false"})
+        @Config.Comment({"Whether to make crafting recipes for Bricks, Nether Bricks, Firebricks, and Coke Bricks harder.", "Default: false"})
         public boolean harderBrickRecipes = false;
 
         @Config.Comment({"Whether to make the recipe for the EBF Controller harder.", "Default: false"})

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -320,6 +320,7 @@ public class MaterialInfoLoader {
                     new MaterialStack(Materials.Paper, M * 9)));
 
             OreDictUnifier.registerOre(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
+                    new MaterialStack(Materials.Wood, M * 8), // chest
                     new MaterialStack(Materials.Obsidian, M * 9 * 6), // 6 dense plates
                     new MaterialStack(Materials.EnderEye, M)));
         } else {

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -314,13 +314,19 @@ public class MaterialInfoLoader {
                     new MaterialStack(Materials.Obsidian, M * 3),
                     new MaterialStack(Materials.Glass, M * 4)));
 
-            OreDictUnifier.registerOre(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 4), new MaterialStack(Materials.Obsidian, M * 3), new MaterialStack(Materials.Paper, M * 9)));
+            OreDictUnifier.registerOre(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W), new ItemMaterialInfo(
+                    new MaterialStack(Materials.Diamond, M * 4),
+                    new MaterialStack(Materials.Obsidian, M * 3),
+                    new MaterialStack(Materials.Paper, M * 9)));
+
+            OreDictUnifier.registerOre(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
+                    new MaterialStack(Materials.Obsidian, M * 9 * 6), // 6 dense plates
+                    new MaterialStack(Materials.EnderEye, M)));
         } else {
             OreDictUnifier.registerOre(new ItemStack(Blocks.BEACON, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.NetherStar, M), new MaterialStack(Materials.Obsidian, M * 3), new MaterialStack(Materials.Glass, M * 5)));
             OreDictUnifier.registerOre(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 2), new MaterialStack(Materials.Obsidian, M * 4), new MaterialStack(Materials.Paper, M * 3)));
+            OreDictUnifier.registerOre(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.EnderEye, M), new MaterialStack(Materials.Obsidian, M * 8)));
         }
-
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.EnderEye, M), new MaterialStack(Materials.Obsidian, M * 8)));
 
         OreDictUnifier.registerOre(new ItemStack(Blocks.FURNACE, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 8)));
         OreDictUnifier.registerOre(new ItemStack(Blocks.STONEBRICK, 1, W), new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));

--- a/src/main/java/gregtech/loaders/WoodTypeEntry.java
+++ b/src/main/java/gregtech/loaders/WoodTypeEntry.java
@@ -39,6 +39,8 @@ public final class WoodTypeEntry {
     public final String doorRecipeName;
     @Nonnull
     public final ItemStack slab;
+    @Nullable
+    public final String slabRecipeName;
     public final boolean addSlabCraftingRecipe;
     public final ItemStack fence;
     @Nullable
@@ -77,9 +79,9 @@ public final class WoodTypeEntry {
     private WoodTypeEntry(@Nonnull String modid, @Nonnull String woodName, @Nonnull ItemStack log,
                           boolean removeCharcoalRecipe, boolean addCharcoalRecipe, @Nonnull ItemStack planks,
                           @Nullable String planksRecipeName, @Nonnull ItemStack door, @Nullable String doorRecipeName,
-                          @Nonnull ItemStack slab, boolean addSlabCraftingRecipe, @Nonnull ItemStack fence,
-                          @Nullable String fenceRecipeName, @Nonnull ItemStack fenceGate,
-                          @Nullable String fenceGateRecipeName, @Nonnull ItemStack stairs,
+                          @Nonnull ItemStack slab, @Nullable String slabRecipeName, boolean addSlabCraftingRecipe,
+                          @Nonnull ItemStack fence, @Nullable String fenceRecipeName,
+                          @Nonnull ItemStack fenceGate, @Nullable String fenceGateRecipeName, @Nonnull ItemStack stairs,
                           boolean addStairsCraftingRecipe, @Nonnull ItemStack boat, @Nullable String boatRecipeName,
                           @Nullable Material material, boolean addLogOreDict, boolean addPlanksOreDict,
                           boolean addDoorsOreDict, boolean addSlabsOreDict, boolean addFencesOreDict,
@@ -97,6 +99,7 @@ public final class WoodTypeEntry {
         this.door = door;
         this.doorRecipeName = doorRecipeName;
         this.slab = slab;
+        this.slabRecipeName = slabRecipeName;
         this.addSlabCraftingRecipe = addSlabCraftingRecipe;
         this.fence = fence;
         this.fenceRecipeName = fenceRecipeName;
@@ -142,6 +145,7 @@ public final class WoodTypeEntry {
         private ItemStack door = ItemStack.EMPTY;
         private String doorRecipeName;
         private ItemStack slab = ItemStack.EMPTY;
+        private String slabRecipeName;
         private boolean addSlabsCraftingRecipe;
         private ItemStack fence = ItemStack.EMPTY;
         private String fenceRecipeName;
@@ -244,8 +248,9 @@ public final class WoodTypeEntry {
          * @param slab the slab to add
          * @return this
          */
-        public Builder slab(@Nonnull ItemStack slab) {
+        public Builder slab(@Nonnull ItemStack slab, @Nullable String slabRecipeName) {
             this.slab = slab;
+            this.slabRecipeName = slabRecipeName;
             return this;
         }
 
@@ -403,7 +408,7 @@ public final class WoodTypeEntry {
         public WoodTypeEntry build() {
             Preconditions.checkArgument(!planks.isEmpty(), "Planks cannot be empty.");
             return new WoodTypeEntry(modid, woodName, log, removeCharcoalRecipe, addCharcoalRecipe, planks,
-                    planksRecipeName, door, doorRecipeName, slab, addSlabsCraftingRecipe, fence, fenceRecipeName,
+                    planksRecipeName, door, doorRecipeName, slab, slabRecipeName, addSlabsCraftingRecipe, fence, fenceRecipeName,
                     fenceGate, fenceGateRecipeName, stairs, addStairsCraftingRecipe, boat, boatRecipeName, material,
                     addLogOreDict, addPlanksOreDict, addDoorsOreDict, addSlabsOreDict, addFencesOreDict,
                     addFenceGatesOreDict, addStairsOreDict, addPlanksUnificationInfo, addDoorsUnificationInfo,

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -491,6 +491,8 @@ public class VanillaOverrideRecipes {
      * - Removes Vanilla Magma Cream Recipe
      * - Removes Vanilla Polished Stone Variant Recipes
      * - Removes Vanilla Brick Smelting Recipe
+     * - Removes Vanilla Fermented Spider Eye recipe
+     * - Removes Vanilla Fire Charge recipe
      */
     private static void miscRecipes() {
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:tnt"));
@@ -662,6 +664,9 @@ public class VanillaOverrideRecipes {
         for (int i = 0; i <= 15; i++) {
             addBedRecipe(i);
         }
+
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:fermented_spider_eye"));
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:fire_charge"));
     }
 
     private static void addBedRecipe(int meta) {

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -15,6 +15,7 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.items.MetaItems;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
@@ -45,6 +46,7 @@ public class VanillaOverrideRecipes {
             ModHandler.addShapedRecipe("brick_from_water", new ItemStack(Blocks.BRICK_BLOCK, 2), "BBB", "BWB", "BBB",
                     'B', new ItemStack(Items.BRICK),
                     'W', new ItemStack(Items.WATER_BUCKET));
+            ModHandler.removeFurnaceSmelting(new ItemStack(Blocks.NETHERRACK));
         }
         removeCompressionRecipes();
         toolArmorRecipes();
@@ -137,7 +139,7 @@ public class VanillaOverrideRecipes {
                 'C', OreDictNames.stoneCobble,
                 'R', new UnificationEntry(OrePrefix.plate, Materials.RedAlloy),
                 'G', new UnificationEntry(OrePrefix.gearSmall, Materials.Iron),
-                'F', "fenceWood"
+                'F', OreDictNames.fenceWood
         );
 
         RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder()
@@ -264,6 +266,7 @@ public class VanillaOverrideRecipes {
         );
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:daylight_detector"));
+        ModHandler.removeRecipeByName(new ResourceLocation("appliedenergistics2:misc/vanilla_daylight_detector"));
         ModHandler.addShapedRecipe("daylight_detector", new ItemStack(Blocks.DAYLIGHT_DETECTOR), "GGG", "PPP", "SRS",
                 'G', new ItemStack(Blocks.GLASS, 1, GTValues.W),
                 'P', new UnificationEntry(OrePrefix.plate, Materials.NetherQuartz),
@@ -343,6 +346,7 @@ public class VanillaOverrideRecipes {
         );
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:comparator"));
+        ModHandler.removeRecipeByName(new ResourceLocation("appliedenergistics2:misc/vanilla_comparator"));
         ModHandler.addShapedRecipe("comparator", new ItemStack(Items.COMPARATOR), "STS", "TQT", "PdP",
                 'S', new UnificationEntry(OrePrefix.screw, Materials.Iron),
                 'T', new ItemStack(Blocks.REDSTONE_TORCH),
@@ -397,7 +401,7 @@ public class VanillaOverrideRecipes {
         );
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:redstone_torch"));
-        ModHandler.addShapedRecipe("redstone_torch", new ItemStack(Blocks.REDSTONE_TORCH), "R", "T", 'R', new UnificationEntry(OrePrefix.dust, Materials.Redstone), 'T', new UnificationEntry(OrePrefix.stick, Materials.Wood));
+        ModHandler.addShapedRecipe("redstone_torch", new ItemStack(Blocks.REDSTONE_TORCH), "R", "T", 'R', new UnificationEntry(OrePrefix.dust, Materials.Redstone), 'T', new ItemStack(Blocks.TORCH));
     }
 
     /**
@@ -474,8 +478,12 @@ public class VanillaOverrideRecipes {
      * Replaces Vanilla Enchantment Table recipe
      * Replaces Vanilla Jukebox recipe
      * Replaces Vanilla Note Block recipe
-     * Replaces Vanilla Furnace
-     * - Removes Vanilla TNT recipe
+     * Replaces Vanilla Furnace recipe
+     * Replaces Vanilla Flower Pot recipe
+     * Replaces Vanilla Armor Stand recipe
+     * Replaces Vanilla Trapped Chest recipe
+     * Replaces Vanilla Ender Chest recipe
+     * Replaces Vanilla Bed recipes
      * - Removes Vanilla Golden Apple Recipe
      * - Removes Vanilla Ender Eye Recipe
      * - Removes Vanilla Glistering Melon Recipe
@@ -620,6 +628,53 @@ public class VanillaOverrideRecipes {
         ModHandler.addShapedRecipe("furnace_minecart", new ItemStack(Items.FURNACE_MINECART), "hIw", " M ", " d ", 'I', new ItemStack(Blocks.FURNACE), 'M', new ItemStack(Items.MINECART));
         ModHandler.addShapedRecipe("tnt_minecart", new ItemStack(Items.TNT_MINECART), "hIw", " M ", " d ", 'I', new ItemStack(Blocks.TNT), 'M', new ItemStack(Items.MINECART));
         ModHandler.addShapedRecipe("hopper_minecart", new ItemStack(Items.HOPPER_MINECART), "hIw", " M ", " d ", 'I', new ItemStack(Blocks.HOPPER), 'M', new ItemStack(Items.MINECART));
+
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:flower_pot"));
+        ModHandler.addShapedRecipe("flower_pot", new ItemStack(Items.FLOWER_POT), "BfB", " B ",
+                'B', new ItemStack(Items.BRICK));
+
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:armor_stand"));
+        ModHandler.addShapedRecipe("armor_stand", new ItemStack(Items.ARMOR_STAND), "BSB", "hSs", "IPI",
+                'B', new UnificationEntry(OrePrefix.bolt, Materials.Wood),
+                'S', new UnificationEntry(OrePrefix.stick, Materials.Wood),
+                'I', new UnificationEntry(OrePrefix.plate, Materials.Iron),
+                'P', new ItemStack(Blocks.STONE_PRESSURE_PLATE));
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(Blocks.STONE_PRESSURE_PLATE)
+                .input(OrePrefix.plate, Materials.Iron, 2)
+                .input(OrePrefix.stick, Materials.Wood, 2)
+                .output(Items.ARMOR_STAND)
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
+
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:trapped_chest"));
+        ModHandler.addShapedRecipe("trapped_chest", new ItemStack(Blocks.TRAPPED_CHEST), " H ", "SCS", " d ",
+                'H', new ItemStack(Blocks.TRIPWIRE_HOOK),
+                'S', new UnificationEntry(OrePrefix.screw, Materials.Iron),
+                'C', new ItemStack(Blocks.CHEST));
+
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:ender_chest"));
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OrePrefix.plateDense, Materials.Obsidian, 6)
+                .input(OrePrefix.plate, Materials.EnderEye)
+                .output(Blocks.ENDER_CHEST)
+                .duration(200).EUt(VA[MV]).buildAndRegister();
+
+        for (int i = 0; i <= 15; i++) {
+            addBedRecipe(i);
+        }
+    }
+
+    private static void addBedRecipe(int meta) {
+        String colorName = EnumDyeColor.byMetadata(meta).getDyeColorName();
+        if ("silver".equals(colorName)) {
+            // thank you mojang
+            colorName = "light_gray";
+        }
+        ModHandler.removeRecipeByName(new ResourceLocation("minecraft:" + colorName + "_bed"));
+        ModHandler.addShapedRecipe(colorName + "_bed", new ItemStack(Items.BED, 1, meta), "WWW", "PPP", "FrF",
+                'W', new ItemStack(Blocks.CARPET, 1, meta),
+                'P', new UnificationEntry(OrePrefix.plank, Materials.Wood),
+                'F', OreDictNames.fenceWood);
     }
 
     /**
@@ -659,6 +714,7 @@ public class VanillaOverrideRecipes {
             ModHandler.removeRecipeByName("minecraft:lapis_block");
             ModHandler.removeRecipeByName("minecraft:lapis_lazuli");
             ModHandler.removeRecipeByName("minecraft:quartz_block");
+            ModHandler.removeRecipeByName("appliedenergistics2:decorative/quartz_block_pure");
             ModHandler.removeRecipeByName("minecraft:clay");
             ModHandler.removeRecipeByName("minecraft:nether_brick");
             ModHandler.removeRecipeByName("minecraft:glowstone");
@@ -696,6 +752,28 @@ public class VanillaOverrideRecipes {
             ModHandler.removeRecipeByName("minecraft:smooth_red_sandstone");
             ModHandler.removeRecipeByName("minecraft:bookshelf");
             ModHandler.removeRecipeByName("minecraft:pillar_quartz_block");
+            ModHandler.removeRecipeByName("minecraft:sea_lantern");
+            ModHandler.removeRecipeByName("minecraft:chiseled_sandstone");
+
+            // Slab replacement
+            ModHandler.removeRecipeByName("minecraft:stone_slab");
+            ModHandler.addShapedRecipe("stone_slab_saw", new ItemStack(Blocks.STONE_SLAB), "sS", 'S', new ItemStack(Blocks.STONE));
+            ModHandler.removeRecipeByName("minecraft:sandstone_slab");
+            ModHandler.addShapedRecipe("sandstone_slab_saw", new ItemStack(Blocks.STONE_SLAB, 1, 1), "sS", 'S', new ItemStack(Blocks.SANDSTONE, 1, W));
+            ModHandler.removeRecipeByName("minecraft:cobblestone_slab");
+            ModHandler.addShapedRecipe("cobblestone_slab_saw", new ItemStack(Blocks.STONE_SLAB, 1, 3), "sS", 'S', new ItemStack(Blocks.COBBLESTONE));
+            ModHandler.removeRecipeByName("minecraft:brick_slab");
+            ModHandler.addShapedRecipe("brick_slab_saw", new ItemStack(Blocks.STONE_SLAB, 1, 4), "sS", 'S', new ItemStack(Blocks.BRICK_BLOCK));
+            ModHandler.removeRecipeByName("minecraft:stone_brick_slab");
+            ModHandler.addShapedRecipe("stone_brick_slab_saw", new ItemStack(Blocks.STONE_SLAB, 1, 5), "sS", 'S', OreDictNames.stoneBricks);
+            ModHandler.removeRecipeByName("minecraft:nether_brick_slab");
+            ModHandler.addShapedRecipe("nether_brick_slab_saw", new ItemStack(Blocks.STONE_SLAB, 1, 6), "sS", 'S', new ItemStack(Blocks.NETHER_BRICK));
+            ModHandler.removeRecipeByName("minecraft:quartz_slab");
+            ModHandler.addShapedRecipe("quartz_slab_saw", new ItemStack(Blocks.STONE_SLAB, 1, 7), "sS", 'S', new ItemStack(Blocks.QUARTZ_BLOCK, 1, W));
+            ModHandler.removeRecipeByName("minecraft:red_sandstone_slab");
+            ModHandler.addShapedRecipe("red_sandstone_slab_saw", new ItemStack(Blocks.STONE_SLAB2), "sS", 'S', new ItemStack(Blocks.RED_SANDSTONE, 1, W));
+            ModHandler.removeRecipeByName("minecraft:purpur_slab");
+            ModHandler.addShapedRecipe("purpur_slab_saw", new ItemStack(Blocks.PURPUR_SLAB), "sS", 'S', new ItemStack(Blocks.PURPUR_BLOCK));
         }
     }
 

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -656,6 +656,7 @@ public class VanillaOverrideRecipes {
 
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:ender_chest"));
         ASSEMBLER_RECIPES.recipeBuilder()
+                .input(OreDictNames.chestWood.name())
                 .input(OrePrefix.plateDense, Materials.Obsidian, 6)
                 .input(OrePrefix.plate, Materials.EnderEye)
                 .output(Blocks.ENDER_CHEST)

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -746,7 +746,7 @@ public class VanillaOverrideRecipes {
             ModHandler.removeRecipeByName("minecraft:polished_granite");
             ModHandler.removeRecipeByName("minecraft:coarse_dirt");
             ModHandler.removeRecipeByName("minecraft:smooth_sandstone");
-            ModHandler.removeRecipeByName("minecraft_chiseled_sandstone");
+            ModHandler.removeRecipeByName("minecraft:chiseled_sandstone");
             ModHandler.removeRecipeByName("minecraft:chiseled_quartz_block");
             ModHandler.removeRecipeByName("minecraft:stonebrick");
             ModHandler.removeRecipeByName("minecraft:chiseled_stonebrick");
@@ -759,7 +759,6 @@ public class VanillaOverrideRecipes {
             ModHandler.removeRecipeByName("minecraft:bookshelf");
             ModHandler.removeRecipeByName("minecraft:pillar_quartz_block");
             ModHandler.removeRecipeByName("minecraft:sea_lantern");
-            ModHandler.removeRecipeByName("minecraft:chiseled_sandstone");
 
             // Slab replacement
             ModHandler.removeRecipeByName("minecraft:stone_slab");

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -554,8 +554,8 @@ public class VanillaStandardRecipes {
             }
 
             CUTTER_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
-                    .inputs(new ItemStack(Blocks.WOOL, 2, i))
-                    .outputs(new ItemStack(Blocks.CARPET, 3, i))
+                    .inputs(new ItemStack(Blocks.WOOL, 1, i))
+                    .outputs(new ItemStack(Blocks.CARPET, 2, i))
                     .buildAndRegister();
 
             ASSEMBLER_RECIPES.recipeBuilder().duration(20).EUt(VA[ULV])
@@ -979,11 +979,11 @@ public class VanillaStandardRecipes {
             ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, NetherQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, CertusQuartz).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
             ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV]).inputs(new ItemStack(Blocks.COBBLESTONE, 6)).input(dust, Redstone, 2).input(plate, Quartzite).outputs(new ItemStack(Blocks.OBSERVER)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
+            ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV]).inputs(new ItemStack(Blocks.STONE_SLAB, 1, 0)).inputs(new ItemStack(Items.STICK, 6)).outputs(new ItemStack(Items.ARMOR_STAND)).buildAndRegister();
         }
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).circuitMeta(3).inputs(new ItemStack(Blocks.NETHER_BRICK)).outputs(new ItemStack(Blocks.NETHER_BRICK_FENCE)).buildAndRegister();
-
-        ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).inputs(new ItemStack(Blocks.OBSIDIAN, 8)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Blocks.ENDER_CHEST)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 0)).buildAndRegister();
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[ULV]).circuitMeta(6).inputs(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, 0)).outputs(new ItemStack(Blocks.COBBLESTONE_WALL, 1, 1)).buildAndRegister();
@@ -997,8 +997,6 @@ public class VanillaStandardRecipes {
         ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(4).input("plankWood", 6).inputs(new ItemStack(Items.STICK)).circuitMeta(9).outputs(new ItemStack(Items.SIGN, 3)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(10).EUt(2).inputs(new ItemStack(Items.BRICK, 3)).outputs(new ItemStack(Items.FLOWER_POT)).buildAndRegister();
-
-        ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(VA[ULV]).inputs(new ItemStack(Blocks.STONE_SLAB, 1, 0)).inputs(new ItemStack(Items.STICK, 6)).outputs(new ItemStack(Items.ARMOR_STAND)).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(30).EUt(16).inputs(new ItemStack(Items.GHAST_TEAR)).inputs(new ItemStack(Items.ENDER_EYE)).outputs(new ItemStack(Items.END_CRYSTAL)).fluidInputs(Glass.getFluid(GTValues.L * 7)).buildAndRegister();
 
@@ -1157,6 +1155,25 @@ public class VanillaStandardRecipes {
                 .input(dust, Blaze, 4)
                 .output(stick, Blaze)
                 .buildAndRegister();
+
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(Blocks.TRIPWIRE_HOOK)
+                .input(Blocks.CHEST)
+                .output(Blocks.TRAPPED_CHEST)
+                .duration(200).EUt(4).buildAndRegister();
+
+        // All 16 bed colors
+        for (int i = 0; i <= 15; i++) {
+            addBedRecipe(i);
+        }
+    }
+
+    private static void addBedRecipe(int meta) {
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.WOOL, 3, meta))
+                .input(plank, Wood, 3)
+                .outputs(new ItemStack(Items.BED, 1, meta))
+                .duration(100).EUt(VA[ULV]).buildAndRegister();
     }
 
     /**

--- a/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
@@ -44,7 +44,7 @@ public class WoodRecipeLoader {
                             .planks(new ItemStack(Blocks.PLANKS), "oak_planks")
                             .log(new ItemStack(Blocks.LOG)).removeCharcoalRecipe()
                             .door(new ItemStack(Items.OAK_DOOR), "wooden_door")
-                            .slab(new ItemStack(Blocks.WOODEN_SLAB))
+                            .slab(new ItemStack(Blocks.WOODEN_SLAB), "oak_wooden_slab")
                             .fence(new ItemStack(Blocks.OAK_FENCE), "fence")
                             .fenceGate(new ItemStack(Blocks.OAK_FENCE_GATE), "fence_gate")
                             .stairs(new ItemStack(Blocks.OAK_STAIRS))
@@ -55,7 +55,7 @@ public class WoodRecipeLoader {
                             .planks(new ItemStack(Blocks.PLANKS, 1, 1), "spruce_planks")
                             .log(new ItemStack(Blocks.LOG, 1, 1)).removeCharcoalRecipe()
                             .door(new ItemStack(Items.SPRUCE_DOOR), "spruce_door")
-                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 1))
+                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 1), "spruce_wooden_slab")
                             .fence(new ItemStack(Blocks.SPRUCE_FENCE), "spruce_fence")
                             .fenceGate(new ItemStack(Blocks.SPRUCE_FENCE_GATE), "spruce_fence_gate")
                             .stairs(new ItemStack(Blocks.SPRUCE_STAIRS))
@@ -66,7 +66,7 @@ public class WoodRecipeLoader {
                             .planks(new ItemStack(Blocks.PLANKS, 1, 2), "birch_planks")
                             .log(new ItemStack(Blocks.LOG, 1, 2)).removeCharcoalRecipe()
                             .door(new ItemStack(Items.BIRCH_DOOR), "birch_door")
-                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 2))
+                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 2), "birch_wooden_slab")
                             .fence(new ItemStack(Blocks.BIRCH_FENCE), "birch_fence")
                             .fenceGate(new ItemStack(Blocks.BIRCH_FENCE_GATE), "birch_fence_gate")
                             .stairs(new ItemStack(Blocks.BIRCH_STAIRS))
@@ -77,7 +77,7 @@ public class WoodRecipeLoader {
                             .planks(new ItemStack(Blocks.PLANKS, 1, 3), "jungle_planks")
                             .log(new ItemStack(Blocks.LOG, 1, 3)).removeCharcoalRecipe()
                             .door(new ItemStack(Items.JUNGLE_DOOR), "jungle_door")
-                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 3))
+                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 3), "jungle_wooden_slab")
                             .fence(new ItemStack(Blocks.JUNGLE_FENCE), "jungle_fence")
                             .fenceGate(new ItemStack(Blocks.JUNGLE_FENCE_GATE), "jungle_fence_gate")
                             .stairs(new ItemStack(Blocks.JUNGLE_STAIRS))
@@ -88,7 +88,7 @@ public class WoodRecipeLoader {
                             .planks(new ItemStack(Blocks.PLANKS, 1, 4), "acacia_planks")
                             .log(new ItemStack(Blocks.LOG2)).removeCharcoalRecipe()
                             .door(new ItemStack(Items.ACACIA_DOOR), "acacia_door")
-                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 4))
+                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 4), "acacia_wooden_slab")
                             .fence(new ItemStack(Blocks.ACACIA_FENCE), "acacia_fence")
                             .fenceGate(new ItemStack(Blocks.ACACIA_FENCE_GATE), "acacia_fence_gate")
                             .stairs(new ItemStack(Blocks.ACACIA_STAIRS))
@@ -99,7 +99,7 @@ public class WoodRecipeLoader {
                             .planks(new ItemStack(Blocks.PLANKS, 1, 5), "dark_oak_planks")
                             .log(new ItemStack(Blocks.LOG2, 1, 1)).removeCharcoalRecipe()
                             .door(new ItemStack(Items.DARK_OAK_DOOR), "dark_oak_door")
-                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 5))
+                            .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 5), "dark_oak_wooden_slab")
                             .fence(new ItemStack(Blocks.DARK_OAK_FENCE), "dark_oak_fence")
                             .fenceGate(new ItemStack(Blocks.DARK_OAK_FENCE_GATE), "dark_oak_fence_gate")
                             .stairs(new ItemStack(Blocks.DARK_OAK_STAIRS))
@@ -110,7 +110,7 @@ public class WoodRecipeLoader {
                             .planks(MetaBlocks.PLANKS.getItemVariant(BlockGregPlanks.BlockType.RUBBER_PLANK), null)
                             .log(new ItemStack(MetaBlocks.RUBBER_LOG)).addCharcoalRecipe()
                             .door(MetaItems.RUBBER_WOOD_DOOR.getStackForm(), null)
-                            .slab(new ItemStack(MetaBlocks.WOOD_SLAB)).addSlabRecipe()
+                            .slab(new ItemStack(MetaBlocks.WOOD_SLAB), null).addSlabRecipe()
                             .fence(new ItemStack(MetaBlocks.RUBBER_WOOD_FENCE), null)
                             .fenceGate(new ItemStack(MetaBlocks.RUBBER_WOOD_FENCE_GATE), null)
                             .stairs(new ItemStack(MetaBlocks.RUBBER_WOOD_STAIRS)).addStairsRecipe()
@@ -121,7 +121,7 @@ public class WoodRecipeLoader {
                     new WoodTypeEntry.Builder(GTValues.MODID, "treated")
                             .planks(MetaBlocks.PLANKS.getItemVariant(BlockGregPlanks.BlockType.TREATED_PLANK), null)
                             .door(MetaItems.TREATED_WOOD_DOOR.getStackForm(), null)
-                            .slab(new ItemStack(MetaBlocks.WOOD_SLAB, 1, 1)).addSlabRecipe()
+                            .slab(new ItemStack(MetaBlocks.WOOD_SLAB, 1, 1), null).addSlabRecipe()
                             .fence(new ItemStack(MetaBlocks.TREATED_WOOD_FENCE), null)
                             .fenceGate(new ItemStack(MetaBlocks.TREATED_WOOD_FENCE_GATE), null)
                             .stairs(new ItemStack(MetaBlocks.TREATED_WOOD_STAIRS)).addStairsRecipe()
@@ -340,7 +340,7 @@ public class WoodRecipeLoader {
 
         // slab
         if (!entry.slab.isEmpty()) {
-            if (entry.addSlabCraftingRecipe) {
+            if (entry.addSlabCraftingRecipe && !ConfigHolder.recipes.hardWoodRecipes) {
                 ModHandler.addShapedRecipe(name + "_slab", GTUtility.copy(6, entry.slab),
                         "PPP", 'P', entry.planks.copy());
             }
@@ -348,6 +348,10 @@ public class WoodRecipeLoader {
             // plank -> slab crafting
             ModHandler.addShapedRecipe(name + "_slab_saw", GTUtility.copy(2, entry.slab),
                     "sS", 'S', entry.planks.copy());
+
+            if (ConfigHolder.recipes.hardWoodRecipes && entry.slabRecipeName != null) {
+                ModHandler.removeRecipeByName(new ResourceLocation(entry.modid, entry.slabRecipeName));
+            }
 
             // plank -> slab cutting
             CUTTER_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -38,7 +38,7 @@ public class PartsRecipeHandler {
         OrePrefix.stickLong.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processLongStick);
         OrePrefix.plate.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processPlate);
         OrePrefix.plateDouble.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processPlateDouble);
-        OrePrefix.plateDense.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processPlateDense);
+        OrePrefix.plateDense.addProcessingHandler(PropertyKey.DUST, PartsRecipeHandler::processPlateDense);
 
         OrePrefix.turbineBlade.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processTurbine);
         OrePrefix.rotor.addProcessingHandler(PropertyKey.INGOT, PartsRecipeHandler::processRotor);
@@ -318,7 +318,7 @@ public class PartsRecipeHandler {
         }
     }
 
-    public static void processPlateDense(OrePrefix orePrefix, Material material, IngotProperty property) {
+    public static void processPlateDense(OrePrefix orePrefix, Material material, DustProperty property) {
         RecipeMaps.BENDER_RECIPES.recipeBuilder()
                 .input(OrePrefix.plate, material, 9)
                 .circuitMeta(9)
@@ -327,13 +327,15 @@ public class PartsRecipeHandler {
                 .EUt(96)
                 .buildAndRegister();
 
-        RecipeMaps.BENDER_RECIPES.recipeBuilder()
-                .input(OrePrefix.ingot, material, 9)
-                .circuitMeta(9)
-                .output(orePrefix, material)
-                .duration((int) Math.max(material.getMass() * 9L, 1L))
-                .EUt(96)
-                .buildAndRegister();
+        if (material.hasProperty(PropertyKey.INGOT)) {
+            RecipeMaps.BENDER_RECIPES.recipeBuilder()
+                    .input(OrePrefix.ingot, material, 9)
+                    .circuitMeta(9)
+                    .output(orePrefix, material)
+                    .duration((int) Math.max(material.getMass() * 9L, 1L))
+                    .EUt(96)
+                    .buildAndRegister();
+        }
     }
 
     public static void processRing(OrePrefix ringPrefix, Material material, IngotProperty property) {


### PR DESCRIPTION
`hardWoodRecipes`:
- Fix vanilla wood slab crafting recipes not being removed (and us adding our own for Rubber/Treated Wood)

`harderBrickRecipes`:
- Remove Netherrack -> Nether Brick smelting recipe

`hardRedstoneRecipes`:
- Remove AE2's vanilla comparator and daylight sensor recipes
- Fix redstone torch recipe override being incorrect

`hardMiscRecipes`:
- Flower Pot, Armor Stand, Trapped Chest, Ender Chest, Beds added
- Now removes vanilla Fermented Spider Eye and Fire Charge recipes, in favor of GT's mixer recipes (which are added by default)

`disableManualCompression`:
- Sea Lantern, Chiseled Sandstone, non-wood vanilla slabs added
- Remove AE2's vanilla quartz block recipe

Default changes:
- Carpet cutter recipe changed from 2->3 to 1->2
- Bed assembler recipes (3 colored wool + 3 wood planks)
- Trapped chest assembler recipe (tripwire hook + chest)