### PR TITLE
make small and tiny dusts a material flag and fix recipes that used them

### DIFF
--- a/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
+++ b/src/main/java/gregtech/api/unification/material/info/MaterialFlags.java
@@ -198,6 +198,14 @@ public class MaterialFlags {
                     .requireProps(PropertyKey.DUST)
                     .build();
 
+    public static final MaterialFlag GENERATE_SMALL_DUST = new MaterialFlag.Builder("small_dust")
+            .requireProps(PropertyKey.DUST)
+            .build();
+
+    public static final MaterialFlag GENERATE_TINY_DUST = new MaterialFlag.Builder("tiny_dust")
+            .requireProps(PropertyKey.DUST)
+            .build();
+
     /////////////////
     // FLUID //
     /////////////////

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -146,6 +146,7 @@ public class ElementMaterials {
                 .dust()
                 .color(0x32323C).iconSet(SHINY)
                 .element(Elements.Cd)
+                .flags(GENERATE_SMALL_DUST)
                 .build();
 
         Cerium = new Material.Builder(20, gregtechId("cerium"))
@@ -153,6 +154,7 @@ public class ElementMaterials {
                 .liquid(new FluidBuilder().temperature(1068))
                 .color(0x87917D).iconSet(METALLIC)
                 .element(Elements.Ce)
+                .flags(GENERATE_SMALL_DUST)
                 .build();
 
         Chlorine = new Material.Builder(21, gregtechId("chlorine"))
@@ -194,7 +196,7 @@ public class ElementMaterials {
                 .ore()
                 .color(0xFF6400).iconSet(SHINY)
                 .flags(EXT_METAL, MORTAR_GRINDABLE, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE,
-                        GENERATE_DOUBLE_PLATE)
+                        GENERATE_DOUBLE_PLATE, GENERATE_TINY_DUST)
                 .element(Elements.Cu)
                 .cableProperties(V[MV], 1, 2)
                 .fluidPipeProperties(1696, 6, true)
@@ -352,6 +354,7 @@ public class ElementMaterials {
                 .liquid(new FluidBuilder().temperature(430))
                 .color(0x400080).iconSet(SHINY)
                 .element(Elements.In)
+                .flags(GENERATE_SMALL_DUST)
                 .build();
 
         Iodine = new Material.Builder(49, gregtechId("iodine"))
@@ -402,6 +405,7 @@ public class ElementMaterials {
                 .liquid(new FluidBuilder().temperature(1193))
                 .color(0x5D7575).iconSet(METALLIC)
                 .element(Elements.La)
+                .flags(GENERATE_SMALL_DUST)
                 .build();
 
         Lawrencium = new Material.Builder(54, gregtechId("lawrencium"))
@@ -427,6 +431,7 @@ public class ElementMaterials {
                 .ore()
                 .color(0xBDC7DB)
                 .element(Elements.Li)
+                .flags(GENERATE_TINY_DUST)
                 .build();
 
         Livermorium = new Material.Builder(57, gregtechId("livermorium"))
@@ -491,7 +496,7 @@ public class ElementMaterials {
         Neodymium = new Material.Builder(66, gregtechId("neodymium"))
                 .ingot().fluid().ore()
                 .color(0x646464).iconSet(METALLIC)
-                .flags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
+                .flags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW, GENERATE_SMALL_DUST)
                 .element(Elements.Nd)
                 .rotorStats(7.0f, 2.0f, 512)
                 .blast(1297, GasTier.MID)
@@ -593,6 +598,7 @@ public class ElementMaterials {
                 .dust()
                 .color(0xFFFF00)
                 .element(Elements.P)
+                .flags(GENERATE_SMALL_DUST)
                 .build();
 
         Polonium = new Material.Builder(79, gregtechId("polonium"))
@@ -617,6 +623,7 @@ public class ElementMaterials {
                 .ore(true)
                 .color(0xF03232).iconSet(METALLIC)
                 .element(Elements.Pu239)
+                .flags(GENERATE_TINY_DUST)
                 .build();
 
         Plutonium241 = new Material.Builder(82, gregtechId("plutonium_241"))
@@ -632,6 +639,7 @@ public class ElementMaterials {
                 .liquid(new FluidBuilder().temperature(337))
                 .color(0xBEDCFF).iconSet(METALLIC)
                 .element(Elements.K)
+                .flags(GENERATE_TINY_DUST)
                 .build();
 
         Praseodymium = new Material.Builder(84, gregtechId("praseodymium"))
@@ -706,7 +714,7 @@ public class ElementMaterials {
                 .ingot()
                 .liquid(new FluidBuilder().temperature(1345))
                 .color(0xFFFFCC).iconSet(METALLIC)
-                .flags(GENERATE_LONG_ROD)
+                .flags(GENERATE_LONG_ROD, GENERATE_SMALL_DUST)
                 .element(Elements.Sm)
                 .blast(b -> b
                         .temp(5400, GasTier.HIGH)
@@ -869,7 +877,7 @@ public class ElementMaterials {
                 .ingot(3)
                 .liquid(new FluidBuilder().temperature(1405))
                 .color(0x32F032).iconSet(METALLIC)
-                .flags(EXT_METAL)
+                .flags(EXT_METAL, GENERATE_TINY_DUST)
                 .element(Elements.U238)
                 .build();
 
@@ -877,7 +885,7 @@ public class ElementMaterials {
                 .ingot(3)
                 .liquid(new FluidBuilder().temperature(1405))
                 .color(0x46FA46).iconSet(SHINY)
-                .flags(EXT_METAL)
+                .flags(EXT_METAL, GENERATE_TINY_DUST)
                 .element(Elements.U235)
                 .build();
 
@@ -904,6 +912,7 @@ public class ElementMaterials {
                 .color(0x76524C).iconSet(METALLIC)
                 .element(Elements.Y)
                 .blast(1799)
+                .flags(GENERATE_SMALL_DUST)
                 .build();
 
         Zinc = new Material.Builder(122, gregtechId("zinc"))
@@ -953,7 +962,7 @@ public class ElementMaterials {
                 .liquid(new FluidBuilder().customStill())
                 .color(0x1E1E1E).iconSet(SHINY)
                 .flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FOIL, GENERATE_GEAR, GENERATE_FINE_WIRE,
-                        GENERATE_BOLT_SCREW)
+                        GENERATE_BOLT_SCREW, GENERATE_TINY_DUST)
                 .element(Elements.Nq2)
                 .blast(b -> b
                         .temp(9000, GasTier.HIGH)

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -53,7 +53,7 @@ public class FirstDegreeMaterials {
         Ash = new Material.Builder(254, gregtechId("ash"))
                 .dust(1)
                 .color(0x969696)
-                .flags(DISABLE_DECOMPOSITION)
+                .flags(DISABLE_DECOMPOSITION, GENERATE_TINY_DUST)
                 .components(Carbon, 1)
                 .build();
 
@@ -81,7 +81,7 @@ public class FirstDegreeMaterials {
         Bone = new Material.Builder(258, gregtechId("bone"))
                 .dust(1)
                 .color(0xFAFAFA)
-                .flags(MORTAR_GRINDABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
+                .flags(MORTAR_GRINDABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GENERATE_TINY_DUST)
                 .components(Calcium, 1)
                 .build();
 
@@ -201,7 +201,7 @@ public class FirstDegreeMaterials {
         DarkAsh = new Material.Builder(275, gregtechId("dark_ash"))
                 .dust(1)
                 .color(0x323232)
-                .flags(DISABLE_DECOMPOSITION)
+                .flags(DISABLE_DECOMPOSITION, GENERATE_TINY_DUST)
                 .components(Carbon, 1)
                 .build();
 
@@ -830,7 +830,7 @@ public class FirstDegreeMaterials {
                 .ingot(1)
                 .liquid(new FluidBuilder().temperature(1511))
                 .color(0xA0A0A0)
-                .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_SMALL_DUST)
                 .components(Arsenic, 1, Gallium, 1)
                 .blast(b -> b.temp(1200, GasTier.LOW).blastStats(VA[MV], 1200))
                 .build();
@@ -938,6 +938,7 @@ public class FirstDegreeMaterials {
                 .dust(1)
                 .color(0xFF084E)
                 .components(Potassium, 2, Chrome, 2, Oxygen, 7)
+                .flags(GENERATE_TINY_DUST)
                 .build();
 
         ChromiumTrioxide = new Material.Builder(368, gregtechId("chromium_trioxide"))
@@ -950,6 +951,7 @@ public class FirstDegreeMaterials {
                 .dust(1)
                 .color(0xE6E6F0)
                 .components(Antimony, 2, Oxygen, 3)
+                .flags(GENERATE_TINY_DUST)
                 .build();
 
         Zincite = new Material.Builder(370, gregtechId("zincite"))
@@ -997,7 +999,7 @@ public class FirstDegreeMaterials {
         SodiumHydroxide = new Material.Builder(377, gregtechId("sodium_hydroxide"))
                 .dust(1)
                 .color(0x003380)
-                .flags(DISABLE_DECOMPOSITION)
+                .flags(DISABLE_DECOMPOSITION, GENERATE_TINY_DUST)
                 .components(Sodium, 1, Oxygen, 1, Hydrogen, 1)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -158,7 +158,7 @@ public class HigherDegreeMaterials {
         Brick = new Material.Builder(2524, gregtechId("brick"))
                 .dust()
                 .color(0x9B5643).iconSet(ROUGH)
-                .flags(EXCLUDE_BLOCK_CRAFTING_RECIPES, NO_SMELTING, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(EXCLUDE_BLOCK_CRAFTING_RECIPES, NO_SMELTING, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_SMALL_DUST)
                 .components(Clay, 1)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -22,7 +22,7 @@ public class SecondDegreeMaterials {
                 .gem(0)
                 .liquid(new FluidBuilder().temperature(1200).customStill())
                 .color(0xFAFAFA).iconSet(GLASS)
-                .flags(GENERATE_LENS, NO_SMASHING, EXCLUDE_BLOCK_CRAFTING_RECIPES, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(GENERATE_LENS, NO_SMASHING, EXCLUDE_BLOCK_CRAFTING_RECIPES, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_SMALL_DUST, GENERATE_TINY_DUST)
                 .components(SiliconDioxide, 1)
                 .build();
 
@@ -145,7 +145,7 @@ public class SecondDegreeMaterials {
         TricalciumPhosphate = new Material.Builder(2015, gregtechId("tricalcium_phosphate"))
                 .dust().ore(3, 1)
                 .color(0xFFFF00).iconSet(FLINT)
-                .flags(NO_SMASHING, NO_SMELTING, FLAMMABLE, EXPLOSIVE, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(NO_SMASHING, NO_SMELTING, FLAMMABLE, EXPLOSIVE, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_SMALL_DUST)
                 .components(Calcium, 3, Phosphate, 2)
                 .build();
 
@@ -381,7 +381,7 @@ public class SecondDegreeMaterials {
         Flint = new Material.Builder(2049, gregtechId("flint"))
                 .gem(1)
                 .color(0x002040).iconSet(FLINT)
-                .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
+                .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_TINY_DUST)
                 .components(SiliconDioxide, 1)
                 .toolStats(ToolProperty.Builder.of(0.0F, 1.0F, 64, 1)
                         .enchantability(5).ignoreCraftingTools()
@@ -491,7 +491,7 @@ public class SecondDegreeMaterials {
         Clay = new Material.Builder(2063, gregtechId("clay"))
                 .dust(1)
                 .color(0xC8C8DC).iconSet(ROUGH)
-                .flags(MORTAR_GRINDABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
+                .flags(MORTAR_GRINDABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GENERATE_SMALL_DUST)
                 .components(Sodium, 2, Lithium, 1, Aluminium, 2, Silicon, 2, Water, 6)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -427,7 +427,7 @@ public class UnknownCompositionMaterials {
         Stone = new Material.Builder(1599, gregtechId("stone"))
                 .dust(2)
                 .color(0xCDCDCD).iconSet(ROUGH)
-                .flags(MORTAR_GRINDABLE, GENERATE_GEAR, NO_SMASHING, NO_SMELTING)
+                .flags(MORTAR_GRINDABLE, GENERATE_GEAR, NO_SMASHING, NO_SMELTING, GENERATE_SMALL_DUST)
                 .build();
 
         Lava = new Material.Builder(1600, gregtechId("lava"))
@@ -517,7 +517,7 @@ public class UnknownCompositionMaterials {
                 .wood()
                 .color(0x896727).iconSet(WOOD)
                 .flags(GENERATE_PLATE, GENERATE_ROD, GENERATE_BOLT_SCREW, GENERATE_LONG_ROD, GENERATE_GEAR,
-                        GENERATE_FRAME)
+                        GENERATE_FRAME, GENERATE_TINY_DUST, GENERATE_SMALL_DUST)
                 .fluidPipeProperties(340, 5, false)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -115,10 +115,10 @@ public class OrePrefix {
 
     // 1/4th of a Dust.
     public static final OrePrefix dustSmall = new OrePrefix("dustSmall", M / 4, null, MaterialIconType.dustSmall,
-            ENABLE_UNIFICATION, hasDustProperty);
+            ENABLE_UNIFICATION, hasDustProperty.and(m -> m.hasFlag(GENERATE_SMALL_DUST)));
     // 1/9th of a Dust.
     public static final OrePrefix dustTiny = new OrePrefix("dustTiny", M / 9, null, MaterialIconType.dustTiny,
-            ENABLE_UNIFICATION, hasDustProperty);
+            ENABLE_UNIFICATION, hasDustProperty.and(m -> m.hasFlag(GENERATE_TINY_DUST)));
     // Dust with impurities. 1 Unit of Main Material and 1/9 - 1/4 Unit of secondary Material
     public static final OrePrefix dustImpure = new OrePrefix("dustImpure", M, null, MaterialIconType.dustImpure,
             ENABLE_UNIFICATION, hasOreProperty,


### PR DESCRIPTION
## What
Makes Material flags for small and tiny dusts

## Implementation Details
material flags go brrr

## Outcome
lot less jei clutter cause a trillion useless small dusts dont exist :)
