### PR TITLE
Improve the Quantum Storage Renderer

### DIFF
--- a/src/main/java/gregtech/api/gui/resources/TextTexture.java
+++ b/src/main/java/gregtech/api/gui/resources/TextTexture.java
@@ -20,14 +20,24 @@ public class TextTexture implements IGuiTexture {
     public TextType type;
     @SideOnly(Side.CLIENT)
     private List<String> texts;
+    private final boolean isClient = FMLCommonHandler.instance().getSide().isClient();
 
     public TextTexture(String text, int color) {
         this.color = color;
         this.type = TextType.NORMAL;
-        if (FMLCommonHandler.instance().getSide().isClient()) {
+        if (isClient) {
             this.text = I18n.format(text);
             texts = Collections.singletonList(this.text);
         }
+    }
+
+    public TextTexture() {
+        this.color = 0xFFFFFF;
+        this.type = TextType.NORMAL;
+        this.text = "";
+
+        if (isClient)
+            this.texts = Collections.singletonList(this.text);
     }
 
     public TextTexture setColor(int color) {
@@ -42,11 +52,18 @@ public class TextTexture implements IGuiTexture {
 
     public TextTexture setWidth(int width) {
         this.width = width;
-        if (FMLCommonHandler.instance().getSide().isClient()) {
-            if (this.width > 0) {
-                texts = Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(text, width);
-            } else {
-                texts = Collections.singletonList(text);
+        return this;
+    }
+
+    public TextTexture setText(String text) {
+        if (this.text.isEmpty() || !this.text.equals(text)) {
+            this.text = text;
+            if (isClient) {
+                if (this.width > 0) {
+                    texts = Minecraft.getMinecraft().fontRenderer.listFormattedStringToWidth(text, width);
+                } else {
+                    texts = Collections.singletonList(text);
+                }
             }
         }
         return this;

--- a/src/main/java/gregtech/api/gui/resources/TextTexture.java
+++ b/src/main/java/gregtech/api/gui/resources/TextTexture.java
@@ -56,7 +56,7 @@ public class TextTexture implements IGuiTexture {
     }
 
     public TextTexture setText(String text) {
-        if (this.text.isEmpty() || !this.text.equals(text)) {
+        if (!this.text.equals(text)) {
             this.text = text;
             if (isClient) {
                 if (this.width > 0) {

--- a/src/main/java/gregtech/client/renderer/handler/MetaTileEntityTESR.java
+++ b/src/main/java/gregtech/client/renderer/handler/MetaTileEntityTESR.java
@@ -46,12 +46,12 @@ public class MetaTileEntityTESR extends TileEntitySpecialRenderer<MetaTileEntity
         buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
 
         MetaTileEntity metaTileEntity = te.getMetaTileEntity();
-        if (metaTileEntity instanceof IFastRenderMetaTileEntity) {
+        if (metaTileEntity instanceof IFastRenderMetaTileEntity fastRender) {
             CCRenderState renderState = CCRenderState.instance();
             renderState.reset();
             renderState.bind(buffer);
             renderState.setBrightness(te.getWorld(), te.getPos());
-            ((IFastRenderMetaTileEntity) metaTileEntity).renderMetaTileEntityFast(renderState,
+            fastRender.renderMetaTileEntityFast(renderState,
                     new Matrix4().translate(x, y, z), partialTicks);
         }
         if (metaTileEntity != null) {

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -7,6 +7,7 @@ import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer.RenderSide;
 import gregtech.client.utils.RenderUtil;
+import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.storage.MetaTileEntityQuantumChest;
 
 import net.minecraft.client.Minecraft;
@@ -107,7 +108,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
     public static void renderChestStack(double x, double y, double z, MetaTileEntityQuantumChest machine,
                                         ItemStack stack, long count, float partialTicks) {
-        if (stack.isEmpty() || count == 0)
+        if (stack.isEmpty() || count == 0 || !ConfigHolder.client.enableFancyChestRender)
             return;
 
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
@@ -132,14 +133,16 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
     public static void renderTankFluid(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline,
                                        FluidTank tank, IBlockAccess world, BlockPos pos, EnumFacing frontFacing) {
+        FluidStack stack = tank.getFluid();
+        if (stack == null || stack.amount == 0 || !ConfigHolder.client.enableFancyChestRender)
+            return;
+
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
+
         if (world != null) {
             renderState.setBrightness(world, pos);
         }
-        FluidStack stack = tank.getFluid();
-        if (stack == null || stack.amount == 0)
-            return;
 
         Cuboid6 partialFluidBox = new Cuboid6(1.0625 / 16.0, 2.0625 / 16.0, 1.0625 / 16.0, 14.9375 / 16.0,
                 14.9375 / 16.0, 14.9375 / 16.0);
@@ -184,6 +187,9 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     }
 
     public static void renderAmountText(double x, double y, double z, long amount, EnumFacing frontFacing) {
+        if (!ConfigHolder.client.enableFancyChestRender)
+            return;
+
         GlStateManager.pushMatrix();
         GlStateManager.translate(x, y, z);
         GlStateManager.translate(frontFacing.getXOffset() * -1 / 16f, frontFacing.getYOffset() * -1 / 16f,

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -113,7 +113,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
         int range = 9;
         if (x > range || y > range || z > range ||
-                x < -range || y < -range ||z < -range)
+                x < -range || y < -range || z < -range)
             return;
 
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
@@ -180,7 +180,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing, long amount) {
         int range = 9;
         if (x > range || y > range || z > range ||
-                x < -range || y < -range ||z < -range)
+                x < -range || y < -range || z < -range)
             return;
 
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -1,6 +1,8 @@
 package gregtech.client.renderer.texture.custom;
 
 import gregtech.api.gui.resources.TextTexture;
+import gregtech.api.metatileentity.ITieredMetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.renderer.texture.cube.SimpleSidedCubeRenderer.RenderSide;
@@ -62,8 +64,10 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
                 .registerSprite(new ResourceLocation("gregtech:blocks/overlay/machine/overlay_screen_glass"));
     }
 
-    public void renderMachine(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline,
-                              EnumFacing frontFacing, int tier) {
+    public <T extends MetaTileEntity & ITieredMetaTileEntity> void renderMachine(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline,
+                                                                       T mte) {
+        EnumFacing frontFacing = mte.getFrontFacing();
+        int tier = mte.getTier();
         Textures.renderFace(renderState, translation, pipeline, frontFacing, glassBox, glassTexture,
                 BlockRenderLayer.CUTOUT_MIPPED);
 

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -111,6 +111,11 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         if (stack.isEmpty() || count == 0 || !ConfigHolder.client.enableFancyChestRender)
             return;
 
+        int range = 9;
+        if (x > range || y > range || z > range ||
+                x < -range || y < -range ||z < -range)
+            return;
+
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         World world = machine.getWorld();
@@ -173,6 +178,11 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     }
 
     public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing, long amount) {
+        int range = 9;
+        if (x > range || y > range || z > range ||
+                x < -range || y < -range ||z < -range)
+            return;
+
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -111,7 +111,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         if (stack.isEmpty() || count == 0 || !ConfigHolder.client.enableFancyChestRender)
             return;
 
-        int range = 9;
+        int range = 16;
         if (x > range || y > range || z > range ||
                 x < -range || y < -range || z < -range)
             return;
@@ -178,7 +178,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     }
 
     public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing, long amount) {
-        int range = 9;
+        int range = 16;
         if (x > range || y > range || z > range ||
                 x < -range || y < -range || z < -range)
             return;

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -43,7 +43,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
     private static final EnumMap<EnumFacing, Cuboid6> boxFacingMap = new EnumMap<>(EnumFacing.class);
 
-    private static final TextTexture textRenderer = new TextTexture("0", 0xFFFFFF);
+    private static final TextTexture textRenderer = new TextTexture().setWidth(32);
 
     @SideOnly(Side.CLIENT)
     private TextureAtlasSprite glassTexture;
@@ -210,8 +210,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         GlStateManager.scale(1f / 64, 1f / 64, 0);
         GlStateManager.translate(-32, -32, 0);
         GlStateManager.disableLighting();
-        textRenderer.text = amountText;
-        textRenderer.setWidth(32);
+        textRenderer.setText(amountText);
         textRenderer.draw(0, 24, 64, 28);
         GlStateManager.enableLighting();
         GlStateManager.popMatrix();

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -122,7 +122,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         GlStateManager.popMatrix();
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
-        renderAmountText(x, y, z, count, frontFacing);
+//        renderAmountText(x, y, z, count, frontFacing);
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
     }
 
@@ -165,7 +165,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
 
-        renderAmountText(x, y, z, amount, frontFacing);
+//        renderAmountText(x, y, z, amount, frontFacing);
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
     }

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -22,6 +22,7 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
@@ -108,12 +109,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
     public static void renderChestStack(double x, double y, double z, MetaTileEntityQuantumChest machine,
                                         ItemStack stack, long count, float partialTicks) {
-        if (stack.isEmpty() || count == 0 || !ConfigHolder.client.enableFancyChestRender)
-            return;
-
-        int range = 16;
-        if (x > range || y > range || z > range ||
-                x < -range || y < -range || z < -range)
+        if (!ConfigHolder.client.enableFancyChestRender || stack.isEmpty() || count == 0 || !canRender(x, y, z))
             return;
 
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
@@ -177,10 +173,19 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         renderState.reset();
     }
 
+    public static boolean canRender(double x, double y, double z) {
+        double distance = (x * x) + (y * y) + (z * z);
+        return canRender(distance);
+    }
+
+    public static boolean canRender(double distanceSq) {
+        double range = 8 *
+                MathHelper.clamp((double) Minecraft.getMinecraft().gameSettings.renderDistanceChunks / 8, 1.0, 2.5);
+        return distanceSq < range * range;
+    }
+
     public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing, long amount) {
-        int range = 16;
-        if (x > range || y > range || z > range ||
-                x < -range || y < -range || z < -range)
+        if (!canRender(x, y, z))
             return;
 
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -118,7 +118,8 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         setLightingCorrectly(world, machine.getPos());
         EnumFacing frontFacing = machine.getFrontFacing();
 
-        if (canRender(x, y, z, 8 * MathHelper.clamp((double) Minecraft.getMinecraft().gameSettings.renderDistanceChunks / 8, 1.0, 2.5))) {
+        if (canRender(x, y, z, 8 *
+                MathHelper.clamp((double) Minecraft.getMinecraft().gameSettings.renderDistanceChunks / 8, 1.0, 2.5))) {
             RenderItem itemRenderer = Minecraft.getMinecraft().getRenderItem();
             float tick = world.getWorldTime() + partialTicks;
             GlStateManager.pushMatrix();
@@ -179,7 +180,6 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
     }
 
     public static void renderTankAmount(double x, double y, double z, EnumFacing frontFacing, long amount) {
-
         float lastBrightnessX = OpenGlHelper.lastBrightnessX;
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -42,6 +42,8 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
     private static final EnumMap<EnumFacing, Cuboid6> boxFacingMap = new EnumMap<>(EnumFacing.class);
 
+    private static final TextTexture textRenderer = new TextTexture("0", 0xFFFFFF);
+
     @SideOnly(Side.CLIENT)
     private TextureAtlasSprite glassTexture;
 
@@ -122,7 +124,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         GlStateManager.popMatrix();
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
-//        renderAmountText(x, y, z, count, frontFacing);
+        renderAmountText(x, y, z, count, frontFacing);
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
     }
 
@@ -165,7 +167,7 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         float lastBrightnessY = OpenGlHelper.lastBrightnessY;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
 
-//        renderAmountText(x, y, z, amount, frontFacing);
+        renderAmountText(x, y, z, amount, frontFacing);
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
     }
@@ -185,7 +187,9 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         GlStateManager.scale(1f / 64, 1f / 64, 0);
         GlStateManager.translate(-32, -32, 0);
         GlStateManager.disableLighting();
-        new TextTexture(amountText, 0xFFFFFF).draw(0, 24, 64, 28);
+        textRenderer.text = amountText;
+        textRenderer.setWidth(32);
+        textRenderer.draw(0, 24, 64, 28);
         GlStateManager.enableLighting();
         GlStateManager.popMatrix();
     }

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -69,18 +69,21 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
         TextureAtlasSprite hullTexture = Textures.VOLTAGE_CASINGS[tier]
                 .getSpriteOnSide(RenderSide.bySide(EnumFacing.NORTH));
-        boxFacingMap.keySet().forEach(facing -> {
-            for (EnumFacing box : EnumFacing.VALUES) {
-                if ((facing != frontFacing || box != frontFacing) &&
-                        (facing != EnumFacing.DOWN || box.getAxis().isVertical())) { // Don't render the front facing
-                                                                                     // box from the front, nor allow
-                                                                                     // Z-fighting to occur on the
-                                                                                     // bottom
-                    Textures.renderFace(renderState, translation, pipeline, facing, boxFacingMap.get(box), hullTexture,
+        for (EnumFacing facing : EnumFacing.VALUES) {
+            for (EnumFacing boxFace : EnumFacing.VALUES) {
+                // do not render the box when "facing" is "frontFacing", otherwise
+                // render when the box face matches facing, or
+                // render when the box face is opposite of facing, or
+                // render when the box face is the front face
+                if (facing != frontFacing &&
+                        (boxFace == facing || boxFace == facing.getOpposite() || boxFace == frontFacing)) {
+
+                    Textures.renderFace(renderState, translation, pipeline, boxFace, boxFacingMap.get(facing),
+                            hullTexture,
                             BlockRenderLayer.CUTOUT_MIPPED);
                 }
             }
-        });
+        }
     }
 
     public static void renderChestStack(double x, double y, double z, MetaTileEntityQuantumChest machine,

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -66,8 +66,10 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
                 .registerSprite(new ResourceLocation("gregtech:blocks/overlay/machine/overlay_screen_glass"));
     }
 
-    public <T extends MetaTileEntity & ITieredMetaTileEntity> void renderMachine(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline,
-                                                                       T mte) {
+    public <T extends MetaTileEntity & ITieredMetaTileEntity> void renderMachine(CCRenderState renderState,
+                                                                                 Matrix4 translation,
+                                                                                 IVertexOperation[] pipeline,
+                                                                                 T mte) {
         EnumFacing frontFacing = mte.getFrontFacing();
         int tier = mte.getTier();
         Textures.renderFace(renderState, translation, pipeline, frontFacing, glassBox, glassTexture,
@@ -158,13 +160,14 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         Textures.renderFace(renderState, translation, pipeline, frontFacing, partialFluidBox, fluidStillSprite,
                 BlockRenderLayer.CUTOUT_MIPPED);
 
-        Textures.renderFace(renderState, translation, pipeline, gas ? EnumFacing.DOWN : EnumFacing.UP, partialFluidBox, fluidStillSprite,
+        Textures.renderFace(renderState, translation, pipeline, gas ? EnumFacing.DOWN : EnumFacing.UP, partialFluidBox,
+                fluidStillSprite,
                 BlockRenderLayer.CUTOUT_MIPPED);
 
-//        for (EnumFacing facing : EnumFacing.VALUES) {
-//            Textures.renderFace(renderState, translation, pipeline, facing, partialFluidBox, fluidStillSprite,
-//                    BlockRenderLayer.CUTOUT_MIPPED);
-//        }
+        // for (EnumFacing facing : EnumFacing.VALUES) {
+        // Textures.renderFace(renderState, translation, pipeline, facing, partialFluidBox, fluidStillSprite,
+        // BlockRenderLayer.CUTOUT_MIPPED);
+        // }
         GlStateManager.resetColor();
 
         renderState.reset();

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -69,21 +69,32 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
 
         TextureAtlasSprite hullTexture = Textures.VOLTAGE_CASINGS[tier]
                 .getSpriteOnSide(RenderSide.bySide(EnumFacing.NORTH));
-        for (EnumFacing facing : EnumFacing.VALUES) {
-            for (EnumFacing boxFace : EnumFacing.VALUES) {
-                // do not render the box when "facing" is "frontFacing", otherwise
-                // render when the box face matches facing, or
-                // render when the box face is opposite of facing, or
-                // render when the box face is the front face
-                if (facing != frontFacing &&
-                        (boxFace == facing || boxFace == facing.getOpposite() || boxFace == frontFacing)) {
 
-                    Textures.renderFace(renderState, translation, pipeline, boxFace, boxFacingMap.get(facing),
-                            hullTexture,
-                            BlockRenderLayer.CUTOUT_MIPPED);
-                }
-            }
+        for (var facing : boxFacingMap.keySet()) {
+            // do not render the box at the front face when "facing" is "frontFacing"
+            if (facing == frontFacing) continue;
+
+            // render when the box face matches facing
+            Textures.renderFace(renderState, translation, pipeline, facing, boxFacingMap.get(facing),
+                    hullTexture, BlockRenderLayer.CUTOUT_MIPPED);
+
+            // render when the box face is opposite of facing
+            Textures.renderFace(renderState, translation, pipeline, facing.getOpposite(), boxFacingMap.get(facing),
+                    hullTexture, BlockRenderLayer.CUTOUT_MIPPED);
         }
+
+        // render the sides of the box that face the front face
+        if (frontFacing.getAxis() == EnumFacing.Axis.Y) return;
+        Textures.renderFace(renderState, translation, pipeline, frontFacing, boxFacingMap.get(EnumFacing.DOWN),
+                hullTexture, BlockRenderLayer.CUTOUT_MIPPED);
+        Textures.renderFace(renderState, translation, pipeline, frontFacing, boxFacingMap.get(EnumFacing.UP),
+                hullTexture, BlockRenderLayer.CUTOUT_MIPPED);
+
+        EnumFacing facing = frontFacing.rotateYCCW();
+        Textures.renderFace(renderState, translation, pipeline, frontFacing, boxFacingMap.get(facing),
+                hullTexture, BlockRenderLayer.CUTOUT_MIPPED);
+        Textures.renderFace(renderState, translation, pipeline, frontFacing, boxFacingMap.get(facing.getOpposite()),
+                hullTexture, BlockRenderLayer.CUTOUT_MIPPED);
     }
 
     public static void renderChestStack(double x, double y, double z, MetaTileEntityQuantumChest machine,

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -174,6 +174,16 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         renderState.reset();
     }
 
+    /**
+     * Takes in the difference in x, y, and z from the camera to the rendering TE and
+     * calculates the squared distance and checks if it's within the range squared
+     * 
+     * @param x     the difference in x from entity to this rendering TE
+     * @param y     the difference in y from entity to this rendering TE
+     * @param z     the difference in z from entity to this rendering TE
+     * @param range distance needed to be rendered
+     * @return true if the camera is within the given range, otherwise false
+     */
     public static boolean canRender(double x, double y, double z, double range) {
         double distance = (x * x) + (y * y) + (z * z);
         return distance < range * range;

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -143,7 +143,8 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
                 14.9375 / 16.0, 14.9375 / 16.0);
 
         double fillFraction = (double) stack.amount / tank.getCapacity();
-        if (tank.getFluid().getFluid().isGaseous()) {
+        boolean gas = stack.getFluid().isGaseous();
+        if (gas) {
             partialFluidBox.min.y = Math.max(13.9375 - (11.875 * fillFraction), 2.0) / 16.0;
         } else {
             partialFluidBox.max.y = Math.min((11.875 * fillFraction) + 2.0625, 14.0) / 16.0;
@@ -153,10 +154,17 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
         ResourceLocation fluidStill = stack.getFluid().getStill(stack);
         TextureAtlasSprite fluidStillSprite = Minecraft.getMinecraft().getTextureMapBlocks()
                 .getAtlasSprite(fluidStill.toString());
-        for (EnumFacing facing : EnumFacing.VALUES) {
-            Textures.renderFace(renderState, translation, pipeline, facing, partialFluidBox, fluidStillSprite,
-                    BlockRenderLayer.CUTOUT_MIPPED);
-        }
+
+        Textures.renderFace(renderState, translation, pipeline, frontFacing, partialFluidBox, fluidStillSprite,
+                BlockRenderLayer.CUTOUT_MIPPED);
+
+        Textures.renderFace(renderState, translation, pipeline, gas ? EnumFacing.DOWN : EnumFacing.UP, partialFluidBox, fluidStillSprite,
+                BlockRenderLayer.CUTOUT_MIPPED);
+
+//        for (EnumFacing facing : EnumFacing.VALUES) {
+//            Textures.renderFace(renderState, translation, pipeline, facing, partialFluidBox, fluidStillSprite,
+//                    BlockRenderLayer.CUTOUT_MIPPED);
+//        }
         GlStateManager.resetColor();
 
         renderState.reset();

--- a/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
+++ b/src/main/java/gregtech/client/renderer/texture/custom/QuantumStorageRenderer.java
@@ -167,10 +167,6 @@ public class QuantumStorageRenderer implements TextureUtils.IIconRegister {
                 fluidStillSprite,
                 BlockRenderLayer.CUTOUT_MIPPED);
 
-        // for (EnumFacing facing : EnumFacing.VALUES) {
-        // Textures.renderFace(renderState, translation, pipeline, facing, partialFluidBox, fluidStillSprite,
-        // BlockRenderLayer.CUTOUT_MIPPED);
-        // }
         GlStateManager.resetColor();
 
         renderState.reset();

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -456,8 +456,8 @@ public class ConfigHolder {
         @Config.Comment({ "Prevent optical and laser cables from animating when active.", "Default: false" })
         public boolean preventAnimatedCables = false;
 
-        @Config.Comment({"Enable the fancy rendering for Super/Quantum Chests/Tanks.",
-                            "Default: true"})
+        @Config.Comment({ "Enable the fancy rendering for Super/Quantum Chests/Tanks.",
+                "Default: true" })
         public boolean enableFancyChestRender = true;
 
         public static class GuiConfig {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -404,7 +404,7 @@ public class ConfigHolder {
 
         @Config.Comment({
                 "Whether or not to enable Emissive Textures for Electric Blast Furnace Coils when the multiblock is working.",
-                "Default: false" })
+                "Default: true" })
         public boolean coilsActiveEmissiveTextures = true;
 
         @Config.Comment({ "Whether or not sounds should be played when using tools outside of crafting.",
@@ -455,6 +455,10 @@ public class ConfigHolder {
 
         @Config.Comment({ "Prevent optical and laser cables from animating when active.", "Default: false" })
         public boolean preventAnimatedCables = false;
+
+        @Config.Comment({"Enable the fancy rendering for Super/Quantum Chests/Tanks.",
+                            "Default: true"})
+        public boolean enableFancyChestRender = true;
 
         public static class GuiConfig {
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeChest.java
@@ -69,7 +69,7 @@ public class MetaTileEntityCreativeChest extends MetaTileEntityQuantumChest {
         Textures.QUANTUM_STORAGE_RENDERER.renderMachine(renderState, translation,
                 ArrayUtils.add(pipeline,
                         new ColourMultiplier(GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()))),
-                this.getFrontFacing(), this.getTier());
+                this);
         Textures.CREATIVE_CONTAINER_OVERLAY.renderSided(EnumFacing.UP, renderState, translation, pipeline);
         Textures.PIPE_OUT_OVERLAY.renderSided(this.getOutputFacing(), renderState, translation, pipeline);
         Textures.ITEM_OUTPUT_OVERLAY.renderSided(this.getOutputFacing(), renderState, translation, pipeline);

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -52,7 +52,7 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
         Textures.QUANTUM_STORAGE_RENDERER.renderMachine(renderState, translation,
                 ArrayUtils.add(pipeline,
                         new ColourMultiplier(GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()))),
-                this.getFrontFacing(), this.getTier());
+                this);
         Textures.CREATIVE_CONTAINER_OVERLAY.renderSided(EnumFacing.UP, renderState, translation, pipeline);
         if (this.getOutputFacing() != null) {
             Textures.PIPE_OUT_OVERLAY.renderSided(this.getOutputFacing(), renderState, translation, pipeline);

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -102,7 +102,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity
         Textures.QUANTUM_STORAGE_RENDERER.renderMachine(renderState, translation,
                 ArrayUtils.add(pipeline,
                         new ColourMultiplier(GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()))),
-                this.getFrontFacing(), this.tier);
+                this);
         Textures.QUANTUM_CHEST_OVERLAY.renderSided(EnumFacing.UP, renderState, translation, pipeline);
         if (outputFacing != null) {
             Textures.PIPE_OUT_OVERLAY.renderSided(outputFacing, renderState, translation, pipeline);

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -135,16 +135,19 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity
                     updatePreviousFluid(null);
                 } else if (previousFluid.getFluid().equals(currentFluid.getFluid()) &&
                         previousFluid.amount != currentFluid.amount) {
-                    int currentFill = MathHelper.floor(16 * ((float) currentFluid.amount) / fluidTank.getCapacity());
-                    int previousFill = MathHelper.floor(16 * ((float) previousFluid.amount) / fluidTank.getCapacity());
-                    // tank has fluid with changed amount
-                    previousFluid.amount = currentFluid.amount;
-                    writeCustomData(UPDATE_FLUID_AMOUNT, buf -> {
-                        buf.writeInt(currentFluid.amount);
-                        buf.writeBoolean(currentFill != previousFill);
-                    });
+                            int currentFill = MathHelper
+                                    .floor(16 * ((float) currentFluid.amount) / fluidTank.getCapacity());
+                            int previousFill = MathHelper
+                                    .floor(16 * ((float) previousFluid.amount) / fluidTank.getCapacity());
+                            // tank has fluid with changed amount
+                            previousFluid.amount = currentFluid.amount;
+                            writeCustomData(UPDATE_FLUID_AMOUNT, buf -> {
+                                buf.writeInt(currentFluid.amount);
+                                buf.writeBoolean(currentFill != previousFill);
+                            });
 
-                } else if (!previousFluid.equals(currentFluid)) {
+                        } else
+                    if (!previousFluid.equals(currentFluid)) {
                         // tank has a different fluid from before
                         updatePreviousFluid(currentFluid);
                     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -292,11 +292,6 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity
         if (this.fluidTank.getFluid() == null || this.fluidTank.getFluid().amount == 0)
             return;
 
-        int range = 9;
-        if (x > range || y > range || z > range ||
-                x < -range || y < -range ||z < -range)
-            return;
-
         QuantumStorageRenderer.renderTankAmount(x, y, z, this.getFrontFacing(), this.fluidTank.getFluid().amount);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -460,17 +460,19 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity
             try {
                 this.fluidTank.setFluid(FluidStack.loadFluidStackFromNBT(buf.readCompoundTag()));
             } catch (IOException ignored) {
-                GTLog.logger.warn("Failed to load fluid from NBT in a quantum tank at " + this.getPos() +
-                        " on a routine fluid update");
+                GTLog.logger.warn("Failed to load fluid from NBT in a quantum tank at {} on a routine fluid update",
+                        this.getPos());
             }
             scheduleRenderUpdate();
         } else if (dataId == UPDATE_FLUID_AMOUNT) {
             // amount must always be read even if it cannot be used to ensure the reader index advances
             int amount = buf.readInt();
+            boolean updateRendering = buf.readBoolean();
             FluidStack stack = fluidTank.getFluid();
             if (stack != null) {
                 stack.amount = Math.min(amount, fluidTank.getCapacity());
-                scheduleRenderUpdate();
+                if (updateRendering)
+                    scheduleRenderUpdate();
             }
         } else if (dataId == UPDATE_IS_VOIDING) {
             setVoiding(buf.readBoolean());

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -266,7 +266,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity
         Textures.QUANTUM_STORAGE_RENDERER.renderMachine(renderState, translation,
                 ArrayUtils.add(pipeline,
                         new ColourMultiplier(GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()))),
-                this.getFrontFacing(), this.tier);
+                this);
         Textures.QUANTUM_TANK_OVERLAY.renderSided(EnumFacing.UP, renderState, translation, pipeline);
         if (outputFacing != null) {
             Textures.PIPE_OUT_OVERLAY.renderSided(outputFacing, renderState, translation, pipeline);

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -291,6 +291,12 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity
     public void renderMetaTileEntity(double x, double y, double z, float partialTicks) {
         if (this.fluidTank.getFluid() == null || this.fluidTank.getFluid().amount == 0)
             return;
+
+        int range = 9;
+        if (x > range || y > range || z > range ||
+                x < -range || y < -range ||z < -range)
+            return;
+
         QuantumStorageRenderer.renderTankAmount(x, y, z, this.getFrontFacing(), this.fluidTank.getFluid().amount);
     }
 


### PR DESCRIPTION
## What
This pr improves the quantum storage render by rendering the minimum amount of faces needed (15). Previously, it would render 31 faces.

also improves quantum tank rendering fluid contents by only rendering the two needed faces instead of all six

## Implementation Details
idk why a `foreach()` was used for the `boxFacingMap`
also previously it was `facing, boxFacingMap.get(box)` in `renderFace()`, which looked backwards to me
store the TextTexture as a static final variable instead of instantiating it every frame

## Outcome
more fps

## Potential Compatibility Issues
none
