### PR TITLE
use chestWood oredict for ULV and LV item buses

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -245,8 +245,8 @@ public class MetaTileEntityMachineRecipeLoader {
                 .duration(300).EUt(VA[EV]).buildAndRegister();
 
         // Item Buses
-        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new GTRecipeOreInput(OreDictNames.chestWood.toString()));
-        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new GTRecipeOreInput(OreDictNames.chestWood.toString()));
+        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], OreDictNames.chestWood.toString());
+        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], OreDictNames.chestWood.toString());
         registerHatchBusRecipe(MV, ITEM_IMPORT_BUS[MV], ITEM_EXPORT_BUS[MV], BRONZE_CRATE.getStackForm());
         registerHatchBusRecipe(HV, ITEM_IMPORT_BUS[HV], ITEM_EXPORT_BUS[HV], STEEL_CRATE.getStackForm());
         registerHatchBusRecipe(EV, ITEM_IMPORT_BUS[EV], ITEM_EXPORT_BUS[EV], ALUMINIUM_CRATE.getStackForm());
@@ -1032,8 +1032,8 @@ public class MetaTileEntityMachineRecipeLoader {
         GTRecipeInput extra;
         if (extraInput instanceof ItemStack stack) {
             extra = new GTRecipeItemInput(stack);
-        } else if (extraInput instanceof GTRecipeInput input) {
-            extra = input;
+        } else if (extraInput instanceof String oreName) {
+            extra = new GTRecipeOreInput(oreName);
         } else {
             throw new IllegalArgumentException("extraInput must be ItemStack or GTRecipeInput");
         }
@@ -1126,29 +1126,18 @@ public class MetaTileEntityMachineRecipeLoader {
     }
 
     private static int getFluidAmount(int offsetTier) {
-        switch (offsetTier) {
-            case 0:
-                return 4;
-            case 1:
-                return 9;
-            case 2:
-                return 18;
-            case 3:
-                return 36;
-            case 4:
-                return 72;
-            case 5:
-                return 144;
-            case 6:
-                return 288;
-            case 7:
-                return 432;
-            case 8:
-                return 576;
-            case 9:
-            default:
-                return 720;
-        }
+        return switch (offsetTier) {
+            case 0 -> 4;
+            case 1 -> 9;
+            case 2 -> 18;
+            case 3 -> 36;
+            case 4 -> 72;
+            case 5 -> 144;
+            case 6 -> 288;
+            case 7 -> 432;
+            case 8 -> 576;
+            default -> 720;
+        };
     }
 
     // TODO clean this up with a CraftingComponent rework

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -3,6 +3,9 @@ package gregtech.loaders.recipe;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.ModHandler;
+import gregtech.api.recipes.ingredients.GTRecipeInput;
+import gregtech.api.recipes.ingredients.GTRecipeItemInput;
+import gregtech.api.recipes.ingredients.GTRecipeOreInput;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.Mods;
 
@@ -18,7 +21,6 @@ import static gregtech.api.unification.ore.OrePrefix.*;
 import static gregtech.common.blocks.MetaBlocks.LD_FLUID_PIPE;
 import static gregtech.common.blocks.MetaBlocks.LD_ITEM_PIPE;
 import static gregtech.common.items.MetaItems.*;
-import static gregtech.common.items.MetaItems.SENSOR_UV;
 import static gregtech.common.metatileentities.MetaTileEntities.*;
 
 public class MetaTileEntityMachineRecipeLoader {
@@ -242,8 +244,8 @@ public class MetaTileEntityMachineRecipeLoader {
                 .duration(300).EUt(VA[EV]).buildAndRegister();
 
         // Item Buses
-        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new ItemStack(Blocks.CHEST));
-        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new ItemStack(Blocks.CHEST));
+        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new GTRecipeOreInput("chestWood"));
+        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new GTRecipeOreInput("chestWood"));
         registerHatchBusRecipe(MV, ITEM_IMPORT_BUS[MV], ITEM_EXPORT_BUS[MV], BRONZE_CRATE.getStackForm());
         registerHatchBusRecipe(HV, ITEM_IMPORT_BUS[HV], ITEM_EXPORT_BUS[HV], STEEL_CRATE.getStackForm());
         registerHatchBusRecipe(EV, ITEM_IMPORT_BUS[EV], ITEM_EXPORT_BUS[EV], ALUMINIUM_CRATE.getStackForm());
@@ -1025,7 +1027,16 @@ public class MetaTileEntityMachineRecipeLoader {
     }
 
     private static void registerHatchBusRecipe(int tier, MetaTileEntity inputBus, MetaTileEntity outputBus,
-                                               ItemStack extra) {
+                                               Object extraInput) {
+        GTRecipeInput extra;
+        if (extraInput instanceof ItemStack stack) {
+            extra = new GTRecipeItemInput(stack);
+        } else if (extraInput instanceof GTRecipeInput input) {
+            extra = input;
+        } else {
+            throw new IllegalArgumentException("extraInput must be ItemStack or GTRecipeInput");
+        }
+
         // Glue recipe for ULV and LV
         // 250L for ULV, 500L for LV
         if (tier <= GTValues.LV) {

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.items.OreDictNames;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
@@ -244,8 +245,8 @@ public class MetaTileEntityMachineRecipeLoader {
                 .duration(300).EUt(VA[EV]).buildAndRegister();
 
         // Item Buses
-        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new GTRecipeOreInput("chestWood"));
-        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new GTRecipeOreInput("chestWood"));
+        registerHatchBusRecipe(ULV, ITEM_IMPORT_BUS[ULV], ITEM_EXPORT_BUS[ULV], new GTRecipeOreInput(OreDictNames.chestWood.toString()));
+        registerHatchBusRecipe(LV, ITEM_IMPORT_BUS[LV], ITEM_EXPORT_BUS[LV], new GTRecipeOreInput(OreDictNames.chestWood.toString()));
         registerHatchBusRecipe(MV, ITEM_IMPORT_BUS[MV], ITEM_EXPORT_BUS[MV], BRONZE_CRATE.getStackForm());
         registerHatchBusRecipe(HV, ITEM_IMPORT_BUS[HV], ITEM_EXPORT_BUS[HV], STEEL_CRATE.getStackForm());
         registerHatchBusRecipe(EV, ITEM_IMPORT_BUS[EV], ITEM_EXPORT_BUS[EV], ALUMINIUM_CRATE.getStackForm());


### PR DESCRIPTION
## What
Uses the `chestWood` oredict instead of specifically the vanilla chest for ULV and LV item buses. This allows for wider mod compatibility, such as mods adding different chests for each wood type.