### PR TITLE
Fix server crashes with alarms

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAlarm.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAlarm.java
@@ -169,14 +169,14 @@ public class MetaTileEntityAlarm extends TieredMetaTileEntity {
     public void writeInitialSyncData(PacketBuffer buf) {
         super.writeInitialSyncData(buf);
         buf.writeBoolean(this.isActive);
-        buf.writeResourceLocation(SoundEvent.REGISTRY.getNameForObject(this.selectedSound));
+        buf.writeResourceLocation(getResourceLocationOfSound(this.selectedSound));
         buf.writeInt(this.radius);
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         data.setBoolean("isActive", this.isActive);
-        data.setString("selectedSound", SoundEvent.REGISTRY.getNameForObject(this.selectedSound).toString());
+        data.setString("selectedSound", getNameOfSound(this.selectedSound));
         data.setInteger("radius", this.radius);
         return super.writeToNBT(data);
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAlarm.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAlarm.java
@@ -85,7 +85,8 @@ public class MetaTileEntityAlarm extends TieredMetaTileEntity {
                             if (this.selectedSound != newSound) {
                                 this.selectedSound = SoundEvent.REGISTRY.getObject(new ResourceLocation(v));
                                 this.writeCustomData(GregtechDataCodes.UPDATE_SOUND,
-                                        (writer) -> writer.writeResourceLocation(getResourceLocationOfSound(this.selectedSound)));
+                                        (writer) -> writer
+                                                .writeResourceLocation(getResourceLocationOfSound(this.selectedSound)));
                             }
                         }))
                 .widget(new ImageWidget(10, 54, 220, 20, GuiTextures.DISPLAY))

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAlarm.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAlarm.java
@@ -76,15 +76,16 @@ public class MetaTileEntityAlarm extends TieredMetaTileEntity {
         return ModularUI.builder(GuiTextures.BACKGROUND, 240, 86)
                 .widget(new LabelWidget(10, 5, getMetaFullName()))
                 .widget(new SelectorWidget(10, 20, 220, 20,
-                        getSounds().stream().map((event) -> event.getSoundName().toString())
+                        getSounds().stream().map(this::getNameOfSound)
                                 .collect(Collectors.toList()),
-                        0x555555, () -> this.selectedSound.getSoundName().toString(), true).setOnChanged((v) -> {
-                            GregTechAPI.soundManager.stopTileSound(getPos());
+                        0x555555, () -> getNameOfSound(this.selectedSound), true).setOnChanged((v) -> {
+                            if (this.getWorld().isRemote)
+                                GregTechAPI.soundManager.stopTileSound(getPos());
                             SoundEvent newSound = SoundEvent.REGISTRY.getObject(new ResourceLocation(v));
                             if (this.selectedSound != newSound) {
                                 this.selectedSound = SoundEvent.REGISTRY.getObject(new ResourceLocation(v));
                                 this.writeCustomData(GregtechDataCodes.UPDATE_SOUND,
-                                        (writer) -> writer.writeResourceLocation(this.selectedSound.getSoundName()));
+                                        (writer) -> writer.writeResourceLocation(getResourceLocationOfSound(this.selectedSound)));
                             }
                         }))
                 .widget(new ImageWidget(10, 54, 220, 20, GuiTextures.DISPLAY))
@@ -168,14 +169,14 @@ public class MetaTileEntityAlarm extends TieredMetaTileEntity {
     public void writeInitialSyncData(PacketBuffer buf) {
         super.writeInitialSyncData(buf);
         buf.writeBoolean(this.isActive);
-        buf.writeResourceLocation(this.selectedSound.getSoundName());
+        buf.writeResourceLocation(SoundEvent.REGISTRY.getNameForObject(this.selectedSound));
         buf.writeInt(this.radius);
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
         data.setBoolean("isActive", this.isActive);
-        data.setString("selectedSound", this.selectedSound.getSoundName().toString());
+        data.setString("selectedSound", SoundEvent.REGISTRY.getNameForObject(this.selectedSound).toString());
         data.setInteger("radius", this.radius);
         return super.writeToNBT(data);
     }
@@ -186,5 +187,13 @@ public class MetaTileEntityAlarm extends TieredMetaTileEntity {
         this.selectedSound = SoundEvent.REGISTRY.getObject(new ResourceLocation(data.getString("selectedSound")));
         this.radius = data.getInteger("radius");
         super.readFromNBT(data);
+    }
+
+    public String getNameOfSound(SoundEvent sound) {
+        return getResourceLocationOfSound(sound).toString();
+    }
+
+    public ResourceLocation getResourceLocationOfSound(SoundEvent sound) {
+        return SoundEvent.REGISTRY.getNameForObject(sound);
     }
 }


### PR DESCRIPTION
The original implementation of alarms involved using SoundEvent#getSoundName(), but unfortunately, this getter happened to be client-side only without anyone (me) noticing. Similarly, stopTileSound in the sound manager was also client-side only.

This simply uses the server-safe method and adds some easy-to-use methods in MetaTileEntityAlarm to stop server crashes.