### PR TITLE
Fix warning with cinnabar

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -155,7 +155,7 @@ public class FirstDegreeMaterials {
         Cinnabar = new Material.Builder(268, gregtechId("cinnabar"))
                 .dust(1).ore()
                 .color(0x960000).iconSet(EMERALD)
-                .flags(CRYSTALLIZABLE, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Mercury, 1, Sulfur, 1)
                 .build();
 


### PR DESCRIPTION
## What
The cinnabar gem was removed (for better eventual TC integration), which causes the Crystallize flag to log an error, since there is no gem. So remove this flag for now

