### PR TITLE
Change order of item in Research Station JEI page

### DIFF
--- a/src/main/java/gregtech/api/recipes/ui/impl/ResearchStationUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/ResearchStationUI.java
@@ -39,11 +39,11 @@ public class ResearchStationUI<R extends RecipeMap<?>> extends RecipeMapUI<R> {
                         GuiTextures.PROGRESS_BAR_RESEARCH_STATION_1, ProgressWidget.MoveType.HORIZONTAL))
                 .widget(new ProgressWidget(pairedSuppliers.getRight(), 119, 32, 10, 18,
                         GuiTextures.PROGRESS_BAR_RESEARCH_STATION_2, ProgressWidget.MoveType.VERTICAL_DOWNWARDS))
-                .widget(new SlotWidget(importItems, 0, 115, 50, true, true)
+                .widget(new SlotWidget(exportItems, 0, 115, 50, true, true)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.DATA_ORB_OVERLAY))
                 .widget(new SlotWidget(importItems, 1, 43, 21, true, true)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.SCANNER_OVERLAY))
-                .widget(new SlotWidget(exportItems, 0, 97, 21, true, true)
+                .widget(new SlotWidget(importItems, 0, 97, 21, true, true)
                         .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.RESEARCH_STATION_OVERLAY));
     }
 }


### PR DESCRIPTION
## What
Changes the order of items in the Research Station JEI page to be a bit more intuitive (in my opinion)

New:
![image](https://github.com/GregTechCEu/GregTech/assets/31759736/9efe2f39-0093-4896-8690-c60ae0f7bbc9)

Research Item in the middle, flowing through an empty data orb, into the filled data orb at the end of the arrow

