### PR TITLE
Rework Generators 2.0 ™️ 

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -46,4 +46,9 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
         // parallel is limited by voltage
         return Integer.MAX_VALUE;
     }
+
+    @Override
+    public boolean isAllowOverclocking() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -111,11 +111,6 @@ public class SimpleGeneratorMetaTileEntity extends WorkableTieredMetaTileEntity 
         builder.widget(new LabelWidget(6, 6, getMetaFullName()))
                 .bindPlayerInventory(player.inventory, GuiTextures.SLOT, yOffset);
 
-        builder.widget(new CycleButtonWidget(7, 62 + yOffset, 18, 18,
-                workable.getAvailableOverclockingTiers(), workable::getOverclockTier, workable::setOverclockTier)
-                        .setTooltipHoverString("gregtech.gui.overclock.description")
-                        .setButtonTexture(GuiTextures.BUTTON_OVERCLOCK));
-
         return builder;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -8,7 +8,6 @@ import gregtech.api.capability.impl.FuelRecipeLogic;
 import gregtech.api.capability.impl.RecipeLogicEnergy;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.widgets.CycleButtonWidget;
 import gregtech.api.gui.widgets.LabelWidget;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.RecipeMap;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -355,6 +355,23 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         }
 
         @Override
+        public void update() {
+            // drain oxygen if present to boost production, and if the dynamo hatch supports it
+            if (combustionEngine.isBoostAllowed() &&
+                    (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 20 == 0)) {
+                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
+                FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
+                if (boosterStack.isFluidStackIdentical(inputTank.drain(boosterStack, false))) {
+                    isOxygenBoosted = true;
+                    inputTank.drain(boosterStack, true);
+                } else {
+                    isOxygenBoosted = false;
+                }
+            }
+            super.update();
+        }
+
+        @Override
         protected boolean shouldSearchForRecipes() {
             // drain lubricant and invalidate if it fails
             if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
@@ -370,24 +387,6 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
             return super.shouldSearchForRecipes() &&
                     LUBRICANT_STACK.isFluidStackIdentical(combustionEngine
                             .getInputFluidInventory().drain(LUBRICANT_STACK, false));
-        }
-
-        @Override
-        protected void trySearchNewRecipe() {
-            // drain oxygen if present to boost production, and if the dynamo hatch supports it
-            if (combustionEngine.isBoostAllowed() &&
-                    (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 20 == 0)) {
-                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
-                FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
-                if (boosterStack.isFluidStackIdentical(inputTank.drain(boosterStack, false))) {
-                    isOxygenBoosted = true;
-                    inputTank.drain(boosterStack, true);
-                } else {
-                    isOxygenBoosted = false;
-                }
-            }
-
-            super.trySearchNewRecipe();
         }
 
         @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -356,9 +356,38 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
 
         @Override
         protected boolean shouldSearchForRecipes() {
+            // drain lubricant and invalidate if it fails
+            if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
+                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
+                if (LUBRICANT_STACK.isFluidStackIdentical(inputTank.drain(LUBRICANT_STACK, false))) {
+                    inputTank.drain(LUBRICANT_STACK, true);
+                } else {
+                    invalidate();
+                    return false;
+                }
+            }
+
             return super.shouldSearchForRecipes() &&
-                    LUBRICANT_STACK.isFluidStackIdentical(((RecipeMapMultiblockController) metaTileEntity)
+                    LUBRICANT_STACK.isFluidStackIdentical(combustionEngine
                             .getInputFluidInventory().drain(LUBRICANT_STACK, false));
+        }
+
+        @Override
+        protected void trySearchNewRecipe() {
+            // drain oxygen if present to boost production, and if the dynamo hatch supports it
+            if (combustionEngine.isBoostAllowed() &&
+                    (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 20 == 0)) {
+                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
+                FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
+                if (boosterStack.isFluidStackIdentical(inputTank.drain(boosterStack, false))) {
+                    isOxygenBoosted = true;
+                    inputTank.drain(boosterStack, true);
+                } else {
+                    isOxygenBoosted = false;
+                }
+            }
+
+            super.trySearchNewRecipe();
         }
 
         @Override
@@ -387,34 +416,6 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         public void invalidate() {
             isOxygenBoosted = false;
             super.invalidate();
-        }
-
-        @Override
-        protected boolean canProgressRecipe() {
-            // drain lubricant and invalidate if it fails
-            if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
-                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
-                if (LUBRICANT_STACK.isFluidStackIdentical(inputTank.drain(LUBRICANT_STACK, false))) {
-                    inputTank.drain(LUBRICANT_STACK, true);
-                } else {
-                    invalidate();
-                    return false;
-                }
-            }
-
-            // drain oxygen if present to boost production, and if the dynamo hatch supports it
-            if (combustionEngine.isBoostAllowed() &&
-                    (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 20 == 0)) {
-                IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
-                FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
-                if (boosterStack.isFluidStackIdentical(inputTank.drain(boosterStack, false))) {
-                    isOxygenBoosted = true;
-                    inputTank.drain(boosterStack, true);
-                } else {
-                    isOxygenBoosted = false;
-                }
-            }
-            return super.canProgressRecipe();
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -372,7 +372,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         }
 
         public boolean checkLubricant() {
-            // drain lubricant and invalidate if it fails
+            // check lubricant and invalidate if it fails
             IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
             if (LUBRICANT_STACK.isFluidStackIdentical(inputTank.drain(LUBRICANT_STACK, false))) {
                 return true;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -396,6 +396,11 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         }
 
         @Override
+        protected boolean canProgressRecipe() {
+            return super.canProgressRecipe() && checkLubricant();
+        }
+
+        @Override
         public long getMaxVoltage() {
             // this multiplies consumption through parallel
             if (isOxygenBoosted)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -355,7 +355,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
             }
         }
 
-        public void checkOxygen() {
+        protected void checkOxygen() {
             // check oxygen if present to boost production, and if the dynamo hatch supports it
             if (combustionEngine.isBoostAllowed()) {
                 IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
@@ -364,14 +364,14 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
             }
         }
 
-        public void drainOxygen() {
+        protected void drainOxygen() {
             if (isOxygenBoosted && totalContinuousRunningTime % 20 == 0) {
                 FluidStack boosterStack = isExtreme ? LIQUID_OXYGEN_STACK : OXYGEN_STACK;
                 combustionEngine.getInputFluidInventory().drain(boosterStack, true);
             }
         }
 
-        public boolean checkLubricant() {
+        protected boolean checkLubricant() {
             // check lubricant and invalidate if it fails
             IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
             if (LUBRICANT_STACK.isFluidStackIdentical(inputTank.drain(LUBRICANT_STACK, false))) {
@@ -382,7 +382,7 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
             }
         }
 
-        public void drainLubricant() {
+        protected void drainLubricant() {
             if (totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0) {
                 IMultipleTankHandler inputTank = combustionEngine.getInputFluidInventory();
                 inputTank.drain(LUBRICANT_STACK, true);


### PR DESCRIPTION
## What
Fixes large combustion engines not boosting on initial recipe run.
Prevents single-block generators from overclocking
overclock button for single-block generators are gone 🦀 
Fixes #2246 

## Implementation Details
the lubricant and oxygen checks have been moved to more appropriate places in the recipe logic. where i moved them in #2229 wasn't actually a good place for them, since `canRecipeProgress()` is only checked once every second.
lubricant check is moved to `shouldSearchForRecipes()`, the oxygen is moved to `update()`

`FuelRecipeLogic` returns false for overclocking, forcing them to parallelize

## Outcome
large combustion engines check if they are boosted before actually running the recipe
single-block gens are no longer sus
