### PR TITLE
Fix electric tool damage config innacuracy

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolHelper.java
@@ -270,7 +270,7 @@ public final class ToolHelper {
                     if (electricItem != null) {
                         electricItem.discharge(electricDamage, tool.getElectricTier(), true, false, false);
                         if (electricItem.getCharge() > 0 &&
-                                random.nextInt(100) > ConfigHolder.tools.rngDamageElectricTools) {
+                                random.nextInt(100) >= ConfigHolder.tools.rngDamageElectricTools) {
                             return;
                         }
                     } else {


### PR DESCRIPTION
## What
Changes the comparison operator between a random integer between 0-99 and the rngRandomDamageElectricTools config option (0-100) from a > to a >= operator. This causes the config option to be treated accurately, instead of acting as if the config is set 1% higher than it actually is.

## Outcome
Fixes #2348 

## Potential Compatibility Issues
None