### PR TITLE
SimpleMachineMetaTileEntity makes it easy to change the logo

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -488,8 +488,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity
 
         if (exportItems.getSlots() + exportFluids.getTanks() <= 9) {
             ImageWidget logo = new ImageWidget(152, 63 + yOffset, 17, 17,
-                    GTValues.XMAS.get() ? GuiTextures.GREGTECH_LOGO_XMAS : GuiTextures.GREGTECH_LOGO)
-                            .setIgnoreColor(true);
+                    GTValues.XMAS.get() ? getXmasLogo() : getLogo()).setIgnoreColor(true);
 
             if (this.circuitInventory != null) {
                 SlotWidget circuitSlot = new GhostCircuitSlotWidget(circuitInventory, 0, 124, 62 + yOffset)
@@ -498,6 +497,14 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity
             }
         }
         return builder;
+    }
+
+    protected @NotNull TextureArea getLogo() {
+        return GuiTextures.GREGTECH_LOGO;
+    }
+
+    protected @NotNull TextureArea getXmasLogo() {
+        return GuiTextures.GREGTECH_LOGO_XMAS;
     }
 
     @Override


### PR DESCRIPTION
## What
Until now, if you want to change the logo of a simple machine, you have to extend the SimpleMachineMetaTileEntity.
For multi block machine `@Override` of the logo is possible, so we changed the specification to the same one.

## Implementation Details
Improved hard coding of logo.

## Potential Compatibility Issues
none
