### PR TITLE
Fix Fluid Drilling Rig sometimes drilling on the incorrect vein

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FluidDrillLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidDrillLogic.java
@@ -166,11 +166,11 @@ public class FluidDrillLogic {
     }
 
     public int getChunkX() {
-        return metaTileEntity.getPos().getX() / 16;
+        return Math.floorDiv(metaTileEntity.getPos().getX(), 16);
     }
 
     public int getChunkZ() {
-        return metaTileEntity.getPos().getZ() / 16;
+        return Math.floorDiv(metaTileEntity.getPos().getZ(), 16);
     }
 
     /**


### PR DESCRIPTION
## What
Fluid drills now drill the correct fluid when close to fluid vein borders and one or more coordinate is negative

## Implementation Details
Uses ``Math.floorDiv`` instead of integer division

## Outcome
Fluid drill now works

## Additional Information
The prospectors do not seem to have the same issue

## Potential Compatibility Issues
Existing fluid drills in the "bugged" state will try to get their amount and deplete from the wrong vein, users need to break and replace their fluid drills
