### PR TITLE
Reduce Small and Tiny Dust Usages

### DIFF
--- a/src/main/java/gregtech/integration/jei/basic/OreByProduct.java
+++ b/src/main/java/gregtech/integration/jei/basic/OreByProduct.java
@@ -178,11 +178,13 @@ public class OreByProduct implements IRecipeWrapper {
 
         // centrifuge impure -> dust
         addToOutputs(material, OrePrefix.dust, 1);
-        addToOutputs(byproducts[0], OrePrefix.dustTiny, 1);
+        addToOutputs(byproducts[0], OrePrefix.dust, 1);
+        addChance(1111, 0);
 
         // ore wash crushed -> crushed purified
         addToOutputs(material, OrePrefix.crushedPurified, 1);
-        addToOutputs(byproducts[0], OrePrefix.dustTiny, 3);
+        addToOutputs(byproducts[0], OrePrefix.dust, 1);
+        addChance(3333, 0);
         List<FluidStack> fluidStacks = new ArrayList<>();
         fluidStacks.add(Materials.Water.getFluid(1000));
         fluidStacks.add(Materials.DistilledWater.getFluid(100));
@@ -190,7 +192,8 @@ public class OreByProduct implements IRecipeWrapper {
 
         // TC crushed/crushed purified -> centrifuged
         addToOutputs(material, OrePrefix.crushedCentrifuged, 1);
-        addToOutputs(byproducts[1], OrePrefix.dustTiny, byproductMultiplier * 3);
+        addToOutputs(byproducts[1], OrePrefix.dust, byproductMultiplier);
+        addChance(3333, 0);
 
         // macerate centrifuged -> dust
         addToOutputs(material, OrePrefix.dust, 1);
@@ -204,7 +207,8 @@ public class OreByProduct implements IRecipeWrapper {
 
         // centrifuge purified -> dust
         addToOutputs(material, OrePrefix.dust, 1);
-        addToOutputs(byproducts[1], OrePrefix.dustTiny, 1);
+        addToOutputs(byproducts[1], OrePrefix.dust, 1);
+        addChance(1111, 0);
 
         // cauldron/simple washer
         addToOutputs(material, OrePrefix.crushed, 1);
@@ -232,16 +236,15 @@ public class OreByProduct implements IRecipeWrapper {
 
         // electromagnetic separator
         if (hasSeparator) {
-            ItemStack separatedStack1 = OreDictUnifier.get(OrePrefix.dustSmall, separatedInto.get(0));
             OrePrefix prefix = (separatedInto.get(separatedInto.size() - 1).getBlastTemperature() == 0 && separatedInto.get(separatedInto.size() - 1).hasProperty(PropertyKey.INGOT))
-                    ? OrePrefix.nugget : OrePrefix.dustSmall;
+                    ? OrePrefix.nugget : OrePrefix.dust;
             ItemStack separatedStack2 = OreDictUnifier.get(prefix, separatedInto.get(separatedInto.size() - 1), prefix == OrePrefix.nugget ? 2 : 1);
 
             addToOutputs(material, OrePrefix.dust, 1);
-            addToOutputs(separatedStack1);
-            addChance(4000, 850);
+            addToOutputs(separatedInto.get(0), OrePrefix.dust, 1);
+            addChance(1000, 250);
             addToOutputs(separatedStack2);
-            addChance(2000, 600);
+            addChance(prefix == OrePrefix.dust ? 500 : 2000, prefix == OrePrefix.dust ? 150 : 600);
         } else {
             addEmptyOutputs(3);
         }

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -903,7 +903,7 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder()
                 .input(stone, Endstone)
                 .output(dust, Endstone)
-                .chancedOutput(dustTiny, Tungstate, 1200, 280)
+                .chancedOutput(dust, Tungstate, 130, 30)
                 .buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
@@ -916,7 +916,7 @@ public class MachineRecipeLoader {
             MACERATOR_RECIPES.recipeBuilder()
                     .input(stone, Soapstone)
                     .output(dustImpure, Talc)
-                    .chancedOutput(dustTiny, Chromite, 1000, 280)
+                    .chancedOutput(dust, Chromite, 111, 30)
                     .buildAndRegister();
 
         if (!OreDictionary.getOres("stoneRedrock").isEmpty())
@@ -947,36 +947,38 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder()
                 .input(stone, GraniteRed)
                 .output(dust, GraniteRed)
-                .chancedOutput(dustSmall, Uranium238, 100, 40)
+                .chancedOutput(dust, Uranium238, 10, 5)
                 .buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .input(stone, Andesite)
                 .output(dust, Andesite)
-                .chancedOutput(dustSmall, Stone, 100, 40)
+                .chancedOutput(dust, Stone, 10, 5)
                 .buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .input(stone, Diorite)
                 .output(dust, Diorite)
-                .chancedOutput(dustSmall, Stone, 100, 40)
+                .chancedOutput(dust, Stone, 10, 5)
                 .buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .input(stone, Granite)
                 .output(dust, Granite)
-                .chancedOutput(dustSmall, Stone, 100, 40)
+                .chancedOutput(dust, Stone, 10, 5)
                 .buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.PORKCHOP))
-                .output(dustSmall, Meat, 6)
+                .output(dust, Meat)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .output(dustTiny, Bone)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.FISH, 1, GTValues.W))
-                .output(dustSmall, Meat, 6)
+                .output(dust, Meat)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .output(dustTiny, Bone)
                 .duration(102).buildAndRegister();
 
@@ -988,13 +990,15 @@ public class MachineRecipeLoader {
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.BEEF))
-                .output(dustSmall, Meat, 6)
+                .output(dust, Meat)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .output(dustTiny, Bone)
                 .duration(102).buildAndRegister();
 
         MACERATOR_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Items.RABBIT))
-                .output(dustSmall, Meat, 6)
+                .output(dust, Meat)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .output(dustTiny, Bone)
                 .duration(102).buildAndRegister();
 
@@ -1003,8 +1007,6 @@ public class MachineRecipeLoader {
                 .output(dust, Meat)
                 .output(dustTiny, Bone)
                 .duration(102).buildAndRegister();
-
-
     }
 
     private static void registerFluidRecipes() {

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -714,7 +714,7 @@ public class MachineRecipeLoader {
                 .input(ingot, Iron)
                 .fluidInputs(Oxygen.getFluid(200))
                 .output(ingot, Steel)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .blastFurnaceTemp(1000)
                 .buildAndRegister();
 
@@ -722,7 +722,7 @@ public class MachineRecipeLoader {
                 .input(dust, Iron)
                 .fluidInputs(Oxygen.getFluid(200))
                 .output(ingot, Steel)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .circuitMeta(2)
                 .blastFurnaceTemp(1000)
                 .buildAndRegister();
@@ -731,7 +731,7 @@ public class MachineRecipeLoader {
                 .input(ingot, WroughtIron)
                 .fluidInputs(Oxygen.getFluid(200))
                 .output(ingot, Steel)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .blastFurnaceTemp(1000)
                 .buildAndRegister();
 
@@ -739,7 +739,7 @@ public class MachineRecipeLoader {
                 .input(dust, WroughtIron)
                 .fluidInputs(Oxygen.getFluid(200))
                 .output(ingot, Steel)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .circuitMeta(2)
                 .blastFurnaceTemp(1000)
                 .buildAndRegister();
@@ -748,7 +748,7 @@ public class MachineRecipeLoader {
                 .input(dust, Iron, 4)
                 .input(dust, Carbon)
                 .output(ingot, Steel, 4)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .blastFurnaceTemp(2000)
                 .buildAndRegister();
 
@@ -756,15 +756,15 @@ public class MachineRecipeLoader {
                 .input(dust, WroughtIron, 4)
                 .input(dust, Carbon)
                 .output(ingot, Steel, 4)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .blastFurnaceTemp(2000)
                 .buildAndRegister();
 
         // Aluminium from aluminium oxide gems
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Ruby).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Ruby).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Ruby).output(nugget, Aluminium, 3).chancedOutput(dust, Ash, 1111, 0).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Ruby).output(nugget, Aluminium, 3).chancedOutput(dust, Ash, 1111, 0).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, GreenSapphire).output(nugget, Aluminium, 3).chancedOutput(dust, Ash, 1111, 0).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).output(nugget, Aluminium, 3).chancedOutput(dust, Ash, 1111, 0).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
 
@@ -842,7 +842,7 @@ public class MachineRecipeLoader {
                 .input(dust, SiliconDioxide, 3)
                 .input(dust, Carbon, 2)
                 .output(ingotHot, Silicon)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(2000))
                 .buildAndRegister();
     }
@@ -852,7 +852,7 @@ public class MachineRecipeLoader {
                 .input(dust, inputMaterial)
                 .fluidInputs(Oxygen.getFluid(3000))
                 .output(dust, outputMaterial)
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(SulfurDioxide.getFluid(sulfurDioxideAmount))
                 .buildAndRegister();
     }

--- a/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
@@ -666,21 +666,21 @@ public class WoodRecipeLoader {
         // COAL TAR ============================================
         PYROLYSE_RECIPES.recipeBuilder().circuitMeta(8)
                 .inputs(new ItemStack(Items.COAL, 32, 1))
-                .output(dustSmall, Ash, 2)
+                .chancedOutput(dust, Ash, 5000, 0)
                 .fluidOutputs(CoalTar.getFluid(1000))
                 .duration(640).EUt(64)
                 .buildAndRegister();
 
         PYROLYSE_RECIPES.recipeBuilder().circuitMeta(8)
                 .inputs(new ItemStack(Items.COAL, 12))
-                .output(dustSmall, DarkAsh, 2)
+                .chancedOutput(dust, DarkAsh, 5000, 0)
                 .fluidOutputs(CoalTar.getFluid(3000))
                 .duration(320).EUt(96)
                 .buildAndRegister();
 
         PYROLYSE_RECIPES.recipeBuilder().circuitMeta(8)
                 .input(gem, Coke, 8)
-                .output(dustSmall, Ash, 3)
+                .chancedOutput(dust, Ash, 7500, 0)
                 .fluidOutputs(CoalTar.getFluid(4000))
                 .duration(320).EUt(96)
                 .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
@@ -5,7 +5,8 @@ import gregtech.common.items.MetaItems;
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.DISTILLATION_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
-import static gregtech.api.unification.ore.OrePrefix.*;
+import static gregtech.api.unification.ore.OrePrefix.dust;
+import static gregtech.api.unification.ore.OrePrefix.dustSmall;
 
 public class DistillationRecipes {
 
@@ -151,7 +152,7 @@ public class DistillationRecipes {
                 .fluidOutputs(SulfurDioxide.getFluid(7500))
                 .fluidOutputs(Helium3.getFluid(2500))
                 .fluidOutputs(Neon.getFluid(500))
-                .chancedOutput(dustSmall, Ash, 9000, 0)
+                .chancedOutput(dust, Ash, 2250, 0)
                 .disableDistilleryRecipes()
                 .duration(2000).EUt(VA[EV]).buildAndRegister();
 
@@ -164,7 +165,7 @@ public class DistillationRecipes {
                 .fluidOutputs(Krypton.getFluid(1000))
                 .fluidOutputs(Xenon.getFluid(1000))
                 .fluidOutputs(Radon.getFluid(1000))
-                .chancedOutput(dustTiny, EnderPearl, 9000, 0)
+                .chancedOutput(dust, EnderPearl, 1000, 0)
                 .disableDistilleryRecipes()
                 .duration(2000).EUt(VA[IV]).buildAndRegister();
     }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/DistillationRecipes.java
@@ -6,7 +6,6 @@ import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.DISTILLATION_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.dust;
-import static gregtech.api.unification.ore.OrePrefix.dustSmall;
 
 public class DistillationRecipes {
 
@@ -30,7 +29,7 @@ public class DistillationRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(CharcoalByproducts.getFluid(1000))
-                .output(dustSmall, Charcoal)
+                .chancedOutput(dust, Charcoal, 2500, 0)
                 .fluidOutputs(WoodTar.getFluid(250))
                 .fluidOutputs(WoodVinegar.getFluid(400))
                 .fluidOutputs(WoodGas.getFluid(250))
@@ -108,14 +107,14 @@ public class DistillationRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(Biomass.getFluid(1000))
-                .output(dustSmall, Wood, 2)
+                .chancedOutput(dust, Wood, 5000, 0)
                 .fluidOutputs(Ethanol.getFluid(600))
                 .fluidOutputs(Water.getFluid(300))
                 .duration(32).EUt(400).buildAndRegister();
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(CoalGas.getFluid(1000))
-                .output(dustSmall, Coke)
+                .chancedOutput(dust, Coke, 2500, 0)
                 .fluidOutputs(CoalTar.getFluid(200))
                 .fluidOutputs(Ammonia.getFluid(300))
                 .fluidOutputs(Ethylbenzene.getFluid(250))
@@ -125,7 +124,7 @@ public class DistillationRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(CoalTar.getFluid(1000))
-                .output(dustSmall, Coke)
+                .chancedOutput(dust, Coke, 2500, 0)
                 .fluidOutputs(Naphthalene.getFluid(400))
                 .fluidOutputs(HydrogenSulfide.getFluid(300))
                 .fluidOutputs(Creosote.getFluid(200))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/NaquadahRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/NaquadahRecipes.java
@@ -3,7 +3,8 @@ package gregtech.loaders.recipe.chemistry;
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
-import static gregtech.api.unification.ore.OrePrefix.*;
+import static gregtech.api.unification.ore.OrePrefix.dust;
+import static gregtech.api.unification.ore.OrePrefix.ingotHot;
 
 public class NaquadahRecipes {
 
@@ -87,7 +88,7 @@ public class NaquadahRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder().EUt(VA[HV]).duration(300)
                 .fluidInputs(EnrichedNaquadahWaste.getFluid(2000))
-                .output(dustSmall, BariumSulfide, 2)
+                .chancedOutput(dust, BariumSulfide, 5000, 0)
                 .fluidOutputs(SulfuricAcid.getFluid(500))
                 .fluidOutputs(EnrichedNaquadahSolution.getFluid(350))
                 .fluidOutputs(NaquadriaSolution.getFluid(150))
@@ -125,7 +126,7 @@ public class NaquadahRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder().EUt(VA[HV]).duration(300)
                 .fluidInputs(NaquadriaWaste.getFluid(2000))
-                .output(dustSmall, GalliumSulfide, 2)
+                .chancedOutput(dust, GalliumSulfide, 5000, 0)
                 .fluidOutputs(SulfuricAcid.getFluid(500))
                 .fluidOutputs(NaquadriaSolution.getFluid(350))
                 .fluidOutputs(EnrichedNaquadahSolution.getFluid(150))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PetrochemRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PetrochemRecipes.java
@@ -5,7 +5,7 @@ import gregtech.api.unification.material.Material;
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.*;
 import static gregtech.api.unification.material.Materials.*;
-import static gregtech.api.unification.ore.OrePrefix.*;
+import static gregtech.api.unification.ore.OrePrefix.dust;
 
 public class PetrochemRecipes {
 
@@ -121,7 +121,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedEthane.getFluid(1000))
-                .output(dustSmall, Carbon)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .fluidOutputs(Ethylene.getFluid(250))
                 .fluidOutputs(Methane.getFluid(1250))
                 .duration(120).EUt(VA[MV]).buildAndRegister();
@@ -146,7 +146,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedPropene.getFluid(1000))
-                .output(dustSmall, Carbon, 2)
+                .chancedOutput(dust, Carbon, 5000, 0)
                 .fluidOutputs(Ethylene.getFluid(1000))
                 .fluidOutputs(Methane.getFluid(500))
                 .duration(120).EUt(VA[MV]).buildAndRegister();
@@ -159,7 +159,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedPropane.getFluid(1000))
-                .output(dustSmall, Carbon)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .fluidOutputs(Ethylene.getFluid(750))
                 .fluidOutputs(Methane.getFluid(1250))
                 .duration(120).EUt(VA[MV]).buildAndRegister();
@@ -173,7 +173,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedButane.getFluid(1000))
-                .output(dustSmall, Carbon)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .fluidOutputs(Propane.getFluid(125))
                 .fluidOutputs(Ethane.getFluid(750))
                 .fluidOutputs(Ethylene.getFluid(750))
@@ -191,7 +191,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedButene.getFluid(1000))
-                .output(dustSmall, Carbon)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .fluidOutputs(Propene.getFluid(250))
                 .fluidOutputs(Ethylene.getFluid(1500))
                 .fluidOutputs(Methane.getFluid(250))
@@ -205,7 +205,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SteamCrackedButadiene.getFluid(1000))
-                .output(dustSmall, Carbon, 2)
+                .chancedOutput(dust, Carbon, 5000, 0)
                 .fluidOutputs(Propene.getFluid(125))
                 .fluidOutputs(Ethylene.getFluid(250))
                 .fluidOutputs(Methane.getFluid(1125))
@@ -233,7 +233,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedHeavyFuel.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dust, Carbon, 1111, 0)
                 .fluidOutputs(LightFuel.getFluid(300))
                 .fluidOutputs(Naphtha.getFluid(50))
                 .fluidOutputs(Toluene.getFluid(25))
@@ -249,7 +249,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedHeavyFuel.getFluid(1000))
-                .output(dustTiny, Carbon, 3)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(LightFuel.getFluid(100))
                 .fluidOutputs(Naphtha.getFluid(125))
                 .fluidOutputs(Toluene.getFluid(80))
@@ -285,7 +285,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedLightFuel.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dust, Carbon, 1111, 0)
                 .fluidOutputs(HeavyFuel.getFluid(150))
                 .fluidOutputs(Naphtha.getFluid(400))
                 .fluidOutputs(Toluene.getFluid(40))
@@ -301,7 +301,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedLightFuel.getFluid(1000))
-                .output(dustTiny, Carbon, 3)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(HeavyFuel.getFluid(50))
                 .fluidOutputs(Naphtha.getFluid(100))
                 .fluidOutputs(Toluene.getFluid(30))
@@ -333,7 +333,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedNaphtha.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dust, Carbon, 1111, 0)
                 .fluidOutputs(HeavyFuel.getFluid(75))
                 .fluidOutputs(LightFuel.getFluid(150))
                 .fluidOutputs(Toluene.getFluid(40))
@@ -349,7 +349,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedNaphtha.getFluid(1000))
-                .output(dustTiny, Carbon, 3)
+                .chancedOutput(dust, Carbon, 3333, 0)
                 .fluidOutputs(HeavyFuel.getFluid(25))
                 .fluidOutputs(LightFuel.getFluid(50))
                 .fluidOutputs(Toluene.getFluid(20))
@@ -379,7 +379,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(LightlySteamCrackedGas.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dust, Carbon, 1111, 0)
                 .fluidOutputs(Propene.getFluid(45))
                 .fluidOutputs(Ethane.getFluid(8))
                 .fluidOutputs(Ethylene.getFluid(85))
@@ -389,7 +389,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder()
                 .fluidInputs(SeverelySteamCrackedGas.getFluid(1000))
-                .output(dustTiny, Carbon)
+                .chancedOutput(dust, Carbon, 1111, 0)
                 .fluidOutputs(Propene.getFluid(8))
                 .fluidOutputs(Ethane.getFluid(45))
                 .fluidOutputs(Ethylene.getFluid(92))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ReactorRecipes.java
@@ -321,6 +321,15 @@ public class ReactorRecipes {
                 .duration(50).EUt(600).buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder()
+                .circuitMeta(4)
+                .input(dust, Aluminium, 16)
+                .fluidInputs(IndiumConcentrate.getFluid(4000))
+                .output(dust, Indium)
+                .output(dust, AluminiumSulfite, 16)
+                .fluidOutputs(LeadZincSolution.getFluid(4000))
+                .duration(200).EUt(600).buildAndRegister();
+
+        CHEMICAL_RECIPES.recipeBuilder()
                 .circuitMeta(3)
                 .fluidInputs(Oxygen.getFluid(1000))
                 .fluidInputs(AceticAcid.getFluid(1000))
@@ -340,7 +349,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .input(gem, Charcoal)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -348,7 +357,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .input(gem, Coal)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -356,7 +365,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .input(dust, Charcoal)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -365,7 +374,7 @@ public class ReactorRecipes {
                 .input(dust, Coal)
                 .circuitMeta(1)
                 .fluidInputs(Oxygen.getFluid(1000))
-                .outputs(OreDictUnifier.get(dustTiny, Ash))
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(1000))
                 .buildAndRegister();
 
@@ -410,7 +419,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(gem, Charcoal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -418,7 +427,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(gem, Coal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -426,7 +435,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(dust, Charcoal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 
@@ -434,7 +443,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .input(dust, Coal)
                 .fluidInputs(Oxygen.getFluid(2000))
-                .output(dustTiny, Ash)
+                .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).buildAndRegister();
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -1,7 +1,6 @@
 package gregtech.loaders.recipe.chemistry;
 
 import gregtech.api.GTValues;
-import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.MetaBlocks;
@@ -129,14 +128,14 @@ public class SeparationRecipes {
                 .inputs(new ItemStack(Blocks.DIRT, 1, GTValues.W))
                 .chancedOutput(PLANT_BALL, 1250, 700)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
-                .chancedOutput(dustTiny, Clay, 4000, 900)
+                .chancedOutput(dust, Clay, 450, 100)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.GRASS))
                 .chancedOutput(MetaItems.PLANT_BALL.getStackForm(), 3000, 1200)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
-                .chancedOutput(dustTiny, Clay, 5000, 900)
+                .chancedOutput(dust, Clay, 450, 100)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(650).EUt(VA[LV])
@@ -144,19 +143,18 @@ public class SeparationRecipes {
                 .chancedOutput(new ItemStack(Blocks.RED_MUSHROOM), 2500, 900)
                 .chancedOutput(new ItemStack(Blocks.BROWN_MUSHROOM), 2500, 900)
                 .chancedOutput(new ItemStack(Blocks.SAND), 5000, 1200)
-                .chancedOutput(dustTiny, Clay, 5000, 900)
+                .chancedOutput(dust, Clay, 450, 100)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(240).EUt(VA[LV])
                 .input(dust, Ash)
-                .chancedOutput(dustSmall, Quicklime, 2, 9900, 0)
-                .chancedOutput(dustSmall, Potash, 6400, 0)
-                .chancedOutput(dustSmall, Magnesia, 6000, 0)
-                .chancedOutput(dustTiny, PhosphorusPentoxide, 500, 0)
-                .chancedOutput(dustTiny, SodaAsh, 5000, 0)
-                .chancedOutput(dustTiny, BandedIron, 2500, 0)
+                .chancedOutput(dust, Quicklime, 4950, 0)
+                .chancedOutput(dust, Potash, 1600, 0)
+                .chancedOutput(dust, Magnesia, 1500, 0)
+                .chancedOutput(dust, PhosphorusPentoxide, 60, 0)
+                .chancedOutput(dust, SodaAsh, 600, 0)
+                .chancedOutput(dust, BandedIron, 275, 0)
                 .buildAndRegister();
-
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(250).EUt(6)
                 .input(dust, DarkAsh)
@@ -164,10 +162,10 @@ public class SeparationRecipes {
                 .output(dust, Carbon)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(488).EUt(80)
-                .input(dust, Glowstone)
-                .output(dustSmall, Redstone, 2)
-                .output(dustSmall, Gold, 2)
+        CENTRIFUGE_RECIPES.recipeBuilder().duration(976).EUt(80)
+                .input(dust, Glowstone, 2)
+                .output(dust, Redstone)
+                .output(dust, Gold)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(36).EUt(VA[LV])
@@ -190,35 +188,35 @@ public class SeparationRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder().duration(320).EUt(20)
                 .input(dust, Endstone)
                 .chancedOutput(new ItemStack(Blocks.SAND), 9000, 300)
-                .chancedOutput(dustSmall, Tungstate, 1250, 450)
-                .chancedOutput(dustTiny, Platinum, 625, 150)
+                .chancedOutput(dust, Tungstate, 315, 110)
+                .chancedOutput(dust, Platinum, 70, 15)
                 .fluidOutputs(Helium.getFluid(120))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(160).EUt(20)
                 .input(dust, Netherrack)
-                .chancedOutput(dustTiny, Redstone, 5625, 850)
-                .chancedOutput(dustTiny, Gold, 625, 120)
-                .chancedOutput(dustSmall, Sulfur, 9900, 100)
-                .chancedOutput(dustTiny, Coal, 5625, 850)
+                .chancedOutput(dust, Redstone, 625, 95)
+                .chancedOutput(dust, Gold, 70, 15)
+                .chancedOutput(dust, Sulfur, 2475, 25)
+                .chancedOutput(dust, Coal, 625, 95)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(200).EUt(80)
                 .inputs(new ItemStack(Blocks.SOUL_SAND))
                 .chancedOutput(new ItemStack(Blocks.SAND), 9000, 130)
-                .chancedOutput(dustSmall, Saltpeter, 8000, 480)
-                .chancedOutput(dustTiny, Coal, 2000, 340)
+                .chancedOutput(dust, Saltpeter, 2000, 160)
+                .chancedOutput(dust, Coal, 225, 40)
                 .fluidOutputs(Oil.getFluid(80))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(80).EUt(80)
                 .fluidInputs(Lava.getFluid(100))
-                .chancedOutput(dustSmall, SiliconDioxide, 5000, 320)
-                .chancedOutput(dustSmall, Magnesia, 1000, 270)
-                .chancedOutput(dustSmall, Quicklime, 1000, 270)
+                .chancedOutput(dust, SiliconDioxide, 1250, 80)
+                .chancedOutput(dust, Magnesia, 250, 70)
+                .chancedOutput(dust, Quicklime, 250, 70)
                 .chancedOutput(nugget, Gold, 250, 80)
-                .chancedOutput(dustSmall, Sapphire, 1250, 270)
-                .chancedOutput(dustSmall, Tantalite, 500, 130)
+                .chancedOutput(dust, Sapphire, 315, 70)
+                .chancedOutput(dust, Tantalite, 125, 35)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(64).EUt(20)
@@ -234,7 +232,7 @@ public class SeparationRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder().duration(50).EUt(VA[LV])
                 .inputs(new ItemStack(Blocks.SAND, 1, 1))
                 .chancedOutput(dust, Iron, 5000, 500)
-                .chancedOutput(dustTiny, Diamond, 100, 100)
+                .chancedOutput(dust, Diamond, 10, 10)
                 .chancedOutput(new ItemStack(Blocks.SAND, 1, 0), 5000, 5000)
                 .buildAndRegister();
 
@@ -274,22 +272,22 @@ public class SeparationRecipes {
         // Stone Dust
         CENTRIFUGE_RECIPES.recipeBuilder().duration(480).EUt(VA[MV])
                 .input(dust, Stone)
-                .output(dustSmall, Quartzite)
-                .output(dustSmall, PotassiumFeldspar)
-                .output(dustTiny, Marble, 2)
-                .output(dustTiny, Biotite)
-                .chancedOutput(dustTiny, MetalMixture, 7500, 750)
-                .chancedOutput(dustTiny, Sodalite, 5000, 500)
+                .chancedOutput(dust, Quartzite, 2500, 0)
+                .chancedOutput(dust, PotassiumFeldspar, 2500, 0)
+                .chancedOutput(dust, Marble, 2222, 0)
+                .chancedOutput(dust, Biotite, 1111, 0)
+                .chancedOutput(dust, MetalMixture, 825, 80)
+                .chancedOutput(dust, Sodalite, 550, 55)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(1000).EUt(900)
                 .input(dust, MetalMixture)
-                .output(dustSmall, BandedIron)
-                .output(dustSmall, Bauxite)
-                .output(dustTiny, Pyrolusite, 2)
-                .output(dustTiny, Barite)
-                .chancedOutput(dustTiny, Chromite, 7500, 750)
-                .chancedOutput(dustTiny, Ilmenite, 5000, 500)
+                .chancedOutput(dust, BandedIron, 2500, 0)
+                .chancedOutput(dust, Bauxite, 2500, 0)
+                .chancedOutput(dust, Pyrolusite, 2222, 0)
+                .chancedOutput(dust, Barite, 1111, 0)
+                .chancedOutput(dust, Chromite, 825, 80)
+                .chancedOutput(dust, Ilmenite, 550, 55)
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(60).EUt(VA[LV])
@@ -340,7 +338,7 @@ public class SeparationRecipes {
                 .input(dust, Sphalerite, 2)
                 .output(dust, Zinc)
                 .output(dust, Sulfur)
-                .chancedOutput(dustSmall, Gallium, 2000, 1000)
+                .chancedOutput(dust, Gallium, 500, 250)
                 .duration(200).EUt(VA[LV]).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -66,7 +66,6 @@ public class MaterialRecipeHandler {
         OreProperty oreProperty = mat.hasProperty(PropertyKey.ORE) ? mat.getProperty(PropertyKey.ORE) : null;
         if (mat.hasProperty(PropertyKey.GEM)) {
             ItemStack gemStack = OreDictUnifier.get(OrePrefix.gem, mat);
-            ItemStack smallDarkAshStack = OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh);
 
             if (mat.hasFlag(CRYSTALLIZABLE)) {
                 RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
@@ -87,13 +86,15 @@ public class MaterialRecipeHandler {
             if (!mat.hasFlag(EXPLOSIVE) && !mat.hasFlag(FLAMMABLE)) {
                 RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
                         .inputs(GTUtility.copy(4, dustStack))
-                        .outputs(GTUtility.copy(3, gemStack), smallDarkAshStack)
+                        .outputs(GTUtility.copy(3, gemStack))
+                        .chancedOutput(dust, Materials.DarkAsh, 2500, 0)
                         .explosivesAmount(2)
                         .buildAndRegister();
 
                 RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
                         .inputs(GTUtility.copy(4, dustStack))
-                        .outputs(GTUtility.copy(3, gemStack), smallDarkAshStack)
+                        .outputs(GTUtility.copy(3, gemStack))
+                        .chancedOutput(dust, Materials.DarkAsh, 2500, 0)
                         .explosivesType(MetaItems.DYNAMITE.getStackForm())
                         .buildAndRegister();
             }

--- a/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
@@ -158,25 +158,25 @@ public class OreRecipeHandler {
                 .input(crushedPrefix, material)
                 .fluidInputs(Materials.Water.getFluid(1000))
                 .circuitMeta(1)
-                .outputs(crushedPurifiedOre,
-                        OreDictUnifier.get(OrePrefix.dustTiny, byproductMaterial, 3),
-                        OreDictUnifier.get(OrePrefix.dust, Materials.Stone))
+                .outputs(crushedPurifiedOre)
+                .chancedOutput(OrePrefix.dust, byproductMaterial, 3333, 0)
+                .output(OrePrefix.dust, Materials.Stone)
                 .buildAndRegister();
 
         RecipeMaps.ORE_WASHER_RECIPES.recipeBuilder()
                 .input(crushedPrefix, material)
                 .fluidInputs(Materials.DistilledWater.getFluid(100))
-                .outputs(crushedPurifiedOre,
-                        OreDictUnifier.get(OrePrefix.dustTiny, byproductMaterial, 3),
-                        OreDictUnifier.get(OrePrefix.dust, Materials.Stone))
+                .outputs(crushedPurifiedOre)
+                .chancedOutput(OrePrefix.dust, byproductMaterial, 3333, 0)
+                .output(OrePrefix.dust, Materials.Stone)
                 .duration(200)
                 .buildAndRegister();
 
         RecipeMaps.THERMAL_CENTRIFUGE_RECIPES.recipeBuilder()
                 .input(crushedPrefix, material)
-                .outputs(crushedCentrifugedOre,
-                        OreDictUnifier.get(OrePrefix.dustTiny, property.getOreByProduct(1, material), property.getByProductMultiplier() * 3),
-                        OreDictUnifier.get(OrePrefix.dust, Materials.Stone))
+                .outputs(crushedCentrifugedOre)
+                .chancedOutput(OrePrefix.dust, property.getOreByProduct(1, material), property.getByProductMultiplier(), 3333, 0)
+                .output(OrePrefix.dust, Materials.Stone)
                 .buildAndRegister();
 
         if (property.getWashedIn().getKey() != null) {
@@ -247,7 +247,8 @@ public class OreRecipeHandler {
         if (!crushedCentrifugedStack.isEmpty()) {
             RecipeMaps.THERMAL_CENTRIFUGE_RECIPES.recipeBuilder()
                     .input(purifiedPrefix, material)
-                    .outputs(crushedCentrifugedStack, OreDictUnifier.get(OrePrefix.dustTiny, byproductMaterial, 3))
+                    .outputs(crushedCentrifugedStack)
+                    .chancedOutput(OrePrefix.dust, byproductMaterial, 3333, 0)
                     .buildAndRegister();
         }
 
@@ -303,7 +304,7 @@ public class OreRecipeHandler {
                 .duration((int) (material.getMass() * 4)).EUt(24);
 
         if (byproduct.hasProperty(PropertyKey.DUST)) {
-            builder.outputs(OreDictUnifier.get(OrePrefix.dustTiny, byproduct));
+            builder.chancedOutput(OrePrefix.dust, byproduct, 1111, 0);
         } else {
             builder.fluidOutputs(byproduct.getFluid(GTValues.L / 9));
         }
@@ -327,17 +328,16 @@ public class OreRecipeHandler {
 
         if (property.getSeparatedInto() != null && !property.getSeparatedInto().isEmpty()) {
             List<Material> separatedMaterial = property.getSeparatedInto();
-            ItemStack separatedStack1 = OreDictUnifier.get(OrePrefix.dustSmall, separatedMaterial.get(0));
             OrePrefix prefix = (separatedMaterial.get(separatedMaterial.size() - 1).getBlastTemperature() == 0 && separatedMaterial.get(separatedMaterial.size() - 1).hasProperty(PropertyKey.INGOT))
-                    ? OrePrefix.nugget : OrePrefix.dustSmall;
+                    ? OrePrefix.nugget : OrePrefix.dust;
 
             ItemStack separatedStack2 = OreDictUnifier.get(prefix, separatedMaterial.get(separatedMaterial.size() - 1), prefix == OrePrefix.nugget ? 2 : 1);
 
             RecipeMaps.ELECTROMAGNETIC_SEPARATOR_RECIPES.recipeBuilder()
                     .input(purePrefix, material)
                     .outputs(dustStack)
-                    .chancedOutput(separatedStack1, 4000, 850)
-                    .chancedOutput(separatedStack2, 2000, 600)
+                    .chancedOutput(OrePrefix.dust, separatedMaterial.get(0), 1000, 250)
+                    .chancedOutput(separatedStack2, prefix == OrePrefix.dust ? 500 : 2000, prefix == OrePrefix.dust ? 150 : 600)
                     .duration(200).EUt(24)
                     .buildAndRegister();
         }
@@ -351,7 +351,8 @@ public class OreRecipeHandler {
 
         RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder()
                 .input(purePrefix, material)
-                .outputs(dustStack, OreDictUnifier.get(OrePrefix.dustTiny, byproductMaterial))
+                .outputs(dustStack)
+                .chancedOutput(OrePrefix.dust, byproductMaterial, 1111, 0)
                 .duration(100)
                 .EUt(5)
                 .buildAndRegister();


### PR DESCRIPTION
## What
Reduces the usage of small and tiny dusts.

List of affected recipes:
1. Ore Processing
2. Material Decomposition
3. Misc. Separation Recipes
4. EBF Recipes producing Ashes
5. Chemistry Recipes producing Ashes
6. Misc. Chemistry Recipes
7. Gem Implosion Recipes

## Outcome
Reduces the amount of small and tiny dusts involved in recipes.

## Potential Compatibility Issues
Existing setups relying on packagers to compact dusts will break.
