### PR TITLE
Fix Issues with Multiblock Generators

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -155,4 +155,9 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         FluidStack fuelStack = previousRecipe.getFluidInputs().get(0).getInputFluidStack();
         return getInputTank().drain(new FluidStack(fuelStack.getFluid(), Integer.MAX_VALUE), false);
     }
+
+    @Override
+    public boolean isAllowOverclocking() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -104,7 +104,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
         // rebuild the recipe and adjust voltage to match the turbine
         RecipeBuilder<?> recipeBuilder = getRecipeMap().recipeBuilder();
         recipeBuilder.append(recipe, parallel, false)
-                .EUt(-turbineMaxVoltage);
+                .EUt(turbineMaxVoltage);
         applyParallelBonus(recipeBuilder);
         recipe = recipeBuilder.build().getResult();
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -128,4 +128,9 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
             tanks.add((IFluidHandler) tank);
         }
     }
+
+    @Override
+    public long getMaximumOverclockVoltage() {
+        return getMaxVoltage();
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -128,9 +128,4 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
             tanks.add((IFluidHandler) tank);
         }
     }
-
-    @Override
-    public long getMaximumOverclockVoltage() {
-        return getMaxVoltage();
-    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -391,7 +391,6 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
 
         @Override
         protected boolean canProgressRecipe() {
-
             // drain lubricant and invalidate if it fails
             if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
                 IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
@@ -417,6 +416,5 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
             }
             return super.canProgressRecipe();
         }
-
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -345,30 +345,6 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         protected void updateRecipeProgress() {
             if (canRecipeProgress && drawEnergy(recipeEUt, true)) {
 
-                // drain lubricant and invalidate if it fails
-                if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
-                    IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
-                    if (LUBRICANT_STACK.isFluidStackIdentical(inputTank.drain(LUBRICANT_STACK, false))) {
-                        inputTank.drain(LUBRICANT_STACK, true);
-                    } else {
-                        invalidate();
-                        return;
-                    }
-                }
-
-                // drain oxygen if present to boost production, and if the dynamo hatch supports it
-                if (combustionEngine.isBoostAllowed() &&
-                        (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 20 == 0)) {
-                    IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
-                    FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
-                    if (boosterStack.isFluidStackIdentical(inputTank.drain(boosterStack, false))) {
-                        isOxygenBoosted = true;
-                        inputTank.drain(boosterStack, true);
-                    } else {
-                        isOxygenBoosted = false;
-                    }
-                }
-
                 drawEnergy(recipeEUt, false);
 
                 // as recipe starts with progress on 1 this has to be > only not => to compensate for it
@@ -414,8 +390,33 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         }
 
         @Override
-        public long getMaximumOverclockVoltage() {
-            return getMaxVoltage();
+        protected boolean canProgressRecipe() {
+
+            // drain lubricant and invalidate if it fails
+            if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
+                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
+                if (LUBRICANT_STACK.isFluidStackIdentical(inputTank.drain(LUBRICANT_STACK, false))) {
+                    inputTank.drain(LUBRICANT_STACK, true);
+                } else {
+                    invalidate();
+                    return false;
+                }
+            }
+
+            // drain oxygen if present to boost production, and if the dynamo hatch supports it
+            if (combustionEngine.isBoostAllowed() &&
+                    (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 20 == 0)) {
+                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
+                FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
+                if (boosterStack.isFluidStackIdentical(inputTank.drain(boosterStack, false))) {
+                    isOxygenBoosted = true;
+                    inputTank.drain(boosterStack, true);
+                } else {
+                    isOxygenBoosted = false;
+                }
+            }
+            return super.canProgressRecipe();
         }
+
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -412,5 +412,10 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
             isOxygenBoosted = false;
             super.invalidate();
         }
+
+        @Override
+        public long getMaximumOverclockVoltage() {
+            return getMaxVoltage();
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -104,10 +104,10 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController
 
     @Override
     protected long getMaxVoltage() {
-        long maxProduction = ((LargeTurbineWorkableHandler) recipeMapWorkable).getMaxVoltage();
+        long maxProduction = recipeMapWorkable.getMaxVoltage();
         long currentProduction = ((LargeTurbineWorkableHandler) recipeMapWorkable).boostProduction((int) maxProduction);
         if (isActive() && currentProduction < maxProduction) {
-            return ((LargeTurbineWorkableHandler) recipeMapWorkable).getMaxVoltage();
+            return recipeMapWorkable.getMaxVoltage();
         } else {
             return 0L;
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockNotifiablePart.java
@@ -27,6 +27,8 @@ public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEnt
             handler = (NotifiableItemStackHandler) getExportItems();
         } else if (!isExportHatch && getImportItems() instanceof NotifiableItemStackHandler) {
             handler = (NotifiableItemStackHandler) getImportItems();
+        } else if (getItemInventory() instanceof NotifiableItemStackHandler) {
+            handler = (NotifiableItemStackHandler) getItemInventory();
         }
         return handler;
     }
@@ -44,11 +46,9 @@ public abstract class MetaTileEntityMultiblockNotifiablePart extends MetaTileEnt
     private List<INotifiableHandler> getPartHandlers() {
         List<INotifiableHandler> handlerList = new ArrayList<>();
 
-        if (this.itemInventory.getSlots() > 0) {
-            NotifiableItemStackHandler itemHandler = getItemHandler();
-            if (itemHandler != null) {
-                handlerList.add(itemHandler);
-            }
+        NotifiableItemStackHandler itemHandler = getItemHandler();
+        if (itemHandler != null && itemHandler.getSlots() > 0) {
+            handlerList.add(itemHandler);
         }
 
         if (this.fluidInventory.getTankProperties().length > 0) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -420,7 +420,8 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
         private void damageRotor(int damageAmount) {
             if (!hasRotor()) return;
 
-            if (getTurbineBehavior().getPartMaxDurability(getTurbineStack()) <= AbstractMaterialPartBehavior.getPartDamage(getTurbineStack()) + damageAmount) {
+            if (getTurbineBehavior().getPartMaxDurability(getTurbineStack()) <=
+                    AbstractMaterialPartBehavior.getPartDamage(getTurbineStack()) + damageAmount) {
                 var holder = getController().getRecipeLogic();
                 if (holder != null && holder.isWorking()) {
                     holder.invalidateInputs();

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -12,6 +12,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.items.behaviors.AbstractMaterialPartBehavior;
 import gregtech.common.items.behaviors.TurbineRotorBehavior;
 import gregtech.common.metatileentities.multi.electric.generator.MetaTileEntityLargeTurbine;
 import gregtech.core.advancement.AdvancementTriggers;
@@ -418,6 +419,14 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
 
         private void damageRotor(int damageAmount) {
             if (!hasRotor()) return;
+
+            if (getTurbineBehavior().getPartMaxDurability(getTurbineStack()) <= AbstractMaterialPartBehavior.getPartDamage(getTurbineStack()) + damageAmount) {
+                var holder = getController().getRecipeLogic();
+                if (holder != null && holder.isWorking()) {
+                    holder.invalidateInputs();
+                }
+            }
+
             // noinspection ConstantConditions
             getTurbineBehavior().applyRotorDamage(getStackInSlot(0), damageAmount);
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -364,7 +364,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
             super.onContentsChanged(slot);
             setRotorColor(getRotorColor());
             scheduleRenderUpdate();
-            if (getController() != null){
+            if (getController() != null) {
                 addNotifiableMetaTileEntity(getController());
             }
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -2,6 +2,7 @@ package gregtech.common.metatileentities.multi.multiblockpart;
 
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.IRotorHolder;
+import gregtech.api.capability.impl.MultiblockFuelRecipeLogic;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.damagesources.DamageSources;
 import gregtech.api.gui.GuiTextures;
@@ -30,6 +31,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
@@ -40,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
+public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockNotifiablePart
                                        implements IMultiblockAbilityPart<IRotorHolder>, IRotorHolder {
 
     static final int SPEED_INCREMENT = 1;
@@ -55,7 +57,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
     private boolean frontFaceFree;
 
     public MetaTileEntityRotorHolder(ResourceLocation metaTileEntityId, int tier) {
-        super(metaTileEntityId, tier);
+        super(metaTileEntityId, tier, false);
         this.inventory = new InventoryRotorHolder();
         this.maxSpeed = 2000 + 1000 * tier;
     }
@@ -63,6 +65,11 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityRotorHolder(metaTileEntityId, getTier());
+    }
+
+    @Override
+    public IItemHandlerModifiable getImportItems() {
+        return this.inventory;
     }
 
     @Override
@@ -365,9 +372,6 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
             super.onContentsChanged(slot);
             setRotorColor(getRotorColor());
             scheduleRenderUpdate();
-            if (getController() != null) {
-                addNotifiableMetaTileEntity(getController());
-            }
         }
 
         @Nullable
@@ -422,9 +426,9 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
 
             if (getTurbineBehavior().getPartMaxDurability(getTurbineStack()) <=
                     AbstractMaterialPartBehavior.getPartDamage(getTurbineStack()) + damageAmount) {
-                var holder = getController().getRecipeLogic();
+                var holder = (MultiblockFuelRecipeLogic) getController().getRecipeLogic();
                 if (holder != null && holder.isWorking()) {
-                    holder.invalidateInputs();
+                    holder.invalidate();
                 }
             }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityRotorHolder.java
@@ -2,10 +2,10 @@ package gregtech.common.metatileentities.multi.multiblockpart;
 
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.IRotorHolder;
+import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.damagesources.DamageSources;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
-import gregtech.api.items.itemhandlers.GTItemStackHandler;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -343,10 +343,10 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
                 getController() != null, hasRotor(), isRotorSpinning, getRotorColor());
     }
 
-    private class InventoryRotorHolder extends GTItemStackHandler {
+    private class InventoryRotorHolder extends NotifiableItemStackHandler {
 
         public InventoryRotorHolder() {
-            super(MetaTileEntityRotorHolder.this, 1);
+            super(MetaTileEntityRotorHolder.this, 1, null, false);
         }
 
         @Override
@@ -360,10 +360,13 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart
         }
 
         @Override
-        protected void onContentsChanged(int slot) {
+        public void onContentsChanged(int slot) {
             super.onContentsChanged(slot);
             setRotorColor(getRotorColor());
             scheduleRenderUpdate();
+            if (getController() != null){
+                addNotifiableMetaTileEntity(getController());
+            }
         }
 
         @Nullable


### PR DESCRIPTION
## What
fixes multi generators from overclocking when they should not be
fixes #2226 
probably fixes #1761 

## Implementation Details
moved oxygen/lubricant checks to `canProgressRecipe()` for LCE's workable handler
prevent overclocking in MultiblockFuelRecipe
fix gas turbine setting the eut to output negative
make rotor holder inventory notifiable
invalidate large turbine recipe logic when rotor breaks
make a small change to MTENotifiableMultiblockPart

## Outcome
a proper amount of power generation
steam/gas turbines aren't as sus

## Potential Compatibility Issues
none
