### PR TITLE
Add default fluid state for storage key

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -285,6 +285,14 @@ public class FluidBuilder {
             throw new IllegalStateException("Could not determine fluid name");
         }
 
+        if (state == null) {
+            if (key != null && key.getDefaultFluidState() != null) {
+                state = key.getDefaultFluidState();
+            } else {
+                state = FluidState.LIQUID; // default fallback
+            }
+        }
+
         // try to find an already registered fluid that we can use instead of a new one
         Fluid fluid = FluidRegistry.getFluid(name);
         if (fluid == null && alternativeName != null) {
@@ -309,7 +317,7 @@ public class FluidBuilder {
 
         if (fluid instanceof AttributedFluid attrFluid) {
             attributes.forEach(attrFluid::addAttribute);
-        } else {
+        } else if (!attributes.isEmpty()) {
             GTLog.logger
                     .warn("Unable to set Fluid Attributes for Fluid {}, as it is owned by another mod! Skipping...");
         }

--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -44,7 +44,7 @@ public class FluidBuilder {
 
     private final Collection<FluidAttribute> attributes = new ArrayList<>();
 
-    private FluidState state = FluidState.LIQUID;
+    private FluidState state = null;
     private int temperature = INFER_TEMPERATURE;
     private int color = INFER_COLOR;
     private boolean isColorEnabled = true;

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
@@ -1,5 +1,6 @@
 package gregtech.api.fluids.store;
 
+import gregtech.api.fluids.FluidState;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.info.MaterialIconType;
 
@@ -22,15 +23,18 @@ public final class FluidStorageKey {
     private final UnaryOperator<String> registryNameOperator;
     private final Function<Material, String> translationKeyFunction;
     private final int hashCode;
+    private final FluidState defaultFluidState;
 
     public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
                            @NotNull UnaryOperator<@NotNull String> registryNameOperator,
-                           @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction) {
+                           @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction,
+                           @Nullable FluidState defaultFluidState) {
         this.resourceLocation = resourceLocation;
         this.iconType = iconType;
         this.registryNameOperator = registryNameOperator;
         this.translationKeyFunction = translationKeyFunction;
         this.hashCode = resourceLocation.hashCode();
+        this.defaultFluidState = defaultFluidState;
         if (keys.containsKey(resourceLocation)) {
             throw new IllegalArgumentException("Cannot create duplicate keys");
         }
@@ -62,6 +66,13 @@ public final class FluidStorageKey {
      */
     public @NotNull String getTranslationKeyFor(@NotNull Material material) {
         return this.translationKeyFunction.apply(material);
+    }
+
+    /**
+     * @return the default fluid state for this storage key, if it exists.
+     */
+    public @Nullable FluidState getDefaultFluidState() {
+        return defaultFluidState;
     }
 
     @Override

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -1,5 +1,6 @@
 package gregtech.api.fluids.store;
 
+import gregtech.api.fluids.FluidState;
 import gregtech.api.unification.material.info.MaterialIconType;
 import gregtech.api.unification.material.properties.PropertyKey;
 
@@ -12,7 +13,8 @@ public final class FluidStorageKeys {
     public static final FluidStorageKey LIQUID = new FluidStorageKey(gregtechId("liquid"),
             MaterialIconType.liquid,
             UnaryOperator.identity(),
-            m -> m.hasProperty(PropertyKey.DUST) ? "gregtech.fluid.liquid_generic" : "gregtech.fluid.generic");
+            m -> m.hasProperty(PropertyKey.DUST) ? "gregtech.fluid.liquid_generic" : "gregtech.fluid.generic",
+            FluidState.LIQUID);
 
     public static final FluidStorageKey GAS = new FluidStorageKey(gregtechId("gas"),
             MaterialIconType.gas,
@@ -25,11 +27,13 @@ public final class FluidStorageKeys {
                     return "gregtech.fluid.gas_generic";
                 }
                 return "gregtech.fluid.generic";
-            });
+            },
+            FluidState.GAS);
 
     public static final FluidStorageKey PLASMA = new FluidStorageKey(gregtechId("plasma"),
             MaterialIconType.plasma,
-            s -> "plasma." + s, m -> "gregtech.fluid.plasma");
+            s -> "plasma." + s, m -> "gregtech.fluid.plasma",
+            FluidState.PLASMA);
 
     private FluidStorageKeys() {}
 }


### PR DESCRIPTION
Adds a default fallback state for a fluid storage key if state is not set through other means before build() is called