### PR TITLE
Rework vacuum freezer recipes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -23,11 +23,13 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.ApiStatus;
 import stanhebben.zenscript.annotations.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.function.UnaryOperator;
 
 @ZenClass("mods.gregtech.material.Material")
 @ZenRegister
@@ -877,23 +879,46 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        /** @deprecated use {@link Material.Builder#blast(int)}. */
+        @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+        @Deprecated
         public Builder blastTemp(int temp) {
+            return blast(temp);
+        }
+
+        /** @deprecated use {@link Material.Builder#blast(int, BlastProperty.GasTier)}. */
+        @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+        @Deprecated
+        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier) {
+            return blast(temp, gasTier);
+        }
+
+        /** @deprecated use {@link Material.Builder#blast(UnaryOperator)} for more detailed stats. */
+        @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+        @Deprecated
+        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
+            return blast(b -> b.temp(temp, gasTier).blastStats(eutOverride));
+        }
+
+        /** @deprecated use {@link Material.Builder#blast(UnaryOperator)} for more detailed stats. */
+        @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+        @Deprecated
+        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
+            return blast(b -> b.temp(temp, gasTier).blastStats(eutOverride, durationOverride));
+        }
+        
+        public Builder blast(int temp) {
             properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp));
             return this;
         }
-
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, -1, -1));
+        
+        public Builder blast(int temp, BlastProperty.GasTier gasTier) {
+            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier));
             return this;
         }
 
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, -1));
-            return this;
-        }
-
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, durationOverride));
+        public Builder blast(UnaryOperator<BlastProperty.Builder> b) {
+            properties.setProperty(PropertyKey.BLAST, b.apply(new BlastProperty.Builder()).build());
             return this;
         }
 

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -948,7 +948,7 @@ public class ElementMaterials {
                 .blast(b -> b
                         .temp(9000, GasTier.HIGH)
                         .blastStats(VA[ZPM], 1200)
-                        .vacuumStats(VA[IV], 300))
+                        .vacuumStats(VA[LuV], 200))
                 .build();
 
         Neutronium = new Material.Builder(127, gregtechId("neutronium"))

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -36,7 +36,7 @@ public class ElementMaterials {
                 .rotorStats(10.0f, 2.0f, 128)
                 .cableProperties(V[EV], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
-                .blastTemp(1700, GasTier.LOW)
+                .blast(1700, GasTier.LOW)
                 .build();
 
         Americium = new Material.Builder(3, gregtechId("americium"))
@@ -168,7 +168,7 @@ public class ElementMaterials {
                 .element(Elements.Cr)
                 .rotorStats(12.0f, 3.0f, 512)
                 .fluidPipeProperties(2180, 35, true, true, false, false)
-                .blastTemp(1700, GasTier.LOW)
+                .blast(1700, GasTier.LOW)
                 .build();
 
         Cobalt = new Material.Builder(23, gregtechId("cobalt"))
@@ -246,7 +246,10 @@ public class ElementMaterials {
                 .element(Elements.Eu)
                 .cableProperties(GTValues.V[GTValues.UHV], 2, 32)
                 .fluidPipeProperties(7750, 300, true)
-                .blastTemp(6000, GasTier.MID, VA[IV], 180)
+                .blast(b -> b
+                        .temp(6000, GasTier.MID)
+                        .blastStats(VA[IV], 180)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         Fermium = new Material.Builder(34, gregtechId("fermium"))
@@ -362,7 +365,10 @@ public class ElementMaterials {
                 .element(Elements.Ir)
                 .rotorStats(7.0f, 3.0f, 2560)
                 .fluidPipeProperties(3398, 250, true, false, true, false)
-                .blastTemp(4500, GasTier.HIGH, VA[IV], 1100)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[IV], 1100)
+                        .vacuumStats(VA[EV], 250))
                 .build();
 
         Iron = new Material.Builder(51, gregtechId("iron"))
@@ -484,7 +490,7 @@ public class ElementMaterials {
                 .flags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .element(Elements.Nd)
                 .rotorStats(7.0f, 2.0f, 512)
-                .blastTemp(1297, GasTier.MID)
+                .blast(1297, GasTier.MID)
                 .build();
 
         Neon = new Material.Builder(67, gregtechId("neon"))
@@ -519,7 +525,9 @@ public class ElementMaterials {
                 .ingot().fluid()
                 .color(0xBEB4C8).iconSet(METALLIC)
                 .element(Elements.Nb)
-                .blastTemp(2750, GasTier.MID, VA[HV], 900)
+                .blast(b -> b
+                        .temp(2750, GasTier.MID)
+                        .blastStats(VA[HV], 900))
                 .build();
 
         Nitrogen = new Material.Builder(72, gregtechId("nitrogen"))
@@ -547,7 +555,10 @@ public class ElementMaterials {
                 .rotorStats(16.0f, 4.0f, 1280)
                 .cableProperties(V[LuV], 4, 2)
                 .itemPipeProperties(256, 8.0f)
-                .blastTemp(4500, GasTier.HIGH, VA[LuV], 1000)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1000)
+                        .vacuumStats(VA[EV], 300))
                 .build();
 
         Oxygen = new Material.Builder(76, gregtechId("oxygen"))
@@ -568,7 +579,10 @@ public class ElementMaterials {
                 .color(0x808080).iconSet(SHINY)
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(Elements.Pd)
-                .blastTemp(1828, GasTier.LOW, VA[HV], 900)
+                .blast(b -> b
+                        .temp(1828, GasTier.LOW)
+                        .blastStats(VA[HV], 900)
+                        .vacuumStats(VA[HV], 150))
                 .build();
 
         Phosphorus = new Material.Builder(78, gregtechId("phosphorus"))
@@ -652,7 +666,10 @@ public class ElementMaterials {
                 .color(0xDC0C58).iconSet(BRIGHT)
                 .flags(EXT2_METAL, GENERATE_GEAR, GENERATE_FINE_WIRE)
                 .element(Elements.Rh)
-                .blastTemp(2237, GasTier.MID, VA[EV], 1200)
+                .blast(b -> b
+                        .temp(2237, GasTier.MID)
+                        .blastStats(VA[EV], 1200)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         Roentgenium = new Material.Builder(91, gregtechId("roentgenium"))
@@ -670,7 +687,10 @@ public class ElementMaterials {
                 .color(0x50ACCD).iconSet(SHINY)
                 .flags(GENERATE_FOIL, GENERATE_GEAR)
                 .element(Elements.Ru)
-                .blastTemp(2607, GasTier.MID, VA[EV], 900)
+                .blast(b -> b
+                        .temp(2607, GasTier.MID)
+                        .blastStats(VA[EV], 900)
+                        .vacuumStats(VA[HV], 200))
                 .build();
 
         Rutherfordium = new Material.Builder(94, gregtechId("rutherfordium"))
@@ -684,7 +704,10 @@ public class ElementMaterials {
                 .color(0xFFFFCC).iconSet(METALLIC)
                 .flags(GENERATE_LONG_ROD)
                 .element(Elements.Sm)
-                .blastTemp(5400, GasTier.HIGH, VA[EV], 1500)
+                .blast(b -> b
+                        .temp(5400, GasTier.HIGH)
+                        .blastStats(VA[EV], 1500)
+                        .vacuumStats(VA[HV], 200))
                 .build();
 
         Scandium = new Material.Builder(96, gregtechId("scandium"))
@@ -707,7 +730,7 @@ public class ElementMaterials {
                 .color(0x3C3C50).iconSet(METALLIC)
                 .flags(GENERATE_FOIL)
                 .element(Elements.Si)
-                .blastTemp(2273) // no gas tier for silicon
+                .blast(2273) // no gas tier for silicon
                 .build();
 
         Silver = new Material.Builder(100, gregtechId("silver"))
@@ -806,7 +829,10 @@ public class ElementMaterials {
                         .enchantability(14).build())
                 .rotorStats(7.0f, 3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
-                .blastTemp(1941, GasTier.MID, VA[HV], 1500)
+                .blast(b -> b
+                        .temp(1941, GasTier.MID)
+                        .blastStats(VA[HV], 1500)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         Tritium = new Material.Builder(114, gregtechId("tritium"))
@@ -825,7 +851,10 @@ public class ElementMaterials {
                 .rotorStats(7.0f, 3.0f, 2560)
                 .cableProperties(V[IV], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
-                .blastTemp(3600, GasTier.MID, VA[EV], 1800)
+                .blast(b -> b
+                        .temp(3600, GasTier.MID)
+                        .blastStats(VA[EV], 1800)
+                        .vacuumStats(VA[HV], 300))
                 .build();
 
         Uranium238 = new Material.Builder(116, gregtechId("uranium"))
@@ -848,7 +877,7 @@ public class ElementMaterials {
                 .ingot().fluid()
                 .color(0x323232).iconSet(METALLIC)
                 .element(Elements.V)
-                .blastTemp(2183, GasTier.MID)
+                .blast(2183, GasTier.MID)
                 .build();
 
         Xenon = new Material.Builder(119, gregtechId("xenon"))
@@ -866,7 +895,7 @@ public class ElementMaterials {
                 .ingot().fluid()
                 .color(0x76524C).iconSet(METALLIC)
                 .element(Elements.Y)
-                .blastTemp(1799)
+                .blast(1799)
                 .build();
 
         Zinc = new Material.Builder(122, gregtechId("zinc"))
@@ -892,7 +921,10 @@ public class ElementMaterials {
                 .rotorStats(6.0f, 4.0f, 1280)
                 .cableProperties(V[ZPM], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
-                .blastTemp(5000, GasTier.HIGH, VA[IV], 600)
+                .blast(b -> b
+                        .temp(5000, GasTier.HIGH)
+                        .blastStats(VA[IV], 600)
+                        .vacuumStats(VA[EV], 150))
                 .build();
 
         NaquadahEnriched = new Material.Builder(125, gregtechId("naquadah_enriched"))
@@ -901,7 +933,10 @@ public class ElementMaterials {
                 .color(0x3C3C3C).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .element(Elements.Nq1)
-                .blastTemp(7000, GasTier.HIGH, VA[IV], 1000)
+                .blast(b -> b
+                        .temp(7000, GasTier.HIGH)
+                        .blastStats(VA[IV], 1000)
+                        .vacuumStats(VA[EV], 150))
                 .build();
 
         Naquadria = new Material.Builder(126, gregtechId("naquadria"))
@@ -910,7 +945,10 @@ public class ElementMaterials {
                 .color(0x1E1E1E).iconSet(SHINY)
                 .flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_GEAR, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(Elements.Nq2)
-                .blastTemp(9000, GasTier.HIGH, VA[ZPM], 1200)
+                .blast(b -> b
+                        .temp(9000, GasTier.HIGH)
+                        .blastStats(VA[ZPM], 1200)
+                        .vacuumStats(VA[IV], 300))
                 .build();
 
         Neutronium = new Material.Builder(127, gregtechId("neutronium"))
@@ -952,7 +990,10 @@ public class ElementMaterials {
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW, GENERATE_GEAR)
                 .element(Elements.Ke)
                 .cableProperties(V[ZPM], 6, 4)
-                .blastTemp(7200, GasTier.HIGH, VA[LuV], 1500)
+                .blast(b -> b
+                        .temp(7200, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1500)
+                        .vacuumStats(VA[IV], 300))
                 .build();
 
     }

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -304,7 +304,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Iron, 1, Aluminium, 1, Chrome, 1)
                 .cableProperties(V[HV], 4, 3)
-                .blastTemp(1800, GasTier.LOW, VA[HV], 900)
+                .blast(b -> b.temp(1800, GasTier.LOW).blastStats(VA[HV], 900))
                 .build();
 
         Lazurite = new Material.Builder(289, gregtechId("lazurite"))
@@ -349,7 +349,10 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_SPRING)
                 .components(Nickel, 4, Chrome, 1)
                 .cableProperties(V[EV], 4, 4)
-                .blastTemp(2700, GasTier.LOW, VA[HV], 1300)
+                .blast(b -> b
+                        .temp(2700, GasTier.LOW)
+                        .blastStats(VA[EV], 1300)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         NiobiumNitride = new Material.Builder(295, gregtechId("niobium_nitride"))
@@ -358,7 +361,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .components(Niobium, 1, Nitrogen, 1)
                 .cableProperties(V[LuV], 1, 1)
-                .blastTemp(2846, GasTier.MID)
+                .blast(2846, GasTier.MID)
                 .build();
 
         NiobiumTitanium = new Material.Builder(296, gregtechId("niobium_titanium"))
@@ -370,7 +373,10 @@ public class FirstDegreeMaterials {
                 .components(Niobium, 1, Titanium, 1)
                 .fluidPipeProperties(5900, 175, true)
                 .cableProperties(V[LuV], 4, 2)
-                .blastTemp(4500, GasTier.HIGH, VA[HV], 1500)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[HV], 1500)
+                        .vacuumStats(VA[HV], 200))
                 .build();
 
         Obsidian = new Material.Builder(297, gregtechId("obsidian"))
@@ -405,7 +411,7 @@ public class FirstDegreeMaterials {
                         .enchantment(Enchantments.SMITE, 3).build())
                 .rotorStats(13.0f, 2.0f, 196)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(1700, GasTier.LOW, VA[MV], 1000)
+                .blast(b -> b.temp(1700, GasTier.LOW).blastStats(VA[MV], 1000))
                 .build();
 
         RoseGold = new Material.Builder(301, gregtechId("rose_gold"))
@@ -419,7 +425,7 @@ public class FirstDegreeMaterials {
                         .enchantment(Enchantments.FORTUNE, 2).build())
                 .rotorStats(14.0f, 2.0f, 152)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(1600, GasTier.LOW, VA[MV], 1000)
+                .blast(b -> b.temp(1600, GasTier.LOW).blastStats(VA[MV], 1000))
                 .build();
 
         BlackBronze = new Material.Builder(302, gregtechId("black_bronze"))
@@ -430,7 +436,7 @@ public class FirstDegreeMaterials {
                 .components(Gold, 1, Silver, 1, Copper, 3)
                 .rotorStats(12.0f, 2.0f, 256)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(2000, GasTier.LOW, VA[MV], 1000)
+                .blast(b -> b.temp(2000, GasTier.LOW).blastStats(VA[MV], 1000))
                 .build();
 
         BismuthBronze = new Material.Builder(303, gregtechId("bismuth_bronze"))
@@ -440,7 +446,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
                 .rotorStats(8.0f, 3.0f, 256)
-                .blastTemp(1100, GasTier.LOW, VA[MV], 1000)
+                .blast(b -> b.temp(1100, GasTier.LOW).blastStats(VA[MV], 1000))
                 .build();
 
         Biotite = new Material.Builder(304, gregtechId("biotite"))
@@ -486,7 +492,10 @@ public class FirstDegreeMaterials {
                 .colorAverage().iconSet(BRIGHT)
                 .flags(GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_LONG_ROD, GENERATE_BOLT_SCREW, GENERATE_FRAME)
                 .components(Ruthenium, 2, Iridium, 1)
-                .blastTemp(4500, GasTier.HIGH, VA[EV], 1600)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[EV], 1600)
+                        .vacuumStats(VA[HV], 300))
                 .build();
 
         Ruby = new Material.Builder(311, gregtechId("ruby"))
@@ -582,7 +591,7 @@ public class FirstDegreeMaterials {
                         .enchantability(14).build())
                 .rotorStats(7.0f, 4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
-                .blastTemp(1700, GasTier.LOW, VA[HV], 1100)
+                .blast(b -> b.temp(1700, GasTier.LOW).blastStats(VA[HV], 1100))
                 .build();
 
         Steel = new Material.Builder(324, gregtechId("steel"))
@@ -598,7 +607,7 @@ public class FirstDegreeMaterials {
                 .rotorStats(6.0f, 3.0f, 512)
                 .fluidPipeProperties(1855, 50, true)
                 .cableProperties(V[EV], 2, 2)
-                .blastTemp(1000, null, VA[MV], 800) // no gas tier for steel
+                .blast(b -> b.temp(1000).blastStats(VA[MV], 800)) // no gas tier for steel
                 .build();
 
         Stibnite = new Material.Builder(325, gregtechId("stibnite"))
@@ -650,7 +659,7 @@ public class FirstDegreeMaterials {
                         .attackSpeed(0.1F).enchantability(21).build())
                 .rotorStats(9.0f, 4.0f, 2048)
                 .itemPipeProperties(128, 16)
-                .blastTemp(2700, GasTier.MID, VA[HV], 1300)
+                .blast(b -> b.temp(2700, GasTier.MID).blastStats(VA[HV], 1300))
                 .build();
 
         Uraninite = new Material.Builder(332, gregtechId("uraninite"))
@@ -674,7 +683,10 @@ public class FirstDegreeMaterials {
                 .flags(STD_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_SPRING_SMALL)
                 .components(Vanadium, 3, Gallium, 1)
                 .cableProperties(V[ZPM], 4, 2)
-                .blastTemp(4500, GasTier.HIGH, VA[EV], 1200)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[EV], 1200)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         WroughtIron = new Material.Builder(335, gregtechId("wrought_iron"))
@@ -711,7 +723,10 @@ public class FirstDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .components(Yttrium, 1, Barium, 2, Copper, 3, Oxygen, 7)
                 .cableProperties(V[UV], 4, 4)
-                .blastTemp(4500, GasTier.HIGH) // todo redo this EBF process
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[IV], 1000)
+                        .vacuumStats(VA[EV], 150))
                 .build();
 
         NetherQuartz = new Material.Builder(339, gregtechId("nether_quartz"))
@@ -766,7 +781,10 @@ public class FirstDegreeMaterials {
                 .components(Iridium, 3, Osmium, 1)
                 .rotorStats(9.0f, 3.0f, 3152)
                 .itemPipeProperties(64, 32)
-                .blastTemp(4500, GasTier.HIGH, VA[LuV], 900)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[LuV], 900)
+                        .vacuumStats(VA[EV], 200))
                 .build();
 
         LithiumChloride = new Material.Builder(345, gregtechId("lithium_chloride"))
@@ -803,7 +821,7 @@ public class FirstDegreeMaterials {
                 .color(0xA0A0A0)
                 .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Arsenic, 1, Gallium, 1)
-                .blastTemp(1200, GasTier.LOW, VA[MV], 1200)
+                .blast(b -> b.temp(1200, GasTier.LOW).blastStats(VA[MV], 1200))
                 .build();
 
         Potash = new Material.Builder(352, gregtechId("potash"))
@@ -1078,7 +1096,10 @@ public class FirstDegreeMaterials {
                         .enchantability(21).build())
                 .rotorStats(12.0f, 4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
-                .blastTemp(3058, GasTier.MID, VA[HV], 1500)
+                .blast(b -> b
+                        .temp(3058, GasTier.MID)
+                        .blastStats(VA[EV], 1200)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         CarbonDioxide = new Material.Builder(397, gregtechId("carbon_dioxide"))
@@ -1281,7 +1302,7 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Manganese, 1, Phosphorus, 1)
                 .cableProperties(GTValues.V[GTValues.LV], 2, 0, true, 78)
-                .blastTemp(1200, GasTier.LOW)
+                .blast(1200, GasTier.LOW)
                 .build();
 
         MagnesiumDiboride = new Material.Builder(425, gregtechId("magnesium_diboride"))
@@ -1291,7 +1312,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Magnesium, 1, Boron, 2)
                 .cableProperties(GTValues.V[GTValues.MV], 4, 0, true, 78)
-                .blastTemp(2500, GasTier.LOW, VA[HV], 1000)
+                .blast(b -> b
+                        .temp(2500, GasTier.LOW)
+                        .blastStats(VA[HV], 1000)
+                        .vacuumStats(VA[MV], 200))
                 .build();
 
         MercuryBariumCalciumCuprate = new Material.Builder(426, gregtechId("mercury_barium_calcium_cuprate"))
@@ -1301,7 +1325,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Mercury, 1, Barium, 2, Calcium, 2, Copper, 3, Oxygen, 8)
                 .cableProperties(GTValues.V[GTValues.HV], 4, 0, true, 78)
-                .blastTemp(3300, GasTier.LOW, VA[HV], 1500)
+                .blast(b -> b
+                        .temp(3300, GasTier.LOW)
+                        .blastStats(VA[HV], 1500)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         UraniumTriplatinum = new Material.Builder(427, gregtechId("uranium_triplatinum"))
@@ -1311,7 +1338,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Uranium238, 1, Platinum, 3)
                 .cableProperties(GTValues.V[GTValues.EV], 6, 0, true, 30)
-                .blastTemp(4400, GasTier.MID, VA[EV], 1000)
+                .blast(b -> b
+                        .temp(4400, GasTier.MID)
+                        .blastStats(VA[EV], 1000)
+                        .vacuumStats(VA[EV], 200))
                 .build()
                 .setFormula("UPt3", true);
 
@@ -1322,7 +1352,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Samarium, 1, Iron, 1, Arsenic, 1, Oxygen, 1)
                 .cableProperties(GTValues.V[GTValues.IV], 6, 0, true, 30)
-                .blastTemp(5200, GasTier.MID, VA[EV], 1500)
+                .blast(b -> b
+                        .temp(5200, GasTier.MID)
+                        .blastStats(VA[EV], 1500)
+                        .vacuumStats(VA[IV], 200))
                 .build();
 
         IndiumTinBariumTitaniumCuprate = new Material.Builder(429, gregtechId("indium_tin_barium_titanium_cuprate"))
@@ -1332,7 +1365,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING, GENERATE_FINE_WIRE)
                 .components(Indium, 4, Tin, 2, Barium, 2, Titanium, 1, Copper, 7, Oxygen, 14)
                 .cableProperties(GTValues.V[GTValues.LuV], 8, 0, true, 5)
-                .blastTemp(6000, GasTier.HIGH, VA[IV], 1000)
+                .blast(b -> b
+                        .temp(6000, GasTier.HIGH)
+                        .blastStats(VA[IV], 1000)
+                        .vacuumStats(VA[LuV]))
                 .build();
 
         UraniumRhodiumDinaquadide = new Material.Builder(430, gregtechId("uranium_rhodium_dinaquadide"))
@@ -1342,7 +1378,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FINE_WIRE)
                 .components(Uranium238, 1, Rhodium, 1, Naquadah, 2)
                 .cableProperties(GTValues.V[GTValues.ZPM], 8, 0, true, 5)
-                .blastTemp(9000, GasTier.HIGH, VA[IV], 1500)
+                .blast(b -> b
+                        .temp(9000, GasTier.HIGH)
+                        .blastStats(VA[IV], 1500)
+                        .vacuumStats(VA[ZPM], 200))
                 .build()
                 .setFormula("URhNq2", true);
 
@@ -1353,7 +1392,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FINE_WIRE)
                 .components(NaquadahEnriched, 4, Trinium, 3, Europium, 2, Duranium, 1)
                 .cableProperties(GTValues.V[GTValues.UV], 16, 0, true, 3)
-                .blastTemp(9900, GasTier.HIGH, VA[LuV], 1000)
+                .blast(b -> b
+                        .temp(9900, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1200)
+                        .vacuumStats(VA[UV], 200))
                 .build();
 
         RutheniumTriniumAmericiumNeutronate = new Material.Builder(432, gregtechId("ruthenium_trinium_americium_neutronate"))
@@ -1363,7 +1405,10 @@ public class FirstDegreeMaterials {
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Ruthenium, 1, Trinium, 2, Americium, 1, Neutronium, 2, Oxygen, 8)
                 .cableProperties(GTValues.V[GTValues.UHV], 24, 0, true, 3)
-                .blastTemp(10800, GasTier.HIGHER)
+                .blast(b -> b
+                        .temp(10800, GasTier.HIGHER)
+                        .blastStats(VA[ZPM], 1000)
+                        .vacuumStats(VA[UHV], 200))
                 .build();
 
         InertMetalMixture = new Material.Builder(433, gregtechId("inert_metal_mixture"))

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -42,7 +42,7 @@ public class HigherDegreeMaterials {
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(ToolProperty.Builder.of(7.0F, 6.0F, 2560, 3)
                         .attackSpeed(0.1F).enchantability(21).build())
-                .blastTemp(1300, GasTier.LOW, VA[HV], 1000)
+                .blast(b -> b.temp(1300, GasTier.LOW).blastStats(VA[HV], 1000))
                 .build();
 
         BlueSteel = new Material.Builder(2511, gregtechId("blue_steel"))
@@ -52,7 +52,7 @@ public class HigherDegreeMaterials {
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(ToolProperty.Builder.of(15.0F, 6.0F, 1024, 3)
                         .attackSpeed(0.1F).enchantability(33).build())
-                .blastTemp(1400, GasTier.LOW, VA[HV], 1000)
+                .blast(b -> b.temp(1400, GasTier.LOW).blastStats(VA[HV], 1000))
                 .build();
 
         Basalt = new Material.Builder(2512, gregtechId("basalt"))
@@ -90,7 +90,10 @@ public class HigherDegreeMaterials {
                 .components(TungstenSteel, 5, Chrome, 1, Molybdenum, 2, Vanadium, 1)
                 .rotorStats(10.0f, 5.5f, 4000)
                 .cableProperties(V[LuV], 4, 2)
-                .blastTemp(4200, GasTier.MID, VA[EV], 1300)
+                .blast(b -> b
+                        .temp(4200, GasTier.MID)
+                        .blastStats(VA[EV], 1300)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         RedAlloy = new Material.Builder(2517, gregtechId("red_alloy"))
@@ -117,7 +120,10 @@ public class HigherDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(5.0F, 10.0F, 3072, 4)
                         .attackSpeed(0.3F).enchantability(33).build())
                 .rotorStats(10.0f, 8.0f, 5120)
-                .blastTemp(5000, GasTier.HIGH, VA[EV], 1400)
+                .blast(b -> b
+                        .temp(5000, GasTier.HIGH)
+                        .blastStats(VA[EV], 1400)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         HSSS = new Material.Builder(2520, gregtechId("hsss"))
@@ -126,7 +132,10 @@ public class HigherDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
                 .rotorStats(15.0f, 7.0f, 3000)
-                .blastTemp(5000, GasTier.HIGH, VA[EV], 1500)
+                .blast(b -> b
+                        .temp(5000, GasTier.HIGH)
+                        .blastStats(VA[EV], 1500)
+                        .vacuumStats(VA[EV], 200))
                 .build();
 
         // FREE ID: 2521

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -98,7 +98,7 @@ public class SecondDegreeMaterials {
                 .flags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .components(Nickel, 1, BlackBronze, 1, Steel, 3)
                 .cableProperties(V[EV], 3, 2)
-                .blastTemp(1200, GasTier.LOW)
+                .blast(1200, GasTier.LOW)
                 .build();
 
         DamascusSteel = new Material.Builder(2012, gregtechId("damascus_steel"))
@@ -110,7 +110,7 @@ public class SecondDegreeMaterials {
                         .attackSpeed(0.3F).enchantability(33)
                         .enchantment(Enchantments.LOOTING, 3)
                         .enchantment(Enchantments.FORTUNE, 3).build())
-                .blastTemp(1500, GasTier.LOW)
+                .blast(1500, GasTier.LOW)
                 .build();
 
         TungstenSteel = new Material.Builder(2013, gregtechId("tungsten_steel"))
@@ -124,7 +124,10 @@ public class SecondDegreeMaterials {
                 .rotorStats(8.0f, 4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
                 .cableProperties(V[IV], 3, 2)
-                .blastTemp(3000, GasTier.MID, GTValues.VA[EV], 1000)
+                .blast(b -> b
+                        .temp(3000, GasTier.MID)
+                        .blastStats(VA[EV], 1000)
+                        .vacuumStats(VA[HV]))
                 .build();
 
         CobaltBrass = new Material.Builder(2014, gregtechId("cobalt_brass"))
@@ -288,7 +291,7 @@ public class SecondDegreeMaterials {
                         .attackSpeed(-0.2F).enchantability(5).build())
                 .rotorStats(7.0f, 3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
-                .blastTemp(1453, GasTier.LOW)
+                .blast(1453, GasTier.LOW)
                 .build();
 
         Potin = new Material.Builder(2037, gregtechId("potin"))
@@ -329,7 +332,10 @@ public class SecondDegreeMaterials {
                         .attackSpeed(0.3F).enchantability(33).magnetic().build())
                 .rotorStats(8.0f, 5.0f, 5120)
                 .cableProperties(V[UV], 2, 4)
-                .blastTemp(7200, GasTier.HIGH, VA[LuV], 1000)
+                .blast(b -> b
+                        .temp(7200, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1000)
+                        .vacuumStats(VA[IV], 300))
                 .build();
 
         SulfuricNickelSolution = new Material.Builder(2043, gregtechId("sulfuric_nickel_solution"))
@@ -474,7 +480,10 @@ public class SecondDegreeMaterials {
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE, GENERATE_SMALL_GEAR, GENERATE_DOUBLE_PLATE)
                 .components(Palladium, 3, Rhodium, 1)
                 .rotorStats(12.0f, 3.0f, 1024)
-                .blastTemp(4500, GasTier.HIGH, VA[IV], 1200)
+                .blast(b -> b
+                        .temp(4500, GasTier.HIGH)
+                        .blastStats(VA[IV], 1200)
+                        .vacuumStats(VA[EV], 300))
                 .build();
 
         Clay = new Material.Builder(2063, gregtechId("clay"))

--- a/src/main/java/gregtech/api/unification/material/properties/BlastProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/BlastProperty.java
@@ -37,15 +37,36 @@ public class BlastProperty implements IMaterialProperty {
      */
     private int eutOverride = -1;
 
+    /**
+     * The duration of the EBF recipe, overriding the stock behavior.
+     * <p>
+     * Default: -1, meaning the duration will be: material.getMass() * 3
+     */
+    private int vacuumDurationOverride = -1;
+
+    /**
+     * The EU/t of the Vacuum Freezer recipe (if needed), overriding the stock behavior.
+     * <p>
+     * Default: -1, meaning the EU/t will be 120 EU/t.
+     */
+    private int vacuumEUtOverride = -1;
+
     public BlastProperty(int blastTemperature) {
         this.blastTemperature = blastTemperature;
     }
 
-    public BlastProperty(int blastTemperature, GasTier gasTier, int eutOverride, int durationOverride) {
+    public BlastProperty(int blastTemperature, GasTier gasTier) {
+        this.blastTemperature = blastTemperature;
+        this.gasTier = gasTier;
+    }
+
+    private BlastProperty(int blastTemperature, GasTier gasTier, int eutOverride, int durationOverride, int vacuumEUtOverride, int vacuumDurationOverride) {
         this.blastTemperature = blastTemperature;
         this.gasTier = gasTier;
         this.eutOverride = eutOverride;
         this.durationOverride = durationOverride;
+        this.vacuumEUtOverride = vacuumEUtOverride;
+        this.vacuumDurationOverride = vacuumDurationOverride;
     }
 
     /**
@@ -88,6 +109,22 @@ public class BlastProperty implements IMaterialProperty {
         this.eutOverride = eut;
     }
 
+    public int getVacuumDurationOverride() {
+        return vacuumDurationOverride;
+    }
+
+    public void setVacuumDurationOverride(int duration) {
+        this.vacuumDurationOverride = duration;
+    }
+
+    public int getVacuumEUtOverride() {
+        return vacuumEUtOverride;
+    }
+
+    public void setVacuumEutOverride(int eut) {
+        this.vacuumEUtOverride = eut;
+    }
+
     @Override
     public void verifyProperty(MaterialProperties properties) {
         properties.ensureSet(PropertyKey.INGOT, true);
@@ -115,5 +152,54 @@ public class BlastProperty implements IMaterialProperty {
         HIGHER, HIGHEST;
 
         public static final GasTier[] VALUES = values();
+    }
+
+    public static class Builder {
+
+        private int temp;
+        private GasTier gasTier;
+        private int eutOverride = -1;
+        private int durationOverride = -1;
+        private int vacuumEUtOverride = -1;
+        private int vacuumDurationOverride = -1;
+
+        public Builder() {}
+
+        public Builder temp(int temperature) {
+            this.temp = temperature;
+            return this;
+        }
+
+        public Builder temp(int temperature, GasTier gasTier) {
+            this.temp = temperature;
+            this.gasTier = gasTier;
+            return this;
+        }
+
+        public Builder blastStats(int eutOverride) {
+            this.eutOverride = eutOverride;
+            return this;
+        }
+
+        public Builder blastStats(int eutOverride, int durationOverride) {
+            this.eutOverride = eutOverride;
+            this.durationOverride = durationOverride;
+            return this;
+        }
+
+        public Builder vacuumStats(int eutOverride) {
+            this.vacuumEUtOverride = eutOverride;
+            return this;
+        }
+
+        public Builder vacuumStats(int eutOverride, int durationOverride) {
+            this.vacuumEUtOverride = eutOverride;
+            this.vacuumDurationOverride = durationOverride;
+            return this;
+        }
+
+        public BlastProperty build() {
+            return new BlastProperty(temp, gasTier, eutOverride, durationOverride, vacuumEUtOverride, vacuumDurationOverride);
+        }
     }
 }

--- a/src/main/java/gregtech/integration/crafttweaker/material/CTMaterialBuilder.java
+++ b/src/main/java/gregtech/integration/crafttweaker/material/CTMaterialBuilder.java
@@ -160,11 +160,16 @@ public class CTMaterialBuilder {
     }
 
     @ZenMethod
-    public CTMaterialBuilder blastTemp(int temp, @Optional String gasTier, @Optional int eutOverride, @Optional int durationOverride) {
+    public CTMaterialBuilder blastTemp(int temp, @Optional String gasTier, @Optional int eutOverride, @Optional int durationOverride, @Optional int vacuumEUtOverride, @Optional int vacuumDurationOverride) {
         BlastProperty.GasTier tier = BlastProperty.validateGasTier(gasTier);
-        if (eutOverride == 0) eutOverride = -1;
-        if (durationOverride == 0) durationOverride = -1;
-        backingBuilder.blastTemp(temp, tier, eutOverride, durationOverride);
+        final int blastEUt = eutOverride != 0 ? eutOverride : -1;
+        final int blastDuration = durationOverride != 0 ? durationOverride : -1;
+        final int vacuumEUt = vacuumEUtOverride != 0 ? vacuumEUtOverride : -1;
+        final int vacuumDuration = vacuumDurationOverride != 0 ? vacuumDurationOverride : -1;
+        backingBuilder.blast(b -> b
+                .temp(temp, tier)
+                .blastStats(blastEUt, blastDuration)
+                .vacuumStats(vacuumEUt, vacuumDuration));
         return this;
     }
 

--- a/src/main/java/gregtech/integration/crafttweaker/material/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/integration/crafttweaker/material/MaterialPropertyExpansion.java
@@ -86,7 +86,7 @@ public class MaterialPropertyExpansion {
     }
 
     @ZenMethod
-    public static void addBlastProperty(Material m, int blastTemp, @Optional String gasTier, @Optional int durationOverride, @Optional int eutOverride) {
+    public static void addBlastProperty(Material m, int blastTemp, @Optional String gasTier, @Optional int durationOverride, @Optional int eutOverride, @Optional int vacuumDurationOverride, @Optional int vacuumEUtOverride) {
         if (checkFrozen("add blast property")) return;
         if (m.hasProperty(PropertyKey.BLAST)) {
             BlastProperty property = m.getProperty(PropertyKey.BLAST);
@@ -94,11 +94,14 @@ public class MaterialPropertyExpansion {
             if (gasTier != null) property.setGasTier(BlastProperty.validateGasTier(gasTier));
             if (durationOverride != 0) property.setDurationOverride(durationOverride);
             if (eutOverride != 0) property.setEutOverride(eutOverride);
+            if (vacuumDurationOverride != 0) property.setVacuumDurationOverride(vacuumDurationOverride);
+            if (vacuumEUtOverride != 0) property.setVacuumEutOverride(vacuumEUtOverride);
         } else {
-            m.setProperty(PropertyKey.BLAST, new BlastProperty(blastTemp,
-                    gasTier == null ? BlastProperty.GasTier.LOW : BlastProperty.validateGasTier(gasTier),
-                    durationOverride == 0 ? -1 : durationOverride,
-                    eutOverride == 0 ? -1 : eutOverride));
+            BlastProperty.Builder builder = new BlastProperty.Builder();
+            builder.temp(blastTemp, gasTier == null ? BlastProperty.GasTier.LOW : BlastProperty.validateGasTier(gasTier));
+            builder.blastStats(durationOverride == 0 ? -1 : durationOverride, eutOverride == 0 ? -1 : eutOverride);
+            builder.vacuumStats(vacuumEUtOverride == 0 ? -1 : vacuumEUtOverride, vacuumDurationOverride == 0 ? -1 : vacuumDurationOverride);
+            m.setProperty(PropertyKey.BLAST, builder.build());
         }
     }
 

--- a/src/main/java/gregtech/integration/groovy/GroovyMaterialBuilderExpansion.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyMaterialBuilderExpansion.java
@@ -62,6 +62,10 @@ public class GroovyMaterialBuilderExpansion {
     }
 
     public static Material.Builder blastTemp(Material.Builder builder, int temp, String raw, int eutOverride, int durationOverride) {
+        return blastTemp(builder, temp, raw, eutOverride, durationOverride, -1, -1);
+    }
+
+    public static Material.Builder blastTemp(Material.Builder builder, int temp, String raw, int eutOverride, int durationOverride, int vacuumEUtOverride, int vacuumDurationOverride) {
         BlastProperty.GasTier gasTier = null;
         String name = raw.toUpperCase();
         for (BlastProperty.GasTier gasTier1 : BlastProperty.GasTier.VALUES) {
@@ -70,8 +74,12 @@ public class GroovyMaterialBuilderExpansion {
                 break;
             }
         }
+        final BlastProperty.GasTier finalGasTier = gasTier;
         if (GroovyScriptModule.validateNonNull(gasTier, () -> "Can't find gas tier for " + name + " in material builder. Valid values are 'low', 'mid', 'high', 'higher', 'highest'!")) {
-            return builder.blastTemp(temp, gasTier, eutOverride, durationOverride);
+            return builder.blast(b -> b
+                    .temp(temp, finalGasTier)
+                    .blastStats(eutOverride, durationOverride)
+                    .vacuumStats(vacuumEUtOverride, vacuumDurationOverride));
         }
         return builder;
     }

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -195,11 +195,15 @@ public class MaterialRecipeHandler {
 
         // Add Vacuum Freezer recipe if required.
         if (ingotHot.doGenerateItem(material)) {
+            int vacuumEUt = property.getVacuumEUtOverride() != -1 ? property.getVacuumEUtOverride() : VA[MV];
+            int vacuumDuration = property.getVacuumDurationOverride() != -1 ? property.getVacuumDurationOverride() : (int) material.getMass() * 3;
+
             if (blastTemp < 5000) {
                 RecipeMaps.VACUUM_RECIPES.recipeBuilder()
                         .input(ingotHot, material)
                         .output(ingot, material)
-                        .duration((int) material.getMass() * 3)
+                        .duration(vacuumDuration)
+                        .EUt(vacuumEUt)
                         .buildAndRegister();
             } else {
                 RecipeMaps.VACUUM_RECIPES.recipeBuilder()
@@ -207,7 +211,8 @@ public class MaterialRecipeHandler {
                         .fluidInputs(Materials.Helium.getFluid(FluidStorageKeys.LIQUID, 500))
                         .output(ingot, material)
                         .fluidOutputs(Materials.Helium.getFluid(250))
-                        .duration((int) material.getMass() * 3)
+                        .duration(vacuumDuration)
+                        .EUt(vacuumEUt)
                         .buildAndRegister();
             }
         }


### PR DESCRIPTION
Reworks vacuum freezer recipe durations and EU/t's.

Typically, a vacuum freezer recipe is one tier below the blast furnace's EU/t, though there is some variety. Additionally, superconductor ingots always require vacuum freezer EU/t matching the superconductor's tier.

Durations generally are reduced by a decent amount from before to account from these changes. However, this will require a lot more vacuum freezer infra than before.

A couple EBF metals had recipe tweaks as well, such as YBCO which was still MV for some reason, Tungstencarbide which was HV (now EV), and one or two more I already forgot