### PR TITLE
fix solar panels not outputting to cables

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverSolarPanel.java
+++ b/src/main/java/gregtech/common/covers/CoverSolarPanel.java
@@ -13,7 +13,6 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -50,10 +49,9 @@ public class CoverSolarPanel extends CoverBase implements ITickable {
     public void update() {
         CoverableView coverable = getCoverableView();
         World world = coverable.getWorld();
-        BlockPos blockPos = coverable.getPos();
-        if (GTUtility.canSeeSunClearly(world, blockPos)) {
+        if (GTUtility.canSeeSunClearly(world, coverable.getPos())) {
             IEnergyContainer energyContainer = coverable.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER,
-                    null);
+                    getAttachedSide());
             if (energyContainer != null) {
                 energyContainer.acceptEnergyFromNetwork(null, EUt, 1);
             }


### PR DESCRIPTION
## What
Fixes solar panel not sending energy through cables when directly attached.

## Implementation Details
Getting the energy container capability from a cable with a `null` facing retrieves the default energy handler. This energy handler is only useful when attempting to determine things like energy capacity, max amperage, and max voltage of the container.

This PR makes the solar panel retrieve the sided capability, which is capable of actually accepting energy, unlike the default container.

## Outcome
Fixes solar panels outputting to cables.
