### PR TITLE
Rewrite TankWidget clicking behavior

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -11,7 +11,9 @@ import gregtech.client.utils.TooltipHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
@@ -21,8 +23,10 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -262,83 +266,213 @@ public class TankWidget extends Widget implements IIngredientSlot {
         } else if (id == 3 && lastFluidInTank != null) {
             this.lastFluidInTank.amount = buffer.readVarInt();
         }
-
-        if (id == 4) {
-            ItemStack currentStack = gui.entityPlayer.inventory.getItemStack();
-            int newStackSize = buffer.readVarInt();
-            currentStack.setCount(newStackSize);
-            gui.entityPlayer.inventory.setItemStack(currentStack);
-        }
     }
 
     @Override
     public void handleClientAction(int id, PacketBuffer buffer) {
         super.handleClientAction(id, buffer);
         if (id == 1) {
-            boolean isShiftKeyDown = buffer.readBoolean();
-            int clickResult = tryClickContainer(isShiftKeyDown);
-            if (clickResult >= 0) {
-                writeUpdateInfo(4, buf -> buf.writeVarInt(clickResult));
+            System.out.println("Old stack: " + gui.entityPlayer.inventory.getItemStack());
+            ItemStack clickResult = tryClickContainer(buffer.readBoolean());
+            if (clickResult != ItemStack.EMPTY) {
+                System.out.println("New stack: " + clickResult);
+                ((EntityPlayerMP) gui.entityPlayer).updateHeldItem();
+            } else {
+                System.out.println("New stack: Empty (no change made)");
             }
         }
     }
 
-    private int tryClickContainer(boolean isShiftKeyDown) {
+    private ItemStack tryClickContainer(boolean tryFillAll) {
         EntityPlayer player = gui.entityPlayer;
         ItemStack currentStack = player.inventory.getItemStack();
-        if (!currentStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null))
-            return -1;
-        int maxAttempts = isShiftKeyDown ? currentStack.getCount() : 1;
+        if (currentStack == ItemStack.EMPTY || currentStack.getCount() == 0) return ItemStack.EMPTY;
 
-        if (allowClickFilling && fluidTank.getFluidAmount() > 0) {
-            boolean performedFill = false;
-            FluidStack initialFluid = fluidTank.getFluid();
-            for (int i = 0; i < maxAttempts; i++) {
-                FluidActionResult result = FluidUtil.tryFillContainer(currentStack,
-                        (IFluidHandler) fluidTank, Integer.MAX_VALUE, null, false);
-                if (!result.isSuccess()) break;
-                ItemStack remainingStack = result.getResult();
-                if (!remainingStack.isEmpty() && !player.inventory.addItemStackToInventory(remainingStack))
-                    break; //do not continue if we can't add resulting container into inventory
-                FluidUtil.tryFillContainer(currentStack, (IFluidHandler) fluidTank, Integer.MAX_VALUE, null, true);
-                currentStack.shrink(1);
-                performedFill = true;
-            }
-            if (performedFill) {
-                if (initialFluid != null) {
-                    SoundEvent soundevent = initialFluid.getFluid().getFillSound(initialFluid);
-                    player.world.playSound(null, player.posX, player.posY + 0.5, player.posZ,
-                            soundevent, SoundCategory.BLOCKS, 1.0F, 1.0F);
-                }
-                gui.entityPlayer.inventory.setItemStack(currentStack);
-                return currentStack.getCount();
-            }
+        ItemStack heldItemSizedOne = currentStack.copy();
+        heldItemSizedOne.setCount(1);
+        IFluidHandlerItem fluidHandlerItem = heldItemSizedOne.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (fluidHandlerItem == null) return ItemStack.EMPTY;
+
+        FluidStack tankFluid = fluidTank.getFluid();
+        FluidStack heldFluid = fluidHandlerItem.drain(Integer.MAX_VALUE, false);
+        if (heldFluid != null && heldFluid.amount <= 0) {
+            heldFluid = null;
         }
 
-        if (allowClickEmptying) {
-            boolean performedEmptying = false;
-            for (int i = 0; i < maxAttempts; i++) {
-                FluidActionResult result = FluidUtil.tryEmptyContainer(currentStack,
-                        (IFluidHandler) fluidTank, Integer.MAX_VALUE, null, false);
-                if (!result.isSuccess()) break;
-                ItemStack remainingStack = result.getResult();
-                if (!remainingStack.isEmpty() && !player.inventory.addItemStackToInventory(remainingStack))
-                    break; //do not continue if we can't add resulting container into inventory
-                FluidUtil.tryEmptyContainer(currentStack, (IFluidHandler) fluidTank, Integer.MAX_VALUE, null, true);
-                currentStack.shrink(1);
-                performedEmptying = true;
+        if (tankFluid == null) {
+            // Tank is empty, only try to drain the held item
+            if (!allowClickEmptying) {
+                // tank does not allow emptying cells into it, return
+                return ItemStack.EMPTY;
             }
-            FluidStack filledFluid = fluidTank.getFluid();
-            if (performedEmptying && filledFluid != null) {
-                SoundEvent soundevent = filledFluid.getFluid().getEmptySound(filledFluid);
-                player.world.playSound(null, player.posX, player.posY + 0.5, player.posZ,
-                        soundevent, SoundCategory.BLOCKS, 1.0F, 1.0F);
-                gui.entityPlayer.inventory.setItemStack(currentStack);
-                return currentStack.getCount();
+            if (heldFluid == null) {
+                // held item has no fluid, return
+                return ItemStack.EMPTY;
             }
+
+            // empty held item into the tank
+            return fillTankFromStack(heldFluid, tryFillAll);
         }
 
-        return -1;
+        if (heldFluid != null && fluidTank.getFluidAmount() < fluidTank.getCapacity()) {
+            // held item has a fluid, and so does the tank. tank still has some room left in it
+            // either action is possible here
+            if (allowClickEmptying) {
+                // try to empty the item into the tank
+                return fillTankFromStack(heldFluid, tryFillAll);
+            }
+            if (!allowClickFilling) {
+                // cannot fill the item from the tank, return
+                return ItemStack.EMPTY;
+            }
+            // slot does not allow filling, so try to take from the slot
+            return drainTankFromStack(tryFillAll);
+        } else {
+            // tank is full, and there is some fluid available to take
+            if (!allowClickFilling) {
+                // slot does not allow taking, return
+                return ItemStack.EMPTY;
+            }
+            // try to take from the slot
+            return drainTankFromStack(tryFillAll);
+        }
+    }
+
+    private ItemStack fillTankFromStack(@NotNull FluidStack heldFluid, boolean tryFillAll) {
+        EntityPlayer player = gui.entityPlayer;
+        ItemStack heldItem = player.inventory.getItemStack();
+        if (heldItem == ItemStack.EMPTY || heldItem.getCount() == 0) return ItemStack.EMPTY;
+
+        ItemStack heldItemSizedOne = heldItem.copy();
+        heldItemSizedOne.setCount(1);
+        FluidStack currentFluid = fluidTank.getFluid();
+        // Fluid type does not match
+        if (currentFluid != null && !currentFluid.isFluidEqual(heldFluid)) return ItemStack.EMPTY;
+
+        int freeSpace = fluidTank.getCapacity() - fluidTank.getFluidAmount();
+        if (freeSpace <= 0) return ItemStack.EMPTY;
+
+        ItemStack itemStackEmptied = ItemStack.EMPTY;
+        int fluidAmountTaken = 0;
+
+        IFluidHandlerItem fluidHandler = heldItemSizedOne.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (fluidHandler == null) return ItemStack.EMPTY;
+
+        FluidStack drained = fluidHandler.drain(freeSpace, true);
+        if (drained != null && drained.amount > 0) {
+            itemStackEmptied = fluidHandler.getContainer();
+            fluidAmountTaken = drained.amount;
+        }
+        if (itemStackEmptied == ItemStack.EMPTY) {
+            return ItemStack.EMPTY;
+        }
+
+        // find out how many fills we can do
+        // same round down behavior as drain
+        int additional = tryFillAll ? Math.min(freeSpace / fluidAmountTaken, heldItem.getCount()) : 1;
+        FluidStack copiedFluidStack = heldFluid.copy();
+        copiedFluidStack.amount = fluidAmountTaken * additional;
+        fluidTank.fill(copiedFluidStack, true);
+
+        itemStackEmptied.setCount(additional);
+        replaceCursorItemStack(itemStackEmptied);
+        playSound(heldFluid, true);
+        return itemStackEmptied;
+    }
+
+    private ItemStack drainTankFromStack(boolean tryFillAll) {
+        EntityPlayer player = gui.entityPlayer;
+        ItemStack heldItem = player.inventory.getItemStack();
+        if (heldItem == ItemStack.EMPTY || heldItem.getCount() == 0) return ItemStack.EMPTY;
+
+        ItemStack heldItemSizedOne = heldItem.copy();
+        heldItemSizedOne.setCount(1);
+        FluidStack currentFluid = fluidTank.getFluid();
+        if (currentFluid == null) return ItemStack.EMPTY;
+        currentFluid = currentFluid.copy();
+
+        int originalFluidAmount = fluidTank.getFluidAmount();
+        IFluidHandlerItem handler = heldItemSizedOne.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (handler == null) return ItemStack.EMPTY;
+        ItemStack filledContainer = fillFluidContainer(currentFluid, heldItemSizedOne);
+        if (filledContainer != ItemStack.EMPTY) {
+            int filledAmount = originalFluidAmount - currentFluid.amount;
+            if (filledAmount <= 0) {
+                return ItemStack.EMPTY;
+            }
+            fluidTank.drain(filledAmount, true);
+            if (tryFillAll) {
+                // Determine how many more items we can fill. One item is already filled. Integer division means
+                // it will round down, so it will only fill equivalent fluid amounts. For example:
+                // Click with 3 cells, with 2500L of fluid in the tank. 2 cells will be filled, and 500L will
+                // be left behind in the tank.
+                int additional = Math.min(heldItem.getCount() - 1, currentFluid.amount / filledAmount);
+                fluidTank.drain(filledAmount * additional, true);
+                filledContainer.grow(additional);
+            }
+            replaceCursorItemStack(filledContainer);
+            playSound(currentFluid, false);
+        }
+        return filledContainer;
+    }
+
+    private ItemStack fillFluidContainer(FluidStack fluidStack, ItemStack itemStack) {
+        IFluidHandlerItem fluidHandlerItem = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+        if (fluidHandlerItem == null) return ItemStack.EMPTY;
+        int filledAmount = fluidHandlerItem.fill(fluidStack, true);
+        if (filledAmount > 0) {
+            fluidStack.amount -= filledAmount;
+            return fluidHandlerItem.getContainer();
+        }
+        return ItemStack.EMPTY;
+    }
+
+    /**
+     * Replace the ItemStack on the player's cursor with the passed stack.
+     * Use to replace empty cells with filled, or filled cells with empty.
+     * If it is not fully emptied/filled, it will place the new items into the player inventory instead,
+     * and shrink the held stack by the appropriate amount.
+     */
+    private void replaceCursorItemStack(ItemStack resultStack) {
+        EntityPlayer player = gui.entityPlayer;
+        int resultStackSize = resultStack.getMaxStackSize();
+        while (resultStack.getCount() > resultStackSize) {
+            player.inventory.getItemStack().shrink(resultStackSize);
+            addItemToPlayerInventory(player, resultStack.splitStack(resultStackSize));
+        }
+        if (player.inventory.getItemStack().getCount() == resultStack.getCount()) {
+            // every item on the cursor is mutated, so leave it there
+            player.inventory.setItemStack(resultStack);
+        } else {
+            // some items not mutated. Mutated items go into the inventory/world.
+            ItemStack heldStack = player.inventory.getItemStack();
+            heldStack.shrink(resultStack.getCount());
+            player.inventory.setItemStack(heldStack);
+            addItemToPlayerInventory(player, resultStack);
+        }
+    }
+
+    /** Place an item into the player's inventory, or drop it in-world as an item entity if it cannot fit. */
+    private static void addItemToPlayerInventory(EntityPlayer player, ItemStack stack) {
+        if (stack == null) return;
+        if (!player.inventory.addItemStackToInventory(stack) && !player.world.isRemote) {
+            EntityItem dropItem = player.entityDropItem(stack, 0);
+            if (dropItem != null) dropItem.setPickupDelay(0);
+        }
+    }
+
+    /** Play the appropriate fluid interaction sound for the fluid. */
+    private void playSound(FluidStack fluid, boolean fill) {
+        if (fluid == null) return;
+        SoundEvent soundEvent;
+        if (fill) {
+            soundEvent = fluid.getFluid().getFillSound(fluid);
+        } else {
+            soundEvent = fluid.getFluid().getEmptySound(fluid);
+        }
+        EntityPlayer player = gui.entityPlayer;
+        player.world.playSound(null, player.posX, player.posY + 0.5, player.posZ,
+                soundEvent, SoundCategory.BLOCKS, 1.0F, 1.0F);
     }
 
     @Override
@@ -346,10 +480,9 @@ public class TankWidget extends Widget implements IIngredientSlot {
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
         if (isMouseOverElement(mouseX, mouseY)) {
             ItemStack currentStack = gui.entityPlayer.inventory.getItemStack();
-            if (button == 0 && (allowClickEmptying || allowClickFilling) &&
+            if ((allowClickEmptying || allowClickFilling) &&
                     currentStack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
-                boolean isShiftKeyDown = TooltipHelper.isShiftDown();
-                writeClientAction(1, writer -> writer.writeBoolean(isShiftKeyDown));
+                writeClientAction(1, writer -> writer.writeBoolean(button == 0));
                 playButtonClickSound();
                 return true;
             }

--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -272,13 +272,9 @@ public class TankWidget extends Widget implements IIngredientSlot {
     public void handleClientAction(int id, PacketBuffer buffer) {
         super.handleClientAction(id, buffer);
         if (id == 1) {
-            System.out.println("Old stack: " + gui.entityPlayer.inventory.getItemStack());
             ItemStack clickResult = tryClickContainer(buffer.readBoolean());
             if (clickResult != ItemStack.EMPTY) {
-                System.out.println("New stack: " + clickResult);
                 ((EntityPlayerMP) gui.entityPlayer).updateHeldItem();
-            } else {
-                System.out.println("New stack: Empty (no change made)");
             }
         }
     }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5236,9 +5236,9 @@ gregtech.recipe.computation_per_tick=Min. Computation: %,d CWU/t
 gregtech.recipe.total_computation=Computation: %,d CWU
 gregtech.recipe.research_result=Research result item, not produced by this recipe directly
 
-gregtech.fluid.click_to_fill=§7Click with a Fluid Container to §bfill §7the tank (Shift-click for a full stack).
-gregtech.fluid.click_combined=§7Click with a Fluid Container to §cempty §7or §bfill §7the tank (Shift-click for a full stack).
-gregtech.fluid.click_to_empty=§7Click with a Fluid Container to §cempty §7the tank (Shift-click for a full stack).
+gregtech.fluid.click_to_fill=§7Left Click with a Fluid Container to §bfill §7the tank (Right Click to process 1 item per click).
+gregtech.fluid.click_combined=§7Left Click with a Fluid Container to §bfill §7or §cempty §7the tank (Right Click to process 1 item per click).
+gregtech.fluid.click_to_empty=§7Left Click with a Fluid Container to §cempty §7the tank (Right Click to process 1 item per click).
 
 gregtech.tool_action.show_tooltips=Hold SHIFT to show Tool Info
 gregtech.tool_action.screwdriver.auto_output_covers=§8Use Screwdriver to Allow Input from Output Side or access Covers


### PR DESCRIPTION
Rewrites our Tank clicking functionality to feel more intuitive, following GTNH's logic for it.
- Left click the tank with an item in hand to fill all items in your cursor, right click for 1 item
- If all items under your cursor can be filled/drained, the item will stay on your cursor
- If only some items under your cursor can be filled/drained, the newly filled/drained items are moved to your inventory, and the remaining items are left on your cursor
- If items are moved to your inventory like above, they will now drop in-world if there is no room instead of failing to transfer