### PR TITLE
Fix fluid drilling rig display units

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFluidDrill.java
@@ -184,7 +184,7 @@ public class MetaTileEntityFluidDrill extends MultiblockWithDisplayBase
                                     TextFormatting.BLUE,
                                     TextFormattingUtil.formatNumbers(
                                             minerLogic.getFluidToProduce() * 20L / FluidDrillLogic.MAX_PROGRESS) +
-                                            " L/t");
+                                            " L/s");
                             tl.add(TextComponentUtil.translationWithColor(
                                     TextFormatting.GRAY,
                                     "gregtech.multiblock.fluid_rig.fluid_amount",


### PR DESCRIPTION
## What
Makes the fluid drilling rig display in units of L/s as it should, rather than in L/t which is inaccurate.

## Outcome
Fixes #2412 

## Additional Information
units moment
