### PR TITLE
fix pipe capability retrieval logic

### DIFF
--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -335,24 +335,28 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
     @Nullable
     @Override
     public final <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
-        boolean isCoverable = capability == GregtechTileCapabilities.CAPABILITY_COVER_HOLDER;
-        Cover cover = facing == null ? null : coverableImplementation.getCoverAtSide(facing);
-        T defaultValue;
-        if (getPipeBlock() == null)
-            defaultValue = null;
-        else
-            defaultValue = getCapabilityInternal(capability, facing);
+        T pipeCapability = getPipeBlock() == null ? null : getCapabilityInternal(capability, facing);
 
-        if (isCoverable) {
-            return defaultValue;
+        if (capability == GregtechTileCapabilities.CAPABILITY_COVER_HOLDER) {
+            return pipeCapability;
         }
-        if (cover == null && facing != null) {
-            return isConnected(facing) ? defaultValue : null;
+
+        Cover cover = facing == null ? null : coverableImplementation.getCoverAtSide(facing);
+        if (cover == null) {
+            if (facing == null || isConnected(facing)) {
+                return pipeCapability;
+            }
+            return null;
         }
-        if (cover != null) {
-            return cover.getCapability(capability, defaultValue);
+
+        T coverCapability = cover.getCapability(capability, pipeCapability);
+        if (coverCapability == pipeCapability) {
+            if (isConnected(facing)) {
+                return pipeCapability;
+            }
+            return null;
         }
-        return defaultValue;
+        return coverCapability;
     }
 
     @Override


### PR DESCRIPTION
## What
Pipes currently return the wrong capability result when a cover is attached to the side being retrieved from. This causes energy emitters, for example, to output power to cables not connected to them which can cause significant problems for players due to cable burning or machine explosions. 

The easiest way to reproduce this is to have an energy emitter pointing towards an unconnected cable, and then place a facade cover between the two. If the cable has a destination needing power, the destination will receive power despite the cable not being connected to the emitter.

## Implementation Details
Pipes previously did not check if they were connected to the side when the cover had no specific capability (when it returns the pipe capability). This PR adds the connection check to make the return values the same between having a cover at the side and not, when the attached cover has no specific capabilities of its own. 

## Outcome
Fixes pipes returning the wrong capability result when a cover is attached to the side.
