### PR TITLE
Creative energy improvements

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5633,6 +5633,8 @@ gregtech.creative.tank.tpc=Ticks per Cycle
 
 gregtech.creative.energy.amperage=Amperage
 gregtech.creative.energy.voltage=Voltage
+gregtech.creative.energy.sink=Sink
+gregtech.creative.energy.source=Source
 
 gregtech.creative.activity.on=Active
 gregtech.creative.activity.off=Not active


### PR DESCRIPTION
## What
- Adds the ability for the creative source to interact with lasers.
- Also localise the source/sink button (why wasn't it ???)

## Implementation Details
`MetaTileEntityCreativeEnergy` now implements `ILaserContainer` instead of `IEnergyContainer`
  
## Outcome
Creative Energy now can now be used with lasers

## Potential Compatibility Issues
None i can see