### PR TITLE
adjust recipe input expected cache size dynamically

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -3,6 +3,7 @@ package gregtech;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.modules.ModuleContainerRegistryEvent;
+import gregtech.api.persistence.PersistentData;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.modules.GregTechModules;
 import gregtech.modules.ModuleManager;
@@ -50,6 +51,7 @@ public class GregTechMod {
 
     @EventHandler
     public void onConstruction(FMLConstructionEvent event) {
+        PersistentData.instance().init();
         moduleManager = ModuleManager.getInstance();
         GregTechAPI.moduleManager = moduleManager;
         moduleManager.registerContainer(new GregTechModules());

--- a/src/main/java/gregtech/api/persistence/PersistentData.java
+++ b/src/main/java/gregtech/api/persistence/PersistentData.java
@@ -1,0 +1,56 @@
+package gregtech.api.persistence;
+
+import gregtech.api.GTValues;
+
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.Loader;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public final class PersistentData {
+
+    public static final String CATEGORY_NAME = "persistent data";
+
+    private static final PersistentData INSTANCE = new PersistentData();
+    private static final String FILE_NAME = "persistent_data.cfg";
+
+    private @Nullable Configuration config;
+
+    public static @NotNull PersistentData instance() {
+        return INSTANCE;
+    }
+
+    private PersistentData() {}
+
+    /**
+     * @return the persistent data storage
+     */
+    public @NotNull Configuration getConfig() {
+        if (config == null) {
+            Path configFolderPath = Loader.instance().getConfigDir().toPath().resolve(GTValues.MODID);
+            File file = configFolderPath.resolve(FILE_NAME).toFile();
+            config = new Configuration(file);
+        }
+        return config;
+    }
+
+    @ApiStatus.Internal
+    public void init() {
+        Configuration configuration = getConfig();
+        configuration.load();
+        String comment = """
+                GregTech Persistent Data. Items in this file will persist across game loads.
+                Modifications to this file may be overwritten by GT.
+                If you are a modpack author, you should ship this file in releases.""";
+        configuration.addCustomCategoryComment(CATEGORY_NAME, comment);
+
+        if (configuration.hasChanged()) {
+            configuration.save();
+        }
+    }
+}

--- a/src/main/java/gregtech/api/persistence/PersistentData.java
+++ b/src/main/java/gregtech/api/persistence/PersistentData.java
@@ -1,25 +1,28 @@
 package gregtech.api.persistence;
 
 import gregtech.api.GTValues;
+import gregtech.api.util.GTLog;
 
-import net.minecraftforge.common.config.Configuration;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fml.common.Loader;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public final class PersistentData {
 
-    public static final String CATEGORY_NAME = "persistent data";
-
     private static final PersistentData INSTANCE = new PersistentData();
-    private static final String FILE_NAME = "persistent_data.cfg";
 
-    private @Nullable Configuration config;
+    private @Nullable Path path;
+    private @Nullable NBTTagCompound tag;
 
     public static @NotNull PersistentData instance() {
         return INSTANCE;
@@ -27,30 +30,79 @@ public final class PersistentData {
 
     private PersistentData() {}
 
-    /**
-     * @return the persistent data storage
-     */
-    public @NotNull Configuration getConfig() {
-        if (config == null) {
-            Path configFolderPath = Loader.instance().getConfigDir().toPath().resolve(GTValues.MODID);
-            File file = configFolderPath.resolve(FILE_NAME).toFile();
-            config = new Configuration(file);
-        }
-        return config;
-    }
-
     @ApiStatus.Internal
     public void init() {
-        Configuration configuration = getConfig();
-        configuration.load();
-        String comment = """
-                GregTech Persistent Data. Items in this file will persist across game loads.
-                Modifications to this file may be overwritten by GT.
-                If you are a modpack author, you should ship this file in releases.""";
-        configuration.addCustomCategoryComment(CATEGORY_NAME, comment);
+        this.path = Loader.instance().getConfigDir().toPath()
+                .resolve(GTValues.MODID)
+                .resolve("persistent_data.dat");
+    }
 
-        if (configuration.hasChanged()) {
-            configuration.save();
+    /**
+     * @return the stored persistent data
+     */
+    public synchronized @NotNull NBTTagCompound getTag() {
+        if (this.tag == null) {
+            this.tag = read();
+        }
+        return this.tag;
+    }
+
+    /**
+     * @return the read NBTTagCompound from disk
+     */
+    private @NotNull NBTTagCompound read() {
+        GTLog.logger.debug("Reading persistent data from path {}", path);
+        if (this.path == null) {
+            throw new IllegalStateException("Persistent data path cannot be null");
+        }
+
+        if (!Files.exists(path)) {
+            return new NBTTagCompound();
+        }
+
+        try (InputStream inputStream = Files.newInputStream(this.path)) {
+            return CompressedStreamTools.readCompressed(inputStream);
+        } catch (IOException e) {
+            GTLog.logger.error("Failed to read persistent data", e);
+            return new NBTTagCompound();
+        }
+    }
+
+    /**
+     * Save the GT Persistent data to disk
+     */
+    public synchronized void save() {
+        if (this.tag != null) {
+            write(this.tag);
+        }
+    }
+
+    /**
+     * @param tagCompound the tag compound to save to disk
+     */
+    private void write(@NotNull NBTTagCompound tagCompound) {
+        GTLog.logger.debug("Writing persistent data to path {}", path);
+        if (tagCompound.isEmpty()) {
+            return;
+        }
+
+        if (this.path == null) {
+            throw new IllegalStateException("Persistent data path cannot be null");
+        }
+
+        if (!Files.exists(path)) {
+            try {
+                Files.createDirectories(path.getParent());
+            } catch (IOException e) {
+                GTLog.logger.error("Could not create persistent data dir", e);
+                return;
+            }
+        }
+
+        try (OutputStream outputStream = Files.newOutputStream(path)) {
+            CompressedStreamTools.writeCompressed(tagCompound, outputStream);
+        } catch (IOException e) {
+            GTLog.logger.error("Failed to write persistent data", e);
         }
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -44,7 +44,7 @@ public class ConfigHolder {
     @Config.RequiresMcRestart
     public static WorldGenOptions worldgen = new WorldGenOptions();
 
-    @Config.Comment( {"Persistent Data for GT", "Do not modify the contents of this section." })
+    @Config.Comment({ "Persistent Data for GT", "Do not modify the contents of this section." })
     @Config.Name("Persistent Data")
     public static PersistentData persistentData = new PersistentData();
 

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -2,6 +2,7 @@ package gregtech.common;
 
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
+import gregtech.api.recipes.GTRecipeInputCache;
 
 import net.minecraftforge.common.config.Config;
 
@@ -42,6 +43,10 @@ public class ConfigHolder {
     @Config.Name("Worldgen Options")
     @Config.RequiresMcRestart
     public static WorldGenOptions worldgen = new WorldGenOptions();
+
+    @Config.Comment( {"Persistent Data for GT", "Do not modify the contents of this section." })
+    @Config.Name("Persistent Data")
+    public static PersistentData persistentData = new PersistentData();
 
     public static class MachineOptions {
 
@@ -700,5 +705,16 @@ public class ConfigHolder {
         @Config.RangeInt(min = 1, max = 512)
         @Config.Comment({ "The EU/t consumption of the NanoSaber.", "Default: 64" })
         public int energyConsumption = 64;
+    }
+
+    public static class PersistentData {
+
+        @Config.Comment({ "The expected amount of unique GT recipe ingredients.",
+                "This setting improves memory allocation and garbage collection during game-load.",
+                "Do NOT modify this setting. This value is automatically adjusted by GT.",
+                "Manual changes are not preserved and WILL be overwritten." })
+        @Config.RangeInt(min = GTRecipeInputCache.MINIMUM_CACHE_SIZE, max = 1 << 30)
+        @Config.RequiresMcRestart
+        public int expectedIngredientInstances = GTRecipeInputCache.MINIMUM_CACHE_SIZE;
     }
 }

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -2,7 +2,6 @@ package gregtech.common;
 
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
-import gregtech.api.recipes.GTRecipeInputCache;
 
 import net.minecraftforge.common.config.Config;
 
@@ -43,10 +42,6 @@ public class ConfigHolder {
     @Config.Name("Worldgen Options")
     @Config.RequiresMcRestart
     public static WorldGenOptions worldgen = new WorldGenOptions();
-
-    @Config.Comment({ "Persistent Data for GT", "Do not modify the contents of this section." })
-    @Config.Name("Persistent Data")
-    public static PersistentData persistentData = new PersistentData();
 
     public static class MachineOptions {
 
@@ -705,16 +700,5 @@ public class ConfigHolder {
         @Config.RangeInt(min = 1, max = 512)
         @Config.Comment({ "The EU/t consumption of the NanoSaber.", "Default: 64" })
         public int energyConsumption = 64;
-    }
-
-    public static class PersistentData {
-
-        @Config.Comment({ "The expected amount of unique GT recipe ingredients.",
-                "This setting improves memory allocation and garbage collection during game-load.",
-                "Do NOT modify this setting. This value is automatically adjusted by GT.",
-                "Manual changes are not preserved and WILL be overwritten." })
-        @Config.RangeInt(min = GTRecipeInputCache.MINIMUM_CACHE_SIZE, max = 1 << 30)
-        @Config.RequiresMcRestart
-        public int expectedIngredientInstances = GTRecipeInputCache.MINIMUM_CACHE_SIZE;
     }
 }


### PR DESCRIPTION
## What
Adjusts the ingredient cache size based on previously seen sizes. This will prevent re-hashing the hashset during game load, which will help with memory allocation and subsequent GC action during the game loading process.

This optimization is not targeting CPU or load time, only a reduction in memory allocations and subsequent cleaning.

The default value is enough to not requite a re-hash with base GT alone. This work will primarily see benefits in installations with addons and modpacks creating their own recipes. These benefits will carry forward from modpack development to end users by shipping an updated config file with a final expected cache size.

## Implementation Details
This work utilizes the config file as a persistent data storage across game loads. This should maybe be broken out into a separate file with our own handling if desirable. 

## Outcome
Reduces potential memory allocations for subsequent game loads.
