### PR TITLE
Add Pick Block support to Super Tanks

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -45,6 +45,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
@@ -829,7 +830,7 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
     public void getDrops(NonNullList<ItemStack> dropsList, @Nullable EntityPlayer harvester) {
     }
 
-    public ItemStack getPickItem(CuboidRayTraceResult result, EntityPlayer player) {
+    public final ItemStack getPickItem(CuboidRayTraceResult result, EntityPlayer player) {
         IndexedCuboid6 hitCuboid = result.cuboid6;
         if (hitCuboid.data instanceof CoverSideData) {
             CoverSideData coverSideData = (CoverSideData) hitCuboid.data;
@@ -841,10 +842,14 @@ public abstract class MetaTileEntity implements ICoverable, IVoidable {
             if (behavior != null) {
                 return behavior.getPickItem();
             }
-            return getStackForm();
+            return getPickItem(player);
         } else {
             return ItemStack.EMPTY;
         }
+    }
+
+    public ItemStack getPickItem(EntityPlayer player) {
+        return getStackForm();
     }
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -519,7 +519,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     }
 
     @Override
-    public ItemStack getPickItem(CuboidRayTraceResult result, EntityPlayer player) {
+    public ItemStack getPickItem(EntityPlayer player) {
         return this.getClipboard();
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -594,6 +594,20 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     }
 
     @Override
+    public ItemStack getPickItem(EntityPlayer player) {
+        if(!player.isCreative()) return super.getPickItem(player);
+
+        ItemStack baseItemStack = getStackForm();
+        NBTTagCompound tag = new NBTTagCompound();
+
+        this.writeItemStackData(tag);
+        if(!tag.isEmpty()) {
+            baseItemStack.setTagCompound(tag);
+        }
+        return baseItemStack;
+    }
+
+    @Override
     public boolean needsSneakToRotate() {
         return true;
     }


### PR DESCRIPTION
## What
Adds pick block support to Super Tanks when in creative. This will cause them to maintain their stored fluids when picked, compared to losing them when picked.

## Implementation Details
Had to add 1 method to ``MetaTileEntity``, ``getPickItem(EntityPlayer player)``, and modify another (``getPickItem(CuboidRayTraceResult result, EntityPlayer player)``)

``MetaTileEntityQuantumTank`` overrides ``getPickItem(EntityPlayer player)`` to provide an updated ``ItemStack`` with the current ``NBTCompoundTag`` of the picked supertank.

_Thanks to Serenibyss for helping me through MTE classes_

## Outcome
Adds pick block support to Super Tanks so they maintain their stored fluids in block item form


## Potential Compatibility Issues
Some block _may_ have issues with the change of ``getPickItem`` in the MTE class but so far I have not noticed any
