### PR TITLE
fix fluid colors in TOP with new fluid system

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -381,7 +381,8 @@ public class FluidBuilder {
 
         // register cross mod compat for colors
         if (Loader.isModLoaded(GTValues.MODID_TOP_ADDONS)) {
-            Colors.FLUID_NAME_COLOR_MAP.put(name, color);
+            int displayColor = isColorEnabled || material == null ? color : material.getMaterialRGB();
+            Colors.FLUID_NAME_COLOR_MAP.put(name, displayColor);
         }
 
         return fluid;


### PR DESCRIPTION
## What
Fixes a regression caused by #2081, where fluids do not display their colors correctly with TOP Addons installed. Restores the functionality of #1996.
