### PR TITLE
Clean up and add particle effects for machines

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
@@ -10,6 +10,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTUtility;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
@@ -35,6 +36,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -143,32 +145,21 @@ public abstract class SteamMetaTileEntity extends MetaTileEntity {
     @Override
     public void randomDisplayTick() {
         if (this.isActive()) {
-            final BlockPos pos = getPos();
-            float x = pos.getX() + 0.5F;
-            float z = pos.getZ() + 0.5F;
+            EnumParticleTypes smokeParticle = isHighPressure ? EnumParticleTypes.SMOKE_LARGE :
+                    EnumParticleTypes.SMOKE_NORMAL;
+            VanillaParticleEffects.defaultFrontEffect(this, smokeParticle, EnumParticleTypes.FLAME);
 
-            final EnumFacing facing = getFrontFacing();
-            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
-            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F;
-
-            if (facing.getAxis() == EnumFacing.Axis.X) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
-                else x -= 0.52F;
-                z += horizontalOffset;
-            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
-                else z -= 0.52F;
-                x += horizontalOffset;
-            }
             if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
-                getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F,
-                        false);
+                BlockPos pos = getPos();
+                getWorld().playSound(pos.getX(), pos.getY(), pos.getZ(),
+                        SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
             }
-            randomDisplayTick(x, y, z, EnumParticleTypes.FLAME,
-                    isHighPressure ? EnumParticleTypes.SMOKE_LARGE : EnumParticleTypes.SMOKE_NORMAL);
         }
     }
 
+    /** @deprecated No longer used, look at {@link VanillaParticleEffects#defaultFrontEffect} to see old logic. */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     @SideOnly(Side.CLIENT)
     protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
         getWorld().spawnParticle(smoke, x, y, z, 0, 0, 0);

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -33,6 +33,7 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -274,8 +275,10 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     }
 
     /**
-     * Produces the muffler particles
+     * @deprecated Use {@link gregtech.client.particle.VanillaParticleEffects#MUFFLER_SMOKE} instead.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+    @Deprecated
     @SideOnly(Side.CLIENT)
     public void runMufflerEffect(float xPos, float yPos, float zPos, float xSpd, float ySpd, float zSpd) {
         getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, xPos, yPos, zPos, xSpd, ySpd, zSpd);

--- a/src/main/java/gregtech/client/particle/IMachineParticleEffect.java
+++ b/src/main/java/gregtech/client/particle/IMachineParticleEffect.java
@@ -1,0 +1,10 @@
+package gregtech.client.particle;
+
+import gregtech.api.metatileentity.MetaTileEntity;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface IMachineParticleEffect {
+
+    void runEffect(@NotNull MetaTileEntity metaTileEntity);
+}

--- a/src/main/java/gregtech/client/particle/VanillaParticleEffects.java
+++ b/src/main/java/gregtech/client/particle/VanillaParticleEffects.java
@@ -1,0 +1,204 @@
+package gregtech.client.particle;
+
+import gregtech.api.GTValues;
+import gregtech.api.metatileentity.MetaTileEntity;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+public enum VanillaParticleEffects implements IMachineParticleEffect {
+
+    TOP_SMOKE_SMALL(mte -> {
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+        if (mte.getFrontFacing() == EnumFacing.UP || mte.hasCover(EnumFacing.UP)) return;
+
+        BlockPos pos = mte.getPos();
+        float x = pos.getX() + 0.8F - GTValues.RNG.nextFloat() * 0.6F;
+        float y = pos.getY() + 0.9F + GTValues.RNG.nextFloat() * 0.2F;
+        float z = pos.getZ() + 0.8F - GTValues.RNG.nextFloat() * 0.6F;
+        mte.getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y, z, 0, 0, 0);
+    }),
+
+    MUFFLER_SMOKE(mte -> {
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+
+        BlockPos pos = mte.getPos();
+        EnumFacing facing = mte.getFrontFacing();
+        float xPos = facing.getXOffset() * 0.76F + pos.getX() + 0.25F;
+        float yPos = facing.getYOffset() * 0.76F + pos.getY() + 0.25F;
+        float zPos = facing.getZOffset() * 0.76F + pos.getZ() + 0.25F;
+
+        float ySpd = facing.getYOffset() * 0.1F + 0.2F + 0.1F * GTValues.RNG.nextFloat();
+        float xSpd;
+        float zSpd;
+
+        if (facing.getYOffset() == -1) {
+            float temp = GTValues.RNG.nextFloat() * 2 * (float) Math.PI;
+            xSpd = (float) Math.sin(temp) * 0.1F;
+            zSpd = (float) Math.cos(temp) * 0.1F;
+        } else {
+            xSpd = facing.getXOffset() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
+            zSpd = facing.getZOffset() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
+        }
+
+        xPos += GTValues.RNG.nextFloat() * 0.5F;
+        yPos += GTValues.RNG.nextFloat() * 0.5F;
+        zPos += GTValues.RNG.nextFloat() * 0.5F;
+
+        mte.getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, xPos, yPos, zPos, xSpd, ySpd, zSpd);
+    }),
+
+    PBF_SMOKE(mte -> {
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+
+        BlockPos pos = mte.getPos();
+        EnumFacing facing = mte.getFrontFacing().getOpposite();
+        float xPos = facing.getXOffset() * 0.76F + pos.getX() + 0.5F;
+        float yPos = facing.getYOffset() * 0.76F + pos.getY() + 0.25F;
+        float zPos = facing.getZOffset() * 0.76F + pos.getZ() + 0.5F;
+
+        float ySpd = facing.getYOffset() * 0.1F + 0.2F + 0.1F * GTValues.RNG.nextFloat();
+        mte.getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, xPos, yPos, zPos, 0, ySpd, 0);
+    }),
+
+    RANDOM_LAVA_SMOKE(mte -> {
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+
+        EnumFacing facing = mte.getFrontFacing();
+        if (facing.getAxis() == EnumFacing.Axis.Y || mte.hasCover(facing)) return;
+        BlockPos pos = mte.getPos();
+
+        final double offX = pos.getX() + facing.getXOffset() + 0.5D;
+        final double offY = pos.getY() + facing.getYOffset();
+        final double offZ = pos.getZ() + facing.getZOffset() + 0.5D;
+        final double offset = -0.48D;
+        final double horizontal = GTValues.RNG.nextFloat() * 0.625D - 0.3125D;
+
+        double x, z;
+        double y = offY + GTValues.RNG.nextFloat() * 0.375D;
+
+        if (facing == EnumFacing.WEST) {
+            x = offX - offset;
+            z = offZ + horizontal;
+        } else if (facing == EnumFacing.EAST) {
+            x = offX + offset;
+            z = offZ + horizontal;
+        } else if (facing == EnumFacing.NORTH) {
+            x = offX + horizontal;
+            z = offZ - offset;
+        } else { // south
+            x = offX + horizontal;
+            z = offZ + offset;
+        }
+
+        mte.getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y, z, 0, 0, 0);
+        mte.getWorld().spawnParticle(EnumParticleTypes.LAVA, x, y, z, 0, 0, 0);
+    }),
+
+    RANDOM_SPARKS(mte -> {
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+
+        EnumFacing facing = mte.getFrontFacing();
+        if (facing.getAxis() == EnumFacing.Axis.Y || mte.hasCover(facing)) return;
+
+        if (GTValues.RNG.nextInt(3) == 0) {
+            BlockPos pos = mte.getPos();
+
+            final double offset = 0.02D;
+            final double horizontal = 0.5D + GTValues.RNG.nextFloat() * 0.5D - 0.25D;
+
+            double x, z, mX, mZ;
+            double y = pos.getY() + GTValues.RNG.nextFloat() * 0.625D + 0.3125D;
+            if (facing == EnumFacing.WEST) {
+                x = pos.getX() - offset;
+                mX = -0.05D;
+                z = pos.getZ() + horizontal;
+                mZ = 0.0D;
+            } else if (facing == EnumFacing.EAST) {
+                x = pos.getX() + offset;
+                mX = 0.05D;
+                z = pos.getZ() + horizontal;
+                mZ = 0.0D;
+            } else if (facing == EnumFacing.NORTH) {
+                x = pos.getX() + horizontal;
+                mX = 0.0D;
+                z = pos.getZ() - offset;
+                mZ = -0.05D;
+            } else { // south
+                x = pos.getX() + horizontal;
+                mX = 0.0D;
+                z = pos.getZ() + offset;
+                mZ = 0.05D;
+            }
+
+            mte.getWorld().spawnParticle(EnumParticleTypes.LAVA, x, y, z, mX, 0, mZ);
+        }
+    }),
+
+    COMBUSTION_SMOKE(mte -> {
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+        if (mte.hasCover(EnumFacing.UP)) return;
+        BlockPos pos = mte.getPos();
+
+        float x = pos.getX() + 0.125F + GTValues.RNG.nextFloat() * 0.875F;
+        float y = pos.getY() + 1.03125F;
+        float z = pos.getZ() + 0.125F + GTValues.RNG.nextFloat() * 0.875F;
+
+        mte.getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y, z, 0, 0, 0);
+    });
+
+    // Wrap for client-sided stuff
+    private final Consumer<MetaTileEntity> effectConsumer;
+
+    VanillaParticleEffects(Consumer<MetaTileEntity> effectConsumer) {
+        this.effectConsumer = effectConsumer;
+    }
+
+    @Override
+    public void runEffect(@NotNull MetaTileEntity metaTileEntity) {
+        effectConsumer.accept(metaTileEntity);
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void defaultFrontEffect(MetaTileEntity mte, EnumParticleTypes... particles) {
+        defaultFrontEffect(mte, 0.0F, particles);
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void defaultFrontEffect(MetaTileEntity mte, float yOffset, EnumParticleTypes... particles) {
+        if (particles == null || particles.length == 0) return;
+        if (mte.getWorld() == null || mte.getPos() == null) return;
+
+        BlockPos pos = mte.getPos();
+        EnumFacing facing = mte.getFrontFacing();
+
+        if (facing.getAxis() == EnumFacing.Axis.Y || mte.hasCover(facing)) return;
+
+        float x = pos.getX() + 0.5F;
+        float z = pos.getZ() + 0.5F;
+
+        float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F + yOffset;
+        float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F;
+
+        if (facing.getAxis() == EnumFacing.Axis.X) {
+            if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
+            else x -= 0.52F;
+            z += horizontalOffset;
+        } else if (facing.getAxis() == EnumFacing.Axis.Z) {
+            if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
+            else z -= 0.52F;
+            x += horizontalOffset;
+        }
+
+        for (EnumParticleTypes particle : particles) {
+            mte.getWorld().spawnParticle(particle, x, y, z, 0, 0, 0);
+        }
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -13,6 +13,7 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
@@ -406,7 +407,10 @@ public class MetaTileEntities {
                         default -> 4;
                         },
                         tier <= GTValues.MV ? Textures.MACERATOR_OVERLAY : Textures.PULVERIZER_OVERLAY,
-                        tier));
+                        tier,
+                        true,
+                        GTUtility.defaultTankSizeFunction,
+                        VanillaParticleEffects.TOP_SMOKE_SMALL, null));
 
         // Alloy Smelter, IDs 80-94
         registerSimpleMetaTileEntity(ALLOY_SMELTER, 80, "alloy_smelter", RecipeMaps.ALLOY_SMELTER_RECIPES,

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntitySingleCombustion.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntitySingleCombustion.java
@@ -4,10 +4,13 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleGeneratorMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
@@ -44,6 +47,14 @@ public class MetaTileEntitySingleCombustion extends SimpleGeneratorMetaTileEntit
             // Don't render the top overlay if the facing is up, as the textures
             // would collide, otherwise render normally.
             super.renderOverlays(renderState, translation, pipeline);
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        if (isActive()) {
+            VanillaParticleEffects.COMBUSTION_SMOKE.runEffect(this);
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/SimpleMachineMetaTileEntityResizable.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/SimpleMachineMetaTileEntityResizable.java
@@ -5,10 +5,13 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.client.particle.IMachineParticleEffect;
 import gregtech.client.renderer.ICubeRenderer;
 
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.IItemHandlerModifiable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Function;
 
@@ -58,6 +61,23 @@ public class SimpleMachineMetaTileEntityResizable extends SimpleMachineMetaTileE
         initializeInventory();
     }
 
+    public SimpleMachineMetaTileEntityResizable(ResourceLocation metaTileEntityId,
+                                                RecipeMap<?> recipeMap,
+                                                int inputAmount,
+                                                int outputAmount,
+                                                ICubeRenderer renderer,
+                                                int tier,
+                                                boolean hasFrontFacing,
+                                                Function<Integer, Integer> tankScalingFunction,
+                                                @Nullable IMachineParticleEffect tickingParticle,
+                                                @Nullable IMachineParticleEffect randomParticle) {
+        super(metaTileEntityId, recipeMap, renderer, tier, hasFrontFacing, tankScalingFunction, tickingParticle,
+                randomParticle);
+        this.inputAmount = inputAmount;
+        this.outputAmount = outputAmount;
+        initializeInventory();
+    }
+
     @Override
     protected IItemHandlerModifiable createImportItemHandler() {
         if (inputAmount != -1) {
@@ -77,7 +97,8 @@ public class SimpleMachineMetaTileEntityResizable extends SimpleMachineMetaTileE
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new SimpleMachineMetaTileEntityResizable(metaTileEntityId, workable.getRecipeMap(), inputAmount,
-                outputAmount, renderer, getTier());
+                outputAmount, renderer, getTier(), hasFrontFacing(),
+                getTankScalingFunction(), tickingParticle, randomParticle);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
@@ -12,6 +12,7 @@ import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockContro
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.ConfigHolder;
@@ -47,6 +48,7 @@ public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockControll
         return new MetaTileEntityCokeOven(metaTileEntityId);
     }
 
+    @NotNull
     @Override
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
@@ -112,29 +114,13 @@ public class MetaTileEntityCokeOven extends RecipeMapPrimitiveMultiblockControll
     @Override
     public void randomDisplayTick() {
         if (this.isActive()) {
-            final BlockPos pos = getPos();
-            float x = pos.getX() + 0.5F;
-            float z = pos.getZ() + 0.5F;
-
-            final EnumFacing facing = getFrontFacing();
-            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
-            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F + 0.3F;
-
-            if (facing.getAxis() == EnumFacing.Axis.X) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
-                else x -= 0.52F;
-                z += horizontalOffset;
-            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
-                else z -= 0.52F;
-                x += horizontalOffset;
-            }
+            VanillaParticleEffects.defaultFrontEffect(this, 0.3F, EnumParticleTypes.SMOKE_LARGE,
+                    EnumParticleTypes.FLAME);
             if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
-                getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F,
-                        false);
+                BlockPos pos = getPos();
+                getWorld().playSound(pos.getX(), pos.getY(), pos.getZ(),
+                        SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
             }
-            getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, x, y, z, 0, 0, 0);
-            getWorld().spawnParticle(EnumParticleTypes.FLAME, x, y, z, 0, 0, 0);
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -16,6 +16,7 @@ import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.util.GTUtility;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.CubeRendererState;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.cclop.ColourOperation;
@@ -58,6 +59,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
         return new MetaTileEntityPrimitiveBlastFurnace(metaTileEntityId);
     }
 
+    @NotNull
     @Override
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
@@ -137,22 +139,11 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
 
         if (this.isActive()) {
             if (getWorld().isRemote) {
-                pollutionParticles();
+                VanillaParticleEffects.PBF_SMOKE.runEffect(this);
             } else {
                 damageEntitiesAndBreakSnow();
             }
         }
-    }
-
-    private void pollutionParticles() {
-        BlockPos pos = this.getPos();
-        EnumFacing facing = this.getFrontFacing().getOpposite();
-        float xPos = facing.getXOffset() * 0.76F + pos.getX() + 0.5F;
-        float yPos = facing.getYOffset() * 0.76F + pos.getY() + 0.25F;
-        float zPos = facing.getZOffset() * 0.76F + pos.getZ() + 0.5F;
-
-        float ySpd = facing.getYOffset() * 0.1F + 0.2F + 0.1F * GTValues.RNG.nextFloat();
-        runMufflerEffect(xPos, yPos, zPos, 0, ySpd, 0);
     }
 
     private void damageEntitiesAndBreakSnow() {
@@ -167,32 +158,17 @@ public class MetaTileEntityPrimitiveBlastFurnace extends RecipeMapPrimitiveMulti
         }
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public void randomDisplayTick() {
         if (this.isActive()) {
-            final BlockPos pos = getPos();
-            float x = pos.getX() + 0.5F;
-            float z = pos.getZ() + 0.5F;
-
-            final EnumFacing facing = getFrontFacing();
-            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
-            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F + 0.3F;
-
-            if (facing.getAxis() == EnumFacing.Axis.X) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
-                else x -= 0.52F;
-                z += horizontalOffset;
-            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
-                else z -= 0.52F;
-                x += horizontalOffset;
-            }
+            VanillaParticleEffects.defaultFrontEffect(this, 0.3F, EnumParticleTypes.SMOKE_LARGE,
+                    EnumParticleTypes.FLAME);
             if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
-                getWorld().playSound(x, y, z, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F,
-                        false);
+                BlockPos pos = getPos();
+                getWorld().playSound(pos.getX() + 0.5F, pos.getY() + 0.5F, pos.getZ() + 0.5F,
+                        SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
             }
-            getWorld().spawnParticle(EnumParticleTypes.SMOKE_LARGE, x, y, z, 0, 0, 0);
-            getWorld().spawnParticle(EnumParticleTypes.FLAME, x, y, z, 0, 0, 0);
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
@@ -14,6 +14,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.TooltipHelper;
 
@@ -22,7 +23,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -33,6 +33,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -68,7 +69,7 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
 
         if (getWorld().isRemote && getController() instanceof MultiblockWithDisplayBase controller &&
                 controller.isActive()) {
-            pollutionParticles();
+            VanillaParticleEffects.MUFFLER_SMOKE.runEffect(this);
         }
     }
 
@@ -111,32 +112,12 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
         return blockState.getBlock().isAir(blockState, getWorld(), frontPos) || GTUtility.isBlockSnow(blockState);
     }
 
+    /** @deprecated Use {@link VanillaParticleEffects#MUFFLER_SMOKE} instead. */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     @SideOnly(Side.CLIENT)
     public void pollutionParticles() {
-        BlockPos pos = this.getPos();
-        EnumFacing facing = this.getFrontFacing();
-        float xPos = facing.getXOffset() * 0.76F + pos.getX() + 0.25F;
-        float yPos = facing.getYOffset() * 0.76F + pos.getY() + 0.25F;
-        float zPos = facing.getZOffset() * 0.76F + pos.getZ() + 0.25F;
-
-        float ySpd = facing.getYOffset() * 0.1F + 0.2F + 0.1F * GTValues.RNG.nextFloat();
-        float xSpd;
-        float zSpd;
-
-        if (facing.getYOffset() == -1) {
-            float temp = GTValues.RNG.nextFloat() * 2 * (float) Math.PI;
-            xSpd = (float) Math.sin(temp) * 0.1F;
-            zSpd = (float) Math.cos(temp) * 0.1F;
-        } else {
-            xSpd = facing.getXOffset() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
-            zSpd = facing.getZOffset() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
-        }
-        if (getController() instanceof MultiblockWithDisplayBase)
-            ((MultiblockWithDisplayBase) getController()).runMufflerEffect(
-                    xPos + GTValues.RNG.nextFloat() * 0.5F,
-                    yPos + GTValues.RNG.nextFloat() * 0.5F,
-                    zPos + GTValues.RNG.nextFloat() * 0.5F,
-                    xSpd, ySpd, zSpd);
+        VanillaParticleEffects.MUFFLER_SMOKE.runEffect(this);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamGrinder.java
@@ -8,6 +8,7 @@ import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.TooltipHelper;
@@ -18,6 +19,7 @@ import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
@@ -94,5 +96,13 @@ public class MetaTileEntitySteamGrinder extends RecipeMapSteamMultiblockControll
         tooltip.add(I18n.format("gregtech.multiblock.steam_.duration_modifier"));
         tooltip.add(I18n.format("gregtech.universal.tooltip.parallel", PARALLEL_LIMIT));
         tooltip.add(TooltipHelper.BLINKING_ORANGE + I18n.format("gregtech.multiblock.require_steam_parts"));
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        if (isActive()) {
+            VanillaParticleEffects.defaultFrontEffect(this, 0.4F, EnumParticleTypes.SMOKE_NORMAL);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.multi.steam;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.impl.SteamMultiWorkable;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -8,6 +9,7 @@ import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.TooltipHelper;
@@ -19,6 +21,7 @@ import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
@@ -44,6 +47,7 @@ public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController 
         return new MetaTileEntitySteamOven(metaTileEntityId);
     }
 
+    @NotNull
     @Override
     protected BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start()
@@ -117,5 +121,16 @@ public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController 
         tooltip.add(I18n.format("gregtech.multiblock.steam_.duration_modifier"));
         tooltip.add(I18n.format("gregtech.universal.tooltip.parallel", MAX_PARALLELS));
         tooltip.add(TooltipHelper.BLINKING_ORANGE + I18n.format("gregtech.multiblock.require_steam_parts"));
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void randomDisplayTick() {
+        if (isActive()) {
+            VanillaParticleEffects.defaultFrontEffect(this, EnumParticleTypes.SMOKE_LARGE, EnumParticleTypes.FLAME);
+            if (GTValues.RNG.nextBoolean()) {
+                VanillaParticleEffects.defaultFrontEffect(this, 0.5F, EnumParticleTypes.SMOKE_NORMAL);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
@@ -9,6 +9,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -60,10 +61,10 @@ public class SteamAlloySmelter extends SteamMetaTileEntity {
 
     @SideOnly(Side.CLIENT)
     @Override
-    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
-        super.randomDisplayTick(x, y, z, flame, smoke);
-        if (GTValues.RNG.nextBoolean()) {
-            getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y + 0.5F, z, 0, 0, 0);
+    public void randomDisplayTick() {
+        super.randomDisplayTick();
+        if (isActive() && GTValues.RNG.nextBoolean()) {
+            VanillaParticleEffects.defaultFrontEffect(this, 0.5F, EnumParticleTypes.SMOKE_NORMAL);
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
@@ -8,6 +8,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -52,7 +53,9 @@ public class SteamExtractor extends SteamMetaTileEntity {
 
     @SideOnly(Side.CLIENT)
     @Override
-    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
-        getWorld().spawnParticle(EnumParticleTypes.CLOUD, x, y, z, 0, 0, 0);
+    public void randomDisplayTick() {
+        if (isActive()) {
+            VanillaParticleEffects.defaultFrontEffect(this, EnumParticleTypes.CLOUD);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
@@ -1,5 +1,6 @@
 package gregtech.common.metatileentities.steam;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -8,11 +9,16 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -57,7 +63,17 @@ public class SteamFurnace extends SteamMetaTileEntity {
 
     @SideOnly(Side.CLIENT)
     @Override
-    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
-        super.randomDisplayTick(x, y + 0.5F, z, flame, smoke);
+    public void randomDisplayTick() {
+        if (this.isActive()) {
+            EnumParticleTypes smokeParticle = isHighPressure ? EnumParticleTypes.SMOKE_LARGE :
+                    EnumParticleTypes.SMOKE_NORMAL;
+            VanillaParticleEffects.defaultFrontEffect(this, 0.5F, smokeParticle, EnumParticleTypes.FLAME);
+
+            if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
+                BlockPos pos = getPos();
+                getWorld().playSound(pos.getX(), pos.getY(), pos.getZ(),
+                        SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
@@ -8,6 +8,7 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -53,6 +54,8 @@ public class SteamHammer extends SteamMetaTileEntity {
     @SideOnly(Side.CLIENT)
     @Override
     public void randomDisplayTick() {
-        // steam hammers do not make particles
+        if (isActive()) {
+            VanillaParticleEffects.RANDOM_SPARKS.runEffect(this);
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
@@ -1,6 +1,5 @@
 package gregtech.common.metatileentities.steam;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -9,12 +8,11 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -58,16 +56,17 @@ public class SteamMacerator extends SteamMetaTileEntity {
         return 1;
     }
 
+    @Override
+    public void update() {
+        super.update();
+        if (isActive() && getWorld().isRemote) {
+            VanillaParticleEffects.TOP_SMOKE_SMALL.runEffect(this);
+        }
+    }
+
     @SideOnly(Side.CLIENT)
     @Override
     public void randomDisplayTick() {
-        if (isActive()) {
-            final BlockPos pos = getPos();
-            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
-            getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX() + horizontalOffset, pos.getY() + 0.52F,
-                    pos.getZ() + horizontalOffset,
-                    GTValues.RNG.nextFloat() * 0.125F, GTValues.RNG.nextFloat() * 0.375F,
-                    GTValues.RNG.nextFloat() * 0.125F);
-        }
+        // steam macerators do not make particles in this way
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
@@ -10,6 +10,7 @@ import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.block.Block;
@@ -116,8 +117,10 @@ public class SteamRockBreaker extends SteamMetaTileEntity {
 
     @SideOnly(Side.CLIENT)
     @Override
-    protected void randomDisplayTick(float x, float y, float z, EnumParticleTypes flame, EnumParticleTypes smoke) {
-        getWorld().spawnParticle(EnumParticleTypes.SMOKE_NORMAL, x, y + 0.4F, z, 0, 0, 0);
+    public void randomDisplayTick() {
+        if (isActive()) {
+            VanillaParticleEffects.defaultFrontEffect(this, 0.4F, EnumParticleTypes.SMOKE_NORMAL);
+        }
     }
 
     protected class SteamRockBreakerRecipeLogic extends RecipeLogicSteam {

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -18,6 +18,7 @@ import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextFormattingUtil;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
@@ -48,6 +49,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -386,32 +388,21 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
     @Override
     public void randomDisplayTick() {
         if (this.isActive()) {
-            final BlockPos pos = getPos();
-            float x = pos.getX() + 0.5F;
-            float z = pos.getZ() + 0.5F;
+            EnumParticleTypes smokeParticle = isHighPressure ? EnumParticleTypes.SMOKE_LARGE :
+                    EnumParticleTypes.SMOKE_NORMAL;
+            VanillaParticleEffects.defaultFrontEffect(this, smokeParticle, EnumParticleTypes.FLAME);
 
-            if (GTValues.RNG.nextDouble() < 0.1) {
-                getWorld().playSound(x, pos.getY(), z + 0.5F, SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE,
-                        SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+            if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
+                BlockPos pos = getPos();
+                getWorld().playSound(pos.getX() + 0.5F, pos.getY() + 0.5F, pos.getZ() + 0.5F,
+                        SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
             }
-
-            final EnumFacing facing = getFrontFacing();
-            final float horizontalOffset = GTValues.RNG.nextFloat() * 0.6F - 0.3F;
-            final float y = pos.getY() + GTValues.RNG.nextFloat() * 0.375F;
-
-            if (facing.getAxis() == EnumFacing.Axis.X) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) x += 0.52F;
-                else x -= 0.52F;
-                z += horizontalOffset;
-            } else if (facing.getAxis() == EnumFacing.Axis.Z) {
-                if (facing.getAxisDirection() == EnumFacing.AxisDirection.POSITIVE) z += 0.52F;
-                else z -= 0.52F;
-                x += horizontalOffset;
-            }
-            randomDisplayTick(x, y, z);
         }
     }
 
+    /** @deprecated No longer used, look at {@link VanillaParticleEffects#defaultFrontEffect} to see old logic. */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     @SideOnly(Side.CLIENT)
     protected void randomDisplayTick(float x, float y, float z) {
         getWorld().spawnParticle(isHighPressure ? EnumParticleTypes.SMOKE_LARGE : EnumParticleTypes.SMOKE_NORMAL, x, y,

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
@@ -11,11 +11,15 @@ import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.material.Materials;
+import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.ConfigHolder;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
@@ -126,11 +130,14 @@ public class SteamLavaBoiler extends SteamBoiler {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void randomDisplayTick(float x, float y, float z) {
-        super.randomDisplayTick(x, y, z);
-        if (GTValues.RNG.nextFloat() < 0.3F) {
-            getWorld().spawnParticle(EnumParticleTypes.LAVA, x + GTValues.RNG.nextFloat(), y,
-                    z + GTValues.RNG.nextFloat(), 0.0F, 0.0F, 0.0F);
+    public void randomDisplayTick() {
+        if (this.isActive()) {
+            VanillaParticleEffects.RANDOM_LAVA_SMOKE.runEffect(this);
+            if (ConfigHolder.machines.machineSounds && GTValues.RNG.nextDouble() < 0.1) {
+                BlockPos pos = getPos();
+                getWorld().playSound(pos.getX() + 0.5F, pos.getY() + 0.5F, pos.getZ() + 0.5F,
+                        SoundEvents.BLOCK_FURNACE_FIRE_CRACKLE, SoundCategory.BLOCKS, 1.0F, 1.0F, false);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes some minor issues with particle effects for machines, including steam macerator and liquid boiler.

Refactors particle code to deduplicate a lot of particle rendering code, and remove some unnecessary methods on MTE classes.

Adds new particle effects for Steam Grinder, singleblock Combustion Generators, singleblock Macerators, and Steam Forge Hammer.

Adds a new way through API to add custom particles to machines to be run while active, either every tick or on randomDisplayTick()