### PR TITLE
Circuit tweaks

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -248,6 +248,9 @@ public class ConfigHolder {
         @Config.Comment({"How many Multiblock Casings to make per craft. Either 1, 2, or 3.", "Default: 2"})
         @Config.RangeInt(min = 1, max = 3)
         public int casingsPerCraft = 2;
+
+        @Config.Comment({"Whether to nerf the output amounts of the first circuit in a set to 1 (from 2) and SoC to 2 (from 4).", "Default: false"})
+        public boolean harderCircuitRecipes = false;
     }
 
     public static class CompatibilityOptions {

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -7,6 +7,7 @@ import gregtech.api.unification.material.MarkerMaterials.Color;
 import gregtech.api.unification.material.MarkerMaterials.Component;
 import gregtech.api.unification.material.MarkerMaterials.Tier;
 import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.common.ConfigHolder;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
@@ -899,6 +900,8 @@ public class CircuitRecipes {
 
     private static void circuitRecipes() {
 
+        int outputAmount = ConfigHolder.recipes.harderCircuitRecipes ? 1 : 2;
+
         // T1: Electronic ==============================================================================================
 
         // LV
@@ -915,7 +918,7 @@ public class CircuitRecipes {
                 .input(component, Component.Resistor, 2)
                 .input(wireGtSingle, RedAlloy, 2)
                 .input(circuit, Tier.ULV, 2)
-                .output(ELECTRONIC_CIRCUIT_LV, 2)
+                .output(ELECTRONIC_CIRCUIT_LV, outputAmount)
                 .buildAndRegister();
 
         // MV
@@ -945,7 +948,7 @@ public class CircuitRecipes {
                 .input(component, Component.Diode, 2)
                 .input(wireFine, Copper, 2)
                 .input(bolt, Tin, 2)
-                .output(INTEGRATED_CIRCUIT_LV, 2)
+                .output(INTEGRATED_CIRCUIT_LV, outputAmount)
                 .buildAndRegister();
 
         // MV
@@ -956,12 +959,12 @@ public class CircuitRecipes {
                 .input(component, Component.Diode, 2)
                 .input(wireFine, Gold, 4)
                 .input(bolt, Silver, 4)
-                .output(INTEGRATED_CIRCUIT_MV, 2)
+                .output(INTEGRATED_CIRCUIT_MV, outputAmount)
                 .buildAndRegister();
 
         // HV
         CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).duration(800)
-                .input(INTEGRATED_CIRCUIT_MV, 2)
+                .input(INTEGRATED_CIRCUIT_MV, outputAmount) // a little generous for this first HV if harder recipes enabled
                 .input(INTEGRATED_LOGIC_CIRCUIT, 2)
                 .input(RANDOM_ACCESS_MEMORY, 2)
                 .input(component, Component.Transistor, 4)
@@ -978,7 +981,7 @@ public class CircuitRecipes {
                 .input(SIMPLE_SYSTEM_ON_CHIP)
                 .input(bolt, RedAlloy, 2)
                 .input(wireFine, Tin, 2)
-                .output(NAND_CHIP_ULV, 8)
+                .output(NAND_CHIP_ULV, outputAmount * 4)
                 .buildAndRegister();
 
         CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[MV]).duration(300)
@@ -986,7 +989,7 @@ public class CircuitRecipes {
                 .input(SIMPLE_SYSTEM_ON_CHIP)
                 .input(bolt, RedAlloy, 2)
                 .input(wireFine, Tin, 2)
-                .output(NAND_CHIP_ULV, 12)
+                .output(NAND_CHIP_ULV, outputAmount * 6)
                 .buildAndRegister();
 
         // Microprocessor LV
@@ -997,7 +1000,7 @@ public class CircuitRecipes {
                 .input(component, Component.Capacitor, 2)
                 .input(component, Component.Transistor, 2)
                 .input(wireFine, Copper, 2)
-                .output(MICROPROCESSOR_LV, 3)
+                .output(MICROPROCESSOR_LV, ConfigHolder.recipes.harderCircuitRecipes ? 2 : 3)
                 .buildAndRegister();
 
         // Microprocessor LV SoC
@@ -1006,7 +1009,7 @@ public class CircuitRecipes {
                 .input(SYSTEM_ON_CHIP)
                 .input(wireFine, Copper, 2)
                 .input(bolt, Tin, 2)
-                .output(MICROPROCESSOR_LV, 6)
+                .output(MICROPROCESSOR_LV, ConfigHolder.recipes.harderCircuitRecipes ? 3 : 6)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1020,7 +1023,7 @@ public class CircuitRecipes {
                 .input(component, Component.Capacitor, 4)
                 .input(component, Component.Transistor, 4)
                 .input(wireFine, RedAlloy, 4)
-                .output(PROCESSOR_MV, 2)
+                .output(PROCESSOR_MV, outputAmount)
                 .buildAndRegister();
 
         // MV SoC
@@ -1029,7 +1032,7 @@ public class CircuitRecipes {
                 .input(SYSTEM_ON_CHIP)
                 .input(wireFine, RedAlloy, 4)
                 .input(bolt, AnnealedCopper, 4)
-                .output(PROCESSOR_MV, 4)
+                .output(PROCESSOR_MV, outputAmount * 2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1093,7 +1096,7 @@ public class CircuitRecipes {
                 .input(SMD_CAPACITOR, 8)
                 .input(SMD_TRANSISTOR, 8)
                 .input(wireFine, Electrum, 8)
-                .output(NANO_PROCESSOR_HV, 2)
+                .output(NANO_PROCESSOR_HV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1104,7 +1107,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 2)
                 .input(ADVANCED_SMD_TRANSISTOR, 2)
                 .input(wireFine, Electrum, 8)
-                .output(NANO_PROCESSOR_HV, 2)
+                .output(NANO_PROCESSOR_HV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1114,7 +1117,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SYSTEM_ON_CHIP)
                 .input(wireFine, Electrum, 4)
                 .input(bolt, Platinum, 4)
-                .output(NANO_PROCESSOR_HV, 4)
+                .output(NANO_PROCESSOR_HV, outputAmount * 2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1203,7 +1206,7 @@ public class CircuitRecipes {
                 .input(SMD_CAPACITOR, 12)
                 .input(SMD_TRANSISTOR, 12)
                 .input(wireFine, Platinum, 12)
-                .output(QUANTUM_PROCESSOR_EV, 2)
+                .output(QUANTUM_PROCESSOR_EV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1214,7 +1217,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 3)
                 .input(ADVANCED_SMD_TRANSISTOR, 3)
                 .input(wireFine, Platinum, 12)
-                .output(QUANTUM_PROCESSOR_EV, 2)
+                .output(QUANTUM_PROCESSOR_EV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1224,7 +1227,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SYSTEM_ON_CHIP)
                 .input(wireFine, Platinum, 12)
                 .input(bolt, NiobiumTitanium, 8)
-                .output(QUANTUM_PROCESSOR_EV, 4)
+                .output(QUANTUM_PROCESSOR_EV, outputAmount * 2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1313,7 +1316,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 6)
                 .input(ADVANCED_SMD_TRANSISTOR, 6)
                 .input(wireFine, NiobiumTitanium, 8)
-                .output(CRYSTAL_PROCESSOR_IV, 2)
+                .output(CRYSTAL_PROCESSOR_IV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1323,7 +1326,7 @@ public class CircuitRecipes {
                 .input(CRYSTAL_SYSTEM_ON_CHIP)
                 .input(wireFine, NiobiumTitanium, 8)
                 .input(bolt, YttriumBariumCuprate, 8)
-                .output(CRYSTAL_PROCESSOR_IV, 4)
+                .output(CRYSTAL_PROCESSOR_IV, outputAmount * 2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1393,7 +1396,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 8)
                 .input(ADVANCED_SMD_TRANSISTOR, 8)
                 .input(wireFine, YttriumBariumCuprate, 8)
-                .output(WETWARE_PROCESSOR_LUV, 2)
+                .output(WETWARE_PROCESSOR_LUV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 
@@ -1403,7 +1406,7 @@ public class CircuitRecipes {
                 .input(HIGHLY_ADVANCED_SOC)
                 .input(wireFine, YttriumBariumCuprate, 8)
                 .input(bolt, Naquadah, 8)
-                .output(WETWARE_PROCESSOR_LUV, 4)
+                .output(WETWARE_PROCESSOR_LUV, outputAmount * 2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -212,27 +212,27 @@ public class CircuitRecipes {
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(GLASS_TUBE)
-                .input(bolt, Steel)
+                .input(bolt, Steel, 2)
                 .input(wireGtSingle, Copper, 2)
                 .circuitMeta(1)
                 .output(VACUUM_TUBE, 2)
-                .duration(120).EUt(VA[ULV]).buildAndRegister();
+                .duration(160).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(GLASS_TUBE)
-                .input(bolt, Steel)
+                .input(bolt, Steel, 2)
                 .input(wireGtSingle, Copper, 2)
                 .fluidInputs(RedAlloy.getFluid(18))
                 .output(VACUUM_TUBE, 3)
-                .duration(40).EUt(VA[ULV]).buildAndRegister();
+                .duration(160).EUt(VA[ULV]).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(GLASS_TUBE)
-                .input(bolt, Steel)
+                .input(bolt, Steel, 2)
                 .input(wireGtSingle, AnnealedCopper, 2)
                 .fluidInputs(RedAlloy.getFluid(18))
                 .output(VACUUM_TUBE, 4)
-                .duration(40).EUt(VA[ULV]).buildAndRegister();
+                .duration(160).EUt(VA[ULV]).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(dust, Glass)
@@ -927,7 +927,7 @@ public class CircuitRecipes {
                 'B', GOOD_CIRCUIT_BOARD.getStackForm(),
                 'D', DIODE.getStackForm());
 
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[LV]).duration(300)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(16).duration(300)
                 .input(GOOD_CIRCUIT_BOARD)
                 .input(circuit, Tier.LV, 2)
                 .input(component, Component.Diode, 2)
@@ -1034,14 +1034,14 @@ public class CircuitRecipes {
                 .buildAndRegister();
 
         // HV
-        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(VA[MV]).duration(400)
+        CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder().EUt(90).duration(400)
                 .input(PLASTIC_CIRCUIT_BOARD)
                 .input(PROCESSOR_MV, 2)
                 .input(component, Component.Inductor, 4)
                 .input(component, Component.Capacitor, 8)
                 .input(RANDOM_ACCESS_MEMORY, 4)
                 .input(wireFine, RedAlloy, 8)
-                .output(PROCESSOR_ASSEMBLY_HV, 2)
+                .output(PROCESSOR_ASSEMBLY_HV)
                 .solderMultiplier(2)
                 .buildAndRegister();
 
@@ -1126,7 +1126,7 @@ public class CircuitRecipes {
                 .input(SMD_CAPACITOR, 8)
                 .input(RANDOM_ACCESS_MEMORY, 8)
                 .input(wireFine, Electrum, 16)
-                .output(NANO_PROCESSOR_ASSEMBLY_EV, 2)
+                .output(NANO_PROCESSOR_ASSEMBLY_EV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
@@ -1138,7 +1138,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 2)
                 .input(RANDOM_ACCESS_MEMORY, 8)
                 .input(wireFine, Electrum, 16)
-                .output(NANO_PROCESSOR_ASSEMBLY_EV, 2)
+                .output(NANO_PROCESSOR_ASSEMBLY_EV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
@@ -1236,7 +1236,7 @@ public class CircuitRecipes {
                 .input(SMD_CAPACITOR, 16)
                 .input(RANDOM_ACCESS_MEMORY, 4)
                 .input(wireFine, Platinum, 16)
-                .output(QUANTUM_ASSEMBLY_IV, 2)
+                .output(QUANTUM_ASSEMBLY_IV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
@@ -1248,7 +1248,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 4)
                 .input(RANDOM_ACCESS_MEMORY, 4)
                 .input(wireFine, Platinum, 16)
-                .output(QUANTUM_ASSEMBLY_IV, 2)
+                .output(QUANTUM_ASSEMBLY_IV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
@@ -1335,7 +1335,7 @@ public class CircuitRecipes {
                 .input(ADVANCED_SMD_CAPACITOR, 8)
                 .input(RANDOM_ACCESS_MEMORY, 24)
                 .input(wireFine, NiobiumTitanium, 16)
-                .output(CRYSTAL_ASSEMBLY_LUV, 2)
+                .output(CRYSTAL_ASSEMBLY_LUV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
@@ -1416,7 +1416,7 @@ public class CircuitRecipes {
                 .input(RANDOM_ACCESS_MEMORY, 24)
                 .input(wireFine, YttriumBariumCuprate, 16)
                 .solderMultiplier(2)
-                .output(WETWARE_PROCESSOR_ASSEMBLY_ZPM, 2)
+                .output(WETWARE_PROCESSOR_ASSEMBLY_ZPM)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .buildAndRegister();
 


### PR DESCRIPTION
- Vacuum tube assembler recipes increased to two Steel Bolts (vs 1)
- Vacuum tube assembler duration increased to 8s (vs 6s/2s depending on recipe). Matches Resistors
- 1st MV circuit decreased to 16EU/t (vs 30)
- 2nd HV circuit decreased to 90EU/t (vs 120)
- Every 1st -> 2nd circuit in a set was decreased from 2->2 to 2->1, except for the 2nd LV -> 2nd MV. This means:
    - Integrated Processor -> Processor Assembly
    - Nanoprocessor -> Nanoprocessor Assembly
    - Quantumprocessor -> Quantumprocessor Assembly
    - Crystalprocessor -> Crystalprocessor Assembly
    - Wetwareprocessor -> Wetwareprocessor Assembly