### PR TITLE
Fix Player Unable to Climb Frames on Certain Pipes

### DIFF
--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -163,6 +163,7 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
     @Override
     public void onEntityCollision(World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state,
                                   @NotNull Entity entityIn) {
+        super.onEntityCollision(worldIn, pos, state, entityIn);
         if (worldIn.isRemote) return;
         Insulation insulation = getPipeTileEntity(worldIn, pos).getPipeType();
         if (insulation.insulationLevel == -1 && entityIn instanceof EntityLivingBase) {

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/BlockFluidPipe.java
@@ -129,6 +129,7 @@ public class BlockFluidPipe extends BlockMaterialPipe<FluidPipeType, FluidPipePr
     @Override
     public void onEntityCollision(@NotNull World worldIn, @NotNull BlockPos pos, @NotNull IBlockState state,
                                   @NotNull Entity entityIn) {
+        super.onEntityCollision(worldIn, pos, state, entityIn);
         if (worldIn.isRemote) return;
         TileEntityFluidPipe pipe = (TileEntityFluidPipe) getPipeTileEntity(worldIn, pos);
         if (pipe instanceof TileEntityFluidPipeTickable && pipe.getFrameMaterial() == null &&


### PR DESCRIPTION
## What
Fixes an issue where you couldn't climb frames on certain pipes

## Implementation Details
call super for `onEntityCollision()` so that the frame's method is called

## Outcome
the ability to climb and create more jungle gyms
