### PR TITLE
Attempt to fix crash with only plasma fluid

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -8,6 +8,7 @@ import gregtech.api.unification.FluidUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.unification.material.properties.BlastProperty;
+import gregtech.api.unification.material.properties.FluidProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.util.FluidTooltipUtil;
 import gregtech.api.util.GTLog;
@@ -429,7 +430,11 @@ public class FluidBuilder {
                     case GAS -> ROOM_TEMPERATURE;
                     case PLASMA -> {
                         if (material.hasFluid()) {
-                            yield BASE_PLASMA_TEMPERATURE + material.getFluid().getTemperature();
+                            FluidProperty prop = material.getProperty(PropertyKey.FLUID);
+                            if (prop.getStorage().getQueuedBuilder(prop.getPrimaryKey()) != null) {
+                                yield BASE_PLASMA_TEMPERATURE + material.getFluid().getTemperature();
+                            }
+                            yield BASE_PLASMA_TEMPERATURE;
                         }
                         yield BASE_PLASMA_TEMPERATURE;
                     }


### PR DESCRIPTION
## What
This  PR fixes a crash when a material is only generating a plasma. The crash would arise because the plasma would not be finished generating, therefor calling `material.getFluid` would NPE. Therefore, if there is a queued builder for the material, we will fetch the material from there.

I am not really sure about this fix, as I don't konw if it is correct to be passing in `getPrimaryKey`, because it is nullable, and because I don't know if that would reference plasma for a plasma only fluid.

## Outcome
Fixes a crash with plasma only materials
