### PR TITLE
Fix erroring material handlers when liquids don't exist

### DIFF
--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -3,7 +3,6 @@ package gregtech.api.unification.material.properties;
 import gregtech.api.fluids.store.FluidStorage;
 import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.fluids.store.FluidStorageKeys;
-import gregtech.api.unification.material.Material;
 
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -61,7 +60,9 @@ public class FluidProperty implements IMaterialProperty {
 
     /**
      * Sets the fluid that solidifies into the material.
-     * @param solidifyingFluid The Fluid which solidifies into the material. If left null, it will be left as the default value: the material's liquid.
+     * 
+     * @param solidifyingFluid The Fluid which solidifies into the material. If left null, it will be left as the
+     *                         default value: the material's liquid.
      */
     public void setSolidifyingFluid(@Nullable Fluid solidifyingFluid) {
         this.solidifyingFluid = solidifyingFluid;

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -40,17 +40,29 @@ public class FluidProperty implements IMaterialProperty {
     @Override
     public void verifyProperty(MaterialProperties properties) {}
 
-    public Fluid solidifiesFrom(Material material) {
+    /**
+     * @return the Fluid which solidifies into the material.
+     */
+
+    public Fluid solidifiesFrom() {
         if (this.solidifyingFluid == null) {
-            return material.getFluid(FluidStorageKeys.LIQUID);
+            return getStorage().get(FluidStorageKeys.LIQUID);
         }
         return solidifyingFluid;
     }
 
-    public FluidStack solidifiesFrom(Material material, int amount) {
-        return new FluidStack(solidifiesFrom(material), amount);
+    /**
+     * @param amount the size of the returned FluidStack.
+     * @return a FluidStack of the Fluid which solidifies into the material.
+     */
+    public FluidStack solidifiesFrom(int amount) {
+        return new FluidStack(solidifiesFrom(), amount);
     }
 
+    /**
+     * Sets the fluid that solidifies into the material.
+     * @param solidifyingFluid The Fluid which solidifies into the material. If left null, it will be left as the default value: the material's liquid.
+     */
     public void setSolidifyingFluid(@Nullable Fluid solidifyingFluid) {
         this.solidifyingFluid = solidifyingFluid;
     }

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -3,6 +3,12 @@ package gregtech.api.unification.material.properties;
 import gregtech.api.fluids.store.FluidStorage;
 import gregtech.api.fluids.store.FluidStorageKey;
 
+import gregtech.api.fluids.store.FluidStorageKeys;
+
+import gregtech.api.unification.material.Material;
+
+import net.minecraftforge.fluids.Fluid;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,6 +16,7 @@ public class FluidProperty implements IMaterialProperty {
 
     private final FluidStorage storage = new FluidStorage();
     private @Nullable FluidStorageKey primaryKey = null;
+    private @Nullable Fluid solidifyingFluid = null;
 
     public FluidProperty() {}
 
@@ -33,4 +40,15 @@ public class FluidProperty implements IMaterialProperty {
 
     @Override
     public void verifyProperty(MaterialProperties properties) {}
+
+    public Fluid solidifiesFrom(Material material) {
+        if (this.solidifyingFluid == null) {
+            return material.getFluid(FluidStorageKeys.LIQUID);
+        }
+        return solidifyingFluid;
+    }
+
+    public void setSolidifyingFluid(@Nullable Fluid solidifyingFluid) {
+        this.solidifyingFluid = solidifyingFluid;
+    }
 }

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -9,6 +9,8 @@ import gregtech.api.unification.material.Material;
 
 import net.minecraftforge.fluids.Fluid;
 
+import net.minecraftforge.fluids.FluidStack;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,6 +48,10 @@ public class FluidProperty implements IMaterialProperty {
             return material.getFluid(FluidStorageKeys.LIQUID);
         }
         return solidifyingFluid;
+    }
+
+    public FluidStack solidifiesFrom(Material material, int amount) {
+        return new FluidStack(solidifiesFrom(material), amount);
     }
 
     public void setSolidifyingFluid(@Nullable Fluid solidifyingFluid) {

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -2,13 +2,10 @@ package gregtech.api.unification.material.properties;
 
 import gregtech.api.fluids.store.FluidStorage;
 import gregtech.api.fluids.store.FluidStorageKey;
-
 import gregtech.api.fluids.store.FluidStorageKeys;
-
 import gregtech.api.unification.material.Material;
 
 import net.minecraftforge.fluids.Fluid;
-
 import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -286,10 +286,10 @@ public class MaterialRecipeHandler {
             }
         }
 
-        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom() != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT)
-                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(L))
                     .outputs(OreDictUnifier.get(ingotPrefix, material))
                     .duration(20).EUt(VA[ULV])
                     .buildAndRegister();
@@ -424,10 +424,10 @@ public class MaterialRecipeHandler {
                     .output(ingot, material)
                     .buildAndRegister();
 
-            if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
+            if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom() != null) {
                 RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                         .notConsumable(MetaItems.SHAPE_MOLD_NUGGET)
-                        .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L))
+                        .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(L))
                         .outputs(OreDictUnifier.get(orePrefix, material, 9))
                         .duration((int) material.getMass())
                         .EUt(VA[ULV])
@@ -465,10 +465,10 @@ public class MaterialRecipeHandler {
     public static void processBlock(OrePrefix blockPrefix, Material material, DustProperty property) {
         ItemStack blockStack = OreDictUnifier.get(blockPrefix, material);
         long materialAmount = blockPrefix.getMaterialAmount(material);
-        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom() != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
-                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material,
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(
                             ((int) (materialAmount * L / M))))
                     .outputs(blockStack)
                     .duration((int) material.getMass()).EUt(VA[ULV])

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -290,7 +290,7 @@ public class MaterialRecipeHandler {
         if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT)
-                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L))
                     .outputs(OreDictUnifier.get(ingotPrefix, material))
                     .duration(20).EUt(VA[ULV])
                     .buildAndRegister();
@@ -428,7 +428,7 @@ public class MaterialRecipeHandler {
             if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
                 RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                         .notConsumable(MetaItems.SHAPE_MOLD_NUGGET)
-                        .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L))
+                        .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L))
                         .outputs(OreDictUnifier.get(orePrefix, material, 9))
                         .duration((int) material.getMass())
                         .EUt(VA[ULV])
@@ -469,7 +469,7 @@ public class MaterialRecipeHandler {
         if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
-                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), ((int) (materialAmount * L / M))))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, ((int) (materialAmount * L / M))))
                     .outputs(blockStack)
                     .duration((int) material.getMass()).EUt(VA[ULV])
                     .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe.handlers;
 
-import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMaps;
@@ -469,7 +468,8 @@ public class MaterialRecipeHandler {
         if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
-                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, ((int) (materialAmount * L / M))))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material,
+                            ((int) (materialAmount * L / M))))
                     .outputs(blockStack)
                     .duration((int) material.getMass()).EUt(VA[ULV])
                     .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.handlers;
 
+import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMaps;
@@ -286,7 +287,7 @@ public class MaterialRecipeHandler {
             }
         }
 
-        if (material.hasFluid()) {
+        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT)
                     .fluidInputs(material.getFluid(L))
@@ -424,7 +425,7 @@ public class MaterialRecipeHandler {
                     .output(ingot, material)
                     .buildAndRegister();
 
-            if (material.hasFluid()) {
+            if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
                 RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                         .notConsumable(MetaItems.SHAPE_MOLD_NUGGET)
                         .fluidInputs(material.getFluid(L))
@@ -465,7 +466,7 @@ public class MaterialRecipeHandler {
     public static void processBlock(OrePrefix blockPrefix, Material material, DustProperty property) {
         ItemStack blockStack = OreDictUnifier.get(blockPrefix, material);
         long materialAmount = blockPrefix.getMaterialAmount(material);
-        if (material.hasFluid()) {
+        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
                     .fluidInputs(material.getFluid((int) (materialAmount * L / M)))

--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -287,10 +287,10 @@ public class MaterialRecipeHandler {
             }
         }
 
-        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_INGOT)
-                    .fluidInputs(material.getFluid(L))
+                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L))
                     .outputs(OreDictUnifier.get(ingotPrefix, material))
                     .duration(20).EUt(VA[ULV])
                     .buildAndRegister();
@@ -425,10 +425,10 @@ public class MaterialRecipeHandler {
                     .output(ingot, material)
                     .buildAndRegister();
 
-            if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
+            if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
                 RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                         .notConsumable(MetaItems.SHAPE_MOLD_NUGGET)
-                        .fluidInputs(material.getFluid(L))
+                        .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L))
                         .outputs(OreDictUnifier.get(orePrefix, material, 9))
                         .duration((int) material.getMass())
                         .EUt(VA[ULV])
@@ -466,10 +466,10 @@ public class MaterialRecipeHandler {
     public static void processBlock(OrePrefix blockPrefix, Material material, DustProperty property) {
         ItemStack blockStack = OreDictUnifier.get(blockPrefix, material);
         long materialAmount = blockPrefix.getMaterialAmount(material);
-        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_BLOCK)
-                    .fluidInputs(material.getFluid((int) (materialAmount * L / M)))
+                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), ((int) (materialAmount * L / M))))
                     .outputs(blockStack)
                     .duration((int) material.getMass()).EUt(VA[ULV])
                     .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe.handlers;
 
-import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
@@ -22,7 +21,6 @@ import gregtech.common.items.behaviors.AbstractMaterialPartBehavior;
 
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.BENDER_RECIPES;
@@ -206,7 +204,8 @@ public class PartsRecipeHandler {
             boolean isSmall = gearPrefix == OrePrefix.gearSmall;
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(isSmall ? MetaItems.SHAPE_MOLD_GEAR_SMALL : MetaItems.SHAPE_MOLD_GEAR)
-                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L * (isSmall ? 1 : 4)))
+                    .fluidInputs(
+                            material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L * (isSmall ? 1 : 4)))
                     .outputs(stack)
                     .duration(isSmall ? 20 : 100)
                     .EUt(VA[ULV])

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -206,7 +206,7 @@ public class PartsRecipeHandler {
             boolean isSmall = gearPrefix == OrePrefix.gearSmall;
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(isSmall ? MetaItems.SHAPE_MOLD_GEAR_SMALL : MetaItems.SHAPE_MOLD_GEAR)
-                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L * (isSmall ? 1 : 4)))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L * (isSmall ? 1 : 4)))
                     .outputs(stack)
                     .duration(isSmall ? 20 : 100)
                     .EUt(VA[ULV])
@@ -290,7 +290,7 @@ public class PartsRecipeHandler {
         if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_PLATE)
-                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L))
                     .outputs(OreDictUnifier.get(platePrefix, material))
                     .duration(40)
                     .EUt(VA[ULV])
@@ -404,7 +404,7 @@ public class PartsRecipeHandler {
         if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_ROTOR)
-                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L * 4))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L * 4))
                     .outputs(GTUtility.copy(stack))
                     .duration(120)
                     .EUt(20)

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -22,6 +22,7 @@ import gregtech.common.items.behaviors.AbstractMaterialPartBehavior;
 
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.BENDER_RECIPES;
@@ -201,11 +202,11 @@ public class PartsRecipeHandler {
             }
         }
 
-        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             boolean isSmall = gearPrefix == OrePrefix.gearSmall;
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(isSmall ? MetaItems.SHAPE_MOLD_GEAR_SMALL : MetaItems.SHAPE_MOLD_GEAR)
-                    .fluidInputs(material.getFluid(L * (isSmall ? 1 : 4)))
+                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L * (isSmall ? 1 : 4)))
                     .outputs(stack)
                     .duration(isSmall ? 20 : 100)
                     .EUt(VA[ULV])
@@ -286,10 +287,10 @@ public class PartsRecipeHandler {
     }
 
     public static void processPlate(OrePrefix platePrefix, Material material, DustProperty property) {
-        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_PLATE)
-                    .fluidInputs(material.getFluid(L))
+                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L))
                     .outputs(OreDictUnifier.get(platePrefix, material))
                     .duration(40)
                     .EUt(VA[ULV])
@@ -400,10 +401,10 @@ public class PartsRecipeHandler {
                 'S', new UnificationEntry(screw, material),
                 'R', new UnificationEntry(ring, material));
 
-        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_ROTOR)
-                    .fluidInputs(material.getFluid(L * 4))
+                    .fluidInputs(new FluidStack(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material), L * 4))
                     .outputs(GTUtility.copy(stack))
                     .duration(120)
                     .EUt(20)

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -1,5 +1,6 @@
 package gregtech.loaders.recipe.handlers;
 
+import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
@@ -200,7 +201,7 @@ public class PartsRecipeHandler {
             }
         }
 
-        if (material.hasFluid()) {
+        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
             boolean isSmall = gearPrefix == OrePrefix.gearSmall;
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(isSmall ? MetaItems.SHAPE_MOLD_GEAR_SMALL : MetaItems.SHAPE_MOLD_GEAR)
@@ -285,7 +286,7 @@ public class PartsRecipeHandler {
     }
 
     public static void processPlate(OrePrefix platePrefix, Material material, DustProperty property) {
-        if (material.hasFluid()) {
+        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_PLATE)
                     .fluidInputs(material.getFluid(L))
@@ -399,7 +400,7 @@ public class PartsRecipeHandler {
                 'S', new UnificationEntry(screw, material),
                 'R', new UnificationEntry(ring, material));
 
-        if (material.hasFluid()) {
+        if (material.hasFluid() && material.getFluid(FluidStorageKeys.LIQUID) != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_ROTOR)
                     .fluidInputs(material.getFluid(L * 4))

--- a/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/PartsRecipeHandler.java
@@ -200,12 +200,12 @@ public class PartsRecipeHandler {
             }
         }
 
-        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom() != null) {
             boolean isSmall = gearPrefix == OrePrefix.gearSmall;
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(isSmall ? MetaItems.SHAPE_MOLD_GEAR_SMALL : MetaItems.SHAPE_MOLD_GEAR)
                     .fluidInputs(
-                            material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L * (isSmall ? 1 : 4)))
+                            material.getProperty(PropertyKey.FLUID).solidifiesFrom(L * (isSmall ? 1 : 4)))
                     .outputs(stack)
                     .duration(isSmall ? 20 : 100)
                     .EUt(VA[ULV])
@@ -286,10 +286,10 @@ public class PartsRecipeHandler {
     }
 
     public static void processPlate(OrePrefix platePrefix, Material material, DustProperty property) {
-        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom() != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_PLATE)
-                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(L))
                     .outputs(OreDictUnifier.get(platePrefix, material))
                     .duration(40)
                     .EUt(VA[ULV])
@@ -400,10 +400,10 @@ public class PartsRecipeHandler {
                 'S', new UnificationEntry(screw, material),
                 'R', new UnificationEntry(ring, material));
 
-        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom(material) != null) {
+        if (material.hasFluid() && material.getProperty(PropertyKey.FLUID).solidifiesFrom() != null) {
             RecipeMaps.FLUID_SOLIDFICATION_RECIPES.recipeBuilder()
                     .notConsumable(MetaItems.SHAPE_MOLD_ROTOR)
-                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(material, L * 4))
+                    .fluidInputs(material.getProperty(PropertyKey.FLUID).solidifiesFrom(L * 4))
                     .outputs(GTUtility.copy(stack))
                     .duration(120)
                     .EUt(20)


### PR DESCRIPTION
Fixes crashes when scripts add materials with fluid properties but without liquids that also have blocks (or a similar solid material).