### PR TITLE
Fix LCE/ECE from parallelizing too much

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -78,6 +78,11 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         return Integer.MAX_VALUE;
     }
 
+    @Override
+    protected long getMaxParallelVoltage() {
+        return getMaxVoltage();
+    }
+
     /**
      * Boost the energy production.
      * Should not change the state of the workable logic. Only read current values.

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -411,11 +411,6 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         }
 
         @Override
-        protected long getMaxParallelVoltage() {
-            return getMaxVoltage();
-        }
-
-        @Override
         protected long boostProduction(long production) {
             // this multiplies production without increasing consumption
             if (isOxygenBoosted)

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -411,6 +411,11 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
         }
 
         @Override
+        protected long getMaxParallelVoltage() {
+            return getMaxVoltage();
+        }
+
+        @Override
         protected long boostProduction(long production) {
             // this multiplies production without increasing consumption
             if (isOxygenBoosted)


### PR DESCRIPTION
## What
fixes an issue where the LCE/ECE would parallelize too much because `getMaxParallelVoltage()` used `getMaxOverclockVoltage()` which was not overridden in the LCE's workable handler

origin of this issue probably came from #2390 

## Implementation Details
override `getMaxOverclockVoltage()` to return `getMaxVoltage` in the workable handler

## Outcome
a proper amount of fuel consumption and energy production
