### PR TITLE
re-enable sharing for laser hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityLaserHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityLaserHatch.java
@@ -73,11 +73,6 @@ public class MetaTileEntityLaserHatch extends MetaTileEntityMultiblockPart
     }
 
     @Override
-    public boolean canPartShare() {
-        return false;
-    }
-
-    @Override
     public MultiblockAbility<ILaserContainer> getAbility() {
         return isOutput ? MultiblockAbility.OUTPUT_LASER : MultiblockAbility.INPUT_LASER;
     }
@@ -114,7 +109,7 @@ public class MetaTileEntityLaserHatch extends MetaTileEntityMultiblockPart
             tooltip.add(I18n.format("gregtech.universal.tooltip.amperage_in_till", amperage));
         }
         tooltip.add(I18n.format("gregtech.universal.tooltip.energy_storage_capacity", buffer.getEnergyCapacity()));
-        tooltip.add(I18n.format("gregtech.universal.disabled"));
+        tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 
     @NotNull


### PR DESCRIPTION
## What
re-enable sharing for laser hatches

## Outcome
re-enable sharing for laser hatches

## Additional Information
i forgor to do this when making lasers not cringe

## Potential Compatibility Issues
some wack overrides in addons?? i dont think so