### PR TITLE
Fix recipe properties offsetting info text too much

### DIFF
--- a/src/main/java/gregtech/api/recipes/recipeproperties/CleanroomProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/CleanroomProperty.java
@@ -32,6 +32,13 @@ public class CleanroomProperty extends RecipeProperty<CleanroomType> {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.cleanroom", getName(type)), x, y, color);
     }
 
+    @Override
+    public int getInfoHeight(Object value) {
+        CleanroomType type = castValue(value);
+        if (type == null) return 0;
+        return super.getInfoHeight(value);
+    }
+
     @NotNull
     private static String getName(@NotNull CleanroomType value) {
         String name = I18n.format(value.getTranslationKey());

--- a/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
@@ -25,6 +25,11 @@ public class PrimitiveProperty extends RecipeProperty<Boolean> {
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {}
 
     @Override
+    public int getInfoHeight(Object value) {
+        return 0;
+    }
+    
+    @Override
     public boolean hideTotalEU() {
         return true;
     }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
@@ -28,7 +28,7 @@ public class PrimitiveProperty extends RecipeProperty<Boolean> {
     public int getInfoHeight(Object value) {
         return 0;
     }
-    
+
     @Override
     public boolean hideTotalEU() {
         return true;


### PR DESCRIPTION
## What
Some recipe properties like the primitive property don't actually draw any information on JEI previews but still offset the next property by some amount, which causes ugly empty lines like the following:
![](https://github.com/GregTechCEu/GregTech/assets/111296252/ba1bb99d-d7bf-4605-8836-02145120465a)
This is taken from [here](https://github.com/SymmetricDevs/Susy-Core/pull/182).

## Implementation Details
Correctly returns an info height of 0 if nothing is to be drawn for the primitive as well as the cleanroom recipe property

## Outcome
Properly spaces the info text.