### PR TITLE
Fix macerator using wrong overlay at higher tiers

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -329,7 +329,7 @@ public class MetaTileEntities {
                             case 3 -> 3;
                             default -> 4;
                         },
-                        Textures.MACERATOR_OVERLAY,
+                        tier <= GTValues.MV ? Textures.MACERATOR_OVERLAY : Textures.PULVERIZER_OVERLAY,
                         tier));
 
         // Alloy Smelter, IDs 80-94

--- a/src/main/resources/assets/gregtech/textures/blocks/machines/pulverizer/overlay_top_active_emissive.png.mcmeta
+++ b/src/main/resources/assets/gregtech/textures/blocks/machines/pulverizer/overlay_top_active_emissive.png.mcmeta
@@ -1,5 +1,5 @@
 {
    "animation":{
-      "frametime":2
+      "frametime":4
    }
 }


### PR DESCRIPTION
Is supposed to use a different overlay for HV+