### PR TITLE
fix ME hatch packet reading

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -90,10 +90,16 @@ public abstract class MetaTileEntityAEHostablePart extends MetaTileEntityMultibl
     @Override
     public void receiveInitialSyncData(PacketBuffer buf) {
         super.receiveInitialSyncData(buf);
-        if (buf.readBoolean() && this.aeProxy != null) {
+        if (buf.readBoolean()) {
+            NBTTagCompound nbtTagCompound;
             try {
-                this.aeProxy.readFromNBT(buf.readCompoundTag());
-            } catch (IOException ignore) {
+                nbtTagCompound = buf.readCompoundTag();
+            } catch (IOException ignored) {
+                nbtTagCompound = null;
+            }
+
+            if (this.aeProxy != null && nbtTagCompound != null) {
+                this.aeProxy.readFromNBT(nbtTagCompound);
             }
         }
         this.meUpdateTick = buf.readInt();


### PR DESCRIPTION
## What
Fixes ME hatches failing to fully read initialSyncData packet data. This would occur when `aeProxy` is null, so the NBTTagCompound would never get read from the packet. This was fixed by always reading the tag from the packet, even if it might get thrown away after.

This may also fix the occasional logged warnings about ByteBufs not being fully read from before garbage collection. 

## Outcome
Fixes ME Hatch packet reading failure. Finishes the second task of #2182.
