### PR TITLE
Re-implement walking speed bonus

### DIFF
--- a/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
+++ b/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
@@ -6,7 +6,7 @@ import net.minecraft.entity.Entity;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * @deprecated use {@link gregtech.api.util.BlockUtility#addWalkingSpeedBonus(IBlockState, double)}
+ * @deprecated use {@link gregtech.api.util.BlockUtility#setWalkingSpeedBonus(IBlockState, double)}
  */
 @SuppressWarnings("DeprecatedIsStillUsed")
 @Deprecated

--- a/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
+++ b/src/main/java/gregtech/api/block/IWalkingSpeedBonus.java
@@ -3,6 +3,14 @@ package gregtech.api.block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * @deprecated use {@link gregtech.api.util.BlockUtility#addWalkingSpeedBonus(IBlockState, double)}
+ */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated
+@ApiStatus.ScheduledForRemoval(inVersion = "2.9")
 public interface IWalkingSpeedBonus {
 
     default double getWalkingSpeedBonus() {

--- a/src/main/java/gregtech/api/block/VariantActiveBlock.java
+++ b/src/main/java/gregtech/api/block/VariantActiveBlock.java
@@ -120,7 +120,7 @@ public class VariantActiveBlock<T extends Enum<T> & IStringSerializable> extends
     @NotNull
     @Override
     protected BlockStateContainer createBlockState() {
-        Class<T> enumClass = getActualTypeParameter(getClass(), VariantActiveBlock.class, 0);
+        Class<T> enumClass = getActualTypeParameter(getClass(), VariantActiveBlock.class);
         this.VARIANT = PropertyEnum.create("variant", enumClass);
         this.VALUES = enumClass.getEnumConstants();
         return new ExtendedBlockState(this, new IProperty[] { VARIANT, ACTIVE_DEPRECATED },

--- a/src/main/java/gregtech/api/block/VariantBlock.java
+++ b/src/main/java/gregtech/api/block/VariantBlock.java
@@ -26,7 +26,8 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 
-public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block {
+@SuppressWarnings("deprecation")
+public class VariantBlock<T extends Enum<T> & IStringSerializable> extends Block implements IWalkingSpeedBonus {
 
     protected PropertyEnum<T> VARIANT;
     protected T[] VALUES;

--- a/src/main/java/gregtech/api/util/BlockUtility.java
+++ b/src/main/java/gregtech/api/util/BlockUtility.java
@@ -63,13 +63,13 @@ public class BlockUtility {
     }
 
     /**
-     * Add walking speed bonus to the block state. The bonus value is a percentage value that gets added to the player
+     * Set walking speed bonus for the block state. The bonus value is a percentage value that gets added to the player
      * speed; for example, a bonus value of {@link 0.25} will add 25% of extra speed to the player.
      *
      * @param state  block state
      * @param amount amount of walking speed bonus
      */
-    public static void addWalkingSpeedBonus(@NotNull IBlockState state, double amount) {
+    public static void setWalkingSpeedBonus(@NotNull IBlockState state, double amount) {
         Objects.requireNonNull(state, "state == null");
         if (!Double.isFinite(amount)) {
             throw new IllegalArgumentException("Haha funny i put NaN and Infinity in your API method haha no");

--- a/src/main/java/gregtech/api/util/BlockUtility.java
+++ b/src/main/java/gregtech/api/util/BlockUtility.java
@@ -2,14 +2,38 @@ package gregtech.api.util;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
+import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 public class BlockUtility {
 
     private static final BlockWrapper WRAPPER = new BlockWrapper();
+
+    private static final Object2DoubleMap<IBlockState> walkingSpeedBonusInternal = new Object2DoubleOpenHashMap<>();
+    /**
+     * View-only collection of block states that give speed bonus when walking over it. The bonus value is a percentage
+     * value that gets added to the player speed; for example, a bonus value of {@link 0.25} will add 25% of extra speed
+     * to the player.
+     */
+    public static final Object2DoubleMap<IBlockState> WALKING_SPEED_BONUS = Object2DoubleMaps.unmodifiable(
+            walkingSpeedBonusInternal);
+
+    /**
+     * Walking speed bonus applied to asphalt and concrete blocks.
+     */
+    public static final double ASPHALT_WALKING_SPEED_BONUS = 0.6;
+    /**
+     * Walking speed bonus applied to studs.
+     */
+    public static final double STUDS_WALKING_SPEED_BONUS = 0.25;
 
     private static class BlockWrapper extends Block {
 
@@ -30,5 +54,24 @@ public class BlockUtility {
 
     public static NonNullList<ItemStack> stopCaptureDrops() {
         return WRAPPER.captureDrops(false);
+    }
+
+    /**
+     * Add walking speed bonus to the block state. The bonus value is a percentage value that gets added to the player
+     * speed; for example, a bonus value of {@link 0.25} will add 25% of extra speed to the player.
+     *
+     * @param state  block state
+     * @param amount amount of walking speed bonus
+     */
+    public static void addWalkingSpeedBonus(@NotNull IBlockState state, double amount) {
+        Objects.requireNonNull(state, "state == null");
+        if (!Double.isFinite(amount)) {
+            throw new IllegalArgumentException("Haha funny i put NaN and Infinity in your API method haha no");
+        }
+        if (amount == 0) {
+            walkingSpeedBonusInternal.remove(state);
+        } else {
+            walkingSpeedBonusInternal.put(state, amount);
+        }
     }
 }

--- a/src/main/java/gregtech/api/util/BlockUtility.java
+++ b/src/main/java/gregtech/api/util/BlockUtility.java
@@ -12,6 +12,7 @@ import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+import java.util.UUID;
 
 public class BlockUtility {
 
@@ -25,6 +26,11 @@ public class BlockUtility {
      */
     public static final Object2DoubleMap<IBlockState> WALKING_SPEED_BONUS = Object2DoubleMaps.unmodifiable(
             walkingSpeedBonusInternal);
+
+    /**
+     * UUID of the walking speed bonus attribute applied to players.
+     */
+    public static final UUID WALKING_SPEED_UUID = UUID.fromString("415ac431-8339-4150-965c-e673a8a328be");
 
     /**
      * Walking speed bonus applied to asphalt and concrete blocks.

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -1,6 +1,7 @@
 package gregtech.common;
 
 import gregtech.api.GTValues;
+import gregtech.api.block.IWalkingSpeedBonus;
 import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.items.toolitem.ToolClasses;
 import gregtech.api.items.toolitem.ToolHelper;
@@ -8,6 +9,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.pipenet.longdist.LongDistanceNetwork;
 import gregtech.api.pipenet.tile.IPipeTile;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.util.BlockUtility;
 import gregtech.api.util.CapesRegistry;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.VirtualTankRegistry;
@@ -18,8 +20,12 @@ import gregtech.common.items.armor.PowerlessJetpack;
 import gregtech.common.items.behaviors.ToggleEnergyConsumerBehavior;
 import gregtech.common.metatileentities.multi.electric.centralmonitor.MetaTileEntityCentralMonitor;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.entity.EntityOtherPlayerMP;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.monster.EntityEnderman;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
@@ -31,7 +37,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumDifficulty;
+import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.living.EnderTeleportEvent;
 import net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent;
@@ -52,11 +60,15 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
 
+import java.util.UUID;
+
 @Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class EventHandlers {
 
     private static final String HAS_TERMINAL = GTValues.MODID + ".terminal";
     private static ItemStack lastFeetEquip = ItemStack.EMPTY;
+
+    private static final UUID WALKING_SPEED_UUID = UUID.fromString("415ac431-8339-4150-965c-e673a8a328be");
 
     @SubscribeEvent
     public static void onEndermanTeleportEvent(EnderTeleportEvent event) {
@@ -148,8 +160,7 @@ public class EventHandlers {
 
     @SubscribeEvent(priority = EventPriority.LOW)
     public static void onEntityLivingFallEvent(LivingFallEvent event) {
-        if (event.getEntity() instanceof EntityPlayerMP) {
-            EntityPlayerMP player = (EntityPlayerMP) event.getEntity();
+        if (event.getEntity() instanceof EntityPlayerMP player) {
             ItemStack armor = player.getItemStackFromSlot(EntityEquipmentSlot.FEET);
             ItemStack jet = player.getItemStackFromSlot(EntityEquipmentSlot.CHEST);
 
@@ -166,14 +177,14 @@ public class EventHandlers {
                 }
             } else if (!jet.isEmpty() && jet.getItem() instanceof ArmorMetaItem<?> &&
                     GTUtility.getOrCreateNbtCompound(jet).hasKey("flyMode")) {
-                        ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) jet.getItem()).getItem(jet);
-                        if (valueItem != null) {
-                            valueItem.getArmorLogic().damageArmor(player, jet, DamageSource.FALL,
-                                    (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
-                            player.fallDistance = 0;
-                            event.setCanceled(true);
-                        }
-                    }
+                ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) jet.getItem()).getItem(jet);
+                if (valueItem != null) {
+                    valueItem.getArmorLogic().damageArmor(player, jet, DamageSource.FALL,
+                            (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
+                    player.fallDistance = 0;
+                    event.setCanceled(true);
+                }
+            }
         }
     }
 
@@ -206,9 +217,91 @@ public class EventHandlers {
         }
     }
 
+    @SuppressWarnings({ "ConstantValue", "deprecation" })
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        EntityPlayer player = event.player;
+        if (event.phase == TickEvent.Phase.START && !player.world.isRemote) {
+            IAttributeInstance movementSpeed = player.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);
+            if (movementSpeed == null) return;
+            AttributeModifier modifier = movementSpeed.getModifier(WALKING_SPEED_UUID);
+
+            double speedBonus;
+            if (!player.onGround || player.isInWater() || player.isSneaking()) {
+                speedBonus = 0;
+            } else {
+                IBlockState state = player.world.getBlockState(new BlockPos(
+                        player.posX, player.getEntityBoundingBox().minY - 1, player.posZ));
+                speedBonus = BlockUtility.WALKING_SPEED_BONUS.getDouble(state);
+                if (speedBonus == 0 &&
+                        state.getBlock() instanceof IWalkingSpeedBonus walkingSpeedBonus &&
+                        walkingSpeedBonus.bonusSpeedCondition(player) &&
+                        walkingSpeedBonus.checkApplicableBlocks(state)) {
+                    speedBonus = walkingSpeedBonus.getWalkingSpeedBonus();
+                }
+            }
+            if (modifier != null) {
+                if (speedBonus == modifier.getAmount()) return;
+                else movementSpeed.removeModifier(WALKING_SPEED_UUID);
+            } else {
+                if (speedBonus == 0) return;
+            }
+            if (speedBonus != 0) {
+                movementSpeed.applyModifier(new AttributeModifier(WALKING_SPEED_UUID, "Walking Speed Bonus",
+                        speedBonus, 2));
+            }
+        }
+    }
+
+    @SuppressWarnings({ "lossy-conversions", "ConstantValue" })
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
-    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+    public static void onFOVUpdate(FOVUpdateEvent event) { // this event SUCKS
+        EntityPlayer player = event.getEntity();
+        IAttributeInstance movementSpeed = player.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);
+        if (movementSpeed == null || movementSpeed.getModifier(WALKING_SPEED_UUID) == null) return;
+
+        float originalFov = player.capabilities.isFlying ? 1.1f : 1.0f;
+        originalFov *= (movementSpeed.getAttributeValue() / player.capabilities.getWalkSpeed() + 1) / 2;
+
+        if (player.capabilities.getWalkSpeed() == 0 || Float.isNaN(originalFov) || Float.isInfinite(originalFov)) {
+            return;
+        }
+
+        float newFov = player.capabilities.isFlying ? 1.1f : 1.0f;
+        newFov *= (computeValueWithoutWalkingSpeed(movementSpeed) / player.capabilities.getWalkSpeed() + 1) / 2;
+
+        event.setNewfov(newFov / originalFov * event.getNewfov());
+    }
+
+    /**
+     * Computes walking speed without boost from {@link BlockUtility#WALKING_SPEED_BONUS}. Skipping parent check stuff
+     * because movement speed attribute does not have any parent modifier.
+     */
+    private static double computeValueWithoutWalkingSpeed(IAttributeInstance attrib) {
+        double base = attrib.getBaseValue();
+
+        for (AttributeModifier m : attrib.getModifiersByOperation(0)) {
+            base += m.getAmount();
+        }
+
+        double applied = base;
+
+        for (AttributeModifier m : attrib.getModifiersByOperation(1)) {
+            applied += base * m.getAmount();
+        }
+
+        for (AttributeModifier m : attrib.getModifiersByOperation(2)) {
+            if (m.getID() == WALKING_SPEED_UUID) continue;
+            applied *= 1 + m.getAmount();
+        }
+
+        return attrib.getAttribute().clampValue(applied);
+    }
+
+    @SubscribeEvent
+    @SideOnly(Side.CLIENT)
+    public static void onPlayerTickClient(TickEvent.PlayerTickEvent event) {
         if (event.phase == TickEvent.Phase.START && !event.player.isSpectator() &&
                 !(event.player instanceof EntityOtherPlayerMP) && !(event.player instanceof FakePlayer)) {
             ItemStack feetEquip = event.player.getItemStackFromSlot(EntityEquipmentSlot.FEET);

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -173,14 +173,14 @@ public class EventHandlers {
                 }
             } else if (!jet.isEmpty() && jet.getItem() instanceof ArmorMetaItem<?> &&
                     GTUtility.getOrCreateNbtCompound(jet).hasKey("flyMode")) {
-                ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) jet.getItem()).getItem(jet);
-                if (valueItem != null) {
-                    valueItem.getArmorLogic().damageArmor(player, jet, DamageSource.FALL,
-                            (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
-                    player.fallDistance = 0;
-                    event.setCanceled(true);
-                }
-            }
+                        ArmorMetaItem<?>.ArmorMetaValueItem valueItem = ((ArmorMetaItem<?>) jet.getItem()).getItem(jet);
+                        if (valueItem != null) {
+                            valueItem.getArmorLogic().damageArmor(player, jet, DamageSource.FALL,
+                                    (int) (player.fallDistance - 1.2f), EntityEquipmentSlot.FEET);
+                            player.fallDistance = 0;
+                            event.setCanceled(true);
+                        }
+                    }
         }
     }
 

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -235,9 +235,10 @@ public class EventHandlers {
                 speedBonus = BlockUtility.WALKING_SPEED_BONUS.getDouble(state);
                 if (speedBonus == 0 &&
                         state.getBlock() instanceof IWalkingSpeedBonus walkingSpeedBonus &&
+                        walkingSpeedBonus.getWalkingSpeedBonus() != 1 &&
                         walkingSpeedBonus.bonusSpeedCondition(player) &&
                         walkingSpeedBonus.checkApplicableBlocks(state)) {
-                    speedBonus = walkingSpeedBonus.getWalkingSpeedBonus();
+                    speedBonus = walkingSpeedBonus.getWalkingSpeedBonus() - 1;
                 }
             }
             if (modifier != null) {

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -229,6 +229,7 @@ public class EventHandlers {
                 IBlockState state = player.world.getBlockState(new BlockPos(
                         player.posX, player.getEntityBoundingBox().minY - 1, player.posZ));
                 speedBonus = BlockUtility.WALKING_SPEED_BONUS.getDouble(state);
+                // { remove this bit while removing IWalkingSpeedBonus
                 if (speedBonus == 0 &&
                         state.getBlock() instanceof IWalkingSpeedBonus walkingSpeedBonus &&
                         walkingSpeedBonus.getWalkingSpeedBonus() != 1 &&
@@ -236,6 +237,7 @@ public class EventHandlers {
                         walkingSpeedBonus.checkApplicableBlocks(state)) {
                     speedBonus = walkingSpeedBonus.getWalkingSpeedBonus() - 1;
                 }
+                // }
             }
             if (modifier != null) {
                 if (speedBonus == modifier.getAmount()) return;

--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -60,15 +60,11 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
 
-import java.util.UUID;
-
 @Mod.EventBusSubscriber(modid = GTValues.MODID)
 public class EventHandlers {
 
     private static final String HAS_TERMINAL = GTValues.MODID + ".terminal";
     private static ItemStack lastFeetEquip = ItemStack.EMPTY;
-
-    private static final UUID WALKING_SPEED_UUID = UUID.fromString("415ac431-8339-4150-965c-e673a8a328be");
 
     @SubscribeEvent
     public static void onEndermanTeleportEvent(EnderTeleportEvent event) {
@@ -224,7 +220,7 @@ public class EventHandlers {
         if (event.phase == TickEvent.Phase.START && !player.world.isRemote) {
             IAttributeInstance movementSpeed = player.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);
             if (movementSpeed == null) return;
-            AttributeModifier modifier = movementSpeed.getModifier(WALKING_SPEED_UUID);
+            AttributeModifier modifier = movementSpeed.getModifier(BlockUtility.WALKING_SPEED_UUID);
 
             double speedBonus;
             if (!player.onGround || player.isInWater() || player.isSneaking()) {
@@ -243,13 +239,13 @@ public class EventHandlers {
             }
             if (modifier != null) {
                 if (speedBonus == modifier.getAmount()) return;
-                else movementSpeed.removeModifier(WALKING_SPEED_UUID);
+                else movementSpeed.removeModifier(BlockUtility.WALKING_SPEED_UUID);
             } else {
                 if (speedBonus == 0) return;
             }
             if (speedBonus != 0) {
-                movementSpeed.applyModifier(new AttributeModifier(WALKING_SPEED_UUID, "Walking Speed Bonus",
-                        speedBonus, 2));
+                movementSpeed.applyModifier(new AttributeModifier(BlockUtility.WALKING_SPEED_UUID,
+                        "Walking Speed Bonus", speedBonus, 2));
             }
         }
     }
@@ -260,7 +256,7 @@ public class EventHandlers {
     public static void onFOVUpdate(FOVUpdateEvent event) { // this event SUCKS
         EntityPlayer player = event.getEntity();
         IAttributeInstance movementSpeed = player.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);
-        if (movementSpeed == null || movementSpeed.getModifier(WALKING_SPEED_UUID) == null) return;
+        if (movementSpeed == null || movementSpeed.getModifier(BlockUtility.WALKING_SPEED_UUID) == null) return;
 
         float originalFov = player.capabilities.isFlying ? 1.1f : 1.0f;
         originalFov *= (movementSpeed.getAttributeValue() / player.capabilities.getWalkSpeed() + 1) / 2;
@@ -293,7 +289,7 @@ public class EventHandlers {
         }
 
         for (AttributeModifier m : attrib.getModifiersByOperation(2)) {
-            if (m.getID() == WALKING_SPEED_UUID) continue;
+            if (m.getID() == BlockUtility.WALKING_SPEED_UUID) continue;
             applied *= 1 + m.getAmount();
         }
 

--- a/src/main/java/gregtech/common/blocks/BlockAsphalt.java
+++ b/src/main/java/gregtech/common/blocks/BlockAsphalt.java
@@ -32,16 +32,6 @@ public class BlockAsphalt extends VariantBlock<BlockAsphalt.BlockType> {
         return false;
     }
 
-    @Override
-    public double getWalkingSpeedBonus() {
-        return 1.6D;
-    }
-
-    @Override
-    public boolean checkApplicableBlocks(IBlockState state) {
-        return state == getState(BlockType.ASPHALT);
-    }
-
     public enum BlockType implements IStringSerializable, IStateHarvestLevel {
 
         ASPHALT("asphalt", 0);

--- a/src/main/java/gregtech/common/blocks/BlockBatteryPart.java
+++ b/src/main/java/gregtech/common/blocks/BlockBatteryPart.java
@@ -41,7 +41,7 @@ public class BlockBatteryPart extends VariantBlock<BlockBatteryPart.BatteryPartT
     }
 
     @Override
-    public void addInformation(@NotNull ItemStack stack, @Nullable World world, List<String> tooltip,
+    public void addInformation(@NotNull ItemStack stack, @Nullable World world, @NotNull List<String> tooltip,
                                @NotNull ITooltipFlag advanced) {
         super.addInformation(stack, world, tooltip, advanced);
 

--- a/src/main/java/gregtech/common/blocks/BlockColored.java
+++ b/src/main/java/gregtech/common/blocks/BlockColored.java
@@ -12,12 +12,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-public class BlockColored extends VariantBlock<EnumDyeColor> {
+import org.jetbrains.annotations.NotNull;
 
-    public BlockColored() {
-        this(net.minecraft.block.material.Material.IRON, "block_colored", 2.0f, 5.0f, SoundType.METAL,
-                EnumDyeColor.WHITE);
-    }
+public class BlockColored extends VariantBlock<EnumDyeColor> {
 
     public BlockColored(Material material, String translationKey, float hardness, float resistance, SoundType soundType,
                         EnumDyeColor defaultColor) {
@@ -30,23 +27,14 @@ public class BlockColored extends VariantBlock<EnumDyeColor> {
     }
 
     @Override
-    public boolean canCreatureSpawn(IBlockState state, IBlockAccess world, BlockPos pos,
-                                    EntityLiving.SpawnPlacementType type) {
+    public boolean canCreatureSpawn(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos,
+                                    @NotNull EntityLiving.SpawnPlacementType type) {
         return false;
     }
 
     @Override
-    public double getWalkingSpeedBonus() {
-        return 1.25;
-    }
-
-    @Override
-    public boolean checkApplicableBlocks(IBlockState state) {
-        return this == MetaBlocks.STUDS;
-    }
-
-    @Override
-    public boolean recolorBlock(World world, BlockPos pos, EnumFacing side, EnumDyeColor color) {
+    public boolean recolorBlock(World world, @NotNull BlockPos pos, @NotNull EnumFacing side,
+                                @NotNull EnumDyeColor color) {
         if (world.getBlockState(pos) != getState(color)) {
             world.setBlockState(pos, getState(color));
             return true;

--- a/src/main/java/gregtech/common/blocks/BlockSteamCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockSteamCasing.java
@@ -39,7 +39,7 @@ public class BlockSteamCasing extends VariantBlock<BlockSteamCasing.SteamCasingT
     }
 
     @Override
-    public void addInformation(@NotNull ItemStack stack, @Nullable World player, List<String> tooltip,
+    public void addInformation(@NotNull ItemStack stack, @Nullable World player, @NotNull List<String> tooltip,
                                @NotNull ITooltipFlag advanced) {
         int ordinal = getState(stack).ordinal();
         if (ordinal < 2) {

--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -49,7 +49,7 @@ public class BlockWireCoil extends VariantActiveBlock<BlockWireCoil.CoilType> {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void addInformation(@NotNull ItemStack itemStack, @Nullable World worldIn, List<String> lines,
+    public void addInformation(@NotNull ItemStack itemStack, @Nullable World worldIn, @NotNull List<String> lines,
                                @NotNull ITooltipFlag tooltipFlag) {
         super.addInformation(itemStack, worldIn, lines, tooltipFlag);
 

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -11,17 +11,30 @@ import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.registry.MaterialRegistry;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.ore.StoneType;
+import gregtech.api.util.BlockUtility;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.function.TriConsumer;
 import gregtech.client.model.SimpleStateMapper;
 import gregtech.client.model.modelfactories.BakedModelHandler;
 import gregtech.client.renderer.handler.MetaTileEntityRenderer;
 import gregtech.client.renderer.handler.MetaTileEntityTESR;
-import gregtech.client.renderer.pipe.*;
+import gregtech.client.renderer.pipe.CableRenderer;
+import gregtech.client.renderer.pipe.FluidPipeRenderer;
+import gregtech.client.renderer.pipe.ItemPipeRenderer;
+import gregtech.client.renderer.pipe.LaserPipeRenderer;
+import gregtech.client.renderer.pipe.OpticalPipeRenderer;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.foam.BlockFoam;
 import gregtech.common.blocks.foam.BlockPetrifiedFoam;
-import gregtech.common.blocks.wood.*;
+import gregtech.common.blocks.wood.BlockGregFence;
+import gregtech.common.blocks.wood.BlockGregFenceGate;
+import gregtech.common.blocks.wood.BlockGregPlanks;
+import gregtech.common.blocks.wood.BlockGregWoodSlab;
+import gregtech.common.blocks.wood.BlockRubberDoor;
+import gregtech.common.blocks.wood.BlockRubberLeaves;
+import gregtech.common.blocks.wood.BlockRubberLog;
+import gregtech.common.blocks.wood.BlockRubberSapling;
+import gregtech.common.blocks.wood.BlockWoodenDoor;
 import gregtech.common.items.MetaItems;
 import gregtech.common.pipelike.cable.BlockCable;
 import gregtech.common.pipelike.cable.Insulation;
@@ -44,9 +57,15 @@ import gregtech.common.pipelike.optical.BlockOpticalPipe;
 import gregtech.common.pipelike.optical.OpticalPipeType;
 import gregtech.common.pipelike.optical.tile.TileEntityOpticalPipe;
 
-import net.minecraft.block.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFence;
+import net.minecraft.block.BlockFenceGate;
+import net.minecraft.block.BlockLog;
 import net.minecraft.block.BlockLog.EnumAxis;
+import net.minecraft.block.BlockSlab;
 import net.minecraft.block.BlockSlab.EnumBlockHalf;
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.SoundType;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -73,8 +92,14 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -333,7 +358,8 @@ public class MetaBlocks {
     }
 
     /**
-     * Deterministically populates a category of MetaBlocks based on the unique registry ID of each qualifying Material.
+     * Deterministically populates a category of MetaBlocks based on the unique registry ID of each qualifying
+     * Material.
      *
      * @param materialPredicate a filter for determining if a Material qualifies for generation in the category.
      * @param blockGenerator    a function which accepts a Materials set to pack into a MetaBlock, and the ordinal this
@@ -599,6 +625,21 @@ public class MetaBlocks {
         blockColors.registerBlockColorHandler((s, w, p, i) -> ConfigHolder.client.defaultPaintingColor,
                 HERMETIC_CASING);
         itemColors.registerItemColorHandler((s, i) -> ConfigHolder.client.defaultPaintingColor, HERMETIC_CASING);
+    }
+
+    public static void registerWalkingSpeedBonus() {
+        for (IBlockState state : ASPHALT.getBlockState().getValidStates()) {
+            BlockUtility.addWalkingSpeedBonus(state, BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
+        }
+        for (IBlockState state : STUDS.getBlockState().getValidStates()) {
+            BlockUtility.addWalkingSpeedBonus(state, BlockUtility.STUDS_WALKING_SPEED_BONUS);
+        }
+        for (StoneVariantBlock block : STONE_BLOCKS.values()) {
+            BlockUtility.addWalkingSpeedBonus(block.getState(StoneVariantBlock.StoneType.CONCRETE_DARK),
+                    BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
+            BlockUtility.addWalkingSpeedBonus(block.getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT),
+                    BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
+        }
     }
 
     public static void registerOreDict() {

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -629,15 +629,15 @@ public class MetaBlocks {
 
     public static void registerWalkingSpeedBonus() {
         for (IBlockState state : ASPHALT.getBlockState().getValidStates()) {
-            BlockUtility.addWalkingSpeedBonus(state, BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
+            BlockUtility.setWalkingSpeedBonus(state, BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
         }
         for (IBlockState state : STUDS.getBlockState().getValidStates()) {
-            BlockUtility.addWalkingSpeedBonus(state, BlockUtility.STUDS_WALKING_SPEED_BONUS);
+            BlockUtility.setWalkingSpeedBonus(state, BlockUtility.STUDS_WALKING_SPEED_BONUS);
         }
         for (StoneVariantBlock block : STONE_BLOCKS.values()) {
-            BlockUtility.addWalkingSpeedBonus(block.getState(StoneVariantBlock.StoneType.CONCRETE_DARK),
+            BlockUtility.setWalkingSpeedBonus(block.getState(StoneVariantBlock.StoneType.CONCRETE_DARK),
                     BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
-            BlockUtility.addWalkingSpeedBonus(block.getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT),
+            BlockUtility.setWalkingSpeedBonus(block.getState(StoneVariantBlock.StoneType.CONCRETE_LIGHT),
                     BlockUtility.ASPHALT_WALKING_SPEED_BONUS);
         }
     }

--- a/src/main/java/gregtech/common/blocks/StoneVariantBlock.java
+++ b/src/main/java/gregtech/common/blocks/StoneVariantBlock.java
@@ -58,16 +58,6 @@ public class StoneVariantBlock extends VariantBlock<StoneVariantBlock.StoneType>
     }
 
     @Override
-    public double getWalkingSpeedBonus() {
-        return 1.6D;
-    }
-
-    @Override
-    public boolean checkApplicableBlocks(@NotNull IBlockState state) {
-        return state == getState(StoneType.CONCRETE_DARK) || state == getState(StoneType.CONCRETE_LIGHT);
-    }
-
-    @Override
     protected boolean canSilkHarvest() {
         return this.stoneVariant == StoneVariant.SMOOTH;
     }
@@ -103,36 +93,20 @@ public class StoneVariantBlock extends VariantBlock<StoneVariantBlock.StoneType>
         }
 
         public OrePrefix getOrePrefix() {
-            switch (this) {
-                case BLACK_GRANITE:
-                case RED_GRANITE:
-                case MARBLE:
-                case BASALT:
-                    return OrePrefix.stone;
-                case CONCRETE_LIGHT:
-                case CONCRETE_DARK:
-                    return OrePrefix.block;
-                default:
-                    throw new IllegalStateException("Unreachable");
-            }
+            return switch (this) {
+                case BLACK_GRANITE, RED_GRANITE, MARBLE, BASALT -> OrePrefix.stone;
+                case CONCRETE_LIGHT, CONCRETE_DARK -> OrePrefix.block;
+            };
         }
 
         public Material getMaterial() {
-            switch (this) {
-                case BLACK_GRANITE:
-                    return Materials.GraniteBlack;
-                case RED_GRANITE:
-                    return Materials.GraniteRed;
-                case MARBLE:
-                    return Materials.Marble;
-                case BASALT:
-                    return Materials.Basalt;
-                case CONCRETE_LIGHT:
-                case CONCRETE_DARK:
-                    return Materials.Concrete;
-                default:
-                    throw new IllegalStateException("Unreachable");
-            }
+            return switch (this) {
+                case BLACK_GRANITE -> Materials.GraniteBlack;
+                case RED_GRANITE -> Materials.GraniteRed;
+                case MARBLE -> Materials.Marble;
+                case BASALT -> Materials.Basalt;
+                case CONCRETE_LIGHT, CONCRETE_DARK -> Materials.Concrete;
+            };
         }
     }
 

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -48,7 +48,19 @@ import gregtech.core.advancement.AdvancementTriggers;
 import gregtech.core.advancement.internal.AdvancementManager;
 import gregtech.core.command.internal.CommandManager;
 import gregtech.core.network.internal.NetworkHandler;
-import gregtech.core.network.packets.*;
+import gregtech.core.network.packets.PacketBlockParticle;
+import gregtech.core.network.packets.PacketClipboard;
+import gregtech.core.network.packets.PacketClipboardNBTUpdate;
+import gregtech.core.network.packets.PacketClipboardUIWidgetUpdate;
+import gregtech.core.network.packets.PacketFluidVeinList;
+import gregtech.core.network.packets.PacketKeysPressed;
+import gregtech.core.network.packets.PacketNotifyCapeChange;
+import gregtech.core.network.packets.PacketPluginSynced;
+import gregtech.core.network.packets.PacketRecoverMTE;
+import gregtech.core.network.packets.PacketReloadShaders;
+import gregtech.core.network.packets.PacketUIClientAction;
+import gregtech.core.network.packets.PacketUIOpen;
+import gregtech.core.network.packets.PacketUIWidgetUpdate;
 import gregtech.core.sound.GTSoundEvents;
 import gregtech.core.sound.internal.SoundManager;
 import gregtech.core.unification.material.internal.MaterialRegistryManager;
@@ -62,7 +74,13 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.LoaderException;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.*;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
 import org.apache.logging.log4j.LogManager;
@@ -74,11 +92,11 @@ import java.util.Map;
 import static gregtech.api.GregTechAPI.*;
 
 @GregTechModule(
-                moduleID = GregTechModules.MODULE_CORE,
-                containerID = GTValues.MODID,
-                name = "GregTech Core",
-                description = "Core GregTech content. Disabling this disables the entire mod and all its addons.",
-                coreModule = true)
+        moduleID = GregTechModules.MODULE_CORE,
+        containerID = GTValues.MODID,
+        name = "GregTech Core",
+        description = "Core GregTech content. Disabling this disables the entire mod and all its addons.",
+        coreModule = true)
 public class CoreModule implements IGregTechModule {
 
     public static final Logger logger = LogManager.getLogger("GregTech Core");
@@ -235,6 +253,7 @@ public class CoreModule implements IGregTechModule {
         /* End Cover Definition Registration */
 
         DungeonLootLoader.init();
+        MetaBlocks.registerWalkingSpeedBonus();
     }
 
     @Override

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -92,11 +92,11 @@ import java.util.Map;
 import static gregtech.api.GregTechAPI.*;
 
 @GregTechModule(
-        moduleID = GregTechModules.MODULE_CORE,
-        containerID = GTValues.MODID,
-        name = "GregTech Core",
-        description = "Core GregTech content. Disabling this disables the entire mod and all its addons.",
-        coreModule = true)
+                moduleID = GregTechModules.MODULE_CORE,
+                containerID = GTValues.MODID,
+                name = "GregTech Core",
+                description = "Core GregTech content. Disabling this disables the entire mod and all its addons.",
+                coreModule = true)
 public class CoreModule implements IGregTechModule {
 
     public static final Logger logger = LogManager.getLogger("GregTech Core");


### PR DESCRIPTION
## What
This PR re-implements walking speed bonus logic to provide better user experience and code flexibility.

## Implementation Details
The previous approach involved multiplying set constant value to player's XZ velocity directly, which created very awkward interactions; the speed boosts felt rather "slippery", but not quite like things like ice, due to velocity multiplier getting applied regardless of player input. Also the system generally had a hard time dealing with speed building up uncontrollably. Furthermore, the logic itself was a part of `VariantBlock`, which prevented other blocks from utilizing the feature.

The new implementation is attribute based; it directly gives speed bonus to the player entity, which eliminates the slipperiness. Additional measures are put into place to prevent the bonus from altering FOV.

A new API method, `BlockUtility#setWalkingSpeedBonus(IBlockState, double)` can be used to set walking speed bonus to any block.

All blocks using `IWalkingSpeedBonus` have been migrated to the new API.

## Outcome
You can walk now! (fimally!)

## Additional Information
I am quite certain that the values chosen for the speed bonuses (0.6 and 0.25) does not reflect the _actual_ speed boost gained from previous implementation. If someone has better candidate for the speed boost values, please let me know.

Also the `FOVUpdateEvent` is so bad holy shit ASM would almost have been easier than this, shoutouts to MachineMuse (Claire Semple) for making the event class in 6:07 PM, 9/5/13

## Potential Compatibility Issues
The `IWalkingSpeedBonus` interface has been deprecated, and `VariantBlock`'s previous walking speed code has been removed. Addons using this feature will need to migrate to the new API until next minor release.
