### PR TITLE
Allow Data Stick to copy-paste ME bus settings

### DIFF
--- a/src/main/java/gregtech/api/capability/IDataStickIntractable.java
+++ b/src/main/java/gregtech/api/capability/IDataStickIntractable.java
@@ -1,0 +1,11 @@
+package gregtech.api.capability;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public interface IDataStickIntractable {
+
+    void onDataStickLeftClick(EntityPlayer player, ItemStack dataStick);
+
+    boolean onDataStickRightClick(EntityPlayer player, ItemStack dataStick);
+}

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -6,6 +6,7 @@ import gregtech.api.block.machines.BlockMachine;
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
+import gregtech.api.capability.IDataStickIntractable;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
 import gregtech.api.capability.impl.FluidHandlerProxy;
@@ -35,6 +36,8 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.common.ConfigHolder;
 import gregtech.common.creativetab.GTCreativeTabs;
+
+import gregtech.common.items.MetaItems;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.state.BlockFaceShape;
@@ -487,6 +490,12 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     public boolean onRightClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing,
                                 CuboidRayTraceResult hitResult) {
         ItemStack heldStack = playerIn.getHeldItem(hand);
+        if (this instanceof IDataStickIntractable dsi) {
+            if (MetaItems.TOOL_DATA_STICK.isItemEqual(heldStack) && dsi.onDataStickRightClick(playerIn, heldStack)) {
+                return true;
+            }
+        }
+
         if (!playerIn.isSneaking() && openGUIOnRightClick()) {
             if (getWorld() != null && !getWorld().isRemote) {
                 if (usesMui2()) {
@@ -642,7 +651,14 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
         return true;
     }
 
-    public void onLeftClick(EntityPlayer player, EnumFacing facing, CuboidRayTraceResult hitResult) {}
+    public void onLeftClick(EntityPlayer player, EnumFacing facing, CuboidRayTraceResult hitResult) {
+        if (this instanceof IDataStickIntractable dsi) {
+            ItemStack stack = player.getHeldItemMainhand();
+            if (MetaItems.TOOL_DATA_STICK.isItemEqual(stack)) {
+                dsi.onDataStickLeftClick(player, stack);
+            }
+        }
+    }
 
     /**
      * @return true if the player must sneak to rotate this metatileentity, otherwise false

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -36,7 +36,6 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.BloomEffectUtil;
 import gregtech.common.ConfigHolder;
 import gregtech.common.creativetab.GTCreativeTabs;
-
 import gregtech.common.items.MetaItems;
 
 import net.minecraft.block.Block;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -1,6 +1,7 @@
 package gregtech.common.metatileentities.multi.multiblockpart.appeng;
 
 import gregtech.api.capability.IControllable;
+import gregtech.api.capability.IDataStickIntractable;
 import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockNotifiablePart;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -1,7 +1,6 @@
 package gregtech.common.metatileentities.multi.multiblockpart.appeng;
 
 import gregtech.api.capability.IControllable;
-import gregtech.api.capability.IDataStickIntractable;
 import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockNotifiablePart;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputBus.java
@@ -55,7 +55,7 @@ import java.util.List;
 
 public class MetaTileEntityMEInputBus extends MetaTileEntityAEHostablePart<IAEItemStack>
                                       implements IMultiblockAbilityPart<IItemHandlerModifiable>,
-                                                 IGhostSlotConfigurable, IDataStickIntractable {
+                                      IGhostSlotConfigurable, IDataStickIntractable {
 
     public final static String ITEM_BUFFER_TAG = "ItemSlots";
     public final static String WORKING_TAG = "WorkingEnabled";
@@ -349,7 +349,6 @@ public class MetaTileEntityMEInputBus extends MetaTileEntityAEHostablePart<IAEIt
         }
     }
 
-    // todo tooltip for data stick with settings applied
     @Override
     public final void onDataStickLeftClick(EntityPlayer player, ItemStack dataStick) {
         NBTTagCompound tag = new NBTTagCompound();

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputBus.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.multi.multiblockpart.appeng;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IDataStickIntractable;
 import gregtech.api.capability.IGhostSlotConfigurable;
 import gregtech.api.capability.INotifiableHandler;
 import gregtech.api.capability.impl.GhostCircuitItemStackHandler;
@@ -54,15 +55,15 @@ import java.util.List;
 
 public class MetaTileEntityMEInputBus extends MetaTileEntityAEHostablePart<IAEItemStack>
                                       implements IMultiblockAbilityPart<IItemHandlerModifiable>,
-                                      IGhostSlotConfigurable {
+                                                 IGhostSlotConfigurable, IDataStickIntractable {
 
     public final static String ITEM_BUFFER_TAG = "ItemSlots";
     public final static String WORKING_TAG = "WorkingEnabled";
     private final static int CONFIG_SIZE = 16;
     private boolean workingEnabled = true;
     protected ExportOnlyAEItemList aeItemHandler;
-    private GhostCircuitItemStackHandler circuitInventory;
-    private NotifiableItemStackHandler extraSlotInventory;
+    protected GhostCircuitItemStackHandler circuitInventory;
+    protected NotifiableItemStackHandler extraSlotInventory;
     private ItemHandlerList actualImportItems;
 
     public MetaTileEntityMEInputBus(ResourceLocation metaTileEntityId) {
@@ -318,6 +319,7 @@ public class MetaTileEntityMEInputBus extends MetaTileEntityAEHostablePart<IAEIt
         tooltip.add(I18n.format("gregtech.machine.item_bus.import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.item_import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me_import_item_hatch.configs.tooltip"));
+        tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 
@@ -344,6 +346,64 @@ public class MetaTileEntityMEInputBus extends MetaTileEntityAEHostablePart<IAEIt
         this.circuitInventory.setCircuitValue(config);
         if (!getWorld().isRemote) {
             markDirty();
+        }
+    }
+
+    // todo tooltip for data stick with settings applied
+    @Override
+    public final void onDataStickLeftClick(EntityPlayer player, ItemStack dataStick) {
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setTag("MEInputBus", writeConfigToTag());
+        dataStick.setTagCompound(tag);
+        dataStick.setTranslatableName("gregtech.machine.me.item_import.data_stick.name");
+        player.sendStatusMessage(new TextComponentTranslation("gregtech.machine.me.import_copy_settings"), true);
+    }
+
+    protected NBTTagCompound writeConfigToTag() {
+        NBTTagCompound tag = new NBTTagCompound();
+        NBTTagCompound configStacks = new NBTTagCompound();
+        tag.setTag("ConfigStacks", configStacks);
+        for (int i = 0; i < CONFIG_SIZE; i++) {
+            var slot = this.aeItemHandler.getInventory()[i];
+            IAEItemStack config = slot.getConfig();
+            if (config == null) {
+                continue;
+            }
+            NBTTagCompound stackNbt = new NBTTagCompound();
+            config.getDefinition().writeToNBT(stackNbt);
+            configStacks.setTag(Integer.toString(i), stackNbt);
+        }
+        tag.setByte("GhostCircuit", (byte) this.circuitInventory.getCircuitValue());
+        return tag;
+    }
+
+    @Override
+    public final boolean onDataStickRightClick(EntityPlayer player, ItemStack dataStick) {
+        NBTTagCompound tag = dataStick.getTagCompound();
+        if (tag == null || !tag.hasKey("MEInputBus")) {
+            return false;
+        }
+        readConfigFromTag(tag.getCompoundTag("MEInputBus"));
+        syncME();
+        player.sendStatusMessage(new TextComponentTranslation("gregtech.machine.me.import_paste_settings"), true);
+        return true;
+    }
+
+    protected void readConfigFromTag(NBTTagCompound tag) {
+        if (tag.hasKey("ConfigStacks")) {
+            NBTTagCompound configStacks = tag.getCompoundTag("ConfigStacks");
+            for (int i = 0; i < CONFIG_SIZE; i++) {
+                String key = Integer.toString(i);
+                if (configStacks.hasKey(key)) {
+                    NBTTagCompound configTag = configStacks.getCompoundTag(key);
+                    this.aeItemHandler.getInventory()[i].setConfig(WrappedItemStack.fromNBT(configTag));
+                } else {
+                    this.aeItemHandler.getInventory()[i].setConfig(null);
+                }
+            }
+        }
+        if (tag.hasKey("GhostCircuit")) {
+            this.setGhostCircuitConfig(tag.getByte("GhostCircuit"));
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.multi.multiblockpart.appeng;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IDataStickIntractable;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -26,6 +27,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.IFluidTank;
@@ -44,7 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart<IAEFluidStack>
-                                        implements IMultiblockAbilityPart<IFluidTank> {
+                                        implements IMultiblockAbilityPart<IFluidTank>, IDataStickIntractable {
 
     public final static String FLUID_BUFFER_TAG = "FluidTanks";
     public final static String WORKING_TAG = "WorkingEnabled";
@@ -257,6 +259,7 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart<IAE
         tooltip.add(I18n.format("gregtech.machine.fluid_hatch.import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.fluid_import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me_import_fluid_hatch.configs.tooltip"));
+        tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 
@@ -268,5 +271,58 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart<IAE
     @Override
     public void registerAbilities(List<IFluidTank> list) {
         list.addAll(Arrays.asList(this.getAEFluidHandler().getInventory()));
+    }
+
+    @Override
+    public final void onDataStickLeftClick(EntityPlayer player, ItemStack dataStick) {
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setTag("MEInputHatch", writeConfigToTag());
+        dataStick.setTagCompound(tag);
+        dataStick.setTranslatableName("gregtech.machine.me.fluid_import.data_stick.name");
+        player.sendStatusMessage(new TextComponentTranslation("gregtech.machine.me.import_copy_settings"), true);
+    }
+
+    protected NBTTagCompound writeConfigToTag() {
+        NBTTagCompound tag = new NBTTagCompound();
+        NBTTagCompound configStacks = new NBTTagCompound();
+        tag.setTag("ConfigStacks", configStacks);
+        for (int i = 0; i < CONFIG_SIZE; i++) {
+            var slot = this.aeFluidHandler.getInventory()[i];
+            IAEFluidStack config = slot.getConfig();
+            if (config == null) {
+                continue;
+            }
+            NBTTagCompound stackNbt = new NBTTagCompound();
+            config.writeToNBT(stackNbt);
+            configStacks.setTag(Integer.toString(i), stackNbt);
+        }
+        return tag;
+    }
+
+    @Override
+    public final boolean onDataStickRightClick(EntityPlayer player, ItemStack dataStick) {
+        NBTTagCompound tag = dataStick.getTagCompound();
+        if (tag == null || !tag.hasKey("MEInputHatch")) {
+            return false;
+        }
+        readConfigFromTag(tag.getCompoundTag("MEInputHatch"));
+        syncME();
+        player.sendStatusMessage(new TextComponentTranslation("gregtech.machine.me.import_paste_settings"), true);
+        return true;
+    }
+
+    protected void readConfigFromTag(NBTTagCompound tag) {
+        if (tag.hasKey("ConfigStacks")) {
+            NBTTagCompound configStacks = tag.getCompoundTag("ConfigStacks");
+            for (int i = 0; i < CONFIG_SIZE; i++) {
+                String key = Integer.toString(i);
+                if (configStacks.hasKey(key)) {
+                    NBTTagCompound configTag = configStacks.getCompoundTag(key);
+                    this.aeFluidHandler.getInventory()[i].setConfig(WrappedFluidStack.fromNBT(configTag));
+                } else {
+                    this.aeFluidHandler.getInventory()[i].setConfig(null);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -358,8 +358,36 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
         tooltip.add(I18n.format("gregtech.machine.item_bus.import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.stocking_item.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me_import_item_hatch.configs.tooltip"));
+        tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.stocking_item.tooltip.2"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
+    }
+
+    @Override
+    protected NBTTagCompound writeConfigToTag() {
+        if (!autoPull) {
+            NBTTagCompound tag = super.writeConfigToTag();
+            tag.setBoolean("AutoPull", false);
+            return tag;
+        }
+        // if in auto-pull, no need to write actual configured slots, but still need to write the ghost circuit
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setBoolean("AutoPull", true);
+        tag.setByte("GhostCircuit", (byte) this.circuitInventory.getCircuitValue());
+        return tag;
+    }
+
+    @Override
+    protected void readConfigFromTag(NBTTagCompound tag) {
+        if (tag.getBoolean("AutoPull")) {
+            // if being set to auto-pull, no need to read the configured slots
+            this.setAutoPull(true);
+            this.setGhostCircuitConfig(tag.getByte("GhostCircuit"));
+            return;
+        }
+        // set auto pull first to avoid issues with clearing the config after reading from the data stick
+        this.setAutoPull(false);
+        super.readConfigFromTag(tag);
     }
 
     private static class ExportOnlyAEStockingItemList extends ExportOnlyAEItemList {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -263,8 +263,34 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
         tooltip.add(I18n.format("gregtech.machine.fluid_hatch.import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.stocking_fluid.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me_import_fluid_hatch.configs.tooltip"));
+        tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.stocking_fluid.tooltip.2"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
+    }
+
+    @Override
+    protected NBTTagCompound writeConfigToTag() {
+        if (!autoPull) {
+            NBTTagCompound tag = super.writeConfigToTag();
+            tag.setBoolean("AutoPull", false);
+            return tag;
+        }
+        // if in auto-pull, no need to write actual configured slots, but still need to write the ghost circuit
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setBoolean("AutoPull", true);
+        return tag;
+    }
+
+    @Override
+    protected void readConfigFromTag(NBTTagCompound tag) {
+        if (tag.getBoolean("AutoPull")) {
+            // if being set to auto-pull, no need to read the configured slots
+            this.setAutoPull(true);
+            return;
+        }
+        // set auto pull first to avoid issues with clearing the config after reading from the data stick
+        this.setAutoPull(false);
+        super.readConfigFromTag(tag);
     }
 
     private static class ExportOnlyAEStockingFluidSlot extends ExportOnlyAEFluidSlot {

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5278,6 +5278,11 @@ gregtech.machine.me.fluid_export.tooltip=Stores fluids directly into the ME netw
 gregtech.machine.me.fluid_export.tooltip.2=Can cache an infinite amount of fluid
 gregtech.machine.me.stocking_auto_pull_enabled=Auto-Pull Enabled
 gregtech.machine.me.stocking_auto_pull_disabled=Auto-Pull Disabled
+gregtech.machine.me.copy_paste.tooltip=Left-click with Data Stick to copy settings, right-click to apply
+gregtech.machine.me.import_copy_settings=Saved settings to Data Stick
+gregtech.machine.me.import_paste_settings=Applied settings from Data Stick
+gregtech.machine.me.item_import.data_stick.name=§oME Input Bus Configuration Data
+gregtech.machine.me.fluid_import.data_stick.name=§oME Input Hatch Configuration Data
 
 # Universal tooltips
 gregtech.universal.tooltip.voltage_in=§aVoltage IN: §f%,d EU/t (%s§f)


### PR DESCRIPTION
Left-click a ME bus/hatch to copy, and right click to paste. Does a "best attempt" to copy-paste all settings.
- Copies configured items/fluids, and can copy between the two tiers
- Copies ghost circuit for ME Input Bus/Stocking Bus
- Copies auto-pull setting for Stocking Bus/Stocking Hatch
- If a configuration from a Stocking part with auto-pull enabled is pasted onto an Input part (which does not support auto-pull), the ghost circuit will be set (if applicable) but the configured stacks are left alone. This could be changed to instead clear the configured stacks if desired