### PR TITLE
Fix NPE from facing being null when drawing grid overlays

### DIFF
--- a/src/main/java/gregtech/common/ToolEventHandlers.java
+++ b/src/main/java/gregtech/common/ToolEventHandlers.java
@@ -477,6 +477,8 @@ public class ToolEventHandlers {
 
     @SideOnly(Side.CLIENT)
     private static void drawGridOverlays(EnumFacing facing, AxisAlignedBB box, Predicate<EnumFacing> test) {
+        if (facing == null) return;
+
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder buffer = tessellator.getBuffer();
         buffer.begin(3, DefaultVertexFormats.POSITION_COLOR);


### PR DESCRIPTION
## What
(Hopefully) prevents the rare NPE crash detailed here: https://mclo.gs/t4pMRQa

## Implementation Details
if (facing == null) return;

## Outcome
Safe fail rather than outright crashing.