### PR TITLE
fix material tree crash

### DIFF
--- a/src/main/java/gregtech/integration/jei/basic/MaterialTree.java
+++ b/src/main/java/gregtech/integration/jei/basic/MaterialTree.java
@@ -73,7 +73,7 @@ public class MaterialTree implements IRecipeWrapper {
         }
 
         List<FluidStack> matFluidsStack = new ArrayList<>();
-        if (material.hasProperty(PropertyKey.FLUID)) {
+        if (material.getFluid() != null) {
             matFluidsStack.add(material.getFluid(1000));
         }
         this.fluidInputs.add(matFluidsStack);


### PR DESCRIPTION
## What
Fixes a crash with the material tree caused by materials which have a fluid property but do not have a "trivially retrievable fluid" via `Material#getFluid`.
