### PR TITLE
fix crash with fluid filters with null delegate containers

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FluidHandlerDelegate.java
+++ b/src/main/java/gregtech/api/capability/impl/FluidHandlerDelegate.java
@@ -4,13 +4,14 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FluidHandlerDelegate implements IFluidHandler {
 
     public final IFluidHandler delegate;
 
-    public FluidHandlerDelegate(IFluidHandler delegate) {
+    public FluidHandlerDelegate(@NotNull IFluidHandler delegate) {
         this.delegate = delegate;
     }
 

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -112,15 +112,13 @@ public class CoverFluidFilter extends CoverBase implements CoverWithUI {
     @Override
     public <T> T getCapability(@NotNull Capability<T> capability, @Nullable T defaultValue) {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            if (defaultValue == null) {
-                return null;
+            if (defaultValue instanceof IFluidHandler delegate) {
+                if (fluidHandler == null || fluidHandler.delegate != delegate) {
+                    this.fluidHandler = new FluidHandlerFiltered(delegate);
+                }
+                return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(fluidHandler);
             }
-
-            IFluidHandler delegate = (IFluidHandler) defaultValue;
-            if (fluidHandler == null || fluidHandler.delegate != delegate) {
-                this.fluidHandler = new FluidHandlerFiltered(delegate);
-            }
-            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(fluidHandler);
+            return null;
         }
         return defaultValue;
     }

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -110,8 +110,12 @@ public class CoverFluidFilter extends CoverBase implements CoverWithUI {
     }
 
     @Override
-    public <T> T getCapability(@NotNull Capability<T> capability, T defaultValue) {
+    public <T> T getCapability(@NotNull Capability<T> capability, @Nullable T defaultValue) {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+            if (defaultValue == null) {
+                return null;
+            }
+
             IFluidHandler delegate = (IFluidHandler) defaultValue;
             if (fluidHandler == null || fluidHandler.delegate != delegate) {
                 this.fluidHandler = new FluidHandlerFiltered(delegate);
@@ -141,7 +145,7 @@ public class CoverFluidFilter extends CoverBase implements CoverWithUI {
 
     private class FluidHandlerFiltered extends FluidHandlerDelegate {
 
-        public FluidHandlerFiltered(IFluidHandler delegate) {
+        public FluidHandlerFiltered(@NotNull IFluidHandler delegate) {
             super(delegate);
         }
 

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -11,7 +11,12 @@ import gregtech.api.cover.CoverWithUI;
 import gregtech.api.cover.CoverableView;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.widgets.*;
+import gregtech.api.gui.widgets.CycleButtonWidget;
+import gregtech.api.gui.widgets.ImageWidget;
+import gregtech.api.gui.widgets.IncrementButtonWidget;
+import gregtech.api.gui.widgets.LabelWidget;
+import gregtech.api.gui.widgets.TextFieldWidget2;
+import gregtech.api.gui.widgets.WidgetGroup;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer;
@@ -23,7 +28,12 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.IStringSerializable;
+import net.minecraft.util.ITickable;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
@@ -397,7 +407,7 @@ public class CoverPump extends CoverBase implements CoverWithUI, ITickable, ICon
 
     private class CoverableFluidHandlerWrapper extends FluidHandlerDelegate {
 
-        public CoverableFluidHandlerWrapper(IFluidHandler delegate) {
+        public CoverableFluidHandlerWrapper(@NotNull IFluidHandler delegate) {
             super(delegate);
         }
 

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/longdistance/MetaTileEntityLDFluidEndpoint.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/longdistance/MetaTileEntityLDFluidEndpoint.java
@@ -27,6 +27,7 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class MetaTileEntityLDFluidEndpoint extends MetaTileEntityLongDistanceEndpoint {
@@ -101,7 +102,7 @@ public class MetaTileEntityLDFluidEndpoint extends MetaTileEntityLongDistanceEnd
 
     private static class FluidHandlerWrapper extends FluidHandlerDelegate {
 
-        public FluidHandlerWrapper(IFluidHandler delegate) {
+        public FluidHandlerWrapper(@NotNull IFluidHandler delegate) {
             super(delegate);
         }
 


### PR DESCRIPTION
## What
Fixes crash where XNet cables connected to gt machines with filters on them will crash due to a missing null check.

## Implementation Details
The fluid pump makes the same check added here, so it is likely an oversight since `getCapability()`'s default value parameter is `@Nullable`.

## Outcome
Fixes crash with XNet interacting with GT machines.

