### PR TITLE
Use locale formatting where possible in WAILA and The One Probe

### DIFF
--- a/src/main/java/gregtech/api/util/TextFormattingUtil.java
+++ b/src/main/java/gregtech/api/util/TextFormattingUtil.java
@@ -16,7 +16,7 @@ public class TextFormattingUtil {
     private static final char[] metricSuffixChars = {
             'k', 'M', 'G', 'T', 'P', 'E'
     };
-    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
+    protected static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
 
     public static String formatLongToCompactString(long value, int precision) {
         if (value == 0 || Math.abs(value) < Math.pow(10, precision)) {

--- a/src/main/java/gregtech/api/util/TextFormattingUtil.java
+++ b/src/main/java/gregtech/api/util/TextFormattingUtil.java
@@ -16,7 +16,7 @@ public class TextFormattingUtil {
     private static final char[] metricSuffixChars = {
             'k', 'M', 'G', 'T', 'P', 'E'
     };
-    protected static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
+    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
 
     public static String formatLongToCompactString(long value, int precision) {
         if (value == 0 || Math.abs(value) < Math.pow(10, precision)) {

--- a/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
@@ -71,13 +71,15 @@ public class ConverterDataProvider extends CapabilityDataProvider<ConverterTrait
                             TextFormatting.RESET + " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");
                 } else {
                     tooltip.add(I18n.format("gregtech.top.transform_input") + " " +
-                            TextFormattingUtil.formatNumbers(FeCompat.toFe(voltage * amperage, FeCompat.ratio(true))) + " FE");
+                            TextFormattingUtil.formatNumbers(FeCompat.toFe(voltage * amperage, FeCompat.ratio(true))) +
+                            " FE");
                 }
             } else {
                 tooltip.add(I18n.format("gregtech.top.convert_eu"));
                 if (accessor.getSide() == frontFacing) {
                     tooltip.add(I18n.format("gregtech.top.transform_output") + " " +
-                            TextFormattingUtil.formatNumbers(FeCompat.toFe(voltage * amperage, FeCompat.ratio(false))) + " FE");
+                            TextFormattingUtil.formatNumbers(FeCompat.toFe(voltage * amperage, FeCompat.ratio(false))) +
+                            " FE");
                 } else {
                     tooltip.add(I18n.format("gregtech.top.transform_input") + " " + voltageName + TextFormatting.RESET +
                             " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");

--- a/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.converter.ConverterTrait;
 
 import net.minecraft.client.resources.I18n;
@@ -67,19 +68,19 @@ public class ConverterDataProvider extends CapabilityDataProvider<ConverterTrait
                 tooltip.add(I18n.format("gregtech.top.convert_fe"));
                 if (accessor.getSide() == frontFacing) {
                     tooltip.add(I18n.format("gregtech.top.transform_output") + " " + voltageName +
-                            TextFormatting.RESET + " (" + amperage + "A)");
+                            TextFormatting.RESET + " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");
                 } else {
                     tooltip.add(I18n.format("gregtech.top.transform_input") + " " +
-                            FeCompat.toFe(voltage * amperage, FeCompat.ratio(true)) + " FE");
+                            TextFormattingUtil.formatNumbers(FeCompat.toFe(voltage * amperage, FeCompat.ratio(true))) + " FE");
                 }
             } else {
                 tooltip.add(I18n.format("gregtech.top.convert_eu"));
                 if (accessor.getSide() == frontFacing) {
                     tooltip.add(I18n.format("gregtech.top.transform_output") + " " +
-                            FeCompat.toFe(voltage * amperage, FeCompat.ratio(false)) + " FE");
+                            TextFormattingUtil.formatNumbers(FeCompat.toFe(voltage * amperage, FeCompat.ratio(false))) + " FE");
                 } else {
                     tooltip.add(I18n.format("gregtech.top.transform_input") + " " + voltageName + TextFormatting.RESET +
-                            " (" + amperage + "A)");
+                            " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");
                 }
             }
         }

--- a/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
@@ -3,6 +3,7 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.electric.MetaTileEntityDiode;
 
 import net.minecraft.client.resources.I18n;
@@ -59,9 +60,9 @@ public class DiodeDataProvider extends ElectricContainerDataProvider {
             final EnumFacing frontFacing = EnumFacing.byIndex(tag.getInteger("FrontFacing"));
 
             if (accessor.getSide() == frontFacing) { // output side
-                tooltip.add(I18n.format("gregtech.top.transform_output") + " " + outputAmperage + " A");
+                tooltip.add(I18n.format("gregtech.top.transform_output") + " " + TextFormattingUtil.formatNumbers(outputAmperage) + " A");
             } else {
-                tooltip.add(I18n.format("gregtech.top.transform_input") + " " + inputAmperage + " A");
+                tooltip.add(I18n.format("gregtech.top.transform_input") + " " + TextFormattingUtil.formatNumbers(inputAmperage) + " A");
             }
         }
         return tooltip;

--- a/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
@@ -60,9 +60,11 @@ public class DiodeDataProvider extends ElectricContainerDataProvider {
             final EnumFacing frontFacing = EnumFacing.byIndex(tag.getInteger("FrontFacing"));
 
             if (accessor.getSide() == frontFacing) { // output side
-                tooltip.add(I18n.format("gregtech.top.transform_output") + " " + TextFormattingUtil.formatNumbers(outputAmperage) + " A");
+                tooltip.add(I18n.format("gregtech.top.transform_output") + " " +
+                        TextFormattingUtil.formatNumbers(outputAmperage) + " A");
             } else {
-                tooltip.add(I18n.format("gregtech.top.transform_input") + " " + TextFormattingUtil.formatNumbers(inputAmperage) + " A");
+                tooltip.add(I18n.format("gregtech.top.transform_input") + " " +
+                        TextFormattingUtil.formatNumbers(inputAmperage) + " A");
             }
         }
         return tooltip;

--- a/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
@@ -3,7 +3,6 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IPrimitivePump;
-
 import gregtech.api.util.TextFormattingUtil;
 
 import net.minecraft.client.resources.I18n;

--- a/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
@@ -4,6 +4,8 @@ import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IPrimitivePump;
 
+import gregtech.api.util.TextFormattingUtil;
+
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -58,7 +60,8 @@ public class PrimitivePumpDataProvider implements IWailaDataProvider {
         if (accessor.getNBTData().hasKey("gregtech.IPrimitivePump")) {
             NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.IPrimitivePump");
             int production = tag.getInteger("Production");
-            tooltip.add(I18n.format("gregtech.top.primitive_pump_production") + " " + TextFormatting.AQUA + production +
+            tooltip.add(I18n.format("gregtech.top.primitive_pump_production") + " " + TextFormatting.AQUA +
+                    TextFormattingUtil.formatNumbers(production) +
                     TextFormatting.RESET + " L/s");
         }
         return tooltip;

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -9,6 +9,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
 
 import net.minecraft.client.resources.I18n;
@@ -65,7 +66,6 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
             NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.AbstractRecipeLogic");
             if (tag.getBoolean("Working")) {
                 int EUt = tag.getInteger("RecipeEUt");
-                NumberFormat format = NumberFormat.getNumberInstance();
                 int absEUt = Math.abs(EUt);
                 boolean consumer = EUt > 0;
                 String endText = null;
@@ -74,7 +74,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                     MetaTileEntity mte = gtte.getMetaTileEntity();
                     if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                             mte instanceof RecipeMapSteamMultiblockController) {
-                        endText = ": " + format.format(absEUt) + TextFormatting.RESET + " L/t " +
+                        endText = ": " + TextFormattingUtil.formatNumbers(absEUt) + TextFormatting.RESET + " L/t " +
                                 I18n.format(Materials.Steam.getUnlocalizedName());
                     }
                     AbstractRecipeLogic arl = mte.getRecipeLogic();
@@ -83,7 +83,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                     }
                 }
                 if (endText == null) {
-                    endText = ": " + format.format(absEUt) + TextFormatting.RESET + " EU/t (" +
+                    endText = ": " + TextFormattingUtil.formatNumbers(absEUt) + TextFormatting.RESET + " EU/t (" +
                             GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.RESET + ")";
                 }
 

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -23,6 +23,7 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaRegistrar;
 import org.jetbrains.annotations.NotNull;
 
+import java.text.NumberFormat;
 import java.util.List;
 
 public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractRecipeLogic> {
@@ -64,6 +65,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
             NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.AbstractRecipeLogic");
             if (tag.getBoolean("Working")) {
                 int EUt = tag.getInteger("RecipeEUt");
+                NumberFormat format = NumberFormat.getNumberInstance();
                 int absEUt = Math.abs(EUt);
                 boolean consumer = EUt > 0;
                 String endText = null;
@@ -72,7 +74,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                     MetaTileEntity mte = gtte.getMetaTileEntity();
                     if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                             mte instanceof RecipeMapSteamMultiblockController) {
-                        endText = ": " + absEUt + TextFormatting.RESET + " L/t " +
+                        endText = ": " + format.format(absEUt) + TextFormatting.RESET + " L/t " +
                                 I18n.format(Materials.Steam.getUnlocalizedName());
                     }
                     AbstractRecipeLogic arl = mte.getRecipeLogic();
@@ -81,7 +83,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                     }
                 }
                 if (endText == null) {
-                    endText = ": " + absEUt + TextFormatting.RESET + " EU/t (" +
+                    endText = ": " + format.format(absEUt) + TextFormatting.RESET + " EU/t (" +
                             GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.RESET + ")";
                 }
 

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -24,7 +24,6 @@ import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaRegistrar;
 import org.jetbrains.annotations.NotNull;
 
-import java.text.NumberFormat;
 import java.util.List;
 
 public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractRecipeLogic> {

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -66,7 +66,8 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
 
                 // Creating steam
                 if (steamRate > 0 && hasWater) {
-                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + TextFormattingUtil.formatNumbers(steamRate / 10) + " L/t " +
+                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " +
+                            TextFormattingUtil.formatNumbers(steamRate / 10) + " L/t " +
                             I18n.format(Materials.Steam.getUnlocalizedName()));
                 }
 

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -3,6 +3,7 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.steam.boiler.SteamBoiler;
 
 import net.minecraft.client.resources.I18n;
@@ -65,7 +66,7 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
 
                 // Creating steam
                 if (steamRate > 0 && hasWater) {
-                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + (steamRate / 10) + " L/t " +
+                    tooltip.add(I18n.format("gregtech.top.energy_production") + ": " + TextFormattingUtil.formatNumbers(steamRate / 10) + " L/t " +
                             I18n.format(Materials.Steam.getUnlocalizedName()));
                 }
 

--- a/src/main/java/gregtech/integration/hwyla/provider/TransformerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/TransformerDataProvider.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.electric.MetaTileEntityTransformer;
 
 import net.minecraft.client.resources.I18n;
@@ -82,7 +83,7 @@ public class TransformerDataProvider extends ElectricContainerDataProvider {
                     .append(GTValues.VNF[GTUtility.getTierByVoltage(inputVoltage)])
                     .append(TextFormatting.RESET)
                     .append(" (")
-                    .append(inputAmperage)
+                    .append(TextFormattingUtil.formatNumbers(inputAmperage))
                     .append("A)");
 
             StringBuilder output = new StringBuilder()
@@ -90,7 +91,7 @@ public class TransformerDataProvider extends ElectricContainerDataProvider {
                     .append(GTValues.VNF[GTUtility.getTierByVoltage(outputVoltage)])
                     .append(TextFormatting.RESET)
                     .append(" (")
-                    .append(outputAmperage)
+                    .append(TextFormattingUtil.formatNumbers(outputAmperage))
                     .append("A)");
 
             // Step Up/Step Down line

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.FeCompat;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.converter.ConverterTrait;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -45,18 +46,18 @@ public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait
         if (capability.isFeToEu()) {
             if (data.getSideHit() == facing) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + voltageN +
-                        TextFormatting.GREEN + " (" + amperage + "A)");
+                        TextFormatting.GREEN + " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");
             } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + TextFormatting.RED +
-                        FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(true)) + " FE");
+                        TextFormattingUtil.formatNumbers(FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(true))) + " FE");
             }
         } else {
             if (data.getSideHit() == facing) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + TextFormatting.RED +
-                        FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(false)) + " FE");
+                        TextFormattingUtil.formatNumbers(FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(false))) + " FE");
             } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + voltageN +
-                        TextFormatting.GREEN + " (" + amperage + "A)");
+                        TextFormatting.GREEN + " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ConverterInfoProvider.java
@@ -49,12 +49,16 @@ public class ConverterInfoProvider extends CapabilityInfoProvider<ConverterTrait
                         TextFormatting.GREEN + " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");
             } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + TextFormatting.RED +
-                        TextFormattingUtil.formatNumbers(FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(true))) + " FE");
+                        TextFormattingUtil.formatNumbers(
+                                FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(true))) +
+                        " FE");
             }
         } else {
             if (data.getSideHit() == facing) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_output*} " + TextFormatting.RED +
-                        TextFormattingUtil.formatNumbers(FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(false))) + " FE");
+                        TextFormattingUtil.formatNumbers(
+                                FeCompat.toFe(capability.getVoltage() * amperage, FeCompat.ratio(false))) +
+                        " FE");
             } else {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.transform_input*} " + voltageN +
                         TextFormatting.GREEN + " (" + TextFormattingUtil.formatNumbers(amperage) + "A)");

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverInfoProvider.java
@@ -204,7 +204,8 @@ public class CoverInfoProvider extends CapabilityInfoProvider<CoverHolder> {
     private static void transferModeText(@NotNull IProbeInfo probeInfo, @NotNull TransferMode mode,
                                          @NotNull String rateUnit, int rate, boolean hasFilter) {
         String text = TextStyleClass.OK + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
-        if (!hasFilter && mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + TextFormattingUtil.formatNumbers(rate) + rateUnit;
+        if (!hasFilter && mode != TransferMode.TRANSFER_ANY)
+            text += TextStyleClass.LABEL + " " + TextFormattingUtil.formatNumbers(rate) + rateUnit;
         probeInfo.text(text);
     }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/CoverInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/CoverInfoProvider.java
@@ -204,7 +204,7 @@ public class CoverInfoProvider extends CapabilityInfoProvider<CoverHolder> {
     private static void transferModeText(@NotNull IProbeInfo probeInfo, @NotNull TransferMode mode,
                                          @NotNull String rateUnit, int rate, boolean hasFilter) {
         String text = TextStyleClass.OK + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
-        if (!hasFilter && mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + rate + rateUnit;
+        if (!hasFilter && mode != TransferMode.TRANSFER_ANY) text += TextStyleClass.LABEL + " " + TextFormattingUtil.formatNumbers(rate) + rateUnit;
         probeInfo.text(text);
     }
 
@@ -220,7 +220,7 @@ public class CoverInfoProvider extends CapabilityInfoProvider<CoverHolder> {
     private static void voidingText(@NotNull IProbeInfo probeInfo, @NotNull VoidingMode mode, @NotNull String unit,
                                     int amount, boolean hasFilter) {
         String text = TextFormatting.RED + IProbeInfo.STARTLOC + mode.getName() + IProbeInfo.ENDLOC;
-        if (mode != VoidingMode.VOID_ANY && !hasFilter) text += " " + amount + unit;
+        if (mode != VoidingMode.VOID_ANY && !hasFilter) text += " " + TextFormattingUtil.formatNumbers(amount) + unit;
         probeInfo.text(text);
     }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -4,6 +4,8 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 
+import gregtech.api.util.TextFormattingUtil;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
@@ -11,6 +13,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import org.jetbrains.annotations.NotNull;
+
+import java.text.NumberFormat;
 
 public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnergyContainer> {
 
@@ -36,9 +40,9 @@ public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnerg
         long maxStorage = capability.getEnergyCapacity();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
         probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
-                .suffix(" / " + maxStorage + " EU")
+                .suffix(" / " + TextFormattingUtil.formatNumbers(maxStorage) + " EU")
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
-                .borderColor(0xFF555555));
+                .borderColor(0xFF555555).numberFormat(mcjty.theoneprobe.api.NumberFormat.COMMAS));
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ElectricContainerInfoProvider.java
@@ -3,7 +3,6 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
-
 import gregtech.api.util.TextFormattingUtil;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -13,8 +12,6 @@ import net.minecraftforge.common.capabilities.Capability;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import org.jetbrains.annotations.NotNull;
-
-import java.text.NumberFormat;
 
 public class ElectricContainerInfoProvider extends CapabilityInfoProvider<IEnergyContainer> {
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
@@ -3,10 +3,7 @@ package gregtech.integration.theoneprobe.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.ILaserContainer;
-
 import gregtech.api.util.TextFormattingUtil;
-
-import mcjty.theoneprobe.api.NumberFormat;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -14,6 +11,7 @@ import net.minecraftforge.common.capabilities.Capability;
 
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.NumberFormat;
 import org.jetbrains.annotations.NotNull;
 
 public class LaserContainerInfoProvider extends CapabilityInfoProvider<ILaserContainer> {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/LaserContainerInfoProvider.java
@@ -4,6 +4,10 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.ILaserContainer;
 
+import gregtech.api.util.TextFormattingUtil;
+
+import mcjty.theoneprobe.api.NumberFormat;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
@@ -31,10 +35,10 @@ public class LaserContainerInfoProvider extends CapabilityInfoProvider<ILaserCon
         long maxStorage = capability.getEnergyCapacity();
         if (maxStorage == 0) return; // do not add empty max storage progress bar
         probeInfo.progress(capability.getEnergyStored(), maxStorage, probeInfo.defaultProgressStyle()
-                .suffix(" / " + maxStorage + " EU")
+                .suffix(" / " + TextFormattingUtil.formatNumbers(maxStorage) + " EU")
                 .filledColor(0xFFEEE600)
                 .alternateFilledColor(0xFFEEE600)
-                .borderColor(0xFF555555));
+                .borderColor(0xFF555555).numberFormat(NumberFormat.COMMAS));
     }
 
     @Override

--- a/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
@@ -5,6 +5,8 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IPrimitivePump;
 
+import gregtech.api.util.TextFormattingUtil;
+
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -32,7 +34,7 @@ public class PrimitivePumpInfoProvider implements IProbeInfoProvider {
             if (metaTileEntity instanceof IPrimitivePump) {
                 probeInfo.text(
                         TextStyleClass.INFO + "{*gregtech.top.primitive_pump_production*} " + TextFormatting.AQUA +
-                                ((IPrimitivePump) metaTileEntity).getFluidProduction() + TextFormatting.RESET + " L/s");
+                                TextFormattingUtil.formatNumbers(((IPrimitivePump) metaTileEntity).getFluidProduction()) + TextFormatting.RESET + " L/s");
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/PrimitivePumpInfoProvider.java
@@ -4,7 +4,6 @@ import gregtech.api.GTValues;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IPrimitivePump;
-
 import gregtech.api.util.TextFormattingUtil;
 
 import net.minecraft.block.state.IBlockState;
@@ -34,7 +33,9 @@ public class PrimitivePumpInfoProvider implements IProbeInfoProvider {
             if (metaTileEntity instanceof IPrimitivePump) {
                 probeInfo.text(
                         TextStyleClass.INFO + "{*gregtech.top.primitive_pump_production*} " + TextFormatting.AQUA +
-                                TextFormattingUtil.formatNumbers(((IPrimitivePump) metaTileEntity).getFluidProduction()) + TextFormatting.RESET + " L/s");
+                                TextFormattingUtil
+                                        .formatNumbers(((IPrimitivePump) metaTileEntity).getFluidProduction()) +
+                                TextFormatting.RESET + " L/s");
             }
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -10,6 +10,7 @@ import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.multi.MetaTileEntityLargeBoiler;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -48,7 +49,6 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             }
             int EUt = capability.getInfoProviderEUt();
             int absEUt = Math.abs(EUt);
-            NumberFormat format = NumberFormat.getNumberInstance();
             String text = null;
 
             if (tileEntity instanceof IGregTechTileEntity) {
@@ -56,14 +56,14 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
                 if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                         mte instanceof RecipeMapSteamMultiblockController) {
-                    text = TextFormatting.AQUA.toString() + format.format(absEUt) + TextStyleClass.INFO + " L/t {*" +
+                    text = TextFormatting.AQUA.toString() + TextFormattingUtil.formatNumbers(absEUt) + TextStyleClass.INFO + " L/t {*" +
                             Materials.Steam.getUnlocalizedName() + "*}";
                 }
             }
             if (text == null) {
                 // Default behavior, if this TE is not a steam machine (or somehow not instanceof
                 // IGregTechTileEntity...)
-                text = TextFormatting.RED.toString() + format.format(absEUt) + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
+                text = TextFormatting.RED.toString() + TextFormattingUtil.formatNumbers(absEUt) + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
                         " (" + GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.GREEN + ")";
             }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -22,6 +22,8 @@ import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
 import org.jetbrains.annotations.NotNull;
 
+import java.text.NumberFormat;
+
 public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractRecipeLogic> {
 
     @Override
@@ -46,6 +48,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             }
             int EUt = capability.getInfoProviderEUt();
             int absEUt = Math.abs(EUt);
+            NumberFormat format = NumberFormat.getNumberInstance();
             String text = null;
 
             if (tileEntity instanceof IGregTechTileEntity) {
@@ -53,14 +56,14 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
                 if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                         mte instanceof RecipeMapSteamMultiblockController) {
-                    text = TextFormatting.AQUA.toString() + absEUt + TextStyleClass.INFO + " L/t {*" +
+                    text = TextFormatting.AQUA.toString() + format.format(absEUt) + TextStyleClass.INFO + " L/t {*" +
                             Materials.Steam.getUnlocalizedName() + "*}";
                 }
             }
             if (text == null) {
                 // Default behavior, if this TE is not a steam machine (or somehow not instanceof
                 // IGregTechTileEntity...)
-                text = TextFormatting.RED.toString() + absEUt + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
+                text = TextFormatting.RED.toString() + format.format(absEUt) + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
                         " (" + GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.GREEN + ")";
             }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -23,8 +23,6 @@ import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.TextStyleClass;
 import org.jetbrains.annotations.NotNull;
 
-import java.text.NumberFormat;
-
 public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractRecipeLogic> {
 
     @Override
@@ -56,14 +54,16 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
                 if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                         mte instanceof RecipeMapSteamMultiblockController) {
-                    text = TextFormatting.AQUA.toString() + TextFormattingUtil.formatNumbers(absEUt) + TextStyleClass.INFO + " L/t {*" +
+                    text = TextFormatting.AQUA.toString() + TextFormattingUtil.formatNumbers(absEUt) +
+                            TextStyleClass.INFO + " L/t {*" +
                             Materials.Steam.getUnlocalizedName() + "*}";
                 }
             }
             if (text == null) {
                 // Default behavior, if this TE is not a steam machine (or somehow not instanceof
                 // IGregTechTileEntity...)
-                text = TextFormatting.RED.toString() + TextFormattingUtil.formatNumbers(absEUt) + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
+                text = TextFormatting.RED.toString() + TextFormattingUtil.formatNumbers(absEUt) + TextStyleClass.INFO +
+                        " EU/t" + TextFormatting.GREEN +
                         " (" + GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.GREEN + ")";
             }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
@@ -37,7 +37,8 @@ public class SteamBoilerInfoProvider implements IProbeInfoProvider {
                         // Creating steam
                         if (steamOutput > 0 && boiler.hasWater()) {
                             probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " +
-                                    TextFormatting.AQUA + TextFormattingUtil.formatNumbers(steamOutput / 10) + TextStyleClass.INFO + " L/t" + " {*" +
+                                    TextFormatting.AQUA + TextFormattingUtil.formatNumbers(steamOutput / 10) +
+                                    TextStyleClass.INFO + " L/t" + " {*" +
                                     Materials.Steam.getUnlocalizedName() + "*}");
                         }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.steam.boiler.SteamBoiler;
 
 import net.minecraft.block.state.IBlockState;
@@ -36,7 +37,7 @@ public class SteamBoilerInfoProvider implements IProbeInfoProvider {
                         // Creating steam
                         if (steamOutput > 0 && boiler.hasWater()) {
                             probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " +
-                                    TextFormatting.AQUA + (steamOutput / 10) + TextStyleClass.INFO + " L/t" + " {*" +
+                                    TextFormatting.AQUA + TextFormattingUtil.formatNumbers(steamOutput / 10) + TextStyleClass.INFO + " L/t" + " {*" +
                                     Materials.Steam.getUnlocalizedName() + "*}");
                         }
 

--- a/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/TransformerInfoProvider.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.GTUtility;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.electric.MetaTileEntityTransformer;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -33,14 +34,14 @@ public class TransformerInfoProvider extends ElectricContainerInfoProvider {
                         .append(GTValues.VNF[GTUtility.getTierByVoltage(capability.getInputVoltage())])
                         .append(TextFormatting.GREEN)
                         .append(" (")
-                        .append(capability.getInputAmperage())
+                        .append(TextFormattingUtil.formatNumbers(capability.getInputAmperage()))
                         .append("A)");
 
                 StringBuilder output = new StringBuilder()
                         .append(GTValues.VNF[GTUtility.getTierByVoltage(capability.getOutputVoltage())])
                         .append(TextFormatting.GREEN)
                         .append(" (")
-                        .append(capability.getOutputAmperage())
+                        .append(TextFormattingUtil.formatNumbers(capability.getOutputAmperage()))
                         .append("A)");
 
                 // Step Up/Step Down line

--- a/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
@@ -4,10 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.ComputationRecipeLogic;
-
 import gregtech.api.util.TextFormattingUtil;
-
-import mcjty.theoneprobe.api.NumberFormat;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
@@ -15,6 +12,7 @@ import net.minecraftforge.common.capabilities.Capability;
 
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.NumberFormat;
 import org.jetbrains.annotations.NotNull;
 
 public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/WorkableInfoProvider.java
@@ -5,6 +5,10 @@ import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.ComputationRecipeLogic;
 
+import gregtech.api.util.TextFormattingUtil;
+
+import mcjty.theoneprobe.api.NumberFormat;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.capabilities.Capability;
@@ -52,7 +56,7 @@ public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {
         } else {
             currentProgress = Math.round(currentProgress / 20.0F);
             maxProgress = Math.round(maxProgress / 20.0F);
-            text = " / " + maxProgress + " s";
+            text = " / " + TextFormattingUtil.formatNumbers(maxProgress) + " s";
         }
 
         if (maxProgress > 0) {
@@ -61,7 +65,7 @@ public class WorkableInfoProvider extends CapabilityInfoProvider<IWorkable> {
                     .suffix(text)
                     .filledColor(color)
                     .alternateFilledColor(color)
-                    .borderColor(0xFF555555));
+                    .borderColor(0xFF555555).numberFormat(NumberFormat.COMMAS));
         }
     }
 }


### PR DESCRIPTION
## What

I noticed that The One Probe and WAILA tooltips and don't use locale formatting for their production and consumption the same way that JEI recipes (and most other parts of the mod) do.

## Implementation Details

I took a pass throught the WAILA and The One Probe integrations and updated them to use `TextFormattingUtil.formatNumbers` wherever a number might conceivably become large. This should use the the default locale.

## Outcome

Numbers are now locale formatted.

## Additional Information
**Before:**
![image](https://github.com/GregTechCEu/GregTech/assets/37082009/f38326eb-ee0c-4c6f-bc9d-89763fb4d22f)

**After:**
![image](https://github.com/GregTechCEu/GregTech/assets/37082009/0da2a824-7f04-42b4-b1c9-a26da13d5174)

## Potential Compatibility Issues
Just addressing a localization issue, so shouldn't cause any compat issues.