### PR TITLE
allow multiple build actions per recipemap

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuildAction.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuildAction.java
@@ -1,0 +1,17 @@
+package gregtech.api.recipes;
+
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+public interface RecipeBuildAction<R extends RecipeBuilder<R>> {
+
+    /**
+     * Process a RecipeBuilder to perform an action with.
+     * <p>
+     * <strong>Do not call {@link RecipeBuilder#buildAndRegister()} on the passed builder.</strong>
+     * It is safe to do so only on other builders, i.e. created through {@link RecipeBuilder#copy()}.
+     *
+     * @param builder the builder to utilize
+     */
+    void accept(@NotNull R builder);
+}

--- a/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
@@ -5,15 +5,16 @@ import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.recipes.ui.RecipeMapUI;
 import gregtech.api.recipes.ui.RecipeMapUIFunction;
 
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectArrayMap;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 
 import static gregtech.api.recipes.ui.RecipeMapUI.computeOverlayKey;
 
@@ -44,7 +45,7 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     private SoundEvent sound;
     private boolean allowEmptyOutputs;
 
-    private @Nullable List<RecipeBuildAction<B>> buildActions;
+    private @Nullable Map<ResourceLocation, RecipeBuildAction<B>> buildActions;
 
     /**
      * @param unlocalizedName      the name of the recipemap
@@ -255,14 +256,17 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     /**
      * Add a recipe build action to be performed upon this RecipeMap's builder's recipe registration.
      *
+     * @param name   the unique name of the action
      * @param action the action to perform
      * @return this
      */
-    public @NotNull RecipeMapBuilder<B> onBuild(@NotNull RecipeBuildAction<B> action) {
+    public @NotNull RecipeMapBuilder<B> onBuild(@NotNull ResourceLocation name, @NotNull RecipeBuildAction<B> action) {
         if (buildActions == null) {
-            buildActions = new ArrayList<>();
+            buildActions = new Object2ObjectOpenHashMap<>();
+        } else if (buildActions.containsKey(name)) {
+            throw new IllegalArgumentException("Cannot register RecipeBuildAction with duplicate name: " + name);
         }
-        buildActions.add(action);
+        buildActions.put(name, action);
         return this;
     }
 
@@ -280,7 +284,7 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
             recipeMap.allowEmptyOutput();
         }
         if (buildActions != null) {
-            recipeMap.setOnBuildActions(buildActions);
+            recipeMap.onRecipeBuild(buildActions);
         }
         return recipeMap;
     }

--- a/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
@@ -12,6 +12,9 @@ import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static gregtech.api.recipes.ui.RecipeMapUI.computeOverlayKey;
 
 public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
@@ -40,6 +43,8 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
 
     private SoundEvent sound;
     private boolean allowEmptyOutputs;
+
+    private @Nullable List<RecipeBuildAction<B>> buildActions;
 
     /**
      * @param unlocalizedName      the name of the recipemap
@@ -248,6 +253,20 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     }
 
     /**
+     * Add a recipe build action to be performed upon this RecipeMap's builder's recipe registration.
+     *
+     * @param action the action to perform
+     * @return this
+     */
+    public @NotNull RecipeMapBuilder<B> onBuild(@NotNull RecipeBuildAction<B> action) {
+        if (buildActions == null) {
+            buildActions = new ArrayList<>();
+        }
+        buildActions.add(action);
+        return this;
+    }
+
+    /**
      * <strong>Do not call this twice. RecipeMapBuilders are not re-usable.</strong>
      *
      * @return a new RecipeMap
@@ -259,6 +278,9 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
         recipeMap.setSound(sound);
         if (allowEmptyOutputs) {
             recipeMap.allowEmptyOutput();
+        }
+        if (buildActions != null) {
+            recipeMap.setOnBuildActions(buildActions);
         }
         return recipeMap;
     }

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -44,6 +44,7 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenProperty;
 
 import static gregtech.api.GTValues.*;
+import static gregtech.api.util.GTUtility.gregtechId;
 
 /**
  * Notes:
@@ -123,7 +124,7 @@ public final class RecipeMaps {
                     .fluidOutputs(1)
                     .progressBar(GuiTextures.PROGRESS_BAR_ARC_FURNACE)
                     .sound(GTSoundEvents.ARC)
-                    .onBuild(recipeBuilder -> {
+                    .onBuild(gregtechId("arc_furnace_oxygen"), recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
                             recipeBuilder.fluidInputs(Materials.Oxygen.getFluid(recipeBuilder.getDuration()));
                         }
@@ -151,7 +152,7 @@ public final class RecipeMaps {
                     .itemSlotOverlay(GuiTextures.CIRCUIT_OVERLAY, false)
                     .progressBar(GuiTextures.PROGRESS_BAR_CIRCUIT)
                     .sound(GTSoundEvents.ASSEMBLER)
-                    .onBuild(recipeBuilder -> {
+                    .onBuild(gregtechId("assembler_solder"), recipeBuilder -> {
                         var fluidInputs = recipeBuilder.getFluidInputs();
                         if (fluidInputs.size() == 1 && fluidInputs.get(0).getInputFluidStack().getFluid() ==
                                 Materials.SolderingAlloy.getFluid()) {
@@ -160,7 +161,8 @@ public final class RecipeMaps {
                             recipeBuilder.copy().clearFluidInputs().fluidInputs(Materials.Tin.getFluid(amount * 2))
                                     .buildAndRegister();
                         }
-
+                    })
+                    .onBuild(gregtechId("assembler_recycling"), recipeBuilder -> {
                         if (recipeBuilder.isWithRecycling()) {
                             // ignore input fluids for recycling
                             ItemStack outputStack = recipeBuilder.getOutputs().get(0);
@@ -195,7 +197,8 @@ public final class RecipeMaps {
     @ZenProperty
     public static final RecipeMap<AssemblyLineRecipeBuilder> ASSEMBLY_LINE_RECIPES = new RecipeMapAssemblyLine<>(
             "assembly_line", new AssemblyLineRecipeBuilder(), AssemblyLineUI::new)
-                    .onRecipeBuild(AssemblyLineManager::createDefaultResearchRecipe);
+                    .onRecipeBuild(gregtechId("default_research_recipe"),
+                            AssemblyLineManager::createDefaultResearchRecipe);
 
     /**
      * Example:
@@ -435,7 +438,7 @@ public final class RecipeMaps {
                     .fluidSlotOverlay(GuiTextures.VIAL_OVERLAY_2, true)
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTValues.FOOLS.get() ? GTSoundEvents.SCIENCE : GTSoundEvents.CHEMICAL_REACTOR)
-                    .onBuild(recipeBuilder -> RecipeMaps.LARGE_CHEMICAL_RECIPES.recipeBuilder()
+                    .onBuild(gregtechId("lcr_copy"), recipeBuilder -> RecipeMaps.LARGE_CHEMICAL_RECIPES.recipeBuilder()
                             .inputs(recipeBuilder.getInputs().toArray(new GTRecipeInput[0]))
                             .fluidInputs(recipeBuilder.getFluidInputs())
                             .outputs(recipeBuilder.getOutputs())
@@ -484,7 +487,7 @@ public final class RecipeMaps {
                     .itemSlotOverlay(GuiTextures.CIRCUIT_OVERLAY, false)
                     .progressBar(GuiTextures.PROGRESS_BAR_CIRCUIT_ASSEMBLER)
                     .sound(GTSoundEvents.ASSEMBLER)
-                    .onBuild(recipeBuilder -> {
+                    .onBuild(gregtechId("circuit_assembler_solder"), recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
                             recipeBuilder.copy()
                                     .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1,
@@ -606,7 +609,7 @@ public final class RecipeMaps {
                     .itemSlotOverlay(GuiTextures.DUST_OVERLAY, true, true)
                     .progressBar(GuiTextures.PROGRESS_BAR_SLICE)
                     .sound(GTSoundEvents.CUT)
-                    .onBuild(recipeBuilder -> {
+                    .onBuild(gregtechId("cutter_fluid"), recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
                             int duration = recipeBuilder.getDuration();
                             int eut = recipeBuilder.getEUt();

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -123,13 +123,12 @@ public final class RecipeMaps {
                     .fluidOutputs(1)
                     .progressBar(GuiTextures.PROGRESS_BAR_ARC_FURNACE)
                     .sound(GTSoundEvents.ARC)
-                    .build()
-                    .onRecipeBuild(recipeBuilder -> {
-                        recipeBuilder.invalidateOnBuildAction();
+                    .onBuild(recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
                             recipeBuilder.fluidInputs(Materials.Oxygen.getFluid(recipeBuilder.getDuration()));
                         }
-                    });
+                    })
+                    .build();
 
     /**
      * Example:
@@ -152,9 +151,7 @@ public final class RecipeMaps {
                     .itemSlotOverlay(GuiTextures.CIRCUIT_OVERLAY, false)
                     .progressBar(GuiTextures.PROGRESS_BAR_CIRCUIT)
                     .sound(GTSoundEvents.ASSEMBLER)
-                    .build()
-                    .onRecipeBuild(recipeBuilder -> {
-                        recipeBuilder.invalidateOnBuildAction();
+                    .onBuild(recipeBuilder -> {
                         var fluidInputs = recipeBuilder.getFluidInputs();
                         if (fluidInputs.size() == 1 && fluidInputs.get(0).getInputFluidStack().getFluid() ==
                                 Materials.SolderingAlloy.getFluid()) {
@@ -173,7 +170,8 @@ public final class RecipeMaps {
                                 OreDictUnifier.registerOre(outputStack, info);
                             }
                         }
-                    });
+                    })
+                    .build();
 
     /**
      * Example:
@@ -437,21 +435,18 @@ public final class RecipeMaps {
                     .fluidSlotOverlay(GuiTextures.VIAL_OVERLAY_2, true)
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTValues.FOOLS.get() ? GTSoundEvents.SCIENCE : GTSoundEvents.CHEMICAL_REACTOR)
-                    .build()
-                    .onRecipeBuild(recipeBuilder -> {
-                        recipeBuilder.invalidateOnBuildAction();
-                        RecipeMaps.LARGE_CHEMICAL_RECIPES.recipeBuilder()
-                                .inputs(recipeBuilder.getInputs().toArray(new GTRecipeInput[0]))
-                                .fluidInputs(recipeBuilder.getFluidInputs())
-                                .outputs(recipeBuilder.getOutputs())
-                                .chancedOutputs(recipeBuilder.getChancedOutputs())
-                                .fluidOutputs(recipeBuilder.getFluidOutputs())
-                                .chancedFluidOutputs(recipeBuilder.getChancedFluidOutputs())
-                                .cleanroom(recipeBuilder.getCleanroom())
-                                .duration(recipeBuilder.getDuration())
-                                .EUt(recipeBuilder.getEUt())
-                                .buildAndRegister();
-                    });
+                    .onBuild(recipeBuilder -> RecipeMaps.LARGE_CHEMICAL_RECIPES.recipeBuilder()
+                            .inputs(recipeBuilder.getInputs().toArray(new GTRecipeInput[0]))
+                            .fluidInputs(recipeBuilder.getFluidInputs())
+                            .outputs(recipeBuilder.getOutputs())
+                            .chancedOutputs(recipeBuilder.getChancedOutputs())
+                            .fluidOutputs(recipeBuilder.getFluidOutputs())
+                            .chancedFluidOutputs(recipeBuilder.getChancedFluidOutputs())
+                            .cleanroom(recipeBuilder.getCleanroom())
+                            .duration(recipeBuilder.getDuration())
+                            .EUt(recipeBuilder.getEUt())
+                            .buildAndRegister())
+                    .build();
 
     /**
      * Example:
@@ -489,9 +484,7 @@ public final class RecipeMaps {
                     .itemSlotOverlay(GuiTextures.CIRCUIT_OVERLAY, false)
                     .progressBar(GuiTextures.PROGRESS_BAR_CIRCUIT_ASSEMBLER)
                     .sound(GTSoundEvents.ASSEMBLER)
-                    .build()
-                    .onRecipeBuild(recipeBuilder -> {
-                        recipeBuilder.invalidateOnBuildAction();
+                    .onBuild(recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
                             recipeBuilder.copy()
                                     .fluidInputs(Materials.SolderingAlloy.getFluid(Math.max(1,
@@ -504,7 +497,8 @@ public final class RecipeMaps {
                             recipeBuilder.fluidInputs(Materials.Tin.getFluid(Math.max(1, GTValues.L *
                                     recipeBuilder.getSolderMultiplier())));
                         }
-                    });
+                    })
+                    .build();
 
     /**
      * Example:
@@ -612,11 +606,8 @@ public final class RecipeMaps {
                     .itemSlotOverlay(GuiTextures.DUST_OVERLAY, true, true)
                     .progressBar(GuiTextures.PROGRESS_BAR_SLICE)
                     .sound(GTSoundEvents.CUT)
-                    .build()
-                    .onRecipeBuild(recipeBuilder -> {
-                        recipeBuilder.invalidateOnBuildAction();
+                    .onBuild(recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
-
                             int duration = recipeBuilder.getDuration();
                             int eut = recipeBuilder.getEUt();
                             recipeBuilder
@@ -642,7 +633,8 @@ public final class RecipeMaps {
                                     .duration(Math.max(1, duration));
 
                         }
-                    });
+                    })
+                    .build();
 
     /**
      * Examples:

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -192,7 +192,8 @@ public final class RecipeMaps {
      *         .duration(600).EUt(6000).buildAndRegister();
      * </pre>
      *
-     * The Assembly Line Recipe Builder has no special properties/build actions yet, but will in the future
+     * The Assembly Line Recipe Builder creates additional Research Recipes for its outputs in the Scanner or Research
+     * Station when specified.
      */
     @ZenProperty
     public static final RecipeMap<AssemblyLineRecipeBuilder> ASSEMBLY_LINE_RECIPES = new RecipeMapAssemblyLine<>(


### PR DESCRIPTION
## What
Allows multiple build actions per RecipeMap. This prevents addons having to copy paste the default ones and add to them. Also prevents addons overwriting each other.

Requires build actions to have an associated ResourceLocation to denote them. Also allows removal via this location.

## Potential Compatibility Issues
Is not backwards compatible. Build actions now have a required namespace field, which cannot be inferred on our end for backwards-compatibility.
