### PR TITLE
fix data stick entry removal from AL

### DIFF
--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -54,6 +54,7 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
                 for (ResearchPropertyData.ResearchEntry entry : data) {
                     removeDataStickEntry(entry.getResearchId(), recipe);
                 }
+                return true;
             }
             return false;
         }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -52,7 +52,7 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
             ResearchPropertyData data = recipe.getProperty(ResearchProperty.getInstance(), null);
             if (data != null) {
                 for (ResearchPropertyData.ResearchEntry entry : data) {
-                    return removeDataStickEntry(entry.getResearchId(), recipe);
+                    removeDataStickEntry(entry.getResearchId(), recipe);
                 }
             }
             return false;


### PR DESCRIPTION
## What
Fixes the AL RecipeMap not removing all data stick entries upon recipe removal.
