### PR TITLE
Fix MTEs sometimes not syncing

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -32,7 +32,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
         dataWriter.accept(new PacketBuffer(backedBuffer));
         byte[] updateData = Arrays.copyOfRange(backedBuffer.array(), 0, backedBuffer.writerIndex());
         this.updates.add(discriminator, updateData);
-        if (this.updates.size() == 1) notifyWorld(); // if the data is not empty we already notified the world
+        notifyWorld(); // if the data is not empty we already notified the world
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -32,7 +32,7 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity {
         dataWriter.accept(new PacketBuffer(backedBuffer));
         byte[] updateData = Arrays.copyOfRange(backedBuffer.array(), 0, backedBuffer.writerIndex());
         this.updates.add(discriminator, updateData);
-        notifyWorld(); // if the data is not empty we already notified the world
+        notifyWorld();
     }
 
     /**


### PR DESCRIPTION
## What
This PR fixes certain MTEs (namely quantum chests) from not receiving update packets

## Implementation Details
Removes the check for the update size

## Outcome
Fixes part of #2142

## Potential Compatibility Issues
none
