### PR TITLE
check for a valid MTE before rendering

### DIFF
--- a/src/main/java/gregtech/client/renderer/handler/MetaTileEntityRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/MetaTileEntityRenderer.java
@@ -94,7 +94,7 @@ public class MetaTileEntityRenderer implements ICCBlockRenderer, IItemRenderer {
     @Override
     public boolean renderBlock(IBlockAccess world, BlockPos pos, IBlockState state, BufferBuilder buffer) {
         MetaTileEntity metaTileEntity = GTUtility.getMetaTileEntity(world, pos);
-        if (metaTileEntity == null) {
+        if (metaTileEntity == null || !metaTileEntity.isValid()) {
             return false;
         }
         CCRenderState renderState = CCRenderState.instance();


### PR DESCRIPTION
## What
Fixes MTEs sometimes having an air block instead of the appropriate MTE block when rendering. This would cause CCL error logs when determining the opacity of the MTE block in some circumstances. This PR stops rendering invalid MTEs.

## Outcome
Fixes CCL error log/chat spam when rendering invalid MTEs.
