### PR TITLE
Fix Issues with Fusion Reactor Overclocking

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -640,7 +640,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
             // MK3 reactor can overclock a MK2 recipe once, or a MK1 recipe twice.
             long euToStart = storage.getRecipePropertyValue(FusionEUToStartProperty.getInstance(), 0L);
             int fusionTier = FusionEUToStartProperty.getFusionTier(euToStart);
-            if (fusionTier != 0) fusionTier -= MetaTileEntityFusionReactor.this.tier;
+            if (fusionTier != 0) fusionTier = MetaTileEntityFusionReactor.this.tier - fusionTier;
             values[2] = Math.min(fusionTier, values[2]);
         }
 


### PR DESCRIPTION
## What
fixes an issue where:
```java
if (fusionTier != 0) fusionTier -= MetaTileEntityFusionReactor.this.tier;
values[2] = Math.min(fusionTier, values[2]);
```
was subtracting incorrectly (in the case of a mk2 reactor running a mk1 recipe, it would do 6 - 7 = -1) for amount of OCs

## Implementation Details
subtract correctly :floppaxd:

## Outcome
fusion reactors can overclock once again
