### PR TITLE
Fix plasma temp NPE for plasma-only materials

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -428,7 +428,7 @@ public class FluidBuilder {
                     }
                     case GAS -> ROOM_TEMPERATURE;
                     case PLASMA -> {
-                        if (material.hasFluid()) {
+                        if (material.hasFluid() && material.getFluid() != null) {
                             yield BASE_PLASMA_TEMPERATURE + material.getFluid().getTemperature();
                         }
                         yield BASE_PLASMA_TEMPERATURE;

--- a/src/main/java/gregtech/api/fluids/store/FluidStorage.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorage.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Comparator;
 import java.util.Map;
 
 public final class FluidStorage {
@@ -69,12 +70,14 @@ public final class FluidStorage {
             enqueueRegistration(FluidStorageKeys.LIQUID, new FluidBuilder());
         }
 
-        for (var entry : toRegister.entrySet()) {
-            Fluid fluid = entry.getValue().build(material.getModid(), material, entry.getKey());
-            if (!storeNoOverwrites(entry.getKey(), fluid)) {
-                GTLog.logger.error("{} already has an associated fluid for material {}", material);
-            }
-        }
+        toRegister.entrySet().stream()
+                .sorted(Comparator.comparingInt(e -> -e.getKey().getRegistrationPriority()))
+                .forEach(entry -> {
+                    Fluid fluid = entry.getValue().build(material.getModid(), material, entry.getKey());
+                    if (!storeNoOverwrites(entry.getKey(), fluid)) {
+                        GTLog.logger.error("{} already has an associated fluid for material {}", material);
+                    }
+                });
         toRegister = null;
         registered = true;
     }

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
@@ -24,6 +24,7 @@ public final class FluidStorageKey {
     private final Function<Material, String> translationKeyFunction;
     private final int hashCode;
     private final FluidState defaultFluidState;
+    private final int registrationPriority;
 
     public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
                            @NotNull UnaryOperator<@NotNull String> registryNameOperator,
@@ -35,12 +36,20 @@ public final class FluidStorageKey {
                            @NotNull UnaryOperator<@NotNull String> registryNameOperator,
                            @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction,
                            @Nullable FluidState defaultFluidState) {
+        this(resourceLocation, iconType, registryNameOperator, translationKeyFunction, defaultFluidState, 0);
+    }
+
+    public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
+                           @NotNull UnaryOperator<@NotNull String> registryNameOperator,
+                           @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction,
+                           @Nullable FluidState defaultFluidState, int registrationPriority) {
         this.resourceLocation = resourceLocation;
         this.iconType = iconType;
         this.registryNameOperator = registryNameOperator;
         this.translationKeyFunction = translationKeyFunction;
         this.hashCode = resourceLocation.hashCode();
         this.defaultFluidState = defaultFluidState;
+        this.registrationPriority = registrationPriority;
         if (keys.containsKey(resourceLocation)) {
             throw new IllegalArgumentException("Cannot create duplicate keys");
         }
@@ -79,6 +88,14 @@ public final class FluidStorageKey {
      */
     public @Nullable FluidState getDefaultFluidState() {
         return defaultFluidState;
+    }
+
+    /**
+     * @return The registration priority for this fluid type, determining the build order for fluids.
+     *         Useful for when your fluid building requires some properties from previous fluids.
+     */
+    public int getRegistrationPriority() {
+        return registrationPriority;
     }
 
     @Override

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -33,7 +33,7 @@ public final class FluidStorageKeys {
     public static final FluidStorageKey PLASMA = new FluidStorageKey(gregtechId("plasma"),
             MaterialIconType.plasma,
             s -> "plasma." + s, m -> "gregtech.fluid.plasma",
-            FluidState.PLASMA);
+            FluidState.PLASMA, -1);
 
     private FluidStorageKeys() {}
 }

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -159,8 +159,9 @@ public class RecyclingRecipes {
 
         // Find the first Material which can create a Fluid.
         // If no Material in the list can create a Fluid, return.
-        MaterialStack fluidMs = materials.stream().filter(ms -> ms.material.hasProperty(PropertyKey.FLUID)).findFirst()
-                .orElse(null);
+        MaterialStack fluidMs = materials.stream()
+                .filter(ms -> ms.material.hasProperty(PropertyKey.FLUID) && ms.material.getFluid() != null)
+                .findFirst().orElse(null);
         if (fluidMs == null) return;
 
         // Find the next MaterialStack, which will be the Item output.

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -140,7 +140,10 @@ public class RecyclingRecipes {
             if (m.hasProperty(PropertyKey.INGOT) && m.getProperty(PropertyKey.INGOT).getMacerateInto() != m) {
                 m = m.getProperty(PropertyKey.INGOT).getMacerateInto();
             }
-            if (!m.hasProperty(PropertyKey.FLUID) || (prefix == OrePrefix.dust && m.hasProperty(PropertyKey.BLAST))) {
+            if (!m.hasProperty(PropertyKey.FLUID) || m.getFluid() == null) {
+                return;
+            }
+            if (prefix == OrePrefix.dust && m.hasProperty(PropertyKey.BLAST)) {
                 return;
             }
             RecipeMaps.EXTRACTOR_RECIPES.recipeBuilder()


### PR DESCRIPTION
Supersedes #2295 

Allows FluidPropertyKey's to give a registration priority, which is used now to sort plasma to the end, meaning if there is some other registered fluid, it will be available so no need to check for an enqueued builder. And if it is null, then it is plasma only, and we can use the default temperature