### PR TITLE
Allow opening covers on the grid with empty hand

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -445,19 +445,20 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
                     return true;
                 }
             }
+
+            // Try to do cover right-click behavior on this specific side first
             EnumFacing hitFacing = hitResult.sideHit;
             CoverBehavior coverBehavior = hitFacing == null ? null : getCoverAtSide(hitFacing);
-            if (coverBehavior == null) {
-                return false;
+            if (coverBehavior != null) {
+                EnumActionResult result = coverBehavior.onRightClick(playerIn, hand, hitResult);
+                if (result == EnumActionResult.SUCCESS) return true;
             }
-            EnumActionResult result = coverBehavior.onRightClick(playerIn, hand, hitResult);
 
-            if (result == EnumActionResult.SUCCESS) {
-                return true;
-            }
-            else if (playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
-                result = coverBehavior.onScrewdriverClick(playerIn, hand, hitResult);
-
+            // Then try to do cover screwdriver-click behavior on the cover grid side next
+            EnumFacing gridSideHit = ICoverable.determineGridSideHit(hitResult);
+            coverBehavior = gridSideHit == null ? null : getCoverAtSide(gridSideHit);
+            if (coverBehavior != null && playerIn.isSneaking() && playerIn.getHeldItemMainhand().isEmpty()) {
+                EnumActionResult result = coverBehavior.onScrewdriverClick(playerIn, hand, hitResult);
                 return result == EnumActionResult.SUCCESS;
             }
         }

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -350,10 +350,12 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
             }
         }
 
-        if (itemStack.getItem().getToolClasses(itemStack).contains(ToolClasses.SCREWDRIVER)) {
+        if ((itemStack.isEmpty() && entityPlayer.isSneaking()) || itemStack.getItem().getToolClasses(itemStack).contains(ToolClasses.SCREWDRIVER)) {
             if (coverBehavior.onScrewdriverClick(entityPlayer, hand, hit) == EnumActionResult.SUCCESS) {
-                ToolHelper.damageItem(itemStack, entityPlayer);
-                ToolHelper.playToolSound(itemStack, entityPlayer);
+                if (!itemStack.isEmpty()) {
+                    ToolHelper.damageItem(itemStack, entityPlayer);
+                    ToolHelper.playToolSound(itemStack, entityPlayer);
+                }
                 return true;
             }
         }

--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -289,6 +289,10 @@ public class ToolEventHandlers {
 
     @SideOnly(Side.CLIENT)
     private static boolean shouldRenderGridOverlays(@Nonnull IBlockState state, TileEntity tile, ItemStack mainHand, ItemStack offHand, boolean isSneaking) {
+        // Cheapest case to check, always show when sneaking with empty hand
+        if (mainHand.isEmpty() && isSneaking) {
+            return true;
+        }
         if (state.getBlock() instanceof BlockPipe) {
             BlockPipe<?, ?, ?> pipe = (BlockPipe<?, ?, ?>) state.getBlock();
             if (isSneaking && mainHand.getItem().getClass() == Item.getItemFromBlock(pipe).getClass()) {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -176,7 +176,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
         if (playerIn.getHeldItem(hand).hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null)) {
             return getWorld().isRemote || (!playerIn.isSneaking() && FluidUtil.interactWithFluidHandler(playerIn, hand, fluidTank));
         }
-        return false;
+        return super.onRightClick(playerIn, hand, facing, hitResult);
     }
 
     @Override


### PR DESCRIPTION
As title states. Implemented and tested for MTEs and any pipe type