### PR TITLE
invalidate pipenet routepaths on chunk unload

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/NeighborCacheTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/NeighborCacheTileEntityBase.java
@@ -7,6 +7,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,21 +29,31 @@ public abstract class NeighborCacheTileEntityBase extends SyncedTileEntityBase i
         }
     }
 
+    @MustBeInvokedByOverriders
     @Override
     public void setWorld(@NotNull World worldIn) {
         super.setWorld(worldIn);
         invalidateNeighbors();
     }
 
+    @MustBeInvokedByOverriders
     @Override
     public void setPos(@NotNull BlockPos posIn) {
         super.setPos(posIn);
         invalidateNeighbors();
     }
 
+    @MustBeInvokedByOverriders
     @Override
     public void invalidate() {
         super.invalidate();
+        invalidateNeighbors();
+    }
+
+    @MustBeInvokedByOverriders
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
         invalidateNeighbors();
     }
 

--- a/src/main/java/gregtech/api/pipenet/PipeNet.java
+++ b/src/main/java/gregtech/api/pipenet/PipeNet.java
@@ -15,8 +15,13 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCompound> {
 
@@ -62,6 +67,11 @@ public abstract class PipeNet<NodeDataType> implements INBTSerializable<NBTTagCo
     public void onPipeConnectionsUpdate() {}
 
     public void onNeighbourUpdate(BlockPos fromPos) {}
+
+    /**
+     * Is called when any Pipe TE in the PipeNet is unloaded
+     */
+    public void onChunkUnload() {}
 
     public Map<BlockPos, Node<NodeDataType>> getAllNodes() {
         return unmodifiableNodeByBlockPos;

--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -26,6 +26,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
 
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -537,6 +538,17 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     public boolean shouldRefresh(@NotNull World world, @NotNull BlockPos pos, IBlockState oldState,
                                  IBlockState newSate) {
         return oldState.getBlock() != newSate.getBlock();
+    }
+
+    @MustBeInvokedByOverriders
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        WorldPipeNet<?, ?> worldPipeNet = getPipeBlock().getWorldPipeNet(getWorld());
+        PipeNet<?> net = worldPipeNet.getNetFromPos(pos);
+        if (net != null) {
+            net.onChunkUnload();
+        }
     }
 
     public void doExplosion(float explosionPower) {

--- a/src/main/java/gregtech/common/pipelike/cable/net/EnergyNet.java
+++ b/src/main/java/gregtech/common/pipelike/cable/net/EnergyNet.java
@@ -11,7 +11,10 @@ import net.minecraft.world.World;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 
 public class EnergyNet extends PipeNet<WireProperties> {
 
@@ -64,6 +67,11 @@ public class EnergyNet extends PipeNet<WireProperties> {
 
     @Override
     public void onPipeConnectionsUpdate() {
+        NET_DATA.clear();
+    }
+
+    @Override
+    public void onChunkUnload() {
         NET_DATA.clear();
     }
 

--- a/src/main/java/gregtech/common/pipelike/cable/tile/TileEntityCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/tile/TileEntityCable.java
@@ -258,7 +258,7 @@ public class TileEntityCable extends TileEntityMaterialPipeBase<Insulation, Wire
         if (capability == GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER) {
             if (world.isRemote)
                 return GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER.cast(clientCapability);
-            if (handlers.size() == 0)
+            if (handlers.isEmpty())
                 initHandlers();
             checkNetwork();
             return GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER.cast(handlers.getOrDefault(facing, defaultHandler));
@@ -291,6 +291,12 @@ public class TileEntityCable extends TileEntityMaterialPipeBase<Insulation, Wire
             this.currentEnergyNet = new WeakReference<>(currentEnergyNet);
         }
         return currentEnergyNet;
+    }
+
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        this.handlers.clear();
     }
 
     @Override

--- a/src/main/java/gregtech/common/pipelike/itempipe/net/ItemPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/net/ItemPipeNet.java
@@ -9,7 +9,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ItemPipeNet extends PipeNet<ItemPipeProperties> {
 
@@ -40,6 +44,11 @@ public class ItemPipeNet extends PipeNet<ItemPipeProperties> {
 
     @Override
     public void onPipeConnectionsUpdate() {
+        NET_DATA.clear();
+    }
+
+    @Override
+    public void onChunkUnload() {
         NET_DATA.clear();
     }
 

--- a/src/main/java/gregtech/common/pipelike/itempipe/tile/TileEntityItemPipe.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/tile/TileEntityItemPipe.java
@@ -153,4 +153,10 @@ public class TileEntityItemPipe extends TileEntityMaterialPipeBase<ItemPipeType,
         updateTransferredState();
         return this.transferredItems;
     }
+
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        this.handlers.clear();
+    }
 }

--- a/src/main/java/gregtech/common/pipelike/laser/net/LaserPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/laser/net/LaserPipeNet.java
@@ -47,6 +47,11 @@ public class LaserPipeNet extends PipeNet<LaserPipeProperties> {
     }
 
     @Override
+    public void onChunkUnload() {
+        netData.clear();
+    }
+
+    @Override
     protected void transferNodeData(Map<BlockPos, Node<LaserPipeProperties>> transferredNodes,
                                     PipeNet<LaserPipeProperties> parentNet) {
         super.transferNodeData(transferredNodes, parentNet);

--- a/src/main/java/gregtech/common/pipelike/laser/tile/TileEntityLaserPipe.java
+++ b/src/main/java/gregtech/common/pipelike/laser/tile/TileEntityLaserPipe.java
@@ -224,6 +224,12 @@ public class TileEntityLaserPipe extends TileEntityPipeBase<LaserPipeType, Laser
         }
     }
 
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        this.handlers.clear();
+    }
+
     private static class DefaultLaserContainer implements ILaserContainer {
 
         @Override

--- a/src/main/java/gregtech/common/pipelike/optical/net/OpticalPipeNet.java
+++ b/src/main/java/gregtech/common/pipelike/optical/net/OpticalPipeNet.java
@@ -48,6 +48,11 @@ public class OpticalPipeNet extends PipeNet<OpticalPipeProperties> {
     }
 
     @Override
+    public void onChunkUnload() {
+        NET_DATA.clear();
+    }
+
+    @Override
     protected void transferNodeData(Map<BlockPos, Node<OpticalPipeProperties>> transferredNodes,
                                     PipeNet<OpticalPipeProperties> parentNet) {
         super.transferNodeData(transferredNodes, parentNet);

--- a/src/main/java/gregtech/common/pipelike/optical/tile/TileEntityOpticalPipe.java
+++ b/src/main/java/gregtech/common/pipelike/optical/tile/TileEntityOpticalPipe.java
@@ -194,6 +194,12 @@ public class TileEntityOpticalPipe extends TileEntityPipeBase<OpticalPipeType, O
         }
     }
 
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        this.handlers.clear();
+    }
+
     private static class DefaultDataHandler implements IDataAccessHatch {
 
         @Override


### PR DESCRIPTION
## What
Invalidates pipenet routepaths on chunk unload. This ensures the TEs in the route paths are not used on chunk re-load, since they will be different instances than the ones in the TE neighbor caches. TEs are not marked as invalid when they are unloaded, so the cache would not be invalidated either. This caused pipenets to use the original TEs as valid and not properly transfer data across them.

## Outcome
Fixes #2291.
