### PR TITLE
Fix Fluid Jetpacks being caught on one fluid type

### DIFF
--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -13,9 +13,9 @@ import gregtech.api.util.VirtualTankRegistry;
 import gregtech.api.worldgen.bedrockFluids.BedrockFluidVeinSaveData;
 import gregtech.common.items.MetaItems;
 import gregtech.common.items.armor.IStepAssist;
+import gregtech.common.items.armor.PowerlessJetpack;
 import gregtech.common.items.behaviors.ToggleEnergyConsumerBehavior;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
-import gregtech.tools.enchants.EnchantmentHardHammer;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityEnderman;
@@ -193,6 +193,12 @@ public class EventHandlers {
         if (valueItem.isItemEqual(MetaItems.QUANTUM_CHESTPLATE.getStackForm()) ||
                 valueItem.isItemEqual(MetaItems.QUANTUM_CHESTPLATE_ADVANCED.getStackForm())) {
             event.getEntity().isImmuneToFire = false;
+        }
+
+        // Workaround to recipe caching issue with fluid jetpack
+        // TODO, rewrite logic and remove in armor rewrite
+        if (valueItem.isItemEqual(MetaItems.SEMIFLUID_JETPACK.getStackForm())) {
+            ((PowerlessJetpack) valueItem.getArmorLogic()).resetRecipe();
         }
     }
 

--- a/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
+++ b/src/main/java/gregtech/common/items/armor/PowerlessJetpack.java
@@ -84,6 +84,8 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDP
             }
         }
 
+        // This causes a caching issue. currentRecipe is only set to null in findNewRecipe, so the fuel is never updated
+        // Rewrite in Armor Rework
         if (currentRecipe == null)
             findNewRecipe(stack);
 
@@ -149,8 +151,9 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDP
     @Override
     public boolean canUseEnergy(ItemStack stack, int amount) {
         FluidStack fuel = getFuel();
-        if (fuel == null)
+        if (fuel == null) {
             return false;
+        }
 
         IFluidHandlerItem fluidHandlerItem = getIFluidHandlerItem(stack);
         if (fluidHandlerItem == null)
@@ -202,9 +205,15 @@ public class PowerlessJetpack implements ISpecialArmorLogic, IJetpack, IItemHUDP
         currentRecipe = null;
     }
 
+    public void resetRecipe() {
+        currentRecipe = null;
+        previousRecipe = null;
+    }
+
     public FluidStack getFuel() {
-        if (currentRecipe != null)
+        if (currentRecipe != null) {
             return currentRecipe.getFluidInputs().get(0).getInputFluidStack();
+        }
 
         return null;
     }


### PR DESCRIPTION
## What
This PR fixes Fluid Jetpacks being cached on one fluid type, in a temporary manor. Since there is an armor rewrite somewhat in progress, I applied a simple fix for now, leaving the logic to get revamped better in that PR.

Closes #1589


## Outcome
Fixes Fluid Jetpacks being caught on one fluid type
