### PR TITLE
Fix crashes when other mods add fluids of same name

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -306,10 +306,10 @@ public class FluidBuilder {
         Fluid properFluid = GTFluidRegistration.INSTANCE.registerFluid(fluid, modid, hasBucket);
 
         if (material != null) {
-            FluidUnifier.registerFluid(fluid, material);
+            FluidUnifier.registerFluid(properFluid, material);
         }
 
-        FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createGTFluidTooltip(fluid));
+        FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createFluidTooltip(material, properFluid, state));
 
         if (hasFluidBlock) {
             if (fluid == properFluid) {

--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -1,6 +1,7 @@
 package gregtech.api.fluids;
 
 import gregtech.api.GTValues;
+import gregtech.api.fluids.attribute.AttributedFluid;
 import gregtech.api.fluids.attribute.FluidAttribute;
 import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.unification.FluidUnifier;
@@ -290,8 +291,8 @@ public class FluidBuilder {
             }
         }
 
-        if (fluid instanceof GTFluid gtFluid) {
-            attributes.forEach(gtFluid::addAttribute);
+        if (fluid instanceof AttributedFluid attrFluid) {
+            attributes.forEach(attrFluid::addAttribute);
         } else {
             GTLog.logger
                     .warn("Unable to set Fluid Attributes for Fluid {}, as it is owned by another mod! Skipping...");

--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -291,7 +291,8 @@ public class FluidBuilder {
         if (fluid instanceof GTFluid gtFluid) {
             attributes.forEach(gtFluid::addAttribute);
         } else {
-            GTLog.logger.warn("Unable to set Fluid Attributes for Fluid {}, as it is owned by another mod! Skipping...");
+            GTLog.logger
+                    .warn("Unable to set Fluid Attributes for Fluid {}, as it is owned by another mod! Skipping...");
         }
 
         determineTemperature(material);
@@ -340,7 +341,9 @@ public class FluidBuilder {
                 fluidBlock.setMaxScaledLight(fluid.getLuminosity());
                 fluidBlock.setTickRate(fluid.getViscosity() / 200);
             } else {
-                GTLog.logger.warn("Unable to set custom Fluid Block stats for Fluid {}, Fluid Block owned by other mod with unknown type!", fluid.getName());
+                GTLog.logger.warn(
+                        "Unable to set custom Fluid Block stats for Fluid {}, Fluid Block owned by other mod with unknown type!",
+                        fluid.getName());
             }
         }
 

--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -275,7 +275,9 @@ public class FluidBuilder {
         }
 
         Fluid fluid = FluidRegistry.getFluid(name);
+        boolean needsRegistration = false;
         if (fluid == null) {
+            needsRegistration = true;
             if (material == null) {
                 fluid = new GTFluid(name, still, flowing, state);
             } else if (key != null) {
@@ -312,7 +314,12 @@ public class FluidBuilder {
         determineViscosity(material);
         fluid.setViscosity(viscosity);
 
-        GTFluidRegistration.INSTANCE.registerFluid(fluid, modid, hasBucket);
+        if (needsRegistration) {
+            GTFluidRegistration.INSTANCE.registerFluid(fluid, modid, hasBucket);
+        } else if (hasBucket) {
+            // In case it didn't have it before, but now it does
+            FluidRegistry.addBucketForFluid(fluid);
+        }
 
         if (material != null) {
             FluidUnifier.registerFluid(fluid, material);

--- a/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
+++ b/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
@@ -77,14 +77,14 @@ public class GTFluidRegistration {
      * @param generateBucket if a universal bucket entry should be generated
      */
     public void registerFluid(@NotNull Fluid fluid, @NotNull String modid, boolean generateBucket) {
+        FluidRegistry.registerFluid(fluid);
         if (fluid instanceof GTFluid) {
             // instanceof GTFluid means that this is a fresh fluid of our own
             // creation and not one which is being transformed by a Material.
             fluidSprites.add(fluid.getStill());
             fluidSprites.add(fluid.getFlowing());
+            fixFluidRegistryName(fluid, modid);
         }
-        FluidRegistry.registerFluid(fluid);
-        fixFluidRegistryName(fluid, modid);
         if (generateBucket) {
             FluidRegistry.addBucketForFluid(fluid);
         }

--- a/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
+++ b/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
@@ -77,8 +77,9 @@ public class GTFluidRegistration {
      * @param generateBucket if a universal bucket entry should be generated
      */
     public void registerFluid(@NotNull Fluid fluid, @NotNull String modid, boolean generateBucket) {
+        boolean didExist = FluidRegistry.getFluid(fluid.getName()) != null;
         FluidRegistry.registerFluid(fluid);
-        if (fluid instanceof GTFluid) {
+        if (!didExist) {
             // instanceof GTFluid means that this is a fresh fluid of our own
             // creation and not one which is being transformed by a Material.
             fluidSprites.add(fluid.getStill());

--- a/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
+++ b/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
@@ -76,16 +76,19 @@ public class GTFluidRegistration {
      * @param modid          the modid which owns the fluid
      * @param generateBucket if a universal bucket entry should be generated
      */
-    public void registerFluid(@NotNull Fluid fluid, @NotNull String modid, boolean generateBucket) {
-        fluidSprites.add(fluid.getStill());
-        fluidSprites.add(fluid.getFlowing());
-
-        FluidRegistry.registerFluid(fluid);
-        fixFluidRegistryName(fluid, modid);
-
+    public Fluid registerFluid(@NotNull Fluid fluid, @NotNull String modid, boolean generateBucket) {
+        if (!FluidRegistry.registerFluid(fluid)) {
+            // Try to use already registered fluid over ours, so that we don't get a registry mismatch
+            fluid = FluidRegistry.getFluid(fluid.getName());
+        } else {
+            fluidSprites.add(fluid.getStill());
+            fluidSprites.add(fluid.getFlowing());
+            fixFluidRegistryName(fluid, modid);
+        }
         if (generateBucket) {
             FluidRegistry.addBucketForFluid(fluid);
         }
+        return fluid;
     }
 
     /**

--- a/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
+++ b/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
@@ -76,19 +76,18 @@ public class GTFluidRegistration {
      * @param modid          the modid which owns the fluid
      * @param generateBucket if a universal bucket entry should be generated
      */
-    public Fluid registerFluid(@NotNull Fluid fluid, @NotNull String modid, boolean generateBucket) {
-        if (!FluidRegistry.registerFluid(fluid)) {
-            // Try to use already registered fluid over ours, so that we don't get a registry mismatch
-            fluid = FluidRegistry.getFluid(fluid.getName());
-        } else {
+    public void registerFluid(@NotNull Fluid fluid, @NotNull String modid, boolean generateBucket) {
+        if (fluid instanceof GTFluid) {
+            // instanceof GTFluid means that this is a fresh fluid of our own
+            // creation and not one which is being transformed by a Material.
             fluidSprites.add(fluid.getStill());
             fluidSprites.add(fluid.getFlowing());
-            fixFluidRegistryName(fluid, modid);
         }
+        FluidRegistry.registerFluid(fluid);
+        fixFluidRegistryName(fluid, modid);
         if (generateBucket) {
             FluidRegistry.addBucketForFluid(fluid);
         }
-        return fluid;
     }
 
     /**

--- a/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
+++ b/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
@@ -80,7 +80,7 @@ public class GTFluidRegistration {
         boolean didExist = FluidRegistry.getFluid(fluid.getName()) != null;
         FluidRegistry.registerFluid(fluid);
         if (!didExist) {
-            // instanceof GTFluid means that this is a fresh fluid of our own
+            // If it didn't exist, that means that this is a fresh fluid of our own
             // creation and not one which is being transformed by a Material.
             fluidSprites.add(fluid.getStill());
             fluidSprites.add(fluid.getFlowing());


### PR DESCRIPTION
GT now defers to the already registered fluid, ensuring that the fluid it stores in materials is the "master fluid reference" instead of being a secondary reference. Using secondary reference has issues with some fluid registry calls, notably getFluidName(), which is used in many places including serialization and bucket items