### PR TITLE
Reimplement alternative fluid names

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static gregtech.api.fluids.FluidConstants.*;
 
@@ -59,6 +60,7 @@ public class FluidBuilder {
 
     private boolean hasFluidBlock = false;
     private boolean hasBucket = true;
+    private String alternativeName = null;
 
     public FluidBuilder() {}
 
@@ -214,6 +216,15 @@ public class FluidBuilder {
     }
 
     /**
+     * @param name Alternative registry name for this fluid to look for
+     * @return this
+     */
+    public @NotNull FluidBuilder alternativeName(@NotNull String name) {
+        this.alternativeName = name;
+        return this;
+    }
+
+    /**
      * Mark this fluid as having a custom still texture
      * 
      * @return this
@@ -275,7 +286,13 @@ public class FluidBuilder {
             throw new IllegalStateException("Could not determine fluid name");
         }
 
+        // try to find an already registered fluid that we can use instead of a new one
         Fluid fluid = FluidRegistry.getFluid(name);
+        if (fluid == null && alternativeName != null) {
+            // try to use alternative fluid name if needed
+            fluid = FluidRegistry.getFluid(alternativeName);
+        }
+
         boolean needsRegistration = false;
         if (fluid == null) {
             needsRegistration = true;

--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 import static gregtech.api.fluids.FluidConstants.*;
 

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -263,7 +263,8 @@ public class FirstDegreeMaterials {
                 .dust(0)
                 .liquid(new FluidBuilder()
                         .temperature(273)
-                        .customStill())
+                        .customStill()
+                        .alternativeName("fluid.ice"))
                 .color(0xC8C8FF).iconSet(SHINY)
                 .flags(NO_SMASHING, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 2, Oxygen, 1)
@@ -1281,7 +1282,7 @@ public class FirstDegreeMaterials {
                 .build();
 
         DistilledWater = new Material.Builder(421, gregtechId("distilled_water"))
-                .fluid()
+                .liquid(new FluidBuilder().alternativeName("fluidDistWater"))
                 .color(0x4A94FF)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Hydrogen, 2, Oxygen, 1)

--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -392,7 +392,7 @@ public class OrganicChemistryMaterials {
         // FREE ID 1053
 
         Ethanol = new Material.Builder(1054, gregtechId("ethanol"))
-                .liquid(new FluidBuilder().customStill())
+                .liquid(new FluidBuilder().customStill().alternativeName("bio.ethanol"))
                 .color(0xFC4C04)
                 .flags(DISABLE_DECOMPOSITION)
                 .components(Carbon, 2, Hydrogen, 6, Oxygen, 1)

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -48,7 +48,7 @@ public class UnknownCompositionMaterials {
                 .flags(STICKY).build();
 
         Diesel = new Material.Builder(1508, gregtechId("diesel"))
-                .liquid(new FluidBuilder().customStill())
+                .liquid(new FluidBuilder().customStill().alternativeName("fuel"))
                 .color(0xFCF404)
                 .flags(FLAMMABLE, EXPLOSIVE).build();
 
@@ -72,7 +72,7 @@ public class UnknownCompositionMaterials {
                 .color(0x0E2950).build();
 
         SeedOil = new Material.Builder(1514, gregtechId("seed_oil"))
-                .liquid(new FluidBuilder().customStill())
+                .liquid(new FluidBuilder().customStill().alternativeName("seed.oil"))
                 .color(0xE4FC8C)
                 .flags(STICKY, FLAMMABLE).build();
 


### PR DESCRIPTION
Closes #2220 

Allows fluids to set alternative names, which if a fluid is registered with this alternative name, that fluid will be treated as if it has the same name as our new fluid (i.e., it will be used and transformed for GT's purposes rather than GT creating an entirely new fluid)