### PR TITLE
Fix GT Water/Lava materials storing the wrong object

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -536,7 +536,8 @@ public class Material implements Comparable<Material> {
             properties.ensureSet(PropertyKey.FLUID);
             FluidProperty property = properties.getProperty(PropertyKey.FLUID);
             property.getStorage().store(key, fluid);
-            postProcessors.add(m -> FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createFluidTooltip(m, fluid, state)));
+            postProcessors.add(
+                    m -> FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createFluidTooltip(m, fluid, state)));
             return this;
         }
 

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -523,6 +523,19 @@ public class Material implements Comparable<Material> {
         }
 
         /**
+         * Assign an existing fluid to this material. Useful for things like Lava and Water where MC
+         * already has a fluid to use, or for cross-mod compatibility.
+         *
+         * @param fluid The existing liquid
+         */
+        public Builder fluid(@NotNull Fluid fluid, @NotNull FluidStorageKey fluidType) {
+            properties.ensureSet(PropertyKey.FLUID);
+            FluidProperty property = properties.getProperty(PropertyKey.FLUID);
+            property.getStorage().store(fluidType, fluid);
+            return this;
+        }
+
+        /**
          * Add a liquid for this material.
          * 
          * @see #fluid(FluidStorageKey, FluidState)

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -13,6 +13,7 @@ import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.material.properties.*;
 import gregtech.api.unification.material.registry.MaterialRegistry;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.util.FluidTooltipUtil;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.SmallDigits;
@@ -35,6 +36,7 @@ import stanhebben.zenscript.annotations.ZenMethod;
 import stanhebben.zenscript.annotations.ZenOperator;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 @ZenClass("mods.gregtech.material.Material")
@@ -457,6 +459,8 @@ public class Material implements Comparable<Material> {
         private final MaterialProperties properties;
         private final MaterialFlags flags;
 
+        private final List<Consumer<Material>> postProcessors = new ArrayList<>(1);
+
         /*
          * The temporary list of components for this Material.
          */
@@ -528,10 +532,11 @@ public class Material implements Comparable<Material> {
          *
          * @param fluid The existing liquid
          */
-        public Builder fluid(@NotNull Fluid fluid, @NotNull FluidStorageKey fluidType) {
+        public Builder fluid(@NotNull Fluid fluid, @NotNull FluidStorageKey key, @NotNull FluidState state) {
             properties.ensureSet(PropertyKey.FLUID);
             FluidProperty property = properties.getProperty(PropertyKey.FLUID);
-            property.getStorage().store(fluidType, fluid);
+            property.getStorage().store(key, fluid);
+            postProcessors.add(m -> FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createFluidTooltip(m, fluid, state)));
             return this;
         }
 
@@ -1071,7 +1076,9 @@ public class Material implements Comparable<Material> {
         public Material build() {
             materialInfo.componentList = ImmutableList.copyOf(composition);
             materialInfo.verifyInfo(properties, averageRGB);
-            return new Material(materialInfo, properties, flags);
+            Material m = new Material(materialInfo, properties, flags);
+            if (!postProcessors.isEmpty()) postProcessors.forEach(p -> p.accept(m));
+            return m;
         }
     }
 

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -3,12 +3,14 @@ package gregtech.api.unification.material.materials;
 import gregtech.api.GTValues;
 import gregtech.api.fluids.FluidBuilder;
 import gregtech.api.fluids.attribute.FluidAttributes;
+import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.BlastProperty.GasTier;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.properties.ToolProperty;
 
 import net.minecraft.init.Enchantments;
+import net.minecraftforge.fluids.FluidRegistry;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.unification.material.Materials.*;
@@ -157,7 +159,7 @@ public class FirstDegreeMaterials {
                 .build();
 
         Water = new Material.Builder(269, gregtechId("water"))
-                .liquid(new FluidBuilder().temperature(300))
+                .fluid(FluidRegistry.WATER, FluidStorageKeys.LIQUID)
                 .color(0x0000FF)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 2, Oxygen, 1)

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -2,6 +2,7 @@ package gregtech.api.unification.material.materials;
 
 import gregtech.api.GTValues;
 import gregtech.api.fluids.FluidBuilder;
+import gregtech.api.fluids.FluidState;
 import gregtech.api.fluids.attribute.FluidAttributes;
 import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.material.Material;
@@ -159,7 +160,7 @@ public class FirstDegreeMaterials {
                 .build();
 
         Water = new Material.Builder(269, gregtechId("water"))
-                .fluid(FluidRegistry.WATER, FluidStorageKeys.LIQUID)
+                .fluid(FluidRegistry.WATER, FluidStorageKeys.LIQUID, FluidState.LIQUID)
                 .color(0x0000FF)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 2, Oxygen, 1)

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -1,6 +1,7 @@
 package gregtech.api.unification.material.materials;
 
 import gregtech.api.fluids.FluidBuilder;
+import gregtech.api.fluids.FluidState;
 import gregtech.api.fluids.attribute.FluidAttributes;
 import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.material.Material;
@@ -430,7 +431,7 @@ public class UnknownCompositionMaterials {
                 .build();
 
         Lava = new Material.Builder(1600, gregtechId("lava"))
-                .fluid(FluidRegistry.LAVA, FluidStorageKeys.LIQUID)
+                .fluid(FluidRegistry.LAVA, FluidStorageKeys.LIQUID, FluidState.LIQUID)
                 .color(0xFF4000)
                 .flags(GLOWING)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -2,7 +2,10 @@ package gregtech.api.unification.material.materials;
 
 import gregtech.api.fluids.FluidBuilder;
 import gregtech.api.fluids.attribute.FluidAttributes;
+import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.material.Material;
+
+import net.minecraftforge.fluids.FluidRegistry;
 
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
@@ -427,7 +430,7 @@ public class UnknownCompositionMaterials {
                 .build();
 
         Lava = new Material.Builder(1600, gregtechId("lava"))
-                .fluid()
+                .fluid(FluidRegistry.LAVA, FluidStorageKeys.LIQUID)
                 .color(0xFF4000)
                 .flags(GLOWING)
                 .build();

--- a/src/main/java/gregtech/api/util/FluidTooltipUtil.java
+++ b/src/main/java/gregtech/api/util/FluidTooltipUtil.java
@@ -83,7 +83,8 @@ public class FluidTooltipUtil {
         return createFluidTooltip(material, fluid, fluid.getState());
     }
 
-    public static Supplier<List<String>> createFluidTooltip(@Nullable Material material, @NotNull Fluid fluid, @NotNull FluidState fluidState) {
+    public static Supplier<List<String>> createFluidTooltip(@Nullable Material material, @NotNull Fluid fluid,
+                                                            @NotNull FluidState fluidState) {
         return () -> {
             List<String> tooltip = new ArrayList<>();
             if (material != null && !material.getChemicalFormula().isEmpty()) {

--- a/src/main/java/gregtech/api/util/FluidTooltipUtil.java
+++ b/src/main/java/gregtech/api/util/FluidTooltipUtil.java
@@ -1,5 +1,6 @@
 package gregtech.api.util;
 
+import gregtech.api.fluids.FluidState;
 import gregtech.api.fluids.GTFluid;
 import gregtech.api.unification.material.Material;
 
@@ -10,6 +11,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -76,19 +78,23 @@ public class FluidTooltipUtil {
         return getFluidTooltip(FluidRegistry.getFluid(fluidName));
     }
 
-    public static Supplier<List<String>> createGTFluidTooltip(GTFluid fluid) {
+    public static Supplier<List<String>> createGTFluidTooltip(@NotNull GTFluid fluid) {
+        Material material = fluid instanceof GTFluid.GTMaterialFluid matFluid ? matFluid.getMaterial() : null;
+        return createFluidTooltip(material, fluid, fluid.getState());
+    }
+
+    public static Supplier<List<String>> createFluidTooltip(@Nullable Material material, @NotNull Fluid fluid, @NotNull FluidState fluidState) {
         return () -> {
             List<String> tooltip = new ArrayList<>();
-            if (fluid instanceof GTFluid.GTMaterialFluid materialFluid) {
-                Material material = materialFluid.getMaterial();
-                if (!material.getChemicalFormula().isEmpty()) {
-                    tooltip.add(TextFormatting.YELLOW + material.getChemicalFormula());
-                }
+            if (material != null && !material.getChemicalFormula().isEmpty()) {
+                tooltip.add(TextFormatting.YELLOW + material.getChemicalFormula());
             }
 
             tooltip.add(I18n.format("gregtech.fluid.temperature", fluid.getTemperature()));
-            tooltip.add(I18n.format(fluid.getState().getTranslationKey()));
-            fluid.getAttributes().forEach(a -> a.appendFluidTooltips(tooltip));
+            tooltip.add(I18n.format(fluidState.getTranslationKey()));
+            if (fluid instanceof GTFluid gtFluid) {
+                gtFluid.getAttributes().forEach(a -> a.appendFluidTooltips(tooltip));
+            }
 
             if (fluid.getTemperature() < CRYOGENIC_FLUID_THRESHOLD) {
                 tooltip.add(I18n.format("gregtech.fluid.temperature.cryogenic"));


### PR DESCRIPTION
Also adds an API way to assign fluids from other mods as the fluid for a GT material with specified fluid storage key