### PR TITLE
Fixed AbstractRecipeLogic only attempting the first valid recipe.

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -370,7 +370,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     protected void trySearchNewRecipe() {
         long maxVoltage = getMaxVoltage();
         Recipe currentRecipe = null;
-        Iterator<Recipe> recipeIterator = null;
+        Iterator<Recipe> recipeIterator;
         IItemHandlerModifiable importInventory = getInputInventory();
         IMultipleTankHandler importFluids = getInputTank();
 
@@ -387,9 +387,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             return;
         }
 
+        // Search for a new recipe if the previous one is no longer valid
         while (recipeIterator != null && recipeIterator.hasNext()) {
             Recipe next = recipeIterator.next();
             if (next == null) continue;
+
+            // since previous attempts to prepare a recipe will have flagged either the input
+            // or outputs as invalid we must reset the flags before attempting to prepare another recipe
             this.isOutputsFull = false;
             this.invalidInputsForRecipes = false;
 
@@ -400,7 +404,9 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             }
         }
 
-        // this.isOutputsFull = true;
+        // if no valid recipes are found mark the inputs and outputs as invalid so any changes
+        // will re-trigger a recipe search
+        this.isOutputsFull = true;
         this.invalidInputsForRecipes = true;
     }
 

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -232,7 +232,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return true if recipes should be searched for
      */
     protected boolean shouldSearchForRecipes() {
-        return canWorkWithInputs() && canFitNewOutputs();
+        return canWorkWithInputs() || canFitNewOutputs();
     }
 
     /**

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -563,12 +563,12 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * Find a recipe Supplier using inputs
+     * Creates a Recipe Iterator using inputs
      *
      * @param maxVoltage  the maximum voltage the recipe can have
      * @param inputs      the item inputs used to search for the recipe
      * @param fluidInputs the fluid inputs used to search for the recipe
-     * @return the recipe if found, otherwise null
+     * @return the recipe iterator if this.recipeMap is valid, otherwise null
      */
     @Nullable
     protected Iterator<Recipe> getRecipeIterator(long maxVoltage, IItemHandlerModifiable inputs,

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -400,7 +400,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             }
         }
 
-//        this.isOutputsFull = true;
+        // this.isOutputsFull = true;
         this.invalidInputsForRecipes = true;
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeIterator.java
+++ b/src/main/java/gregtech/api/recipes/RecipeIterator.java
@@ -1,0 +1,47 @@
+package gregtech.api.recipes;
+
+import gregtech.api.recipes.map.AbstractMapIngredient;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class RecipeIterator implements Iterator<Recipe> {
+
+    int index;
+    List<List<AbstractMapIngredient>> ingredients;
+    @NotNull
+    RecipeMap<?> recipeMap;
+    @NotNull
+    Predicate<Recipe> canHandle;
+
+    RecipeIterator(@NotNull RecipeMap<?> recipeMap, List<List<AbstractMapIngredient>> ingredients,
+                   @NotNull Predicate<Recipe> canHandle) {
+        this.ingredients = ingredients;
+        this.recipeMap = recipeMap;
+        this.canHandle = canHandle;
+    }
+
+    // does not guarantee a next recipe, just the possibility of one
+    @Override
+    public boolean hasNext() {
+        return ingredients != null && this.index < this.ingredients.size();
+    }
+
+    @Override
+    public Recipe next() {
+        // couldn't build any inputs to use for search, so no recipe could be found
+        if (ingredients == null) return null;
+        // Try each ingredient as a starting point, save current index
+        Recipe r = null;
+        while (index < ingredients.size()) {
+            r = recipeMap.recurseIngredientTreeFindRecipe(ingredients, recipeMap.getLookup(), canHandle, index, 0,
+                    (1L << index));
+            ++index;
+            if (r != null) break;
+        }
+        return r;
+    }
+}

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -610,12 +610,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     /**
-     * Finds a Supplier of Recipes matching the Fluid and/or ItemStack Inputs.
+     * Creates an Iterator of Recipes matching the Fluid and/or ItemStack Inputs.
      *
      * @param voltage     Voltage of the Machine or Long.MAX_VALUE if it has no Voltage
      * @param inputs      the Item Inputs
      * @param fluidInputs the Fluid Inputs
-     * @return the Recipe Supplier
+     * @return the Recipe Iterator
      */
     @NotNull
     public Iterator<Recipe> getRecipeIterator(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs) {
@@ -623,13 +623,13 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     /**
-     * Finds a Supplier of Recipes matching the Fluid and/or ItemStack Inputs.
+     * Creates an Iterator of Recipes matching the Fluid and/or ItemStack Inputs.
      *
      * @param voltage      Voltage of the Machine or Long.MAX_VALUE if it has no Voltage
      * @param inputs       the Item Inputs
      * @param fluidInputs  the Fluid Inputs
      * @param exactVoltage should require exact voltage matching on recipe. used by craftweaker
-     * @return the Recipe Supplier
+     * @return the Recipe Iterator
      */
     @NotNull
     public Iterator<Recipe> getRecipeIterator(long voltage, final List<ItemStack> inputs,
@@ -653,12 +653,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     /**
-     * Finds a Supplier of Recipes using Items and Fluids.
+     * Creates an Iterator of Recipes using Items and Fluids.
      *
      * @param items     a collection of items
      * @param fluids    a collection of fluids
      * @param canHandle a predicate for determining if a recipe is valid
-     * @return the Recipe Supplier
+     * @return the Recipe Iterator
      */
     @NotNull
     public Iterator<Recipe> getRecipeIterator(@NotNull Collection<ItemStack> items,

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -598,6 +598,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public Recipe find(@NotNull Collection<ItemStack> items, @NotNull Collection<FluidStack> fluids,
                        @NotNull Predicate<Recipe> canHandle) {
         List<List<AbstractMapIngredient>> list = prepareRecipeFind(items, fluids);
+        // couldn't build any inputs to use for search, so no recipe could be found
         if (list == null) return null;
         return recurseIngredientTreeFindRecipe(list, lookup, canHandle);
     }


### PR DESCRIPTION
## What
Recipe map only has functions for finding a single recipe. Multiblocks can share recipes, and need a way to find a set of valid recipes given the inputs.

## Implementation Details
created `RecipeIterator` which implements `Iterator<Recipe>`. The `next()` function works as expected although I only made `hasNext()` function return true if there are still untraversed nodes of the recipe tree. aka it doesn't guarantee a next potential recipe, just the possibility of one. I'm sure there is a better way to do this but I couldn't think of anything that didn't involve doing the traversal twice. (tbf that might be the best approach)

Made some changes to ARL:
- obviously `trySearchNewRecipe()` now checks all potential recipes (starting with the previous one) until it finds a valid recipe to run or doesn't. in which case it flags the IO as waiting for changes.
- `prepareRecipe() == true` is used to determine if the recipe is valid, if it returns false I just unflag the IO and continue trying possible recipes until one successfully triggers.
- `shouldSearchForRecipes()` used to check `canWorkWithInputs() && canFitNewOutputs()` this had to be changed to `canWorkWithInputs() || canFitNewOutputs()` since now freeing up space in the output bus/hatch is a condition that should trigger a new recipe search. (this case was not always covered by the original check because if `canWorkWithInputs()` was false the && would not evaluate `canFitNewOutputs()`.

## Outcome
Multiblocks of the same type can now share input hatches - while running different recipes - without locking up.
Multiblocks can now be responsible for multiple recipes, after running one recipe until either the inputs are exhausted or the corresponding output buffer fill up, it will check for any other valid recipes and attempt to perform them.

## Additional Information
N/a

## Potential Compatibility Issues
N/a
