### PR TITLE
Don't initialize I/O if Multiblock tank is not formed

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityMultiblockTank.java
@@ -54,6 +54,10 @@ public class MetaTileEntityMultiblockTank extends MultiblockWithDisplayBase {
     protected void initializeInventory() {
         super.initializeInventory();
 
+        if (!isStructureFormed()) {
+            return;
+        }
+
         FilteredFluidHandler tank = new FilteredFluidHandler(capacity);
         if (!isMetal) {
             tank.setFilter(new PropertyFluidFilter(340, false, false, false, false));


### PR DESCRIPTION
## What
This PR prevents I/O into the multiblock tank controllers if the tank is not formed.

Closes #2151 

However, I am not sure if I/O through the Multiblock tank controller was intended or not, so it is not blocked if the structure is formed. Some clarification on this would be nice.


## Outcome
Prevents I/O in multiblock tank controller if the structure is not formed.
