### PR TITLE
Support Creative Mode Pick Block

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -271,7 +271,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                     if (!customName.isEmpty())
                         ((MetaTileEntityHolder) holder).setCustomName(customName);
 
-                    metaTileEntity.initFromItemStackData(blockTag.getCompoundTag(GregtechDataCodes.TAG_KEY_MTE));
+                    metaTileEntity.readFromNBT(blockTag.getCompoundTag(GregtechDataCodes.TAG_KEY_MTE));
                 } else {
                     metaTileEntity.initFromItemStackData(stackTag);
                 }

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -4,6 +4,7 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.block.BlockCustomParticle;
 import gregtech.api.block.UnlistedIntegerProperty;
 import gregtech.api.block.UnlistedStringProperty;
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.cover.Cover;
 import gregtech.api.cover.IFacadeCover;
 import gregtech.api.items.toolitem.ToolClasses;
@@ -262,9 +263,18 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                 ((MetaTileEntityHolder) holder).setCustomName(stack.getDisplayName());
             }
             MetaTileEntity metaTileEntity = holder.setMetaTileEntity(sampleMetaTileEntity);
-            if (stack.hasTagCompound()) {
-                // noinspection ConstantConditions
-                metaTileEntity.initFromItemStackData(stack.getTagCompound());
+            var stackTag = stack.getTagCompound();
+            if (stackTag != null) {
+                if (stackTag.hasKey(GregtechDataCodes.BLOCK_ENTITY_TAG)) {
+                    var blockTag = stackTag.getCompoundTag(GregtechDataCodes.BLOCK_ENTITY_TAG);
+                    String customName = blockTag.getString(GregtechDataCodes.CUSTOM_NAME);
+                    if (!customName.isEmpty())
+                        ((MetaTileEntityHolder) holder).setCustomName(customName);
+
+                    metaTileEntity.initFromItemStackData(blockTag.getCompoundTag(GregtechDataCodes.TAG_KEY_MTE));
+                } else {
+                    metaTileEntity.initFromItemStackData(stackTag);
+                }
             }
             if (metaTileEntity.isValidFrontFacing(EnumFacing.UP)) {
                 metaTileEntity.setFrontFacing(EnumFacing.getDirectionFromEntityLiving(pos, placer));

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -264,7 +264,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
             }
             MetaTileEntity metaTileEntity = holder.setMetaTileEntity(sampleMetaTileEntity);
             var stackTag = stack.getTagCompound();
-            if (stackTag != null) {
+            if (stackTag != null && !stackTag.isEmpty()) {
                 if (stackTag.hasKey(GregtechDataCodes.BLOCK_ENTITY_TAG)) {
                     var blockTag = stackTag.getCompoundTag(GregtechDataCodes.BLOCK_ENTITY_TAG);
                     String customName = blockTag.getString(GregtechDataCodes.CUSTOM_NAME);

--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -271,7 +271,16 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                     if (!customName.isEmpty())
                         ((MetaTileEntityHolder) holder).setCustomName(customName);
 
-                    metaTileEntity.readFromNBT(blockTag.getCompoundTag(GregtechDataCodes.TAG_KEY_MTE));
+                    var mteTag = blockTag.getCompoundTag(GregtechDataCodes.TAG_KEY_MTE);
+                    List<String> removed = new ArrayList<>();
+                    for (var key : mteTag.getKeySet()) {
+                        var trait = metaTileEntity.getMTETrait(key);
+                        if (trait == null) continue;
+
+                        removed.add(key);
+                    }
+                    removed.forEach(mteTag::removeTag);
+                    metaTileEntity.readFromNBT(mteTag);
                 } else {
                     metaTileEntity.initFromItemStackData(stackTag);
                 }

--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -149,6 +149,8 @@ public class GregtechDataCodes {
 
     // From MetaTileEntityHolder
     public static final String CUSTOM_NAME = "CustomName";
+    public static final String BLOCK_ENTITY_TAG = "BlockEntityTag";
+    public static final String TAG_KEY_MTE = "MetaTileEntity";
 
     // From MetaTileEntity
     public static final String TAG_KEY_PAINTING_COLOR = "PaintingColor";

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -323,9 +323,11 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     /**
      * Called from ItemBlock to initialize this MTE with data contained in ItemStack
      *
-     * @param itemStack itemstack of itemblock
+     * @param stackTag itemstack of itemblock
      */
-    public void initFromItemStackData(NBTTagCompound itemStack) {}
+    public void initFromItemStackData(NBTTagCompound stackTag) {
+        readFromNBT(stackTag);
+    }
 
     /**
      * Called to write MTE specific data when it is destroyed to save it's state

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -323,9 +323,9 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     /**
      * Called from ItemBlock to initialize this MTE with data contained in ItemStack
      *
-     * @param stackTag itemstack of itemblock
+     * @param itemStack itemstack of itemblock
      */
-    public void initFromItemStackData(NBTTagCompound stackTag) {}
+    public void initFromItemStackData(NBTTagCompound itemStack) {}
 
     /**
      * Called to write MTE specific data when it is destroyed to save it's state

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -325,9 +325,7 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
      *
      * @param stackTag itemstack of itemblock
      */
-    public void initFromItemStackData(NBTTagCompound stackTag) {
-        readFromNBT(stackTag);
-    }
+    public void initFromItemStackData(NBTTagCompound stackTag) {}
 
     /**
      * Called to write MTE specific data when it is destroyed to save it's state


### PR DESCRIPTION
## What
Adds support for loading the MTE with a stack's tag when using `Ctrl + Pick Block` in Creative Mode.
There's a small issue where qchest doesn't update it's render correctly when loading from nbt, but otherwise essentially everything works now

## Implementation Details
read the stack tag in `BlockMachine`
add more tag key names to GregtechDataCodes

## Outcome
MTEs are properly initialized from the stack's NBT when using `Ctrl + Pick Block` in Creative Mode.

## Potential Compatibility Issues
none
