### PR TITLE
Allow Titanium, Tungstensteel to be acid proof

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -833,7 +833,7 @@ public class ElementMaterials {
                 .toolStats(ToolProperty.Builder.of(8.0F, 6.0F, 1536, 3)
                         .enchantability(14).build())
                 .rotorStats(7.0f, 3.0f, 1600)
-                .fluidPipeProperties(2426, 150, true)
+                .fluidPipeProperties(2426, 150, true, true, false, false)
                 .blast(b -> b
                         .temp(1941, GasTier.MID)
                         .blastStats(VA[HV], 1500)

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -122,7 +122,7 @@ public class SecondDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(9.0F, 7.0F, 2048, 4)
                         .enchantability(14).build())
                 .rotorStats(8.0f, 4.0f, 2560)
-                .fluidPipeProperties(3587, 225, true)
+                .fluidPipeProperties(3587, 225, true, true, false, false)
                 .cableProperties(V[IV], 3, 2)
                 .blast(b -> b
                         .temp(4000, GasTier.MID)

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -192,7 +192,7 @@ public class MetaItem1 extends StandardMetaItem {
 
         FLUID_CELL_LARGE_TITANIUM = addItem(83, "large_fluid_cell.titanium")
                 .addComponents(new FilteredFluidStats(128000,
-                        Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false,
+                        Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, true,
                         false, false, true), new ItemFluidContainer())
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Titanium, M * 6))) // ingot * 6
                 .setCreativeTabs(GregTechAPI.TAB_GREGTECH_TOOLS);
@@ -200,7 +200,7 @@ public class MetaItem1 extends StandardMetaItem {
         FLUID_CELL_LARGE_TUNGSTEN_STEEL = addItem(84, "large_fluid_cell.tungstensteel")
                 .addComponents(new FilteredFluidStats(512000,
                         Materials.TungstenSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true,
-                        false, false, false, true), new ItemFluidContainer())
+                        true, false, false, true), new ItemFluidContainer())
                 .setMaxStackSize(32)
                 .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.TungstenSteel, M * 8))) // ingot * 8
                 .setCreativeTabs(GregTechAPI.TAB_GREGTECH_TOOLS);


### PR DESCRIPTION
Stainless steel is acid proof, so regardless of realism it makes sense from a QoL standpoint to allow both of these to also be acid proof (primarily changed for Large Cells and Drums, where it is most relevant)

Closes #2148 