### PR TITLE
Temporary hotfix for research ID lookup

### DIFF
--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -63,6 +63,10 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
 
     @Override
     public void addDataStickEntry(@NotNull String researchId, @NotNull Recipe recipe) {
+        if (researchId.contains("xmetaitem.")) {
+            // save compatibility with an issue in 2.8.6, causing research IDs to change
+            addDataStickEntry(researchId.replace("xmetaitem.", "xitem.meta_item."), recipe);
+        }
         Collection<Recipe> collection = researchEntries.computeIfAbsent(researchId, (k) -> new ObjectOpenHashSet<>());
         collection.add(recipe);
     }


### PR DESCRIPTION
This fix is gross, but tested to work for both old and new research IDs. Later, I will rewrite how research data is stored, but this will work for right now