### PR TITLE
Fix Quantum Chest Export Slot Checking

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -592,14 +592,14 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
                 return ItemStack.EMPTY;
             }
 
-            ItemStack exportItems = getExportItems().getStackInSlot(0);
-
             // If there is a virtualized stack and the stack to insert does not match it, do not insert anything
             if (itemsStoredInside > 0L &&
                     !virtualItemStack.isEmpty() &&
                     !areItemStackIdentical(virtualItemStack, insertedStack)) {
                 return insertedStack;
             }
+
+            ItemStack exportItems = getExportItems().getStackInSlot(0);
 
             // if there is an item in the export slot and the inserted stack does not match, do not insert
             if (!exportItems.isEmpty() && !areItemStackIdentical(exportItems, insertedStack)) {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -596,9 +596,13 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
 
             // If there is a virtualized stack and the stack to insert does not match it, do not insert anything
             if (itemsStoredInside > 0L &&
-                    !virtualItemStack.isEmpty() && (
-                    !areItemStackIdentical(virtualItemStack, insertedStack) ||
-                    !areItemStackIdentical(exportItems, insertedStack))) {
+                    !virtualItemStack.isEmpty() &&
+                    !areItemStackIdentical(virtualItemStack, insertedStack)) {
+                return insertedStack;
+            }
+
+            // if there is an item in the export slot and the inserted stack does not match, do not insert
+            if (!exportItems.isEmpty() && !areItemStackIdentical(exportItems, insertedStack)) {
                 return insertedStack;
             }
 

--- a/src/test/java/gregtech/common/metatileentities/storage/QuantumChestTest.java
+++ b/src/test/java/gregtech/common/metatileentities/storage/QuantumChestTest.java
@@ -102,6 +102,26 @@ public class QuantumChestTest {
     }
 
     @Test
+    public void Test_Export_Checking() {
+        for (var quantumChest : createInstances()) {
+            IItemHandler itemHandler = quantumChest.getCombinedInventory();
+            insertItem(itemHandler, GRAVEL.copy(), false);
+
+            ItemStack export = quantumChest.getExportItems().getStackInSlot(0);
+
+            insertItem(itemHandler, SAND.copy(), false);
+            insertItem(itemHandler, SAND.copy(), false);
+
+            insertItem(itemHandler, GRAVEL.copy(), false);
+
+
+            String reason = "The virtualized stack is not the same as the export slot!";
+            boolean isEqual = ItemStack.areItemsEqual(export, quantumChest.virtualItemStack) && export.getMetadata() == quantumChest.virtualItemStack.getMetadata();
+            assertThat(reason, isEqual, is(true));
+        }
+    }
+
+    @Test
     public void Test_Multiple_Insertions() {
         for (var quantumChest : createInstances()) {
             IItemHandler itemInventory = quantumChest.getItemInventory();


### PR DESCRIPTION
## What
moves the check for if the inserted stack matches the export slot stack to it's own if statement, as previous logic allowed a different item to be virtualized than what was in the export slot.

this also adds a test to make sure the virtual stack and the export slot stack match

this pr is based off of the 2.8 branch, and should be pulled after 2.8 is merged

## Implementation Details
it's a new if statement
also adds a new test

## Outcome
inserted stacks will be properly yeeted (returned) if they do not match the export slot stack

## Potential Compatibility Issues
none
