### PR TITLE
Set Hardness and Resistance to LDP Blocks

### DIFF
--- a/src/main/java/gregtech/api/pipenet/longdist/BlockLongDistancePipe.java
+++ b/src/main/java/gregtech/api/pipenet/longdist/BlockLongDistancePipe.java
@@ -11,7 +11,6 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;

--- a/src/main/java/gregtech/api/pipenet/longdist/BlockLongDistancePipe.java
+++ b/src/main/java/gregtech/api/pipenet/longdist/BlockLongDistancePipe.java
@@ -11,6 +11,7 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
@@ -35,6 +36,8 @@ public class BlockLongDistancePipe extends Block implements ILDNetworkPart {
         setTranslationKey("long_distance_" + pipeType.getName() + "_pipeline");
         setCreativeTab(GTCreativeTabs.TAB_GREGTECH);
         setHarvestLevel(ToolClasses.WRENCH, 1);
+        setHardness(2f);
+        setResistance(10f);
     }
 
     @Override


### PR DESCRIPTION
## What
Sets the hardness and resistance of Long Distance Pipe blocks so that they aren't instantly mined with an empty hand

## Implementation Details
Set hardness to `2f`
Set resistance to `10f`

## Outcome
ldp pipes are now stronger than wet toilet paper

## Additional Information
~~i lost ~16 blocks because of this~~
