### PR TITLE
Use EU/t for digital interface

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
+++ b/src/main/java/gregtech/common/covers/CoverDigitalInterface.java
@@ -16,6 +16,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.Position;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.RenderUtil;
 import gregtech.common.terminal.app.prospector.widget.WidgetOreList;
@@ -1046,9 +1047,11 @@ public class CoverDigitalInterface extends CoverBase implements IFastRenderMetaT
         }
         RenderUtil.renderLineChart(inputEnergyList, max, -5.5f / 16, 5.5f / 16, 12f / 16, 6f / 16, 0.005f, 0XFF03FF00);
         RenderUtil.renderLineChart(outputEnergyList, max, -5.5f / 16, 5.5f / 16, 12f / 16, 6f / 16, 0.005f, 0XFFFF2F39);
-        RenderUtil.renderText(-5.7f / 16, -2.3f / 16, 0, 1.0f / 270, 0XFF03FF00, "EU I: " + energyInputPerDur + "EU/s",
+        RenderUtil.renderText(-5.7f / 16, -2.3f / 16, 0, 1.0f / 270, 0XFF03FF00,
+                "EU I: " + TextFormattingUtil.formatNumbers(energyInputPerDur / 20) + "EU/t",
                 false);
-        RenderUtil.renderText(-5.7f / 16, -1.6f / 16, 0, 1.0f / 270, 0XFFFF0000, "EU O: " + energyOutputPerDur + "EU/s",
+        RenderUtil.renderText(-5.7f / 16, -1.6f / 16, 0, 1.0f / 270, 0XFFFF0000,
+                "EU O: " + TextFormattingUtil.formatNumbers(energyOutputPerDur / 20) + "EU/t",
                 false);
         // Bandaid fix to prevent overflowing renders when dealing with items that cause long overflow, ie Ultimate
         // Battery


### PR DESCRIPTION
## What
The digital interface in energy mode shows EU flow in EU/sec instead of EU/t. This is inconsistent with the rest of the mod, makes it hard to compare numbers, and generally produces much larger and harder to read numbers.

## Implementation Details
Switch to EU/t for digital interface energy flow.
Also use locale formatting for the number.
Also add a space between the number and its units.

## Outcome
See implementation details

## Additional Information
![image](https://github.com/GregTechCEu/GregTech/assets/37082009/9a667e75-b84b-462e-99a8-64755176751a)

## Potential Compatibility Issues
Shouldn't break anything.
