### PR TITLE
prevent potential ThreadLocal memory leaks

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -40,7 +40,11 @@ import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
@@ -63,7 +67,12 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 import static gregtech.api.util.GTUtility.getMetaTileEntity;
 
@@ -423,7 +432,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                              @NotNull IBlockState state, @Nullable TileEntity te, @NotNull ItemStack stack) {
         tileEntities.set(te == null ? tileEntities.get() : ((IGregTechTileEntity) te).getMetaTileEntity());
         super.harvestBlock(worldIn, player, pos, state, te, stack);
-        tileEntities.set(null);
+        tileEntities.remove();
     }
 
     @Nullable

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -34,7 +34,12 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
@@ -485,7 +490,7 @@ public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<Node
                              @NotNull IBlockState state, @Nullable TileEntity te, @NotNull ItemStack stack) {
         tileEntities.set(te == null ? tileEntities.get() : (IPipeTile<PipeType, NodeDataType>) te);
         super.harvestBlock(worldIn, player, pos, state, te, stack);
-        tileEntities.set(null);
+        tileEntities.remove();
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -23,7 +23,15 @@ import org.jetbrains.annotations.Nullable;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -631,11 +639,11 @@ public class OrePrefix {
             for (IOreRegistrationHandler registrationHandler : oreProcessingHandlers) {
                 registrationHandler.processMaterial(this, registeredMaterial);
             }
-            currentMaterial.set(null);
+            currentMaterial.remove();
         }
         // clear generated materials for next pass
         generatedMaterials.clear();
-        currentProcessingPrefix.set(null);
+        currentProcessingPrefix.remove();
     }
 
     public void setAlternativeOreName(String name) {

--- a/src/main/java/gregtech/asm/hooks/CTMHooks.java
+++ b/src/main/java/gregtech/asm/hooks/CTMHooks.java
@@ -43,7 +43,7 @@ public class CTMHooks {
                 ForgeHooksClient.setRenderLayer(BloomEffectUtil.getBloomLayer());
                 result.addAll(bakedModel.getQuads(state, side, rand));
                 ForgeHooksClient.setRenderLayer(layer);
-                CTMHooks.ENABLE.set(null);
+                CTMHooks.ENABLE.remove();
                 return result;
             }
         }

--- a/src/main/java/gregtech/client/renderer/handler/MetaTileEntityRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/MetaTileEntityRenderer.java
@@ -115,7 +115,7 @@ public class MetaTileEntityRenderer implements ICCBlockRenderer, IItemRenderer {
 
         metaTileEntity.renderCovers(renderState, translation.copy(), renderLayer);
 
-        Textures.RENDER_STATE.set(null);
+        Textures.RENDER_STATE.remove();
         return true;
     }
 

--- a/src/main/java/gregtech/client/renderer/pipe/PipeRenderer.java
+++ b/src/main/java/gregtech/client/renderer/pipe/PipeRenderer.java
@@ -218,7 +218,7 @@ public abstract class PipeRenderer implements ICCBlockRenderer, IItemRenderer {
             CoverHolder coverHolder = pipeTile.getCoverableImplementation();
             coverHolder.renderCovers(renderState, new Matrix4().translate(pos.getX(), pos.getY(), pos.getZ()),
                     renderLayer);
-            Textures.RENDER_STATE.set(null);
+            Textures.RENDER_STATE.remove();
         }
         return true;
     }


### PR DESCRIPTION
## What
Uses `ThreadLocal#remove` instead of `set(null)`, which fully disassociates the threadlocal with the current thread. Using `set(null)` keeps the association, which can cause memory leaks.

## Outcome
Prevents potential memory leaks due to not removing from `ThreadLocal`s.
