### PR TITLE
Fix parallel overclocks using the wrong voltage for multiblocks

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -434,6 +434,11 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         }
     }
 
+    @Override
+    protected long getMaxParallelVoltage() {
+        return getMaximumOverclockVoltage();
+    }
+
     @Nullable
     @Override
     public RecipeMap<?> getRecipeMap() {


### PR DESCRIPTION
Fixes multiblocks not paralleling as much as they should, since they were using the recipe voltage rather than the overclock voltage