### PR TITLE
Fix framebox transmutation

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockFrame.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrame.java
@@ -189,7 +189,7 @@ public abstract class BlockFrame extends BlockMaterialBase {
                 continue;
             }
             if (canPlaceBlockAt(world, blockPos)) {
-                world.setBlockState(blockPos, this.getStateFromMeta(stack.getItem().getMetadata(stack.getItemDamage())));
+                world.setBlockState(blockPos, frameBlock.getStateFromMeta(stack.getItem().getMetadata(stack.getItemDamage())));
                 SoundType type = getSoundType(stack);
                 world.playSound(null, pos, type.getPlaceSound(), SoundCategory.BLOCKS, (type.getVolume() + 1.0F) / 2.0F, type.getPitch() * 0.8F);
                 if (!player.capabilities.isCreativeMode) {


### PR DESCRIPTION
## What
Fixes stacking frameboxes transmuting materials or creating null frameboxes

## Implementation Details
Use the block the player is holding to get the blockstate to place, instead of the block clicked on

## Outcome
Fixes #2160 