### PR TITLE
Re-enable module configuration file

### DIFF
--- a/src/main/java/gregtech/api/modules/GregTechModule.java
+++ b/src/main/java/gregtech/api/modules/GregTechModule.java
@@ -45,7 +45,7 @@ public @interface GregTechModule {
     String version() default "";
 
     /**
-     * A lang key to use for the description of this module in the module configuration file.
+     * A description of this module in the module configuration file.
      */
-    String descriptionKey() default "";
+    String description() default "";
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -4,7 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import net.minecraftforge.common.config.Config;
 
-@Config(modid = GTValues.MODID)
+@Config(modid = GTValues.MODID, name = GTValues.MODID + '/' + GTValues.MODID)
 public class ConfigHolder {
 
     @Config.Comment("Config options for client-only features")
@@ -31,6 +31,7 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static RecipeOptions recipes = new RecipeOptions();
 
+    //TODO move to ToolsModule config
     @Config.Comment("Config options for Tools and Armor")
     @Config.Name("Tool and Armor Options")
     @Config.RequiresMcRestart

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -13,9 +13,8 @@ import gregtech.api.items.gui.PlayerInventoryUIFactory;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
 import gregtech.api.modules.GregTechModule;
 import gregtech.api.modules.IGregTechModule;
-import gregtech.api.pipenet.longdist.LongDistanceNetwork;
-import gregtech.api.recipes.ModHandler;
 import gregtech.api.pipenet.longdist.LongDistancePipeType;
+import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 import gregtech.api.unification.OreDictUnifier;
@@ -76,7 +75,7 @@ import static gregtech.api.GregTechAPI.*;
         moduleID = GregTechModules.MODULE_CORE,
         containerID = GTValues.MODID,
         name = "GregTech Core",
-        descriptionKey = "gregtech.modules.core.description",
+        description = "Core GregTech content. Disabling this disables the entire mod and all its addons.",
         coreModule = true
 )
 public class CoreModule implements IGregTechModule {

--- a/src/main/java/gregtech/integration/IntegrationModule.java
+++ b/src/main/java/gregtech/integration/IntegrationModule.java
@@ -24,7 +24,7 @@ import java.util.List;
         moduleID = GregTechModules.MODULE_INTEGRATION,
         containerID = GTValues.MODID,
         name = "GregTech Mod Integration",
-        descriptionKey = "gregtech.modules.integration.description"
+        description = "General GregTech Integration Module. Disabling this disables all integration modules."
 )
 public class IntegrationModule extends BaseGregTechModule {
 

--- a/src/main/java/gregtech/integration/baubles/BaublesModule.java
+++ b/src/main/java/gregtech/integration/baubles/BaublesModule.java
@@ -24,7 +24,7 @@ import java.util.List;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_BAUBLES,
         name = "GregTech Baubles Integration",
-        descriptionKey = "gregtech.modules.baubles_integration.description"
+        description = "Baubles Integration Module"
 )
 public class BaublesModule extends IntegrationSubmodule {
 

--- a/src/main/java/gregtech/integration/crafttweaker/CraftTweakerModule.java
+++ b/src/main/java/gregtech/integration/crafttweaker/CraftTweakerModule.java
@@ -27,7 +27,7 @@ import java.util.List;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_CT,
         name = "GregTech CraftTweaker Integration",
-        descriptionKey = "gregtech.modules.ct_integration.description"
+        description = "CraftTweaker Integration Module"
 )
 public class CraftTweakerModule extends IntegrationSubmodule {
 

--- a/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
@@ -49,7 +49,7 @@ import java.util.function.Supplier;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_GROOVYSCRIPT,
         name = "GregTech GroovyScript Integration",
-        descriptionKey = "gregtech.modules.grs_integration.description"
+        description = "GroovyScript Integration Module"
 )
 public class GroovyScriptModule extends IntegrationSubmodule {
 

--- a/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
+++ b/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
@@ -17,7 +17,7 @@ import net.minecraft.item.ItemStack;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_HWYLA,
         name = "GregTech HWYLA Integration",
-        descriptionKey = "gregtech.modules.hwyla_integration.description"
+        description = "HWYLA (WAILA) Integration Module"
 )
 public class HWYLAModule extends IntegrationSubmodule implements IWailaPlugin {
 

--- a/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
+++ b/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
@@ -67,7 +67,7 @@ import java.util.stream.Stream;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_JEI,
         name = "GregTech JEI Integration",
-        descriptionKey = "gregtech.modules.jei_integration.description"
+        description = "JustEnoughItems Integration Module"
 )
 public class JustEnoughItemsModule extends IntegrationSubmodule implements IModPlugin {
 

--- a/src/main/java/gregtech/integration/opencomputers/OpenComputersModule.java
+++ b/src/main/java/gregtech/integration/opencomputers/OpenComputersModule.java
@@ -6,7 +6,10 @@ import gregtech.api.modules.GregTechModule;
 import gregtech.integration.IntegrationSubmodule;
 import gregtech.integration.IntegrationUtil;
 import gregtech.integration.opencomputers.drivers.*;
-import gregtech.integration.opencomputers.drivers.specific.*;
+import gregtech.integration.opencomputers.drivers.specific.DriverConverter;
+import gregtech.integration.opencomputers.drivers.specific.DriverFusionReactor;
+import gregtech.integration.opencomputers.drivers.specific.DriverPowerSubstation;
+import gregtech.integration.opencomputers.drivers.specific.DriverWorldAccelerator;
 import gregtech.modules.GregTechModules;
 import li.cil.oc.api.Driver;
 import li.cil.oc.api.driver.DriverBlock;
@@ -18,7 +21,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_OC,
         name = "GregTech OpenComputers Integration",
-        descriptionKey = "gregtech.modules.oc_integration.description"
+        description = "OpenComputers Integration Module"
 )
 public class OpenComputersModule extends IntegrationSubmodule {
 

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
         containerID = GTValues.MODID,
         modDependencies = GTValues.MODID_TOP,
         name = "GregTech TheOneProbe Integration",
-        descriptionKey = "gregtech.modules.top_integration.description"
+        description = "TheOneProbe Integration Module"
 )
 public class TheOneProbeModule extends IntegrationSubmodule {
 

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableList;
 import gregtech.api.GTValues;
 import gregtech.api.modules.*;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
@@ -357,11 +356,10 @@ public class ModuleManager implements IModuleManager {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private String getComment(IGregTechModule module) {
         GregTechModule annotation = module.getClass().getAnnotation(GregTechModule.class);
 
-        String comment = I18n.translateToLocal(annotation.descriptionKey());
+        String comment = annotation.description();
         Set<ResourceLocation> dependencies = module.getDependencyUids();
         if (!dependencies.isEmpty()) {
             Iterator<ResourceLocation> iterator = dependencies.iterator();

--- a/src/main/java/gregtech/tools/ToolsModule.java
+++ b/src/main/java/gregtech/tools/ToolsModule.java
@@ -1,11 +1,11 @@
 package gregtech.tools;
 
 import gregtech.api.GTValues;
-import gregtech.tools.enchants.EnchantmentEnderDamage;
-import gregtech.tools.enchants.EnchantmentHardHammer;
 import gregtech.api.modules.GregTechModule;
 import gregtech.modules.BaseGregTechModule;
 import gregtech.modules.GregTechModules;
+import gregtech.tools.enchants.EnchantmentEnderDamage;
+import gregtech.tools.enchants.EnchantmentHardHammer;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -20,7 +20,7 @@ import java.util.List;
         moduleID = GregTechModules.MODULE_TOOLS,
         containerID = GTValues.MODID,
         name = "GregTech Tools",
-        descriptionKey = "gregtech.modules.tools.description"
+        description = "GregTech Tools Module. Cannot be disabled for now."
 )
 public class ToolsModule extends BaseGregTechModule {
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1,3 +1,14 @@
+gregtech.modules.core.description=Core GregTech content. Disabling this disables the entire mod and all its addons
+gregtech.modules.tools.description=GregTech Tools Module
+gregtech.modules.ct_integration.description=CraftTweaker Integration Module
+gregtech.modules.grs_integration.description=Groovyscript Integration Module
+gregtech.modules.integration.description=General GregTech Integration Module. Disabling this disables all integration modules.
+gregtech.modules.jei_integration.description=JustEnoughItems Integration Module
+gregtech.modules.top_integration.description=TheOneProbe Integration Module
+gregtech.modules.oc_integration.description=OpenComputers Integration Module
+gregtech.modules.baubles_integration.description=Baubles Integration Module
+gregtech.modules.hwyla_integration.description=HWYLA (WAILA) Integration Module
+
 death.attack.heat=%s was boiled alive
 death.attack.frost=%s explored cryogenics
 death.attack.chemical=%s had a chemical accident

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1,14 +1,3 @@
-gregtech.modules.core.description=Core GregTech content. Disabling this disables the entire mod and all its addons
-gregtech.modules.tools.description=GregTech Tools Module
-gregtech.modules.ct_integration.description=CraftTweaker Integration Module
-gregtech.modules.grs_integration.description=Groovyscript Integration Module
-gregtech.modules.integration.description=General GregTech Integration Module. Disabling this disables all integration modules.
-gregtech.modules.jei_integration.description=JustEnoughItems Integration Module
-gregtech.modules.top_integration.description=TheOneProbe Integration Module
-gregtech.modules.oc_integration.description=OpenComputers Integration Module
-gregtech.modules.baubles_integration.description=Baubles Integration Module
-gregtech.modules.hwyla_integration.description=HWYLA (WAILA) Integration Module
-
 death.attack.heat=%s was boiled alive
 death.attack.frost=%s explored cryogenics
 death.attack.chemical=%s had a chemical accident


### PR DESCRIPTION
Enables the `gregtech/modules.cfg` configuration file for enabling/disabling individual modules. Re-enabling this now since integration module development has picked up again