### PR TITLE
Add argon plasma fuel recipe

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
@@ -282,9 +282,16 @@ public class FuelRecipes {
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
+                .fluidInputs(Argon.getPlasma(1))
+                .fluidOutputs(Argon.getFluid(1))
+                .duration(96)
+                .EUt((int) V[EV])
+                .buildAndRegister();
+
+        RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Iron.getPlasma(1))
                 .fluidOutputs(Iron.getFluid(1))
-                .duration(96)
+                .duration(128)
                 .EUt((int) V[EV])
                 .buildAndRegister();
 


### PR DESCRIPTION
Adds Argon Plasma to the plasma generator fuel list.

Places it as a good MK2 fuel, to potentially be worth doing over Helium Plasma (we will see if it actually turns out that way)

Also buffs Iron Plasma to make it a bit better to make room for Argon Plasma with that previous duration