### PR TITLE
More recipe fixes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -148,7 +148,7 @@ public class FirstDegreeMaterials {
                 .build();
 
         Cinnabar = new Material.Builder(268, gregtechId("cinnabar"))
-                .gem(1).ore()
+                .dust(1).ore()
                 .color(0x960000).iconSet(EMERALD)
                 .flags(CRYSTALLIZABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Mercury, 1, Sulfur, 1)

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -279,7 +279,6 @@ public class OrePrefix {
         excludeAllGems(Materials.EnderEye);
         excludeAllGems(Materials.Flint);
         excludeAllGemsButNormal(Materials.Lapotron);
-        excludeAllGemsButNormal(Materials.Cinnabar);
 
         dust.setIgnored(Materials.Redstone);
         dust.setIgnored(Materials.Glowstone);

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -279,6 +279,7 @@ public class OrePrefix {
         excludeAllGems(Materials.EnderEye);
         excludeAllGems(Materials.Flint);
         excludeAllGemsButNormal(Materials.Lapotron);
+        excludeAllGemsButNormal(Materials.Cinnabar);
 
         dust.setIgnored(Materials.Redstone);
         dust.setIgnored(Materials.Glowstone);

--- a/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
@@ -86,7 +86,7 @@ public class OreRecipeHandler {
             RecipeBuilder<?> builder = RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
                     .input(orePrefix, material)
                     .duration(10).EUt(16);
-            if (material.hasProperty(PropertyKey.GEM) && !OrePrefix.gem.isIgnored(material)) {
+            if (material.hasProperty(PropertyKey.GEM) && !OreDictUnifier.get(OrePrefix.gem, material).isEmpty()) {
                 builder.outputs(GTUtility.copy((int) Math.ceil(amountOfCrushedOre) * oreTypeMultiplier, OreDictUnifier.get(OrePrefix.gem, material, crushedStack.getCount())));
             } else {
                 builder.outputs(GTUtility.copy((int) Math.ceil(amountOfCrushedOre) * oreTypeMultiplier, crushedStack));

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -164,7 +164,7 @@ public class PartsRecipeHandler {
                 .input(OrePrefix.ingot, material)
                 .circuitMeta(3)
                 .output(fineWirePrefix, material, 8)
-                .duration((int) material.getMass() * 3)
+                .duration((int) material.getMass() * 2)
                 .EUt(VA[ULV])
                 .buildAndRegister();
     }

--- a/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PipeRecipeHandler.java
@@ -135,7 +135,7 @@ public class PipeRecipeHandler {
         } else {
             if (ModHandler.isMaterialWood(material)) {
                 ModHandler.addShapedRecipe(String.format("small_%s_pipe", material),
-                        pipeStack, "wXr",
+                        pipeStack, "sXr",
                         'X', new UnificationEntry(OrePrefix.plank, material));
 
                 ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
@@ -177,7 +177,7 @@ public class PipeRecipeHandler {
         } else {
             if (ModHandler.isMaterialWood(material)) {
                 ModHandler.addShapedRecipe(String.format("medium_%s_pipe", material),
-                        pipeStack, "XXX", "w r",
+                        pipeStack, "XXX", "s r",
                         'X', new UnificationEntry(OrePrefix.plank, material));
 
                 ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(VA[LV])
@@ -219,7 +219,7 @@ public class PipeRecipeHandler {
         } else {
             if (ModHandler.isMaterialWood(material)) {
                 ModHandler.addShapedRecipe(String.format("large_%s_pipe", material),
-                        pipeStack, "XXX", "w r", "XXX",
+                        pipeStack, "XXX", "s r", "XXX",
                         'X', new UnificationEntry(OrePrefix.plank, material));
 
                 ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])
@@ -261,7 +261,7 @@ public class PipeRecipeHandler {
         } else if (OrePrefix.plateDouble.doGenerateItem(material)) {
             if (ModHandler.isMaterialWood(material)) {
                 ModHandler.addShapedRecipe(String.format("huge_%s_pipe", material),
-                        pipeStack, "XXX", "w r", "XXX",
+                        pipeStack, "XXX", "s r", "XXX",
                         'X', new UnificationEntry(OrePrefix.plateDouble, material));
 
                 ASSEMBLER_RECIPES.recipeBuilder().duration(100).EUt(VA[LV])

--- a/src/main/java/gregtech/loaders/recipe/handlers/ToolRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/ToolRecipeHandler.java
@@ -174,7 +174,7 @@ public class ToolRecipeHandler {
                     'S', stick);
 
             addToolRecipe(material, ToolItems.FILE, true,
-                    " P ", " P " , " S ",
+                    "P", "P", "S",
                     'P', plate,
                     'S', stick);
 

--- a/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/WireRecipeHandler.java
@@ -89,7 +89,7 @@ public class WireRecipeHandler {
                     .input(prefix, material, multiplier)
                     .circuitMeta(multiplier * 2)
                     .output(wireSize, material)
-                    .duration((int) (material.getMass() * multiplier * 2))
+                    .duration((int) (material.getMass() * multiplier))
                     .EUt(getVoltageMultiplier(material))
                     .buildAndRegister();
         }


### PR DESCRIPTION
- Fix some gem ores not forge hammering to gem, namely gems which had their "default" gem replaced with another, like Diamond, Quartz, Emerald, etc. as it was calling the wrong method to ensure the gem item existed
- Fix file recipe only working in center column of crafting table
- Fix circuit 2, 4, 8, and 16 wiremill recipe durations being slower than they should be
- Reduce the duration on circuit 3 wiremill recipe duration, as in gameplay it felt overly punishing
- Fix wood pipes using a wrench instead of a saw in their handcraft recipes (haven't we fixed this before?)
- Remove all cinnabar gems, to eventually instead use Thaumcraft Quicksilver as the only "gem" from this ore with a future Thaumcraft compat module