### PR TITLE
Use GTCEu maven

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -41,7 +41,7 @@ dependencies {
     // Published dependencies
     api("codechicken:codechickenlib:3.2.3.358")
     api("com.cleanroommc:modularui:2.4.1") { transitive = false }
-    api("com.cleanroommc:groovyscript:0.7.1") { transitive = false }
+    api("com.cleanroommc:groovyscript:0.7.3") { transitive = false }
     api("CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684")
     api rfg.deobf("curse.maven:ae2-extended-life-570458:4402048") // AE2UEL 0.55.6
     api rfg.deobf("curse.maven:ctm-267602:2915363") // CTM 1.0.2.31

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,58 +1,71 @@
 //file:noinspection DependencyNotationArgument
 // TODO remove when fixed in RFG ^
 /*
- * Add your dependencies here. Common configurations:
- *  - implementation("group:name:version:classifier"): if you need this for internal implementation details of the mod.
- *       Available at compiletime and runtime for your environment.
- *
- *  - compileOnlyApi("g:n:v:c"): if you need this for internal implementation details of the mod.
- *       Available at compiletime but not runtime for your environment.
- *
+ * Add your dependencies here. Supported configurations:
+ *  - api("group:name:version:classifier"): if you use the types from this dependency in the public API of this mod
+ *       Available at runtime and compiletime for mods depending on this mod
+ *  - implementation("g:n:v:c"): if you need this for internal implementation details of the mod, but none of it is visible via the public API
+ *       Available at runtime but not compiletime for mods depending on this mod
+ *  - compileOnly("g:n:v:c"): if the mod you're building doesn't need this dependency during runtime at all, e.g. for optional mods
+ *       Not available at all for mods depending on this mod, only visible at compiletime for this mod
+ *  - compileOnlyApi("g:n:v:c"): like compileOnly, but also visible at compiletime for mods depending on this mod
+ *       Available at compiletime but not runtime for mods depending on this mod
+ *  - runtimeOnlyNonPublishable("g:n:v:c"): if you want to include a mod in this mod's runClient/runServer runs, but not publish it as a dependency
+ *       Not available at all for mods depending on this mod, only visible at runtime for this mod
+ *  - devOnlyNonPublishable("g:n:v:c"): a combination of runtimeOnlyNonPublishable and compileOnly for dependencies present at both compiletime and runtime,
+ *       but not published as Maven dependencies - useful for RFG-deobfuscated dependencies or local testing
+ *  - runtimeOnly("g:n:v:c"): if you don't need this at compile time, but want it to be present at runtime
+ *       Available at runtime for mods depending on this mod
  *  - annotationProcessor("g:n:v:c"): mostly for java compiler plugins, if you know you need this, use it, otherwise don't worry
+ *  - testCONFIG("g:n:v:c") - replace CONFIG by one of the above (except api), same as above but for the test sources instead of main
  *
- *  - testCONFIG("g:n:v:c"): replace CONFIG by one of the above, same as above but for the test sources instead of main
+ *  - shadowImplementation("g:n:v:c"): effectively the same as API, but the dependency is included in your jar under a renamed package name
+ *       Requires you to enable usesShadowedDependencies in gradle.properties
+ *       For more info, see https://github.com/GregTechCEu/Buildscripts/blob/master/docs/shadow.md
  *
- * You can exclude transitive dependencies (dependencies of the chosen dependency) by appending { transitive = false } if needed.
+ * You can exclude transitive dependencies (dependencies of the chosen dependency) by appending { transitive = false } if needed,
+ * but use this sparingly as it can break using your mod as another mod's dependency if you're not careful.
+ *
+ * To depend on obfuscated jars you can use `devOnlyNonPublishable(rfg.deobf("dep:spec:1.2.3"))` to fetch an obfuscated jar from maven,
+ * or `devOnlyNonPublishable(rfg.deobf(project.files("libs/my-mod-jar.jar")))` to use a file.
  *
  * To add a mod with CurseMaven, replace '("g:n:v:c")' in the above with 'rfg.deobf("curse.maven:project_slug-project_id:file_id")'
- * Example: implementation rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:4527757")
+ * Example: devOnlyNonPublishable(rfg.deobf("curse.maven:top-245211:2667280"))
  *
- * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
+ * Gradle names for some of the configuration can be misleading, compileOnlyApi and runtimeOnly both get published as dependencies in Maven, but compileOnly does not.
+ * The buildscript adds runtimeOnlyNonPublishable to also have a runtime dependency that's not published.
+ *
+ * For more details, see https://docs.gradle.org/8.4/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    // Hard Dependencies
+    // Published dependencies
+    api("codechicken:codechickenlib:3.2.3.358")
+    api("com.cleanroommc:modularui:2.4.1") { transitive = false }
+    api("com.cleanroommc:groovyscript:0.7.1") { transitive = false }
+    api("CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684")
+    api rfg.deobf("curse.maven:ae2-extended-life-570458:4402048") // AE2UEL 0.55.6
+    api rfg.deobf("curse.maven:ctm-267602:2915363") // CTM 1.0.2.31
 
-    // the CCL deobf jar uses very old MCP mappings, making it error at runtime in runClient/runServer
-    // therefore we manually deobf the regular jar
-    implementation rfg.deobf("curse.maven:codechicken-lib-1-8-242818:2779848") // CCL 3.2.3.358
-    implementation("com.cleanroommc:modularui:2.4.1") { transitive = false }
-
-    // Soft Dependencies
-    // Can change any of these from compileOnlyApi -> implementation to test them in-game.
-
-    implementation "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.684"
-    implementation rfg.deobf("curse.maven:ctm-267602:2915363") // CTM 1.0.2.31
-    implementation("com.cleanroommc:groovyscript:0.7.1") { transitive = false }
-    implementation rfg.deobf("curse.maven:ae2-extended-life-570458:4402048") // AE2UEL 0.55.6
-
-    compileOnlyApi rfg.deobf("curse.maven:opencomputers-223008:4526246") // OpenComputers 1.8.0+9833087
-    compileOnlyApi "curse.maven:journeymap-32274:2916002" // Journeymap 5.7.1
-    compileOnlyApi "curse.maven:voxelmap-225179:3029445" // VoxelMap 1.9.28
-    compileOnlyApi "curse.maven:xaeros-263420:4516832" // Xaero's Minimap 23.4.1
-    compileOnlyApi rfg.deobf("curse.maven:hwyla-253449:2568751") // HWYLA 1.8.26-B41
-    compileOnlyApi rfg.deobf("curse.maven:baubles-227083:2518667") // Baubles 1.5.2
-    compileOnlyApi rfg.deobf("curse.maven:forestry-59751:2684780") // Forestry 5.8.2.387
-    compileOnlyApi rfg.deobf("curse.maven:chisel-235279:2915375") // Chisel 1.0.2.45
+    // Non-published dependencies
+    // Change any to devOnlyNonPublishable to test them in-game.
+    compileOnly("curse.maven:journeymap-32274:2916002") // Journeymap 5.7.1
+    compileOnly("curse.maven:voxelmap-225179:3029445") // VoxelMap 1.9.28
+    compileOnly("curse.maven:xaeros-263420:4516832") // Xaero's Minimap 23.4.1
+    compileOnly rfg.deobf("curse.maven:opencomputers-223008:4526246") // OpenComputers 1.8.0+9833087
+    compileOnly rfg.deobf("curse.maven:hwyla-253449:2568751") // HWYLA 1.8.26-B41
+    compileOnly rfg.deobf("curse.maven:baubles-227083:2518667") // Baubles 1.5.2
+    compileOnly rfg.deobf("curse.maven:forestry-59751:2684780") // Forestry 5.8.2.387
+    compileOnly rfg.deobf("curse.maven:chisel-235279:2915375") // Chisel 1.0.2.45
 
     // Mods with Soft compat but which have no need to be in code, such as isModLoaded() checks and getModItem() recipes.
     // Uncomment any of these to test them in-game.
 
-    // runtimeOnly rfg.deobf("curse.maven:beebetteratbees-244516:2627215") // BeeBetterAtBees 2.0.3 (recommended to enable when testing Forestry compat)
-    // runtimeOnly rfg.deobf("curse.maven:jei-bees-248370:2490058") // JEIBees 0.9.0.5 (recommended to enable when testing Forestry compat)
-    // runtimeOnly rfg.deobf("curse.maven:binnies-mods-223525:2916129") // Binnie 2.5.1.203
-    // runtimeOnly rfg.deobf("curse.maven:magic-bees-65764:2855061") // Magic Bees 3.2.25
-    // runtimeOnly rfg.deobf("curse.maven:gendustry-70492:2516215") // Gendustry 1.6.5.8
-    // runtimeOnly rfg.deobf("curse.maven:bdlib-70496:2518031") // BdLib 1.14.3.12
+    // runtimeOnlyNonPublishable rfg.deobf("curse.maven:beebetteratbees-244516:2627215") // BeeBetterAtBees 2.0.3 (recommended to enable when testing Forestry compat)
+    // runtimeOnlyNonPublishable rfg.deobf("curse.maven:jei-bees-248370:2490058") // JEIBees 0.9.0.5 (recommended to enable when testing Forestry compat)
+    // runtimeOnlyNonPublishable rfg.deobf("curse.maven:binnies-mods-223525:2916129") // Binnie 2.5.1.203
+    // runtimeOnlyNonPublishable rfg.deobf("curse.maven:magic-bees-65764:2855061") // Magic Bees 3.2.25
+    // runtimeOnlyNonPublishable rfg.deobf("curse.maven:gendustry-70492:2516215") // Gendustry 1.6.5.8
+    // runtimeOnlyNonPublishable rfg.deobf("curse.maven:bdlib-70496:2518031") // BdLib 1.14.3.12
 }
 
 minecraft {
@@ -60,7 +73,7 @@ minecraft {
 }
 
 configurations {
-    implementation {
+    compileOnly {
         // exclude GNU trove, FastUtil is superior and still updated
         exclude group: "net.sf.trove4j", module: "trove4j"
         // exclude javax.annotation from findbugs, jetbrains annotations are superior

--- a/gradle.properties
+++ b/gradle.properties
@@ -145,7 +145,7 @@ noPublishedSources = false
 # For maven credentials:
 # Username is set with the 'MAVEN_USER' environment variable, default to "NONE"
 # Password is set with the 'MAVEN_PASSWORD' environment variable, default to "NONE"
-customMavenPublishUrl=
+customMavenPublishUrl= https://maven.gtceu.com
 # The group for maven artifacts. Defaults to the 'project.modGroup' until the last '.' (if any).
 # So 'mymod' becomes 'mymod' and 'com.myname.mymodid' 'becomes com.myname'
 mavenArtifactGroup=


### PR DESCRIPTION
Finally we will have sources and code navigation for CCL

Configurations exclusion block changed from `implementation` -> `compileOnly` to avoid these exclusions from ending up on the POM file