### PR TITLE
make tool click messages display in status bar

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -547,8 +547,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, ICoverable, I
         if (controllable != null) {
             controllable.setWorkingEnabled(!controllable.isWorkingEnabled());
             if (!getWorld().isRemote) {
-                playerIn.sendMessage(new TextComponentTranslation(controllable.isWorkingEnabled() ?
-                        "behaviour.soft_hammer.enabled" : "behaviour.soft_hammer.disabled"));
+                playerIn.sendStatusMessage(new TextComponentTranslation(controllable.isWorkingEnabled() ?
+                        "behaviour.soft_hammer.enabled" : "behaviour.soft_hammer.disabled"), true);
             }
             return true;
         }
@@ -563,8 +563,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, ICoverable, I
     public boolean onHardHammerClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
         toggleMuffled();
         if (!getWorld().isRemote) {
-            playerIn.sendMessage(new TextComponentTranslation(isMuffled() ?
-                    "gregtech.machine.muffle.on" : "gregtech.machine.muffle.off"));
+            playerIn.sendStatusMessage(new TextComponentTranslation(isMuffled() ?
+                    "gregtech.machine.muffle.on" : "gregtech.machine.muffle.off"), true);
         }
         return true;
     }

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -191,11 +191,11 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
             if (isAllowInputFromOutputSideItems()) {
                 setAllowInputFromOutputSideItems(false);
                 setAllowInputFromOutputSideFluids(false);
-                playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"));
+                playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"), true);
             } else {
                 setAllowInputFromOutputSideItems(true);
                 setAllowInputFromOutputSideFluids(true);
-                playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"));
+                playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"), true);
             }
         }
         return true;

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
@@ -57,7 +57,7 @@ public abstract class MultiMapMultiblockController extends RecipeMapMultiblockCo
                 setRecipeMapIndex(index);
                 this.recipeMapWorkable.forceRecipeRecheck();
             } else {
-                playerIn.sendMessage(new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.switch_message"));
+                playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.switch_message"), true);
             }
         }
 

--- a/src/main/java/gregtech/common/covers/CoverFluidVoiding.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidVoiding.java
@@ -11,7 +11,6 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.CycleButtonWidget;
 import gregtech.api.gui.widgets.LabelWidget;
-import gregtech.api.gui.widgets.ToggleButtonWidget;
 import gregtech.api.gui.widgets.WidgetGroup;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.client.renderer.texture.Textures;
@@ -89,8 +88,8 @@ public class CoverFluidVoiding extends CoverPump {
     public EnumActionResult onSoftMalletClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
         this.isWorkingAllowed = !this.isWorkingAllowed;
         if (!playerIn.world.isRemote) {
-            playerIn.sendMessage(new TextComponentTranslation(isWorkingEnabled() ?
-                    "cover.voiding.message.enabled" : "cover.voiding.message.disabled"));
+            playerIn.sendStatusMessage(new TextComponentTranslation(isWorkingEnabled() ?
+                    "cover.voiding.message.enabled" : "cover.voiding.message.disabled"), true);
         }
         return EnumActionResult.SUCCESS;
     }

--- a/src/main/java/gregtech/common/covers/CoverItemVoiding.java
+++ b/src/main/java/gregtech/common/covers/CoverItemVoiding.java
@@ -98,8 +98,8 @@ public class CoverItemVoiding extends CoverConveyor {
     public EnumActionResult onSoftMalletClick(EntityPlayer playerIn, EnumHand hand, CuboidRayTraceResult hitResult) {
         this.isWorkingAllowed = !this.isWorkingAllowed;
         if (!playerIn.world.isRemote) {
-            playerIn.sendMessage(new TextComponentTranslation(isWorkingEnabled() ?
-                    "cover.voiding.message.enabled" : "cover.voiding.message.disabled"));
+            playerIn.sendStatusMessage(new TextComponentTranslation(isWorkingEnabled() ?
+                    "cover.voiding.message.enabled" : "cover.voiding.message.disabled"), true);
         }
         return EnumActionResult.SUCCESS;
     }

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorBase.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorBase.java
@@ -84,7 +84,7 @@ public abstract class CoverDetectorBase extends CoverBehavior {
         String translationKey = isInverted()
                 ? "gregtech.cover.detector_base.message_inverted_state"
                 : "gregtech.cover.detector_base.message_normal_state";
-        playerIn.sendMessage(new TextComponentTranslation(translationKey));
+        playerIn.sendStatusMessage(new TextComponentTranslation(translationKey), true);
 
         toggleInvertedWithNotification();
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -128,7 +128,7 @@ public class MetaTileEntityDiode extends MetaTileEntityMultiblockPart implements
             return true;
         }
         setAmpMode();
-        playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.diode.message", amps));
+        playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.diode.message", amps), true);
         return true;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityItemBus.java
@@ -353,12 +353,12 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
         if (!getWorld().isRemote) {
             if (isAttached) {
                 if (this.autoCollapse) {
-                    playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse_true"));
+                    playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.bus.collapse_true"), true);
                 } else {
-                    playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse_false"));
+                    playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.bus.collapse_false"), true);
                 }
             } else {
-                playerIn.sendMessage(new TextComponentTranslation("gregtech.bus.collapse.error"));
+                playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.bus.collapse.error"), true);
             }
         }
         return true;

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -186,7 +186,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
                 scheduleRenderUpdate();
                 return true;
             }
-            playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.drum." + (isAutoOutput ? "disable" : "enable") + "_output"));
+            playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.drum." + (isAutoOutput ? "disable" : "enable") + "_output"), true);
             toggleOutput();
             return true;
         }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -450,10 +450,10 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             if (!getWorld().isRemote) {
                 if (isAllowInputFromOutputSideItems()) {
                     setAllowInputFromOutputSide(false);
-                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"));
+                    playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"), true);
                 } else {
                     setAllowInputFromOutputSide(true);
-                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"));
+                    playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"), true);
                 }
             }
             return true;

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -531,10 +531,10 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
             if (!getWorld().isRemote) {
                 if (isAllowInputFromOutputSideFluids()) {
                     setAllowInputFromOutputSide(false);
-                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"));
+                    playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"), true);
                 } else {
                     setAllowInputFromOutputSide(true);
-                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"));
+                    playerIn.sendStatusMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"), true);
                 }
             }
             return true;


### PR DESCRIPTION
## What
Moves most tool click chat messages to the status bar, which reduces chat spam and improves UX.

Transformer messages were excluded due to the message being too long to read before the message display expires.