### PR TITLE
fix using client only method for harder bed recipe names

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -649,7 +649,7 @@ public class VanillaOverrideRecipes {
     }
 
     private static void addBedRecipe(int meta) {
-        String colorName = EnumDyeColor.byMetadata(meta).getDyeColorName();
+        String colorName = EnumDyeColor.byMetadata(meta).getName();
         if ("silver".equals(colorName)) {
             // thank you mojang
             colorName = "light_gray";


### PR DESCRIPTION
## What
Fixes crash on the server due to a `SideOnly(Side.CLIENT)` annotation being present on the primary getter. The `getName()` method produces the same result without the annotation - thank you forge.
