### PR TITLE
Allow specifying NBT matching on Research ItemStacks

### DIFF
--- a/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
@@ -155,6 +155,7 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
         private final String researchId;
         private final ItemStack researchStack;
         private final ItemStack dataStack;
+        private final boolean ignoreNBT;
         private final int duration;
         private final int EUt;
         private final int CWUt;
@@ -166,12 +167,35 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
          * @param duration      the duration of the recipe
          * @param EUt           the EUt of the recipe
          * @param CWUt          how much computation per tick this recipe needs if in Research Station
+         *                      <p>
+         *                      By default, will ignore NBT on researchStack input. If NBT matching is desired, see
+         *                      {@link #ResearchRecipeEntry(String, ItemStack, ItemStack, boolean, int, int, int)}
          */
         public ResearchRecipeEntry(@NotNull String researchId, @NotNull ItemStack researchStack,
                                    @NotNull ItemStack dataStack, int duration, int EUt, int CWUt) {
             this.researchId = researchId;
             this.researchStack = researchStack;
             this.dataStack = dataStack;
+            this.duration = duration;
+            this.EUt = EUt;
+            this.CWUt = CWUt;
+            this.ignoreNBT = true;
+        }
+
+        /**
+         * @param researchId    the id of the research to store
+         * @param researchStack the stack to scan for research
+         * @param dataStack     the stack to contain the data
+         * @param duration      the duration of the recipe
+         * @param EUt           the EUt of the recipe
+         * @param CWUt          how much computation per tick this recipe needs if in Research Station
+         */
+        public ResearchRecipeEntry(@NotNull String researchId, @NotNull ItemStack researchStack,
+                                   @NotNull ItemStack dataStack, boolean ignoreNBT, int duration, int EUt, int CWUt) {
+            this.researchId = researchId;
+            this.researchStack = researchStack;
+            this.dataStack = dataStack;
+            this.ignoreNBT = ignoreNBT;
             this.duration = duration;
             this.EUt = EUt;
             this.CWUt = CWUt;
@@ -190,6 +214,10 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
         @NotNull
         public ItemStack getDataStack() {
             return dataStack;
+        }
+
+        public boolean getIgnoreNBT() {
+            return ignoreNBT;
         }
 
         public int getDuration() {

--- a/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
@@ -15,12 +15,22 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
 
     protected ItemStack researchStack;
     protected ItemStack dataStack;
+    protected boolean ignoreNBT;
     protected String researchId;
     protected int eut;
 
     public T researchStack(@NotNull ItemStack researchStack) {
         if (!researchStack.isEmpty()) {
             this.researchStack = researchStack;
+            this.ignoreNBT = true;
+        }
+        return (T) this;
+    }
+
+    public T researchStack(@NotNull ItemStack researchStack, boolean ignoreNBT) {
+        if (!researchStack.isEmpty()) {
+            this.researchStack = researchStack;
+            this.ignoreNBT = ignoreNBT;
         }
         return (T) this;
     }
@@ -99,7 +109,8 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
             validateResearchItem();
             if (duration <= 0) duration = DEFAULT_SCANNER_DURATION;
             if (eut <= 0) eut = DEFAULT_SCANNER_EUT;
-            return new AssemblyLineRecipeBuilder.ResearchRecipeEntry(researchId, researchStack, dataStack, duration,
+            return new AssemblyLineRecipeBuilder.ResearchRecipeEntry(researchId, researchStack, dataStack, ignoreNBT,
+                    duration,
                     eut, 0);
         }
     }
@@ -148,7 +159,8 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
             int duration = totalCWU;
             if (eut <= 0) eut = DEFAULT_STATION_EUT;
 
-            return new AssemblyLineRecipeBuilder.ResearchRecipeEntry(researchId, researchStack, dataStack, duration,
+            return new AssemblyLineRecipeBuilder.ResearchRecipeEntry(researchId, researchStack, dataStack, ignoreNBT,
+                    duration,
                     eut, cwut);
         }
     }


### PR DESCRIPTION
## What
Allows for specifying NBT matching on research ItemStacks, with it defaulting to matching any NBT. This fixes issues with battery scanning recipes, where they would only work with freshly crafted batteries. See https://github.com/Nomi-CEu/Nomi-CEu/issues/541


## Outcome
Allows for specifying for NBT matching on research stacks for the research mechanic
