### PR TITLE
Add FluidStorageKey ctor for compat

### DIFF
--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
@@ -27,6 +27,12 @@ public final class FluidStorageKey {
 
     public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
                            @NotNull UnaryOperator<@NotNull String> registryNameOperator,
+                           @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction) {
+        this(resourceLocation, iconType, registryNameOperator, translationKeyFunction, null);
+    }
+
+    public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
+                           @NotNull UnaryOperator<@NotNull String> registryNameOperator,
                            @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction,
                            @Nullable FluidState defaultFluidState) {
         this.resourceLocation = resourceLocation;


### PR DESCRIPTION
Adds another constructor for FluidStorageKey to maintain compatibility with the original ctor from 2.8.0. Prevents GCYM from needing to update for 2.8.2