### PR TITLE
Fix fluid property with no fluid

### DIFF
--- a/src/main/java/gregtech/api/fluids/store/FluidStorage.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorage.java
@@ -61,6 +61,13 @@ public final class FluidStorage {
             throw new IllegalStateException("FluidStorage has already been registered");
         }
 
+        // if nothing is queued for registration, we need something for the registry to handle
+        // this will prevent cases of a material having a fluid property but no
+        // fluids actually created for the material.
+        if (toRegister.isEmpty()) {
+            enqueueRegistration(FluidStorageKeys.LIQUID, new FluidBuilder());
+        }
+
         for (var entry : toRegister.entrySet()) {
             Fluid fluid = entry.getValue().build(material.getModid(), material, entry.getKey());
             if (!storeNoOverwrites(entry.getKey(), fluid)) {


### PR DESCRIPTION
Fixes materials ending up with a FluidProperty, but having no fluids assigned to them. This is most noticeable in this situation:
```java
Material m = Materials.AmmoniumChloride;
m.addProperty(PropertyKey.FLUID, new FluidProperty());
```
which in 2.7.x and below, was the way to add a fluid to a material. However in 2.8, doing it this way will never create a fluid, causing many issues later on with very unhelpful crash logs.

Let me know if there is a better place to put a fix like this, to ensure no desync between a material having a FluidProperty but no actual fluids