### PR TITLE
Fix fuel recipes JEI page

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.recipes.RecipeMap;
-import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -35,13 +35,6 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
     }
 
     @Override
-    protected void modifyOverclockPost(int[] overclockResults, @NotNull IRecipePropertyStorage storage) {
-        super.modifyOverclockPost(overclockResults, storage);
-        // make EUt negative so it is consumed
-        overclockResults[0] = -overclockResults[0];
-    }
-
-    @Override
     public int getParallelLimit() {
         // parallel is limited by voltage
         return Integer.MAX_VALUE;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -45,9 +45,6 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         if (maintenanceValues.getFirst() > 0) {
             overclockResults[1] = (int) (overclockResults[1] * (1 - 0.1 * maintenanceValues.getFirst()));
         }
-
-        // make EUt negative so it is consumed
-        overclockResults[0] = -overclockResults[0];
     }
 
     @NotNull

--- a/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
@@ -12,91 +12,91 @@ public class FuelRecipes {
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Naphtha.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricLightFuel.getFluid(4))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Methanol.getFluid(4))
                 .duration(8)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Ethanol.getFluid(1))
                 .duration(6)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Octane.getFluid(2))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(BioDiesel.getFluid(1))
                 .duration(8)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(LightFuel.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Diesel.getFluid(1))
                 .duration(15)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(CetaneBoostedDiesel.getFluid(2))
                 .duration(45)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(RocketFuel.getFluid(16))
                 .duration(125)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Gasoline.getFluid(1))
                 .duration(50)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(HighOctaneGasoline.getFluid(1))
                 .duration(100)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Toluene.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(OilLight.getFluid(32))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(RawOil.getFluid(64))
                 .duration(15)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         // steam generator fuels
@@ -104,159 +104,159 @@ public class FuelRecipes {
                 .fluidInputs(Steam.getFluid(640))
                 .fluidOutputs(DistilledWater.getFluid(4))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         // gas turbine fuels
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(NaturalGas.getFluid(8))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(WoodGas.getFluid(8))
                 .duration(6)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricGas.getFluid(32))
                 .duration(25)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricNaphtha.getFluid(4))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(CoalGas.getFluid(1))
                 .duration(3)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Methane.getFluid(2))
                 .duration(7)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Ethylene.getFluid(1))
                 .duration(4)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(RefineryGas.getFluid(1))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Ethane.getFluid(4))
                 .duration(21)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Propene.getFluid(1))
                 .duration(6)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Butadiene.getFluid(16))
                 .duration(102)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Propane.getFluid(4))
                 .duration(29)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Butene.getFluid(1))
                 .duration(8)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Phenol.getFluid(1))
                 .duration(9)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Benzene.getFluid(1))
                 .duration(11)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Butane.getFluid(4))
                 .duration(37)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(LPG.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder() // TODO Too OP pls nerf
                 .fluidInputs(Nitrobenzene.getFluid(1))
                 .duration(40)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         // semi-fluid fuels, like creosote
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Creosote.getFluid(16))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Biomass.getFluid(4))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Oil.getFluid(2))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(OilHeavy.getFluid(16))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricHeavyFuel.getFluid(16))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(HeavyFuel.getFluid(8))
                 .duration(15)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(FishOil.getFluid(16))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt((int) -V[LV])
                 .buildAndRegister();
 
         // plasma turbine
@@ -264,56 +264,56 @@ public class FuelRecipes {
                 .fluidInputs(Helium.getPlasma(1))
                 .fluidOutputs(Helium.getFluid(1))
                 .duration(40)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Oxygen.getPlasma(1))
                 .fluidOutputs(Oxygen.getFluid(1))
                 .duration(48)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Nitrogen.getPlasma(1))
                 .fluidOutputs(Nitrogen.getFluid(1))
                 .duration(64)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Argon.getPlasma(1))
                 .fluidOutputs(Argon.getFluid(1))
                 .duration(96)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Iron.getPlasma(1))
                 .fluidOutputs(Iron.getFluid(1))
                 .duration(112)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Tin.getPlasma(1))
                 .fluidOutputs(Tin.getFluid(1))
                 .duration(128)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Nickel.getPlasma(1))
                 .fluidOutputs(Nickel.getFluid(1))
                 .duration(192)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Americium.getPlasma(1))
                 .fluidOutputs(Americium.getFluid(1))
                 .duration(320)
-                .EUt((int) V[EV])
+                .EUt((int) -V[EV])
                 .buildAndRegister();
     }
 }


### PR DESCRIPTION
## What
Fuel recipes in JEI now show as generating EU instead of using EU

## Implementation Details
The negation in FuelRecipeLogic and MultiblockFuelRecipeLogic is now moved to the recipe builders

## Outcome
The JEI page is correct + now all recipes with negative EU/t are generation and all recipes with positive EU/t are consumption(before it depended on if the machine inherited one of the above fuel recipe logics)

## Potential Compatibility Issues
Addons might also have to negate their generator EU/t