### PR TITLE
Improved Module usability

### DIFF
--- a/src/main/java/gregtech/api/modules/GregTechModule.java
+++ b/src/main/java/gregtech/api/modules/GregTechModule.java
@@ -5,23 +5,47 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * All of your {@link IGregTechModule} classes must be annotated with this to be registered.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GregTechModule {
 
+    /**
+     * The ID of this module. Must be unique within its container.
+     */
     String moduleID();
 
+    /**
+     * The ID of the container to associate this module with.
+     */
     String containerID();
 
+    /**
+     * A human-readable name for this module.
+     */
     String name();
 
+    /**
+     * A list of mod IDs that this module depends on. If any mods specified are not present, the module will not load.
+     */
     String[] modDependencies() default {};
 
+    /**
+     * Whether this module is the "core" module for its container.
+     * Each container must have exactly one core module, which will be loaded before all other modules in the container.
+     * <p>
+     * Core modules should not have mod dependencies.
+     */
     boolean coreModule() default false;
 
     String author() default "";
 
     String version() default "";
 
+    /**
+     * A lang key to use for the description of this module in the module configuration file.
+     */
     String descriptionKey() default "";
 }

--- a/src/main/java/gregtech/api/modules/IGregTechModule.java
+++ b/src/main/java/gregtech/api/modules/IGregTechModule.java
@@ -9,8 +9,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * All modules must implement this interface.
+ * <p>
+ * Provides methods for responding to FML lifecycle events, adding event bus subscriber classes, and processing IMC messages.
+ */
 public interface IGregTechModule {
 
+    /**
+     * What other modules this module depends on.
+     * <p>
+     * e.g. <code>new ResourceLocation("gregtech", "foo_module")</code> represents a dependency on the module "foo_module" in the container "gregtech"
+     */
     @Nonnull
     default Set<ResourceLocation> getDependencyUids() {
         return Collections.emptySet();
@@ -46,9 +56,16 @@ public interface IGregTechModule {
     default void serverStopped(FMLServerStoppedEvent event) {
     }
 
+    /**
+     * Register packets using GregTech's packet handling API here.
+     */
     default void registerPackets() {
     }
 
+    /**
+     * @return A list of classes to subscribe to the Forge event bus.
+     * As the class gets subscribed, not any specific instance, event handlers must be static!
+     */
     @Nonnull
     default List<Class<?>> getEventBusSubscribers() {
         return Collections.emptyList();
@@ -58,6 +75,9 @@ public interface IGregTechModule {
         return false;
     }
 
+    /**
+     * @return A logger to use for this module.
+     */
     @Nonnull
     Logger getLogger();
 }

--- a/src/main/java/gregtech/api/modules/IModuleContainer.java
+++ b/src/main/java/gregtech/api/modules/IModuleContainer.java
@@ -2,5 +2,8 @@ package gregtech.api.modules;
 
 public interface IModuleContainer {
 
+    /**
+     * The ID of this container. If this is your mod's only container, you should use your mod ID to prevent collisions.
+     */
     String getID();
 }

--- a/src/main/java/gregtech/api/modules/ModuleContainer.java
+++ b/src/main/java/gregtech/api/modules/ModuleContainer.java
@@ -5,6 +5,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotate your {@link IModuleContainer} with this for it to be automatically registered.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ModuleContainer {

--- a/src/main/java/gregtech/api/modules/ModuleContainer.java
+++ b/src/main/java/gregtech/api/modules/ModuleContainer.java
@@ -1,0 +1,11 @@
+package gregtech.api.modules;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ModuleContainer {
+}

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -77,6 +77,9 @@ public class ModuleManager implements IModuleManager {
     }
 
     public void setup(ASMDataTable asmDataTable, File configDirectory) {
+        // find and register all containers registered with the @ModuleContainer annotation
+        discoverContainers(asmDataTable);
+
         currentStage = ModuleStage.M_SETUP;
         //configFolder = new File(configDirectory, GTValues.MODID);
         Map<String, List<IGregTechModule>> modules = getModules(asmDataTable);
@@ -327,6 +330,18 @@ public class ModuleManager implements IModuleManager {
             }
         }
         return instances;
+    }
+
+    private void discoverContainers(ASMDataTable table) {
+        Set<ASMDataTable.ASMData> dataSet = table.getAll(ModuleContainer.class.getCanonicalName());
+        for (ASMDataTable.ASMData data : dataSet) {
+            try {
+                Class<?> clazz = Class.forName(data.getClassName());
+                registerContainer((IModuleContainer) clazz.newInstance());
+            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+                logger.error("Could not initialize module container " + data.getClassName(), e);
+            }
+        }
     }
 
     /*


### PR DESCRIPTION
## What
Makes the module API introduced in 2.5.0 significantly more usable for addons.

## Implementation Details
- Added an annotation for registering module containers without having to subscribe to the event bus stupidly early in the loading process
- Made module loading order fully deterministic
- Added javadocs to API classes

## Outcome
Makes modules easier to use and prevents packet ID mismatches from occurring due to the whims of what order a `HashSet` decided modules should load in.

## Potential Compatibility Issues
No changes to the API were made.