### PR TITLE
Recipe logic and Overclocking changes

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -686,13 +686,11 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         modifyOverclockPost(ocResult, recipe.getRecipePropertyStorage());
 
         if (ocResult.parallel() > 1) {
-            Recipe r = subTickOC(ocResult, recipe, importInventory, importFluids);
-            if (r == null) {
+            recipe = subTickOC(ocResult, recipe, importInventory, importFluids);
+            if (recipe == null) {
                 invalidateInputs();
                 return null;
             }
-
-            recipe = r;
         }
 
         if (!hasEnoughPower(ocResult.eut(), ocResult.duration())) {

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -844,7 +844,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
 
         if (ocParams.ocAmount() <= 0) {
             // number of OCs is <= 0, so do not overclock
-            ocResult.init(ocParams.eut(), ocParams.duration(), 0);
+            ocResult.init(ocParams.eut(), ocParams.duration());
         } else {
             runOverclockingLogic(ocParams, ocResult, recipe.getRecipePropertyStorage(), getMaximumOverclockVoltage());
         }

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -712,7 +712,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * @param recipe the recipe to check
+     * @param recipe          the recipe to check
      * @param exportInventory the inventory to output to
      * @return if the recipe can be successfully output to the inventory
      */
@@ -728,7 +728,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * @param recipe the recipe to check
+     * @param recipe       the recipe to check
      * @param exportFluids the inventory to output to
      * @return if the recipe can be successfully output to the inventory
      */
@@ -782,7 +782,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         }
 
         ocResult.setEut(builder.getEUt());
-        r = builder.EUt(recipe.getEUt())
+        r = builder.EUt(builder.getEUt())
                 .build()
                 .getResult();
 

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -16,6 +16,8 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.logic.IParallelableRecipeLogic;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.CleanroomProperty;
 import gregtech.api.recipes.recipeproperties.DimensionProperty;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
@@ -36,6 +38,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -58,14 +61,15 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     protected Recipe previousRecipe;
     private boolean allowOverclocking = true;
     protected int parallelRecipesPerformed;
-    private long overclockVoltage = 0;
-    protected int[] overclockResults;
+    private long overclockVoltage;
+    private final OCParams ocParams = new OCParams();
+    private final OCResult ocResult = new OCResult();
 
     protected boolean canRecipeProgress = true;
 
     protected int progressTime;
     protected int maxProgressTime;
-    protected int recipeEUt;
+    protected long recipeEUt;
     protected List<FluidStack> fluidOutputs;
     protected NonNullList<ItemStack> itemOutputs;
 
@@ -76,7 +80,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     protected boolean isOutputsFull;
     protected boolean invalidInputsForRecipes;
 
-    protected boolean hasPerfectOC = false;
+    protected boolean hasPerfectOC;
 
     /**
      * DO NOT use the parallelLimit field directly, EVER
@@ -117,7 +121,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @param simulate  whether to simulate energy extraction or not
      * @return true if the energy can/was drained, otherwise false
      */
-    protected abstract boolean drawEnergy(int recipeEUt, boolean simulate);
+    protected abstract boolean drawEnergy(long recipeEUt, boolean simulate);
 
     /**
      * @return the maximum voltage the machine can use/handle for recipe searching
@@ -244,16 +248,16 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return true if input inventory contents have changed
      */
     protected boolean hasNotifiedInputs() {
-        return (metaTileEntity.getNotifiedItemInputList().size() > 0 ||
-                metaTileEntity.getNotifiedFluidInputList().size() > 0);
+        return !metaTileEntity.getNotifiedItemInputList().isEmpty() ||
+                !metaTileEntity.getNotifiedFluidInputList().isEmpty();
     }
 
     /**
      * @return true if output inventory contents have changed
      */
     protected boolean hasNotifiedOutputs() {
-        return (metaTileEntity.getNotifiedItemOutputList().size() > 0 ||
-                metaTileEntity.getNotifiedFluidOutputList().size() > 0);
+        return !metaTileEntity.getNotifiedItemOutputList().isEmpty() ||
+                !metaTileEntity.getNotifiedFluidOutputList().isEmpty();
     }
 
     /**
@@ -489,9 +493,12 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
                 getMaxParallelVoltage(),
                 getParallelLimit());
 
-        if (recipe != null && setupAndConsumeRecipeInputs(recipe, inputInventory, inputFluidInventory)) {
-            setupRecipe(recipe);
-            return true;
+        if (recipe != null) {
+            recipe = setupAndConsumeRecipeInputs(recipe, inputInventory, inputFluidInventory);
+            if (recipe != null) {
+                setupRecipe(recipe);
+                return true;
+            }
         }
         return false;
     }
@@ -642,28 +649,38 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
 
     /**
      * Determines if the provided recipe is possible to run from the provided inventory, or if there is anything
-     * preventing
-     * the Recipe from being completed.
+     * preventing the Recipe from being completed.
      * <p>
      * Will consume the inputs of the Recipe if it is possible to run.
      *
-     * @param recipe          - The Recipe that will be consumed from the inputs and ran in the machine
-     * @param importInventory - The inventory that the recipe should be consumed from.
-     *                        Used mainly for Distinct bus implementation for multiblocks to specify
-     *                        a specific bus, or for addons to use external inventories.
-     * @param importFluids    - The tanks that the recipe should be consumed from
-     *                        Used currently in addons to use external tanks.
-     * @return - true if the recipe is successful, false if the recipe is not successful
+     * @param recipe          The Recipe that will be consumed from the inputs and ran in the machine
+     * @param importInventory The inventory that the recipe should be consumed from. Used mainly for Distinct bus
+     *                        implementation for multiblocks to specify a specific bus, or for addons to use external
+     *                        inventories.
+     * @param importFluids    The tanks that the recipe should be consumed from Used currently in addons to use
+     *                        external tanks.
+     * @return the recipe if the setup is successful, null if the setup is not successful
      */
-    protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
-                                                  @NotNull IItemHandlerModifiable importInventory,
-                                                  @NotNull IMultipleTankHandler importFluids) {
-        this.overclockResults = calculateOverclock(recipe);
+    protected final @Nullable Recipe setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
+                                                                 @NotNull IItemHandlerModifiable importInventory,
+                                                                 @NotNull IMultipleTankHandler importFluids) {
+        calculateOverclock(recipe);
 
-        modifyOverclockPost(overclockResults, recipe.getRecipePropertyStorage());
+        modifyOverclockPost(ocResult, recipe.getRecipePropertyStorage());
 
-        if (!hasEnoughPower(overclockResults)) {
-            return false;
+        if (ocResult.parallel() > 1) {
+            Recipe r = subTickOC(ocResult, recipe, importInventory, importFluids);
+            if (r == null) {
+                invalidateInputs();
+                return null;
+            }
+
+            recipe = r;
+        }
+
+        if (!hasEnoughPower(ocResult.eut(), ocResult.duration())) {
+            ocResult.reset();
+            return null;
         }
 
         IItemHandlerModifiable exportInventory = getOutputInventory();
@@ -674,109 +691,154 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (!metaTileEntity.canVoidRecipeItemOutputs() &&
                 !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
             this.isOutputsFull = true;
-            return false;
+            return null;
         }
 
         // We have already trimmed fluid outputs at this time
         if (!metaTileEntity.canVoidRecipeFluidOutputs() &&
                 !GTTransferUtils.addFluidsToFluidHandler(exportFluids, true, recipe.getAllFluidOutputs())) {
             this.isOutputsFull = true;
-            return false;
+            return null;
         }
 
         this.isOutputsFull = false;
         if (recipe.matches(true, importInventory, importFluids)) {
             this.metaTileEntity.addNotifiedInput(importInventory);
-            return true;
+            return recipe;
         }
-        return false;
+        return null;
     }
 
     /**
      * Determines if the provided recipe is possible to run from the provided inventory, or if there is anything
-     * preventing
-     * the Recipe from being completed.
+     * preventing the Recipe from being completed.
      * <p>
      * Will consume the inputs of the Recipe if it is possible to run.
      *
-     * @param recipe          - The Recipe that will be consumed from the inputs and ran in the machine
-     * @param importInventory - The inventory that the recipe should be consumed from.
-     *                        Used mainly for Distinct bus implementation for multiblocks to specify
-     *                        a specific bus
-     * @return - true if the recipe is successful, false if the recipe is not successful
+     * @param recipe          The Recipe that will be consumed from the inputs and ran in the machine
+     * @param importInventory The inventory that the recipe should be consumed from. Used mainly for Distinct bus
+     *                        implementation for multiblocks to specify a specific bus
+     * @return the recipe if the setup is successful, null if the setup is not successful
      */
-    protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
-                                                  @NotNull IItemHandlerModifiable importInventory) {
+    @MustBeInvokedByOverriders
+    protected @Nullable Recipe setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
+                                                           @NotNull IItemHandlerModifiable importInventory) {
         return setupAndConsumeRecipeInputs(recipe, importInventory, this.getInputTank());
     }
 
     /**
-     * @param resultOverclock the overclock data to use. Format: {@code [EUt, duration]}.
+     * Overclock a recipe beyond a duration of 1 tick using parallelization.
+     *
+     * @param ocResult        the result of the overclock
+     * @param recipe          the recipe to overclock
+     * @param importInventory the input item inventory
+     * @param importFluids    the input fluid inventory
+     * @return the recipe if a valid recipe is produced, otherwise null
+     */
+    protected @Nullable Recipe subTickOC(@NotNull OCResult ocResult, @NotNull Recipe recipe,
+                                         @NotNull IItemHandlerModifiable importInventory,
+                                         @NotNull IMultipleTankHandler importFluids) {
+        RecipeMap<?> map = getRecipeMap();
+        if (map == null) {
+            return null;
+        }
+
+        Recipe r = new RecipeBuilder<>(recipe, map)
+                .EUt(ocResult.eut())
+                .build()
+                .getResult();
+
+        if (r == null) {
+            // should be impossible, but check anyway
+            return recipe;
+        }
+
+        RecipeBuilder<?> builder = findMultipliedParallelRecipe(map, r, importInventory, importFluids,
+                getOutputInventory(), getOutputTank(), ocResult.parallel(), ocResult.parallelEUt(),
+                getMetaTileEntity());
+
+        if (builder == null) {
+            return null;
+        }
+
+        if (builder.getParallel() == 0) {
+            return recipe;
+        }
+
+        r = builder.EUt(recipe.getEUt())
+                .build()
+                .getResult();
+
+        if (r == null) {
+            return recipe;
+        }
+
+        ocResult.setEut(r.getEUt());
+        return r;
+    }
+
+    /**
+     * @param eut      the overclocked EUt to check
+     * @param duration the overclocked duration to check
      * @return true if there is enough energy to continue recipe progress
      */
-    protected boolean hasEnoughPower(int @NotNull [] resultOverclock) {
-        // Format of resultOverclock: EU/t, duration
-        int recipeEUt = resultOverclock[0];
-
-        // RIP Ternary
-        // Power Consumption case
-        if (recipeEUt >= 0) {
+    protected boolean hasEnoughPower(long eut, int duration) {
+        if (eut >= 0) {
+            // Power Consumption case
             // ensure it can run for at least 8 ticks. Arbitrary value, but should prevent instant failures
-            return getEnergyStored() >= ((long) recipeEUt << 3);
-        }
-        // Power Generation case
-        else {
+            return getEnergyStored() >= (eut << 3);
+        } else {
+            // Power Generation case
             // Return true if we can fit at least 1A of energy into the energy output
-            return getEnergyStored() - (long) recipeEUt <= getEnergyCapacity();
+            return getEnergyStored() - eut <= getEnergyCapacity();
         }
     }
 
     /**
-     * Method for modifying the overclock results, such as for Multiblock coil bonuses.
-     * Is always called, even if no overclocks are performed.
+     * Method for modifying the overclock results, such as for Multiblock coil bonuses. Is always called, even if no
+     * overclocks are performed.
      *
-     * @param overclockResults The overclocked recipe EUt and duration, in format [EUt, duration]
-     * @param storage          the RecipePropertyStorage of the recipe being processed
+     * @param ocResult The overclock result
+     * @param storage  the RecipePropertyStorage of the recipe being processed
      */
-    protected void modifyOverclockPost(int[] overclockResults, @NotNull IRecipePropertyStorage storage) {}
+    protected void modifyOverclockPost(@NotNull OCResult ocResult, @NotNull IRecipePropertyStorage storage) {}
 
     /**
      * Calculates the overclocked Recipe's final duration and EU/t
      *
      * @param recipe the recipe to run
-     * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
-    @NotNull
-    protected int[] calculateOverclock(@NotNull Recipe recipe) {
+    protected final void calculateOverclock(@NotNull Recipe recipe) {
         // perform the actual overclocking
-        return performOverclocking(recipe);
+        ocParams.initialize(recipe.getEUt(), recipe.getDuration(), getNumberOfOCs(recipe.getEUt()));
+        performOverclocking(recipe, this.ocParams, this.ocResult);
+        ocParams.reset();
     }
 
     /**
-     * Determines the maximum number of overclocks that can be performed for a recipe.
-     * Then performs overclocking on the Recipe.
+     * Determines the maximum number of overclocks that can be performed for a recipe. Then performs overclocking on the
+     * Recipe.
      *
-     * @param recipe the recipe to overclock
-     * @return an int array of {OverclockedEUt, OverclockedDuration}
+     * @param recipe   the recipe to overclock
+     * @param ocParams the parameters for overclocking
+     * @param ocResult the result of overclocking
      */
-    protected int @NotNull [] performOverclocking(@NotNull Recipe recipe) {
-        int[] values = { recipe.getEUt(), recipe.getDuration(), getNumberOfOCs(recipe.getEUt()) };
-        modifyOverclockPre(values, recipe.getRecipePropertyStorage());
+    protected void performOverclocking(@NotNull Recipe recipe, @NotNull OCParams ocParams, @NotNull OCResult ocResult) {
+        modifyOverclockPre(ocParams, recipe.getRecipePropertyStorage());
 
-        if (values[2] <= 0) {
+        if (ocParams.ocAmount() <= 0) {
             // number of OCs is <= 0, so do not overclock
-            return new int[] { values[0], values[1] };
+            ocResult.init(ocParams.eut(), ocParams.duration(), 0);
+        } else {
+            runOverclockingLogic(ocParams, ocResult, recipe.getRecipePropertyStorage(), getMaximumOverclockVoltage());
         }
-
-        return runOverclockingLogic(recipe.getRecipePropertyStorage(), values[0], getMaximumOverclockVoltage(),
-                values[1], values[2]);
     }
 
     /**
      * @param recipeEUt the EUt of the recipe
      * @return the number of times to overclock the recipe
      */
-    protected int getNumberOfOCs(int recipeEUt) {
+    protected int getNumberOfOCs(long recipeEUt) {
         if (!isAllowOverclocking()) return 0;
 
         int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
@@ -792,50 +854,40 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
-     * Perform changes to the recipe EUt, duration, and OC count before overclocking.
-     * Is always called, even if no overclocks are to be performed.
+     * Perform changes to the recipe EUt, duration, and OC count before overclocking. Is always called, even if no
+     * overclocks are to be performed.
      *
-     * @param values  an array of [recipeEUt, recipeDuration, numberOfOCs]
-     * @param storage the RecipePropertyStorage of the recipe being processed
+     * @param ocParams an array of [recipeEUt, recipeDuration, numberOfOCs]
+     * @param storage  the RecipePropertyStorage of the recipe being processed
      */
-    protected void modifyOverclockPre(@NotNull int[] values, @NotNull IRecipePropertyStorage storage) {}
+    protected void modifyOverclockPre(@NotNull OCParams ocParams, @NotNull IRecipePropertyStorage storage) {}
 
     /**
-     * Calls the desired overclocking logic to be run for the recipe.
-     * Performs the actual overclocking on the provided recipe.
-     * Override this to call custom overclocking mechanics
+     * Calls the desired overclocking logic to be run for the recipe. Performs the actual overclocking on the provided
+     * recipe. Override this to call custom overclocking mechanics
      *
+     * @param ocParams        the parameters for the overclock
+     * @param ocResult        the result to store the overclock in
      * @param propertyStorage the recipe's property storage
-     * @param recipeEUt       the EUt of the recipe
      * @param maxVoltage      the maximum voltage the recipe is allowed to be run at
-     * @param duration        the duration of the recipe
-     * @param amountOC        the maximum amount of overclocks to perform
-     * @return an int array of {OverclockedEUt, OverclockedDuration}
      */
-    @NotNull
-    protected int[] runOverclockingLogic(@NotNull IRecipePropertyStorage propertyStorage, int recipeEUt,
-                                         long maxVoltage, int duration, int amountOC) {
-        return standardOverclockingLogic(
-                Math.abs(recipeEUt),
-                maxVoltage,
-                duration,
-                amountOC,
-                getOverclockingDurationDivisor(),
-                getOverclockingVoltageMultiplier());
+    protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                        @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+        standardOC(ocParams, ocResult, maxVoltage, getOverclockingDurationFactor(), getOverclockingVoltageFactor());
     }
 
     /**
-     * @return the divisor to use for reducing duration upon overclocking
+     * @return the multiplier to use for reducing duration upon overclocking
      */
-    protected double getOverclockingDurationDivisor() {
-        return hasPerfectOC ? PERFECT_OVERCLOCK_DURATION_DIVISOR : STANDARD_OVERCLOCK_DURATION_DIVISOR;
+    protected double getOverclockingDurationFactor() {
+        return hasPerfectOC ? PERFECT_DURATION_FACTOR : STD_DURATION_FACTOR;
     }
 
     /**
      * @return the multiplier to use for increasing voltage upon overclocking
      */
-    protected double getOverclockingVoltageMultiplier() {
-        return STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER;
+    protected double getOverclockingVoltageFactor() {
+        return STD_VOLTAGE_FACTOR;
     }
 
     /**
@@ -870,16 +922,22 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      *
      * @param recipe the recipe to run
      */
-    protected void setupRecipe(Recipe recipe) {
+    @MustBeInvokedByOverriders
+    protected void setupRecipe(@NotNull Recipe recipe) {
         this.progressTime = 1;
-        setMaxProgress(overclockResults[1]);
-        this.recipeEUt = overclockResults[0];
+        setMaxProgress(ocResult.duration());
+        this.recipeEUt = consumesEnergy() ? ocResult.eut() : -ocResult.eut();
+
         int recipeTier = GTUtility.getTierByVoltage(recipe.getEUt());
         int machineTier = getOverclockForTier(getMaximumOverclockVoltage());
-        this.fluidOutputs = GTUtility
-                .copyFluidList(recipe.getResultFluidOutputs(recipeTier, machineTier, getRecipeMap()));
-        this.itemOutputs = GTUtility
-                .copyStackList(recipe.getResultItemOutputs(recipeTier, machineTier, getRecipeMap()));
+
+        RecipeMap<?> map = getRecipeMap();
+        if (map != null) {
+            this.fluidOutputs = GTUtility
+                    .copyFluidList(recipe.getResultFluidOutputs(recipeTier, machineTier, map));
+            this.itemOutputs = GTUtility
+                    .copyStackList(recipe.getResultItemOutputs(recipeTier, machineTier, map));
+        }
 
         if (this.wasActiveAndNeedsUpdate) {
             this.wasActiveAndNeedsUpdate = false;
@@ -901,7 +959,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         this.hasNotEnoughEnergy = false;
         this.wasActiveAndNeedsUpdate = true;
         this.parallelRecipesPerformed = 0;
-        this.overclockResults = new int[] { 0, 0 };
+        this.ocResult.reset();
     }
 
     /**
@@ -932,14 +990,14 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     /**
      * @return the current recipe's EU/t
      */
-    public int getRecipeEUt() {
+    public long getRecipeEUt() {
         return recipeEUt;
     }
 
     /**
      * @return the current recipe's EU/t for TOP/Waila/Tricorder
      */
-    public int getInfoProviderEUt() {
+    public long getInfoProviderEUt() {
         return getRecipeEUt();
     }
 
@@ -1075,6 +1133,24 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         setMaximumOverclockVoltage(GTValues.V[tier]);
     }
 
+    /**
+     * Used to reset cached values in the Recipe Logic on events such as multiblock structure deformation
+     */
+    @MustBeInvokedByOverriders
+    public void invalidate() {
+        previousRecipe = null;
+        progressTime = 0;
+        maxProgressTime = 0;
+        recipeEUt = 0;
+        fluidOutputs = null;
+        itemOutputs = null;
+        parallelRecipesPerformed = 0;
+        isOutputsFull = false;
+        invalidInputsForRecipes = false;
+        this.ocResult.reset();
+        setActive(false); // this marks dirty for us
+    }
+
     @Override
     public void receiveCustomData(int dataId, @NotNull PacketBuffer buf) {
         if (dataId == GregtechDataCodes.WORKABLE_ACTIVE) {
@@ -1109,7 +1185,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (progressTime > 0) {
             compound.setInteger("Progress", progressTime);
             compound.setInteger("MaxProgress", maxProgressTime);
-            compound.setInteger("RecipeEUt", this.recipeEUt);
+            compound.setLong("RecipeEUt", this.recipeEUt);
             NBTTagList itemOutputsList = new NBTTagList();
             for (ItemStack itemOutput : itemOutputs) {
                 itemOutputsList.appendTag(itemOutput.writeToNBT(new NBTTagCompound()));
@@ -1135,7 +1211,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (progressTime > 0) {
             this.isActive = true;
             this.maxProgressTime = compound.getInteger("MaxProgress");
-            this.recipeEUt = compound.getInteger("RecipeEUt");
+            this.recipeEUt = compound.getLong("RecipeEUt");
             NBTTagList itemOutputsList = compound.getTagList("ItemOutputs", Constants.NBT.TAG_COMPOUND);
             this.itemOutputs = NonNullList.create();
             for (int i = 0; i < itemOutputsList.tagCount(); i++) {

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -765,6 +765,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             return recipe;
         }
 
+        ocResult.setEut(builder.getEUt());
         r = builder.EUt(recipe.getEUt())
                 .build()
                 .getResult();
@@ -773,7 +774,6 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             return recipe;
         }
 
-        ocResult.setEut(r.getEUt());
         return r;
     }
 

--- a/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/ComputationRecipeLogic.java
@@ -58,7 +58,7 @@ public class ComputationRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected void setupRecipe(Recipe recipe) {
+    protected void setupRecipe(@NotNull Recipe recipe) {
         super.setupRecipe(recipe);
         this.recipeCWUt = recipe.getProperty(ComputationProperty.getInstance(), 0);
         this.isDurationTotalCWU = recipe.hasProperty(TotalComputationProperty.getInstance());

--- a/src/main/java/gregtech/api/capability/impl/EUToFEProvider.java
+++ b/src/main/java/gregtech/api/capability/impl/EUToFEProvider.java
@@ -15,6 +15,8 @@ import net.minecraftforge.energy.IEnergyStorage;
 
 import org.jetbrains.annotations.NotNull;
 
+import static gregtech.api.util.GTUtility.safeCastLongToInt;
+
 public class EUToFEProvider extends CapabilityCompatProvider {
 
     /**
@@ -209,15 +211,5 @@ public class EUToFEProvider extends CapabilityCompatProvider {
         public boolean isOneProbeHidden() {
             return true;
         }
-    }
-
-    /**
-     * Safely cast a Long to an Int without overflow.
-     *
-     * @param v The Long value to cast to an Int.
-     * @return v, casted to Int, or Integer.MAX_VALUE if it would overflow.
-     */
-    public static int safeCastLongToInt(long v) {
-        return v > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) v;
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -4,11 +4,15 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
+
+import static gregtech.api.recipes.logic.OverclockingLogic.standardOC;
 
 public class FuelRecipeLogic extends RecipeLogicEnergy {
 
@@ -29,16 +33,15 @@ public class FuelRecipeLogic extends RecipeLogicEnergy {
     }
 
     @Override
-    protected boolean hasEnoughPower(@NotNull int[] resultOverclock) {
+    protected boolean hasEnoughPower(long eut, int duration) {
         // generators always have enough power to run recipes
         return true;
     }
 
     @Override
-    protected void modifyOverclockPost(int[] overclockResults, @NotNull IRecipePropertyStorage storage) {
-        super.modifyOverclockPost(overclockResults, storage);
-        // make EUt negative so it is consumed
-        overclockResults[0] = -overclockResults[0];
+    protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                        @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+        standardOC(ocParams, ocResult, maxVoltage, getOverclockingDurationFactor(), getOverclockingVoltageFactor());
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -2,13 +2,15 @@ package gregtech.api.capability.impl;
 
 import gregtech.api.capability.IHeatingCoil;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.logic.OverclockingLogic;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.recipes.recipeproperties.TemperatureProperty;
 
 import org.jetbrains.annotations.NotNull;
 
-import static gregtech.api.recipes.logic.OverclockingLogic.heatingCoilOverclockingLogic;
+import static gregtech.api.recipes.logic.OverclockingLogic.heatingCoilOC;
 
 /**
  * RecipeLogic for multiblocks that use temperature for raising speed and lowering energy usage
@@ -24,24 +26,18 @@ public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected void modifyOverclockPre(@NotNull int[] values, @NotNull IRecipePropertyStorage storage) {
-        super.modifyOverclockPre(values, storage);
+    protected void modifyOverclockPre(@NotNull OCParams ocParams, @NotNull IRecipePropertyStorage storage) {
+        super.modifyOverclockPre(ocParams, storage);
         // coil EU/t discount
-        values[0] = OverclockingLogic.applyCoilEUtDiscount(values[0],
+        ocParams.setEut(OverclockingLogic.applyCoilEUtDiscount(ocParams.eut(),
                 ((IHeatingCoil) metaTileEntity).getCurrentTemperature(),
-                storage.getRecipePropertyValue(TemperatureProperty.getInstance(), 0));
+                storage.getRecipePropertyValue(TemperatureProperty.getInstance(), 0)));
     }
 
-    @NotNull
     @Override
-    protected int[] runOverclockingLogic(@NotNull IRecipePropertyStorage propertyStorage, int recipeEUt,
-                                         long maxVoltage, int duration, int amountOC) {
-        return heatingCoilOverclockingLogic(
-                Math.abs(recipeEUt),
-                maxVoltage,
-                duration,
-                amountOC,
-                ((IHeatingCoil) metaTileEntity).getCurrentTemperature(),
+    protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                        @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+        heatingCoilOC(ocParams, ocResult, maxVoltage, ((IHeatingCoil) metaTileEntity).getCurrentTemperature(),
                 propertyStorage.getRecipePropertyValue(TemperatureProperty.getInstance(), 0));
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java
@@ -6,7 +6,10 @@ import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextFormattingUtil;
 
 import net.minecraft.util.Tuple;
@@ -26,28 +29,25 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected void modifyOverclockPre(@NotNull int[] values, @NotNull IRecipePropertyStorage storage) {
+    protected void modifyOverclockPre(@NotNull OCParams ocParams, @NotNull IRecipePropertyStorage storage) {
         // apply maintenance bonuses
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         // duration bonus
         if (maintenanceValues.getSecond() != 1.0) {
-            values[1] = (int) Math.round(values[1] / maintenanceValues.getSecond());
+            ocParams.setDuration((int) Math.round(ocParams.duration() / maintenanceValues.getSecond()));
         }
     }
 
     @Override
-    protected void modifyOverclockPost(int[] overclockResults, @NotNull IRecipePropertyStorage storage) {
+    protected void modifyOverclockPost(@NotNull OCResult ocResult, @NotNull IRecipePropertyStorage storage) {
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         // duration penalty
         if (maintenanceValues.getFirst() > 0) {
-            overclockResults[1] = (int) (overclockResults[1] * (1 - 0.1 * maintenanceValues.getFirst()));
+            ocResult.setDuration((int) (ocResult.duration() * (1 - 0.1 * maintenanceValues.getFirst())));
         }
-
-        // make EUt negative so it is consumed
-        overclockResults[0] = -overclockResults[0];
     }
 
     @NotNull
@@ -57,7 +57,7 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected boolean hasEnoughPower(@NotNull int[] resultOverclock) {
+    protected boolean hasEnoughPower(long eut, int duration) {
         // generators always have enough power to run recipes
         return true;
     }
@@ -95,18 +95,19 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
     }
 
     @Override
-    protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+    protected boolean drawEnergy(long recipeEUt, boolean simulate) {
         long euToDraw = boostProduction(recipeEUt);
         long resultEnergy = getEnergyStored() - euToDraw;
         if (resultEnergy >= 0L && resultEnergy <= getEnergyCapacity()) {
             if (!simulate) getEnergyContainer().changeEnergy(-euToDraw);
             return true;
-        } else return false;
+        }
+        return false;
     }
 
     @Override
-    public int getInfoProviderEUt() {
-        return (int) boostProduction(super.getInfoProviderEUt());
+    public long getInfoProviderEUt() {
+        return boostProduction(super.getInfoProviderEUt());
     }
 
     @Override
@@ -138,10 +139,10 @@ public class MultiblockFuelRecipeLogic extends MultiblockRecipeLogic {
         }
         FluidStack requiredFluidInput = recipe.getFluidInputs().get(0).getInputFluidStack();
 
-        int ocAmount = (int) (getMaxVoltage() / recipe.getEUt());
+        int ocAmount = GTUtility.safeCastLongToInt(getMaxVoltage() / recipe.getEUt());
         int neededAmount = ocAmount * requiredFluidInput.amount;
         if (rotorHolder != null && rotorHolder.hasRotor()) {
-            neededAmount /= (rotorHolder.getTotalEfficiency() / 100f);
+            neededAmount /= (rotorHolder.getTotalEfficiency() / 100.0);
         } else if (rotorHolder != null && !rotorHolder.hasRotor()) {
             return null;
         }

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -10,6 +10,8 @@ import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
@@ -24,6 +26,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import static gregtech.api.recipes.logic.OverclockingLogic.subTickParallelOC;
 
 public class MultiblockRecipeLogic extends AbstractRecipeLogic {
 
@@ -55,19 +59,11 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     /**
      * Used to reset cached values in the Recipe Logic on structure deform
      */
+    @Override
     public void invalidate() {
-        previousRecipe = null;
-        progressTime = 0;
-        maxProgressTime = 0;
-        recipeEUt = 0;
-        fluidOutputs = null;
-        itemOutputs = null;
+        super.invalidate();
         lastRecipeIndex = 0;
-        parallelRecipesPerformed = 0;
-        isOutputsFull = false;
-        invalidInputsForRecipes = false;
         invalidatedInputList.clear();
-        setActive(false); // this marks dirty for us
     }
 
     public void onDistinctChanged() {
@@ -273,37 +269,47 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                 getMaxParallelVoltage(),
                 getParallelLimit());
 
-        if (recipe != null && setupAndConsumeRecipeInputs(recipe, currentDistinctInputBus)) {
-            setupRecipe(recipe);
-            return true;
+        if (recipe != null) {
+            recipe = setupAndConsumeRecipeInputs(recipe, currentDistinctInputBus);
+            if (recipe != null) {
+                setupRecipe(recipe);
+                return true;
+            }
         }
 
         return false;
     }
 
     @Override
-    protected void modifyOverclockPre(int @NotNull [] values, @NotNull IRecipePropertyStorage storage) {
-        super.modifyOverclockPre(values, storage);
+    protected void modifyOverclockPre(@NotNull OCParams ocParams, @NotNull IRecipePropertyStorage storage) {
+        super.modifyOverclockPre(ocParams, storage);
 
         // apply maintenance bonuses
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         // duration bonus
         if (maintenanceValues.getSecond() != 1.0) {
-            values[1] = (int) Math.round(values[1] * maintenanceValues.getSecond());
+            ocParams.setDuration((int) Math.round(ocParams.duration() * maintenanceValues.getSecond()));
         }
     }
 
     @Override
-    protected void modifyOverclockPost(int[] overclockResults, @NotNull IRecipePropertyStorage storage) {
-        super.modifyOverclockPost(overclockResults, storage);
+    protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                        @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+        subTickParallelOC(ocParams, ocResult, maxVoltage, getOverclockingDurationFactor(),
+                getOverclockingVoltageFactor());
+    }
+
+    @Override
+    protected void modifyOverclockPost(@NotNull OCResult ocResult, @NotNull IRecipePropertyStorage storage) {
+        super.modifyOverclockPost(ocResult, storage);
 
         // apply maintenance penalties
         Tuple<Integer, Double> maintenanceValues = getMaintenanceValues();
 
         // duration penalty
         if (maintenanceValues.getFirst() > 0) {
-            overclockResults[1] = (int) (overclockResults[1] * (1 + 0.1 * maintenanceValues.getFirst()));
+            ocResult.setDuration((int) (ocResult.duration() * (1 + 0.1 * maintenanceValues.getFirst())));
         }
     }
 
@@ -394,7 +400,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+    protected boolean drawEnergy(long recipeEUt, boolean simulate) {
         long resultEnergy = getEnergyStored() - recipeEUt;
         if (resultEnergy >= 0L && resultEnergy <= getEnergyCapacity()) {
             if (!simulate) getEnergyContainer().changeEnergy(-recipeEUt);

--- a/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/PrimitiveRecipeLogic.java
@@ -3,11 +3,11 @@ package gregtech.api.capability.impl;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.multiblock.RecipeMapPrimitiveMultiblockController;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 
 import org.jetbrains.annotations.NotNull;
-
-import static gregtech.api.recipes.logic.OverclockingLogic.standardOverclockingLogic;
 
 /**
  * Recipe Logic for a Multiblock that does not require power.
@@ -34,12 +34,12 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+    protected boolean drawEnergy(long recipeEUt, boolean simulate) {
         return true; // spoof energy being drawn
     }
 
     @Override
-    protected boolean hasEnoughPower(int @NotNull [] resultOverclock) {
+    protected boolean hasEnoughPower(long eut, int duration) {
         return true;
     }
 
@@ -49,34 +49,14 @@ public class PrimitiveRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected int @NotNull [] runOverclockingLogic(@NotNull IRecipePropertyStorage propertyStorage, int recipeEUt,
-                                                   long maxVoltage, int recipeDuration, int amountOC) {
-        return standardOverclockingLogic(
-                1,
-                getMaxVoltage(),
-                recipeDuration,
-                amountOC,
-                getOverclockingDurationDivisor(),
-                getOverclockingVoltageMultiplier()
-
-        );
+    protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                        @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+        ocParams.setEut(1L);
+        super.runOverclockingLogic(ocParams, ocResult, propertyStorage, maxVoltage);
     }
 
     @Override
     public long getMaximumOverclockVoltage() {
         return GTValues.V[GTValues.LV];
-    }
-
-    /**
-     * Used to reset cached values in the Recipe Logic on structure deform
-     */
-    public void invalidate() {
-        previousRecipe = null;
-        progressTime = 0;
-        maxProgressTime = 0;
-        recipeEUt = 0;
-        fluidOutputs = null;
-        itemOutputs = null;
-        setActive(false); // this marks dirty for us
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicEnergy.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicEnergy.java
@@ -3,8 +3,15 @@ package gregtech.api.capability.impl;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
+import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
+
+import static gregtech.api.recipes.logic.OverclockingLogic.subTickNonParallelOC;
 
 public class RecipeLogicEnergy extends AbstractRecipeLogic {
 
@@ -33,17 +40,24 @@ public class RecipeLogicEnergy extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+    protected boolean drawEnergy(long recipeEUt, boolean simulate) {
         long resultEnergy = getEnergyStored() - recipeEUt;
         if (resultEnergy >= 0L && resultEnergy <= getEnergyCapacity()) {
             if (!simulate) energyContainer.get().changeEnergy(-recipeEUt);
             return true;
-        } else return false;
+        }
+        return false;
     }
 
     @Override
     public long getMaxVoltage() {
-        return Math.max(energyContainer.get().getInputVoltage(),
-                energyContainer.get().getOutputVoltage());
+        return Math.max(energyContainer.get().getInputVoltage(), energyContainer.get().getOutputVoltage());
+    }
+
+    @Override
+    protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                        @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+        subTickNonParallelOC(ocParams, ocResult, maxVoltage, getOverclockingDurationFactor(),
+                getOverclockingVoltageFactor());
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -194,9 +194,9 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     protected void performOverclocking(@NotNull Recipe recipe, @NotNull OCParams ocParams,
                                        @NotNull OCResult ocResult) {
         if (isHighPressure) {
-            ocResult.init(recipe.getEUt() * 2L, recipe.getDuration(), 0);
+            ocResult.init(recipe.getEUt() * 2L, recipe.getDuration());
         } else {
-            ocResult.init(recipe.getEUt(), recipe.getDuration() * 2, 0);
+            ocResult.init(recipe.getEUt(), recipe.getDuration() * 2);
         }
     }
 

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -7,6 +7,8 @@ import gregtech.api.damagesources.DamageSources;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.core.advancement.AdvancementTriggers;
@@ -188,16 +190,14 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
         tryDoVenting();
     }
 
-    @NotNull
     @Override
-    protected int[] calculateOverclock(@NotNull Recipe recipe) {
-        // EUt, Duration
-        int[] result = new int[2];
-
-        result[0] = isHighPressure ? recipe.getEUt() * 2 : recipe.getEUt();
-        result[1] = isHighPressure ? recipe.getDuration() : recipe.getDuration() * 2;
-
-        return result;
+    protected void performOverclocking(@NotNull Recipe recipe, @NotNull OCParams ocParams,
+                                       @NotNull OCResult ocResult) {
+        if (isHighPressure) {
+            ocResult.init(recipe.getEUt() * 2L, recipe.getDuration(), 0);
+        } else {
+            ocResult.init(recipe.getEUt(), recipe.getDuration() * 2, 0);
+        }
     }
 
     @Override
@@ -216,8 +216,8 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    protected boolean drawEnergy(int recipeEUt, boolean simulate) {
-        int resultDraw = (int) Math.ceil(recipeEUt / conversionRate);
+    protected boolean drawEnergy(long recipeEUt, boolean simulate) {
+        int resultDraw = GTUtility.safeCastLongToInt((long) Math.ceil(recipeEUt / conversionRate));
         return resultDraw >= 0 && steamFluidTank.getFluidAmount() >= resultDraw &&
                 steamFluidTank.drain(resultDraw, !simulate) != null;
     }
@@ -228,8 +228,8 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
     }
 
     @Override
-    protected boolean hasEnoughPower(int @NotNull [] resultOverclock) {
-        int totalSteam = (int) (resultOverclock[0] * resultOverclock[1] / conversionRate);
+    protected boolean hasEnoughPower(long eut, int duration) {
+        long totalSteam = (long) (eut * duration / conversionRate);
         if (totalSteam > 0) {
             long steamStored = getEnergyStored();
             long steamCapacity = getEnergyCapacity();
@@ -241,7 +241,7 @@ public class RecipeLogicSteam extends AbstractRecipeLogic implements IVentable {
             return steamStored >= totalSteam;
         }
         // generation case unchanged
-        return super.hasEnoughPower(resultOverclock);
+        return super.hasEnoughPower(eut, duration);
     }
 
     @NotNull

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -26,9 +26,9 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
 
     @Override
     public void applyParallelBonus(@NotNull RecipeBuilder<?> builder) {
-        int currentRecipeEU = builder.getEUt();
+        long currentRecipeEU = builder.getEUt();
         int currentRecipeDuration = builder.getDuration() / getParallelLimit();
-        builder.EUt((int) Math.min(32.0, Math.ceil(currentRecipeEU * 1.33)))
+        builder.EUt((long) Math.min(32, Math.ceil(currentRecipeEU * 1.33)))
                 .duration((int) (currentRecipeDuration * 1.5));
     }
 }

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.metatileentity.multiblock.RecipeMapSteamMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 
 import net.minecraft.block.Block;
@@ -22,6 +23,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
 
@@ -104,9 +106,9 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+    protected boolean drawEnergy(long recipeEUt, boolean simulate) {
         combineSteamTanks();
-        int resultDraw = (int) Math.ceil(recipeEUt / conversionRate);
+        int resultDraw = GTUtility.safeCastLongToInt((long) Math.ceil(recipeEUt / conversionRate));
         return resultDraw >= 0 && steamFluidTankCombined.getFluidAmount() >= resultDraw &&
                 steamFluidTank.drain(resultDraw, !simulate) != null;
     }
@@ -122,14 +124,17 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
-                                                  @NotNull IItemHandlerModifiable importInventory) {
+    protected @Nullable Recipe setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
+                                                           @NotNull IItemHandlerModifiable importInventory) {
         RecipeMapSteamMultiblockController controller = (RecipeMapSteamMultiblockController) metaTileEntity;
-        if (controller.checkRecipe(recipe, false) &&
-                super.setupAndConsumeRecipeInputs(recipe, importInventory)) {
-            controller.checkRecipe(recipe, true);
-            return true;
-        } else return false;
+        if (controller.checkRecipe(recipe, false)) {
+            recipe = super.setupAndConsumeRecipeInputs(recipe, importInventory);
+            if (recipe != null) {
+                controller.checkRecipe(recipe, true);
+                return recipe;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -169,8 +174,8 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean hasEnoughPower(int @NotNull [] resultOverclock) {
-        int totalSteam = (int) (resultOverclock[0] * resultOverclock[1] / conversionRate);
+    protected boolean hasEnoughPower(long eut, int duration) {
+        long totalSteam = (long) (eut * duration / conversionRate);
         if (totalSteam > 0) {
             long steamStored = getEnergyStored();
             long steamCapacity = getEnergyCapacity();
@@ -182,6 +187,6 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
             return steamStored >= totalSteam;
         }
         // generation case unchanged
-        return super.hasEnoughPower(resultOverclock);
+        return super.hasEnoughPower(eut, duration);
     }
 }

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -88,7 +88,7 @@ public class Recipe {
     /**
      * if > 0 means EU/t consumed, if < 0 - produced
      */
-    private final int EUt;
+    private final long EUt;
 
     /**
      * If this Recipe is hidden from JEI
@@ -113,7 +113,7 @@ public class Recipe {
                   List<FluidStack> fluidOutputs,
                   @NotNull ChancedOutputList<FluidStack, ChancedFluidOutput> chancedFluidOutputs,
                   int duration,
-                  int EUt,
+                  long EUt,
                   boolean hidden,
                   boolean isCTRecipe,
                   IRecipePropertyStorage recipePropertyStorage,
@@ -702,7 +702,7 @@ public class Recipe {
         return duration;
     }
 
-    public int getEUt() {
+    public long getEUt() {
         return EUt;
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -822,6 +822,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.duration(multiplyDuration ? this.duration + recipe.getDuration() * multiplier : recipe.getDuration());
         if (this.parallel == 0) {
             this.parallel = multiplier;
+        } else if (multiplyDuration) {
+            this.parallel += multiplier;
         } else {
             this.parallel *= multiplier;
         }

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -78,7 +78,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     protected ChancedOutputLogic chancedOutputLogic = ChancedOutputLogic.OR;
     protected ChancedOutputLogic chancedFluidOutputLogic = ChancedOutputLogic.OR;
 
-    protected int duration, EUt;
+    protected int duration;
+    protected long EUt;
     protected boolean hidden = false;
     protected GTRecipeCategory category;
     protected boolean isCTRecipe = false;
@@ -819,7 +820,11 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
         this.EUt(multiplyDuration ? recipe.getEUt() : this.EUt + recipe.getEUt() * multiplier);
         this.duration(multiplyDuration ? this.duration + recipe.getDuration() * multiplier : recipe.getDuration());
-        this.parallel += multiplier;
+        if (this.parallel == 0) {
+            this.parallel = multiplier;
+        } else {
+            this.parallel *= multiplier;
+        }
 
         return (R) this;
     }
@@ -874,7 +879,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
-    public R EUt(int EUt) {
+    public R EUt(long EUt) {
         this.EUt = EUt;
         return (R) this;
     }
@@ -1057,7 +1062,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return fluidOutputs;
     }
 
-    public int getEUt() {
+    public long getEUt() {
         return EUt;
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -193,7 +193,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         this.recipeBuilderSample = defaultRecipeBuilder;
 
         this.recipeMapUI = new RecipeMapUI<>(this, modifyItemInputs, modifyItemOutputs, modifyFluidInputs,
-                modifyFluidOutputs);
+                modifyFluidOutputs, false);
         this.recipeMapUI.setJEIVisible(!isHidden);
 
         RECIPE_MAP_REGISTRY.put(unlocalizedName, this);

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -88,7 +88,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private static final Map<String, RecipeMap<?>> RECIPE_MAP_REGISTRY = new Object2ReferenceOpenHashMap<>();
 
     private static final Comparator<Recipe> RECIPE_DURATION_THEN_EU = Comparator.comparingInt(Recipe::getDuration)
-            .thenComparingInt(Recipe::getEUt)
+            .thenComparingLong(Recipe::getEUt)
             .thenComparing(Recipe::hashCode);
 
     private static boolean foundInvalidRecipe = false;

--- a/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
@@ -34,6 +34,8 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     private int fluidOutputs;
     private boolean modifyFluidOutputs = true;
 
+    private boolean isGenerator;
+
     private @Nullable TextureArea progressBar;
     private @Nullable ProgressWidget.MoveType moveType;
 
@@ -129,6 +131,16 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     }
 
     /**
+     * Mark this recipemap is generating energy
+     *
+     * @return this
+     */
+    public @NotNull RecipeMapBuilder<B> generator() {
+        this.isGenerator = true;
+        return this;
+    }
+
+    /**
      * @param progressBar the progress bar texture to use
      * @return this
      */
@@ -217,7 +229,7 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
      */
     private @NotNull RecipeMapUI<?> buildUI(@NotNull RecipeMap<?> recipeMap) {
         RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, modifyItemInputs, modifyItemOutputs, modifyFluidInputs,
-                modifyFluidOutputs);
+                modifyFluidOutputs, isGenerator);
         if (progressBar != null) {
             ui.setProgressBarTexture(progressBar);
         }
@@ -277,8 +289,7 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
      */
     public @NotNull RecipeMap<B> build() {
         RecipeMap<B> recipeMap = new RecipeMap<>(unlocalizedName, defaultRecipeBuilder, this.recipeMapUIFunction,
-                itemInputs,
-                itemOutputs, fluidInputs, fluidOutputs);
+                itemInputs, itemOutputs, fluidInputs, fluidOutputs);
         recipeMap.setSound(sound);
         if (allowEmptyOutputs) {
             recipeMap.allowEmptyOutput();

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -1519,7 +1519,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTSoundEvents.COMBUSTION)
                     .allowEmptyOutputs()
-            .generator()
+                    .generator()
                     .build();
 
     @ZenProperty
@@ -1531,7 +1531,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
-            .generator()
+                    .generator()
                     .build();
 
     private RecipeMaps() {}

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -333,7 +333,7 @@ public final class RecipeMaps {
     public static final RecipeMap<SimpleRecipeBuilder> CANNER_RECIPES = new RecipeMapFluidCanner("canner",
             new SimpleRecipeBuilder(), recipeMap -> {
 
-                RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, true, true, true, true);
+                RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, true, true, true, true, false);
                 ui.setItemSlotOverlay(GuiTextures.CANNER_OVERLAY, false, false);
                 ui.setItemSlotOverlay(GuiTextures.CANISTER_OVERLAY, false, true);
                 ui.setItemSlotOverlay(GuiTextures.CANISTER_OVERLAY, true);
@@ -941,7 +941,7 @@ public final class RecipeMaps {
     @ZenProperty
     public static final RecipeMap<SimpleRecipeBuilder> FURNACE_RECIPES = new RecipeMapFurnace("electric_furnace",
             new SimpleRecipeBuilder(), recipeMap -> {
-                RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, true, true, true, true);
+                RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, true, true, true, true, false);
                 ui.setItemSlotOverlay(GuiTextures.FURNACE_OVERLAY_1, false);
                 ui.setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, ProgressWidget.MoveType.HORIZONTAL);
                 return ui;
@@ -1367,7 +1367,7 @@ public final class RecipeMaps {
     @ZenProperty
     public static final RecipeMap<SimpleRecipeBuilder> SCANNER_RECIPES = new RecipeMapScanner("scanner",
             new SimpleRecipeBuilder(), recipeMap -> {
-                RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, true, true, true, true);
+                RecipeMapUI<?> ui = new RecipeMapUI<>(recipeMap, true, true, true, true, false);
                 ui.setItemSlotOverlay(GuiTextures.DATA_ORB_OVERLAY, false, false);
                 ui.setItemSlotOverlay(GuiTextures.SCANNER_OVERLAY, false, true);
                 ui.setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, ProgressWidget.MoveType.HORIZONTAL);
@@ -1485,6 +1485,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTSoundEvents.COMBUSTION)
                     .allowEmptyOutputs()
+                    .generator()
                     .build();
 
     @ZenProperty
@@ -1495,6 +1496,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
+                    .generator()
                     .build();
 
     @ZenProperty
@@ -1506,6 +1508,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
+                    .generator()
                     .build();
 
     @ZenProperty
@@ -1516,6 +1519,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTSoundEvents.COMBUSTION)
                     .allowEmptyOutputs()
+            .generator()
                     .build();
 
     @ZenProperty
@@ -1527,6 +1531,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
+            .generator()
                     .build();
 
     private RecipeMaps() {}

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -33,6 +33,7 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.util.AssemblyLineManager;
+import gregtech.api.util.GTUtility;
 import gregtech.core.sound.GTSoundEvents;
 
 import net.minecraft.init.SoundEvents;
@@ -612,18 +613,19 @@ public final class RecipeMaps {
                     .onBuild(gregtechId("cutter_fluid"), recipeBuilder -> {
                         if (recipeBuilder.getFluidInputs().isEmpty()) {
                             int duration = recipeBuilder.getDuration();
-                            int eut = recipeBuilder.getEUt();
+                            long eut = recipeBuilder.getEUt();
                             recipeBuilder
                                     .copy()
-                                    .fluidInputs(Materials.Water.getFluid(Math.max(4,
-                                            Math.min(1000, duration * eut / 320))))
+                                    .fluidInputs(Materials.Water.getFluid(GTUtility.safeCastLongToInt(Math.max(4,
+                                            Math.min(1000, duration * eut / 320)))))
                                     .duration(duration * 2)
                                     .buildAndRegister();
 
                             recipeBuilder
                                     .copy()
-                                    .fluidInputs(Materials.DistilledWater.getFluid(Math.max(3,
-                                            Math.min(750, duration * eut / 426))))
+                                    .fluidInputs(
+                                            Materials.DistilledWater.getFluid(GTUtility.safeCastLongToInt(Math.max(3,
+                                                    Math.min(750, duration * eut / 426)))))
                                     .duration((int) (duration * 1.5))
                                     .buildAndRegister();
 
@@ -631,8 +633,8 @@ public final class RecipeMaps {
                             // middle of a buildAndRegister call.
                             // Adding a second call will result in duplicate recipe generation attempts
                             recipeBuilder
-                                    .fluidInputs(Materials.Lubricant.getFluid(Math.max(1,
-                                            Math.min(250, duration * eut / 1280))))
+                                    .fluidInputs(Materials.Lubricant.getFluid(GTUtility.safeCastLongToInt(Math.max(1,
+                                            Math.min(250, duration * eut / 1280)))))
                                     .duration(Math.max(1, duration));
 
                         }

--- a/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.Nullable;
 
-import static gregtech.api.recipes.logic.OverclockingLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR;
+import static gregtech.api.recipes.logic.OverclockingLogic.STD_DURATION_FACTOR_INV;
 
 public class UniversalDistillationRecipeBuilder extends RecipeBuilder<UniversalDistillationRecipeBuilder> {
 
@@ -45,7 +45,7 @@ public class UniversalDistillationRecipeBuilder extends RecipeBuilder<UniversalD
             int ratio = getRatioForDistillery(this.fluidInputs.get(0).getInputFluidStack(), this.fluidOutputs.get(i),
                     !this.outputs.isEmpty() ? this.outputs.get(0) : null);
 
-            int recipeDuration = (int) (this.duration * STANDARD_OVERCLOCK_DURATION_DIVISOR);
+            int recipeDuration = (int) (this.duration * STD_DURATION_FACTOR_INV);
 
             boolean shouldDivide = ratio != 1;
 

--- a/src/main/java/gregtech/api/recipes/logic/OCParams.java
+++ b/src/main/java/gregtech/api/recipes/logic/OCParams.java
@@ -1,0 +1,44 @@
+package gregtech.api.recipes.logic;
+
+public final class OCParams {
+
+    private long eut;
+    private int duration;
+    private int ocAmount;
+
+    public void initialize(long eut, int duration, int ocAmount) {
+        this.eut = eut;
+        this.duration = duration;
+        this.ocAmount = ocAmount;
+    }
+
+    public void reset() {
+        this.eut = 0L;
+        this.duration = 0;
+        this.ocAmount = 0;
+    }
+
+    public long eut() {
+        return eut;
+    }
+
+    public void setEut(long eut) {
+        this.eut = eut;
+    }
+
+    public int duration() {
+        return duration;
+    }
+
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    public int ocAmount() {
+        return ocAmount;
+    }
+
+    public void setOcAmount(int ocAmount) {
+        this.ocAmount = ocAmount;
+    }
+}

--- a/src/main/java/gregtech/api/recipes/logic/OCResult.java
+++ b/src/main/java/gregtech/api/recipes/logic/OCResult.java
@@ -14,7 +14,7 @@ public final class OCResult {
     }
 
     public void init(long eut, int duration, int parallel) {
-        init(eut, duration, parallel, eut);
+        init(eut, duration, parallel, parallel == 0 ? eut : eut * parallel);
     }
 
     public void init(long eut, int duration, int parallel, long parallelEUt) {

--- a/src/main/java/gregtech/api/recipes/logic/OCResult.java
+++ b/src/main/java/gregtech/api/recipes/logic/OCResult.java
@@ -1,0 +1,74 @@
+package gregtech.api.recipes.logic;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class OCResult {
+
+    private long eut;
+    private long parallelEUt;
+    private int duration;
+    private int parallel;
+
+    public void init(long eut, int duration) {
+        init(eut, duration, 0);
+    }
+
+    public void init(long eut, int duration, int parallel) {
+        init(eut, duration, parallel, eut);
+    }
+
+    public void init(long eut, int duration, int parallel, long parallelEUt) {
+        this.eut = eut;
+        this.duration = duration;
+        this.parallel = parallel;
+        this.parallelEUt = parallelEUt;
+    }
+
+    public void reset() {
+        this.eut = 0L;
+        this.parallelEUt = 0L;
+        this.duration = 0;
+        this.parallel = 0;
+    }
+
+    public long eut() {
+        return eut;
+    }
+
+    public void setEut(long eut) {
+        this.eut = eut;
+    }
+
+    public long parallelEUt() {
+        return parallelEUt;
+    }
+
+    public void setParallelEUt(long parallelEUt) {
+        this.parallelEUt = parallelEUt;
+    }
+
+    public int duration() {
+        return duration;
+    }
+
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    public int parallel() {
+        return parallel;
+    }
+
+    public void setParallel(int parallel) {
+        this.parallel = parallel;
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "OCResult[" +
+                "EUt=" + eut + ", " +
+                "duration=" + duration + ", " +
+                "parallel=" + parallel + ", " +
+                "parallelEUt=" + parallelEUt + ']';
+    }
+}

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -84,13 +84,7 @@ public final class OverclockingLogic {
         double eut = params.eut();
         int ocAmount = params.ocAmount();
 
-        boolean subtick = false;
-
         while (ocAmount-- > 0) {
-            if (subtick) {
-                break;
-            }
-
             double potentialEUt = eut * voltageFactor;
             if (potentialEUt > maxVoltage || potentialEUt < 1) {
                 break;
@@ -102,8 +96,6 @@ public final class OverclockingLogic {
                 if (potentialEUt > maxVoltage || potentialEUt < 1) {
                     break;
                 }
-
-                subtick = true;
             } else {
                 duration = potentialDuration;
             }
@@ -265,7 +257,7 @@ public final class OverclockingLogic {
      * @param requiredTemp the temperature required by the recipe
      */
     public static void heatingCoilNonSubTickOC(@NotNull OCParams params, @NotNull OCResult result, long maxVoltage,
-                                     int providedTemp, int requiredTemp) {
+                                               int providedTemp, int requiredTemp) {
         int perfectOCAmount = calculateAmountCoilEUtDiscount(providedTemp, requiredTemp) / 2;
         double duration = params.duration();
         double eut = params.eut();
@@ -296,12 +288,11 @@ public final class OverclockingLogic {
         result.init((long) eut, (int) duration);
     }
 
-
-        /**
-         * @param providedTemp the temperate provided by the machine
-         * @param requiredTemp the required temperature of the recipe
-         * @return the amount of EU/t discounts to apply
-         */
+    /**
+     * @param providedTemp the temperate provided by the machine
+     * @param requiredTemp the required temperature of the recipe
+     * @return the amount of EU/t discounts to apply
+     */
     private static int calculateAmountCoilEUtDiscount(int providedTemp, int requiredTemp) {
         return Math.max(0, (providedTemp - requiredTemp) / COIL_EUT_DISCOUNT_TEMPERATURE);
     }

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -5,54 +5,254 @@ import org.jetbrains.annotations.NotNull;
 /**
  * A class for holding all the various Overclocking logics
  */
-public class OverclockingLogic {
+public final class OverclockingLogic {
 
+    @Deprecated
     public static final double STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER = 4.0;
+    @Deprecated
     public static final double STANDARD_OVERCLOCK_DURATION_DIVISOR = 2.0;
+    @Deprecated
     public static final double PERFECT_OVERCLOCK_DURATION_DIVISOR = 4.0;
+
+    public static final double STD_VOLTAGE_FACTOR = 4.0;
+    public static final double PERFECT_HALF_VOLTAGE_FACTOR = 2.0;
+
+    public static final double STD_DURATION_FACTOR = 0.5;
+    public static final double STD_DURATION_FACTOR_INV = 2.0;
+    public static final double PERFECT_DURATION_FACTOR = 0.25;
+    public static final double PERFECT_DURATION_FACTOR_INV = 4.0;
+    public static final double PERFECT_HALF_DURATION_FACTOR = 0.5;
+    public static final double PERFECT_HALF_DURATION_FACTOR_INV = 2.0;
 
     public static final int COIL_EUT_DISCOUNT_TEMPERATURE = 900;
 
+    private OverclockingLogic() {}
+
     /**
-     * applies standard logic for overclocking, where each overclock modifies energy and duration
+     * Standard overclocking algorithm with no sub-tick behavior.
+     * <p>
+     * While there are overclocks remaining:
+     * <ol>
+     * <li>Multiplies {@code EUt} by {@code voltageFactor}
+     * <li>Multiplies {@code duration} by {@code durationFactor}
+     * <li>Limit {@code duration} to {@code 1} tick, and stop overclocking early if needed
      *
-     * @param recipeEUt         the EU/t of the recipe to overclock
-     * @param maxVoltage        the maximum voltage the recipe is allowed to be run at
-     * @param recipeDuration    the duration of the recipe to overclock
-     * @param durationDivisor   the value to divide the duration by for each overclock
-     * @param voltageMultiplier the value to multiply the voltage by for each overclock
-     * @param numberOfOCs       the maximum amount of overclocks allowed
-     * @return an int array of {OverclockedEUt, OverclockedDuration}
+     * @param params         the overclocking parameters
+     * @param result         the result of the overclock
+     * @param maxVoltage     the maximum voltage allowed to be overclocked to
+     * @param durationFactor the factor to multiply duration by
+     * @param voltageFactor  the factor to multiply voltage by
      */
+    public static void standardOC(@NotNull OCParams params, @NotNull OCResult result, long maxVoltage,
+                                  double durationFactor, double voltageFactor) {
+        double duration = params.duration();
+        double eut = params.eut();
+        int ocAmount = params.ocAmount();
+
+        while (ocAmount-- > 0) {
+            double potentialEUt = eut * voltageFactor;
+            if (potentialEUt > maxVoltage) {
+                break;
+            }
+
+            double potentialDuration = duration * durationFactor;
+            if (potentialDuration < 1) {
+                break;
+            }
+
+            // only update EUt if duration is also valid
+            eut = potentialEUt;
+            duration = potentialDuration;
+        }
+
+        result.init((long) eut, (int) duration);
+    }
+
+    /**
+     * Overclocking algorithm with sub-tick logic, which improves energy efficiency without parallelization.
+     * <p>
+     * While there are overclocks remaining:
+     * <ol>
+     * <li>Multiplies {@code EUt} by {@code voltageFactor}
+     * <li>Multiplies {@code duration} by {@code durationFactor}
+     * <li>Limit {@code duration} to {@code 1} tick
+     * <li>Multiply {@code EUt} by {@code durationFactor} and maintain {@code duration} at {@code 1} tick for
+     * overclocks that would have {@code duration < 1}
+     *
+     * @param params         the overclocking parameters
+     * @param result         the result of the overclock
+     * @param maxVoltage     the maximum voltage allowed to be overclocked to
+     * @param durationFactor the factor to multiply duration by
+     * @param voltageFactor  the factor to multiply voltage by
+     */
+    public static void subTickNonParallelOC(@NotNull OCParams params, @NotNull OCResult result, long maxVoltage,
+                                            double durationFactor, double voltageFactor) {
+        double duration = params.duration();
+        double eut = params.eut();
+        int ocAmount = params.ocAmount();
+
+        boolean subtick = false;
+
+        while (ocAmount-- > 0) {
+            if (subtick) {
+                double potentialEUt = eut * durationFactor;
+                if (potentialEUt > maxVoltage || potentialEUt < 1) {
+                    break;
+                }
+
+                eut = potentialEUt;
+            } else {
+                double potentialEUt = eut * voltageFactor;
+                if (potentialEUt > maxVoltage) {
+                    break;
+                }
+
+                double potentialDuration = duration * durationFactor;
+                if (potentialDuration <= 1) {
+                    duration = 1;
+                    potentialEUt = eut * durationFactor;
+                    if (potentialEUt > maxVoltage || potentialEUt < 1) {
+                        break;
+                    }
+
+                    subtick = true;
+                } else {
+                    duration = potentialDuration;
+                }
+                eut = potentialEUt;
+            }
+        }
+
+        result.init((long) eut, (int) duration);
+    }
+
+    /**
+     * Overclocking algorithm with sub-tick parallelization.
+     * <p>
+     * While there are overclocks remaining:
+     * <ol>
+     * <li>Multiplies {@code EUt} by {@code voltageFactor}
+     * <li>Multiplies {@code duration} by {@code durationFactor}
+     * <li>Limit {@code duration} to {@code 1} tick
+     * <li>Parallelize {@code EUt} with {@code voltageFactor} and maintain {@code duration} at {@code 1} tick for
+     * overclocks that would have {@code duration < 1}
+     * <li>Parallel amount per overclock is {@code 1 / durationFactor}
+     *
+     * @param params         the overclocking parameters
+     * @param result         the result of the overclock
+     * @param maxVoltage     the maximum voltage allowed to be overclocked to
+     * @param durationFactor the factor to multiply duration by
+     * @param voltageFactor  the factor to multiply voltage by
+     */
+    public static void subTickParallelOC(@NotNull OCParams params, @NotNull OCResult result, long maxVoltage,
+                                         double durationFactor, double voltageFactor) {
+        double duration = params.duration();
+        double eut = params.eut();
+        int ocAmount = params.ocAmount();
+        double parallel = 1;
+        boolean shouldParallel = false;
+
+        while (ocAmount-- > 0) {
+            double potentialEUt = eut * voltageFactor;
+            if (potentialEUt > maxVoltage) {
+                break;
+            }
+            eut = potentialEUt;
+
+            if (shouldParallel) {
+                parallel /= durationFactor;
+            } else {
+                double potentialDuration = duration * durationFactor;
+                if (potentialDuration <= 1) {
+                    duration = 1;
+                    parallel *= voltageFactor;
+                    shouldParallel = true;
+                } else {
+                    duration = potentialDuration;
+                }
+            }
+        }
+
+        result.init((long) (eut / parallel), (int) duration, (int) parallel, (long) eut);
+    }
+
+    /**
+     * Heating Coil overclocking algorithm with sub-tick parallelization.
+     * <p>
+     * While there are overclocks remaining:
+     * <ol>
+     * <li>Multiplies {@code EUt} by {@link #STD_VOLTAGE_FACTOR}
+     * <li>Multiplies {@code duration} by {@link #PERFECT_DURATION_FACTOR} if there are perfect OCs remaining,
+     * otherwise multiplies by {@link #STD_DURATION_FACTOR}
+     * <li>Limit {@code duration} to {@code 1} tick
+     * <li>Parallelize {@code EUt} with {@link #STD_VOLTAGE_FACTOR} and maintain {@code duration} at {@code 1} tick for
+     * overclocks that would have {@code duration < 1}
+     * <li>Parallelization amount per overclock is {@link #PERFECT_DURATION_FACTOR_INV} if there are perfect OCs
+     * remaining, otherwise uses {@link #STD_DURATION_FACTOR_INV}
+     * <li>The maximum amount of perfect OCs is determined by {@link #calculateAmountCoilEUtDiscount(int, int)}, divided
+     * by 2.
+     *
+     * @param params       the overclocking parameters
+     * @param result       the result of the overclock
+     * @param maxVoltage   the maximum voltage allowed to be overclocked to
+     * @param providedTemp the provided temperature
+     * @param requiredTemp the temperature required by the recipe
+     */
+    public static void heatingCoilOC(@NotNull OCParams params, @NotNull OCResult result, long maxVoltage,
+                                     int providedTemp, int requiredTemp) {
+        int perfectOCAmount = calculateAmountCoilEUtDiscount(providedTemp, requiredTemp) / 2;
+        double duration = params.duration();
+        double eut = params.eut();
+        int ocAmount = params.ocAmount();
+        double parallel = 1;
+        boolean shouldParallel = false;
+
+        while (ocAmount-- > 0) {
+            boolean perfect = perfectOCAmount-- > 0;
+
+            double potentialEUt = eut * STD_VOLTAGE_FACTOR;
+            if (potentialEUt > maxVoltage) {
+                break;
+            }
+            eut = potentialEUt;
+
+            if (shouldParallel) {
+                if (perfect) {
+                    parallel *= PERFECT_DURATION_FACTOR_INV;
+                } else {
+                    parallel *= STD_DURATION_FACTOR_INV;
+                }
+            } else {
+                double potentialDuration;
+                if (perfect) {
+                    potentialDuration = duration * PERFECT_DURATION_FACTOR;
+                } else {
+                    potentialDuration = duration * STD_DURATION_FACTOR;
+                }
+
+                if (potentialDuration <= 1) {
+                    duration = 1;
+                    if (perfect) {
+                        parallel *= PERFECT_DURATION_FACTOR_INV;
+                    } else {
+                        parallel *= STD_DURATION_FACTOR_INV;
+                    }
+
+                    shouldParallel = true;
+                } else {
+                    duration = potentialDuration;
+                }
+            }
+        }
+
+        result.init((long) (eut / parallel), (int) duration, (int) parallel, (long) eut);
+    }
+
+    @Deprecated
     public static int @NotNull [] standardOverclockingLogic(int recipeEUt, long maxVoltage, int recipeDuration,
                                                             int numberOfOCs,
                                                             double durationDivisor, double voltageMultiplier) {
-        double resultDuration = recipeDuration;
-        double resultVoltage = recipeEUt;
-
-        for (; numberOfOCs > 0; numberOfOCs--) {
-            // make sure that duration is not already as low as it can do
-            if (resultDuration == 1) break;
-
-            // it is important to do voltage first,
-            // so overclocking voltage does not go above the limit before changing duration
-
-            double potentialVoltage = resultVoltage * voltageMultiplier;
-            // do not allow voltage to go above maximum
-            if (potentialVoltage > maxVoltage) break;
-
-            double potentialDuration = resultDuration / durationDivisor;
-            // do not allow duration to go below one tick
-            if (potentialDuration < 1) potentialDuration = 1;
-            // update the duration for the next iteration
-            resultDuration = potentialDuration;
-
-            // update the voltage for the next iteration after everything else
-            // in case duration overclocking would waste energy
-            resultVoltage = potentialVoltage;
-        }
-
-        return new int[] { (int) resultVoltage, (int) resultDuration };
+        return null;
     }
 
     /**
@@ -72,32 +272,17 @@ public class OverclockingLogic {
      * @param requiredTemp the required temperature of the recipe
      * @return the discounted EU/t
      */
-    public static int applyCoilEUtDiscount(int recipeEUt, int providedTemp, int requiredTemp) {
+    public static long applyCoilEUtDiscount(long recipeEUt, int providedTemp, int requiredTemp) {
         if (requiredTemp < COIL_EUT_DISCOUNT_TEMPERATURE) return recipeEUt;
         int amountEUtDiscount = calculateAmountCoilEUtDiscount(providedTemp, requiredTemp);
         if (amountEUtDiscount < 1) return recipeEUt;
-        return (int) (recipeEUt * Math.min(1, Math.pow(0.95, amountEUtDiscount)));
+        return (long) (recipeEUt * Math.min(1, Math.pow(0.95, amountEUtDiscount)));
     }
 
+    @Deprecated
     public static int @NotNull [] heatingCoilOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration,
                                                                int maxOverclocks, int currentTemp,
                                                                int recipeRequiredTemp) {
-        int amountPerfectOC = calculateAmountCoilEUtDiscount(currentTemp, recipeRequiredTemp) / 2;
-
-        // perfect overclock for every 1800k over recipe temperature
-        if (amountPerfectOC > 0) {
-            // use the normal overclock logic to do perfect OCs up to as many times as calculated
-            int[] overclock = standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, amountPerfectOC,
-                    PERFECT_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER);
-
-            // overclock normally as much as possible after perfects are exhausted
-            return standardOverclockingLogic(overclock[0], maximumVoltage, overclock[1],
-                    maxOverclocks - amountPerfectOC, STANDARD_OVERCLOCK_DURATION_DIVISOR,
-                    STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER);
-        }
-
-        // no perfects are performed, do normal overclocking
-        return standardOverclockingLogic(recipeEUt, maximumVoltage, recipeDuration, maxOverclocks,
-                STANDARD_OVERCLOCK_DURATION_DIVISOR, STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER);
+        return null;
     }
 }

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -7,13 +7,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class OverclockingLogic {
 
-    @Deprecated
-    public static final double STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER = 4.0;
-    @Deprecated
-    public static final double STANDARD_OVERCLOCK_DURATION_DIVISOR = 2.0;
-    @Deprecated
-    public static final double PERFECT_OVERCLOCK_DURATION_DIVISOR = 4.0;
-
     public static final double STD_VOLTAGE_FACTOR = 4.0;
     public static final double PERFECT_HALF_VOLTAGE_FACTOR = 2.0;
 
@@ -108,7 +101,7 @@ public final class OverclockingLogic {
                 }
 
                 double potentialDuration = duration * durationFactor;
-                if (potentialDuration <= 1) {
+                if (potentialDuration < 1) {
                     duration = 1;
                     potentialEUt = eut * durationFactor;
                     if (potentialEUt > maxVoltage || potentialEUt < 1) {
@@ -163,7 +156,7 @@ public final class OverclockingLogic {
                 parallel /= durationFactor;
             } else {
                 double potentialDuration = duration * durationFactor;
-                if (potentialDuration <= 1) {
+                if (potentialDuration < 1) {
                     duration = 1;
                     parallel *= voltageFactor;
                     shouldParallel = true;
@@ -230,7 +223,7 @@ public final class OverclockingLogic {
                     potentialDuration = duration * STD_DURATION_FACTOR;
                 }
 
-                if (potentialDuration <= 1) {
+                if (potentialDuration < 1) {
                     duration = 1;
                     if (perfect) {
                         parallel *= PERFECT_DURATION_FACTOR_INV;
@@ -246,13 +239,6 @@ public final class OverclockingLogic {
         }
 
         result.init((long) (eut / parallel), (int) duration, (int) parallel, (long) eut);
-    }
-
-    @Deprecated
-    public static int @NotNull [] standardOverclockingLogic(int recipeEUt, long maxVoltage, int recipeDuration,
-                                                            int numberOfOCs,
-                                                            double durationDivisor, double voltageMultiplier) {
-        return null;
     }
 
     /**
@@ -277,12 +263,5 @@ public final class OverclockingLogic {
         int amountEUtDiscount = calculateAmountCoilEUtDiscount(providedTemp, requiredTemp);
         if (amountEUtDiscount < 1) return recipeEUt;
         return (long) (recipeEUt * Math.min(1, Math.pow(0.95, amountEUtDiscount)));
-    }
-
-    @Deprecated
-    public static int @NotNull [] heatingCoilOverclockingLogic(int recipeEUt, long maximumVoltage, int recipeDuration,
-                                                               int maxOverclocks, int currentTemp,
-                                                               int recipeRequiredTemp) {
-        return null;
     }
 }

--- a/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/OverclockingLogic.java
@@ -143,6 +143,7 @@ public final class OverclockingLogic {
         double eut = params.eut();
         int ocAmount = params.ocAmount();
         double parallel = 1;
+        int parallelIterAmount = 0;
         boolean shouldParallel = false;
 
         while (ocAmount-- > 0) {
@@ -154,11 +155,13 @@ public final class OverclockingLogic {
 
             if (shouldParallel) {
                 parallel /= durationFactor;
+                parallelIterAmount++;
             } else {
                 double potentialDuration = duration * durationFactor;
                 if (potentialDuration < 1) {
                     duration = 1;
-                    parallel *= voltageFactor;
+                    parallel /= durationFactor;
+                    parallelIterAmount++;
                     shouldParallel = true;
                 } else {
                     duration = potentialDuration;
@@ -166,7 +169,8 @@ public final class OverclockingLogic {
             }
         }
 
-        result.init((long) (eut / parallel), (int) duration, (int) parallel, (long) eut);
+        result.init((long) (eut / Math.pow(voltageFactor, parallelIterAmount)), (int) duration, (int) parallel,
+                (long) eut);
     }
 
     /**
@@ -198,6 +202,7 @@ public final class OverclockingLogic {
         double eut = params.eut();
         int ocAmount = params.ocAmount();
         double parallel = 1;
+        int parallelIterAmount = 0;
         boolean shouldParallel = false;
 
         while (ocAmount-- > 0) {
@@ -215,6 +220,7 @@ public final class OverclockingLogic {
                 } else {
                     parallel *= STD_DURATION_FACTOR_INV;
                 }
+                parallelIterAmount++;
             } else {
                 double potentialDuration;
                 if (perfect) {
@@ -231,6 +237,7 @@ public final class OverclockingLogic {
                         parallel *= STD_DURATION_FACTOR_INV;
                     }
 
+                    parallelIterAmount++;
                     shouldParallel = true;
                 } else {
                     duration = potentialDuration;
@@ -238,7 +245,8 @@ public final class OverclockingLogic {
             }
         }
 
-        result.init((long) (eut / parallel), (int) duration, (int) parallel, (long) eut);
+        result.init((long) (eut / Math.pow(STD_VOLTAGE_FACTOR, parallelIterAmount)), (int) duration, (int) parallel,
+                (long) eut);
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -8,6 +8,7 @@ import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.util.GTHashMaps;
+import gregtech.api.util.GTUtility;
 import gregtech.api.util.ItemStackHashStrategy;
 import gregtech.api.util.OverlayedFluidHandler;
 import gregtech.api.util.OverlayedItemHandler;
@@ -23,7 +24,11 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class ParallelLogic {
 
@@ -496,9 +501,9 @@ public abstract class ParallelLogic {
         limitByOutput = ParallelLogic.limitByOutputMerging(currentRecipe, exportInventory, exportFluids,
                 multiplierByInputs, voidItems, voidFluids);
 
-        int recipeEUt = currentRecipe.getEUt();
+        long recipeEUt = currentRecipe.getEUt();
         if (recipeEUt != 0) {
-            int limitByVoltage = Math.abs((int) (maxVoltage / recipeEUt));
+            int limitByVoltage = GTUtility.safeCastLongToInt(Math.abs(maxVoltage / recipeEUt));
             int parallelizable = Math.min(limitByVoltage, limitByOutput);
             if (parallelizable != 0)
                 // Use the minimum between the amount of recipes we can run with available inputs and amount of recipe

--- a/src/main/java/gregtech/api/recipes/ui/RecipeMapUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/RecipeMapUI.java
@@ -34,6 +34,8 @@ public class RecipeMapUI<R extends RecipeMap<?>> {
     private final boolean modifyFluidInputs;
     private final boolean modifyFluidOutputs;
 
+    private final boolean isGenerator;
+
     private TextureArea progressBarTexture = GuiTextures.PROGRESS_BAR_ARROW;
     private ProgressWidget.MoveType moveType = ProgressWidget.MoveType.HORIZONTAL;
     private @Nullable TextureArea specialTexture;
@@ -49,12 +51,13 @@ public class RecipeMapUI<R extends RecipeMap<?>> {
      * @param modifyFluidOutputs if fluid output amounts can be modified
      */
     public RecipeMapUI(@NotNull R recipeMap, boolean modifyItemInputs, boolean modifyItemOutputs,
-                       boolean modifyFluidInputs, boolean modifyFluidOutputs) {
+                       boolean modifyFluidInputs, boolean modifyFluidOutputs, boolean isGenerator) {
         this.recipeMap = recipeMap;
         this.modifyItemInputs = modifyItemInputs;
         this.modifyItemOutputs = modifyItemOutputs;
         this.modifyFluidInputs = modifyFluidInputs;
         this.modifyFluidOutputs = modifyFluidOutputs;
+        this.isGenerator = isGenerator;
     }
 
     /**
@@ -421,6 +424,13 @@ public class RecipeMapUI<R extends RecipeMap<?>> {
      */
     public boolean canModifyFluidOutputs() {
         return modifyFluidOutputs;
+    }
+
+    /**
+     * @return if this UI represents an energy generating recipemap
+     */
+    public boolean isGenerator() {
+        return isGenerator;
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/ui/impl/AssemblyLineUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/AssemblyLineUI.java
@@ -20,7 +20,7 @@ public final class AssemblyLineUI<R extends RecipeMap<?>> extends RecipeMapUI<R>
      * @param recipeMap the recipemap corresponding to this ui
      */
     public AssemblyLineUI(@NotNull R recipeMap) {
-        super(recipeMap, false, false, false, false);
+        super(recipeMap, false, false, false, false, false);
         setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, ProgressWidget.MoveType.HORIZONTAL);
     }
 

--- a/src/main/java/gregtech/api/recipes/ui/impl/CokeOvenUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/CokeOvenUI.java
@@ -19,7 +19,7 @@ public class CokeOvenUI<R extends RecipeMap<?>> extends RecipeMapUI<R> {
      * @param recipeMap the recipemap corresponding to this ui
      */
     public CokeOvenUI(@NotNull R recipeMap) {
-        super(recipeMap, false, false, false, false);
+        super(recipeMap, false, false, false, false, false);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/ui/impl/CrackerUnitUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/CrackerUnitUI.java
@@ -21,7 +21,7 @@ import java.util.function.DoubleSupplier;
 public class CrackerUnitUI<R extends RecipeMap<?>> extends RecipeMapUI<R> {
 
     public CrackerUnitUI(@NotNull R recipeMap) {
-        super(recipeMap, true, true, false, true);
+        super(recipeMap, true, true, false, true, false);
         setFluidSlotOverlay(GuiTextures.CRACKING_OVERLAY_1, false);
         setFluidSlotOverlay(GuiTextures.CRACKING_OVERLAY_2, true);
         setItemSlotOverlay(GuiTextures.CIRCUIT_OVERLAY, false);

--- a/src/main/java/gregtech/api/recipes/ui/impl/DistillationTowerUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/DistillationTowerUI.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 public class DistillationTowerUI<R extends RecipeMap<?>> extends RecipeMapUI<R> {
 
     public DistillationTowerUI(@NotNull R recipeMap) {
-        super(recipeMap, true, true, true, false);
+        super(recipeMap, true, true, true, false, false);
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/ui/impl/FormingPressUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/FormingPressUI.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 public class FormingPressUI<R extends RecipeMap<?>> extends RecipeMapUI<R> {
 
     public FormingPressUI(@NotNull R recipeMap) {
-        super(recipeMap, true, true, true, true);
+        super(recipeMap, true, true, true, true, false);
         setProgressBar(GuiTextures.PROGRESS_BAR_COMPRESS, ProgressWidget.MoveType.HORIZONTAL);
     }
 

--- a/src/main/java/gregtech/api/recipes/ui/impl/ResearchStationUI.java
+++ b/src/main/java/gregtech/api/recipes/ui/impl/ResearchStationUI.java
@@ -22,7 +22,7 @@ import java.util.function.DoubleSupplier;
 public class ResearchStationUI<R extends RecipeMap<?>> extends RecipeMapUI<R> {
 
     public ResearchStationUI(@NotNull R recipeMap) {
-        super(recipeMap, true, true, true, true);
+        super(recipeMap, true, true, true, true, false);
         setItemSlotOverlay(GuiTextures.SCANNER_OVERLAY, false);
         setItemSlotOverlay(GuiTextures.RESEARCH_STATION_OVERLAY, true);
         setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, ProgressWidget.MoveType.HORIZONTAL);

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -891,4 +891,14 @@ public class GTUtility {
                 (1.0 / (1 - splitPoint)) * (tracker.get() - splitPoint) : 0;
         return Pair.of(supplier1, supplier2);
     }
+
+    /**
+     * Safely cast a Long to an Int without overflow.
+     *
+     * @param v The Long value to cast to an Int.
+     * @return v, casted to Int, or Integer.MAX_VALUE if it would overflow.
+     */
+    public static int safeCastLongToInt(long v) {
+        return v > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) v;
+    }
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -896,7 +896,7 @@ public class GTUtility {
      * Safely cast a Long to an Int without overflow.
      *
      * @param v The Long value to cast to an Int.
-     * @return v, casted to Int, or Integer.MAX_VALUE if it would overflow.
+     * @return v, cast to Int, or Integer.MAX_VALUE if it would overflow.
      */
     public static int safeCastLongToInt(long v) {
         return v > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) v;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCrackingUnit.java
@@ -11,6 +11,7 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextComponentUtil;
@@ -149,16 +150,15 @@ public class MetaTileEntityCrackingUnit extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected void modifyOverclockPost(int[] resultOverclock, @NotNull IRecipePropertyStorage storage) {
-            super.modifyOverclockPost(resultOverclock, storage);
+        protected void modifyOverclockPost(@NotNull OCResult ocResult, @NotNull IRecipePropertyStorage storage) {
+            super.modifyOverclockPost(ocResult, storage);
 
             int coilTier = ((MetaTileEntityCrackingUnit) metaTileEntity).getCoilTier();
             if (coilTier <= 0)
                 return;
 
-            resultOverclock[0] *= 1.0f - coilTier * 0.1; // each coil above cupronickel (coilTier = 0) uses 10% less
-                                                         // energy
-            resultOverclock[0] = Math.max(1, resultOverclock[0]);
+            // each coil above cupronickel (coilTier = 0) uses 10% less energy
+            ocResult.setEut(Math.max(1, (long) (ocResult.eut() * (1.0 - coilTier * 0.1))));
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -36,6 +36,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -33,10 +33,8 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -180,40 +180,14 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
         }
 
         @Override
-        protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
-                                                      @NotNull IItemHandlerModifiable importInventory,
-                                                      @NotNull IMultipleTankHandler importFluids) {
-            this.overclockResults = calculateOverclock(recipe);
-
-            modifyOverclockPost(overclockResults, recipe.getRecipePropertyStorage());
-
-            if (!hasEnoughPower(overclockResults)) {
-                return false;
-            }
-
-            IItemHandlerModifiable exportInventory = getOutputInventory();
-
-            // We have already trimmed outputs and chanced outputs at this time
-            // Attempt to merge all outputs + chanced outputs into the output bus, to prevent voiding chanced outputs
-            if (!metaTileEntity.canVoidRecipeItemOutputs() &&
-                    !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
-                this.isOutputsFull = true;
-                return false;
-            }
-
+        protected boolean checkOutputSpaceFluids(@NotNull Recipe recipe, @NotNull IMultipleTankHandler exportFluids) {
             // We have already trimmed fluid outputs at this time
             if (!metaTileEntity.canVoidRecipeFluidOutputs() &&
                     !handler.applyFluidToOutputs(recipe.getAllFluidOutputs(), false)) {
                 this.isOutputsFull = true;
                 return false;
             }
-
-            this.isOutputsFull = false;
-            if (recipe.matches(true, importInventory, importFluids)) {
-                this.metaTileEntity.addNotifiedInput(importInventory);
-                return true;
-            }
-            return false;
+            return true;
         }
 
         @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -29,6 +29,7 @@ import gregtech.api.pattern.MultiblockShapeInfo;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.logic.OCParams;
 import gregtech.api.recipes.recipeproperties.FusionEUToStartProperty;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.util.RelativeDirection;
@@ -82,6 +83,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.DoubleSupplier;
+
+import static gregtech.api.recipes.logic.OverclockingLogic.PERFECT_HALF_DURATION_FACTOR;
+import static gregtech.api.recipes.logic.OverclockingLogic.PERFECT_HALF_VOLTAGE_FACTOR;
 
 public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
                                          implements IFastRenderMetaTileEntity, IBloomEffect {
@@ -577,13 +581,13 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
         }
 
         @Override
-        protected double getOverclockingDurationDivisor() {
-            return 2.0D;
+        protected double getOverclockingDurationFactor() {
+            return PERFECT_HALF_DURATION_FACTOR;
         }
 
         @Override
-        protected double getOverclockingVoltageMultiplier() {
-            return 2.0D;
+        protected double getOverclockingVoltageFactor() {
+            return PERFECT_HALF_VOLTAGE_FACTOR;
         }
 
         @Override
@@ -632,8 +636,8 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
         }
 
         @Override
-        protected void modifyOverclockPre(int @NotNull [] values, @NotNull IRecipePropertyStorage storage) {
-            super.modifyOverclockPre(values, storage);
+        protected void modifyOverclockPre(@NotNull OCParams ocParams, @NotNull IRecipePropertyStorage storage) {
+            super.modifyOverclockPre(ocParams, storage);
 
             // Limit the number of OCs to the difference in fusion reactor MK.
             // I.e., a MK2 reactor can overclock a MK1 recipe once, and a
@@ -641,7 +645,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
             long euToStart = storage.getRecipePropertyValue(FusionEUToStartProperty.getInstance(), 0L);
             int fusionTier = FusionEUToStartProperty.getFusionTier(euToStart);
             if (fusionTier != 0) fusionTier = MetaTileEntityFusionReactor.this.tier - fusionTier;
-            values[2] = Math.min(fusionTier, values[2]);
+            ocParams.setOcAmount(Math.min(fusionTier, ocParams.ocAmount()));
         }
 
         @NotNull

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
@@ -4,13 +4,20 @@ import gregtech.api.block.IHeatingCoilBlockStats;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.*;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
+import gregtech.api.metatileentity.multiblock.ParallelLogicType;
+import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.machines.RecipeMapFurnace;
+import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextComponentUtil;
 import gregtech.api.util.TextFormattingUtil;
@@ -24,13 +31,16 @@ import gregtech.core.sound.GTSoundEvents;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
-import net.minecraft.util.text.*;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+
+import static gregtech.api.recipes.logic.OverclockingLogic.standardOC;
 
 public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
 
@@ -194,6 +204,13 @@ public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
         @Override
         public ParallelLogicType getParallelLogicType() {
             return ParallelLogicType.APPEND_ITEMS;
+        }
+
+        @Override
+        protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                            @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+            standardOC(ocParams, ocResult, maxVoltage, getOverclockingDurationFactor(),
+                    getOverclockingVoltageFactor());
         }
 
         @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -9,13 +9,22 @@ import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.*;
+import gregtech.api.metatileentity.multiblock.DummyCleanroom;
+import gregtech.api.metatileentity.multiblock.ICleanroomProvider;
+import gregtech.api.metatileentity.multiblock.ICleanroomReceiver;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
+import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.OCParams;
+import gregtech.api.recipes.logic.OCResult;
+import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextComponentUtil;
 import gregtech.api.util.TextFormattingUtil;
@@ -47,6 +56,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 import static gregtech.api.GTValues.ULV;
+import static gregtech.api.recipes.logic.OverclockingLogic.subTickNonParallelOC;
 
 public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController implements IMachineHatchMultiblock {
 
@@ -377,7 +387,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         }
 
         @Override
-        protected int getNumberOfOCs(int recipeEUt) {
+        protected int getNumberOfOCs(long recipeEUt) {
             if (!isAllowOverclocking()) return 0;
 
             int recipeTier = Math.max(0,
@@ -391,6 +401,13 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
             if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
 
             return numberOfOCs;
+        }
+
+        @Override
+        protected void runOverclockingLogic(@NotNull OCParams ocParams, @NotNull OCResult ocResult,
+                                            @NotNull IRecipePropertyStorage propertyStorage, long maxVoltage) {
+            subTickNonParallelOC(ocParams, ocResult, maxVoltage, getOverclockingDurationFactor(),
+                    getOverclockingVoltageFactor());
         }
 
         private ItemStack getMachineStack() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -181,7 +181,7 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
                 return;
 
             if (coilTier == 0) {
-                // 25% slower with cupronickel (coilTier = 0)
+                // 75% speed with cupronickel (coilTier = 0)
                 ocResult.setDuration(Math.max(1, (int) (ocResult.duration() * 4.0 / 3)));
             } else {
                 // each coil above kanthal (coilTier = 1) is 50% faster

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -11,6 +11,7 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.logic.OCResult;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextComponentUtil;
@@ -172,22 +173,20 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected void modifyOverclockPost(int[] resultOverclock, @NotNull IRecipePropertyStorage storage) {
-            super.modifyOverclockPost(resultOverclock, storage);
+        protected void modifyOverclockPost(@NotNull OCResult ocResult, @NotNull IRecipePropertyStorage storage) {
+            super.modifyOverclockPost(ocResult, storage);
 
             int coilTier = ((MetaTileEntityPyrolyseOven) metaTileEntity).getCoilTier();
             if (coilTier == -1)
                 return;
 
             if (coilTier == 0) {
-                // 75% speed with cupronickel (coilTier = 0)
-                resultOverclock[1] = 4 * resultOverclock[1] / 3;
+                // 25% slower with cupronickel (coilTier = 0)
+                ocResult.setDuration(Math.max(1, (int) (ocResult.duration() * 4.0 / 3)));
             } else {
                 // each coil above kanthal (coilTier = 1) is 50% faster
-                resultOverclock[1] = resultOverclock[1] * 2 / (coilTier + 1);
+                ocResult.setDuration(Math.max(1, (int) (ocResult.duration() * 2.0 / (coilTier + 1))));
             }
-
-            resultOverclock[1] = Math.max(1, resultOverclock[1]);
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
@@ -262,12 +262,11 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
         }
 
         @Override
-        protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
-                                                      @NotNull IItemHandlerModifiable importInventory) {
+        protected @Nullable Recipe setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
+                                                               @NotNull IItemHandlerModifiable importInventory) {
             // this machine cannot overclock, so don't bother calling it
-            this.overclockResults = new int[] { recipe.getEUt(), recipe.getDuration() };
-            if (!hasEnoughPower(overclockResults)) {
-                return false;
+            if (!hasEnoughPower(recipe.getEUt(), recipe.getDuration())) {
+                return null;
             }
 
             // skip "can fit" checks, it can always fit
@@ -275,14 +274,14 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
             // do not consume inputs here, consume them on completion
             if (recipe.matches(false, importInventory, getInputTank())) {
                 this.metaTileEntity.addNotifiedInput(importInventory);
-                return true;
+                return recipe;
             }
-            return false;
+            return null;
         }
 
         // lock the object holder on recipe start
         @Override
-        protected void setupRecipe(Recipe recipe) {
+        protected void setupRecipe(@NotNull Recipe recipe) {
             IObjectHolder holder = getMetaTileEntity().getObjectHolder();
             holder.setLocked(true);
             super.setupRecipe(recipe);

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -86,7 +86,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
 
     private int getParallel(@NotNull Recipe recipe, double totalHolderEfficiencyCoefficient, long turbineMaxVoltage) {
         return MathHelper.ceil((turbineMaxVoltage - this.excessVoltage) /
-                (Math.abs(recipe.getEUt()) * totalHolderEfficiencyCoefficient));
+                (recipe.getEUt() * totalHolderEfficiencyCoefficient));
     }
 
     private boolean canDoRecipeWithParallel(Recipe recipe) {
@@ -155,7 +155,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
             }
 
             // this is necessary to prevent over-consumption of fuel
-            this.excessVoltage += (long) (parallel * Math.abs(recipe.getEUt()) * holderEfficiency - turbineMaxVoltage);
+            this.excessVoltage += (long) (parallel * recipe.getEUt() * holderEfficiency - turbineMaxVoltage);
         }
 
         // rebuild the recipe and adjust voltage to match the turbine

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -28,7 +29,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
 
     private final int BASE_EU_OUTPUT;
 
-    private int excessVoltage;
+    private long excessVoltage;
 
     public LargeTurbineWorkableHandler(RecipeMapMultiblockController metaTileEntity, int tier) {
         super(metaTileEntity);
@@ -83,7 +84,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
         return 0;
     }
 
-    private int getParallel(Recipe recipe, double totalHolderEfficiencyCoefficient, int turbineMaxVoltage) {
+    private int getParallel(@NotNull Recipe recipe, double totalHolderEfficiencyCoefficient, long turbineMaxVoltage) {
         return MathHelper.ceil((turbineMaxVoltage - this.excessVoltage) /
                 (Math.abs(recipe.getEUt()) * totalHolderEfficiencyCoefficient));
     }
@@ -93,7 +94,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
         if (rotorHolder == null || !rotorHolder.hasRotor())
             return false;
         double totalHolderEfficiencyCoefficient = rotorHolder.getTotalEfficiency() / 100.0;
-        int turbineMaxVoltage = (int) getMaxVoltage();
+        long turbineMaxVoltage = getMaxVoltage();
         int parallel = getParallel(recipe, totalHolderEfficiencyCoefficient, turbineMaxVoltage);
 
         FluidStack recipeFluidStack = recipe.getFluidInputs().get(0).getInputFluidStack();
@@ -136,7 +137,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
         if (rotorHolder == null || !rotorHolder.hasRotor())
             return false;
 
-        int turbineMaxVoltage = (int) getMaxVoltage();
+        long turbineMaxVoltage = getMaxVoltage();
         FluidStack recipeFluidStack = recipe.getFluidInputs().get(0).getInputFluidStack();
         int parallel = 0;
 
@@ -154,7 +155,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
             }
 
             // this is necessary to prevent over-consumption of fuel
-            this.excessVoltage += (int) (parallel * Math.abs(recipe.getEUt()) * holderEfficiency - turbineMaxVoltage);
+            this.excessVoltage += (long) (parallel * Math.abs(recipe.getEUt()) * holderEfficiency - turbineMaxVoltage);
         }
 
         // rebuild the recipe and adjust voltage to match the turbine
@@ -164,17 +165,20 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
         applyParallelBonus(recipeBuilder);
         recipe = recipeBuilder.build().getResult();
 
-        if (recipe != null && setupAndConsumeRecipeInputs(recipe, getInputInventory())) {
-            setupRecipe(recipe);
-            return true;
+        if (recipe != null) {
+            recipe = setupAndConsumeRecipeInputs(recipe, getInputInventory());
+            if (recipe != null) {
+                setupRecipe(recipe);
+                return true;
+            }
         }
         return false;
     }
 
     @Override
     public void invalidate() {
-        excessVoltage = 0;
         super.invalidate();
+        excessVoltage = 0;
     }
 
     public void updateTanks() {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeCombustionEngine.java
@@ -10,7 +10,12 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.*;
+import gregtech.api.metatileentity.multiblock.FuelMultiblockController;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.IProgressBarMultiblock;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.metatileentity.multiblock.MultiblockDisplayText;
+import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
@@ -425,8 +430,8 @@ public class MetaTileEntityLargeCombustionEngine extends FuelMultiblockControlle
 
         @Override
         public void invalidate() {
-            isOxygenBoosted = false;
             super.invalidate();
+            isOxygenBoosted = false;
         }
     }
 }

--- a/src/main/java/gregtech/integration/crafttweaker/recipe/CTRecipe.java
+++ b/src/main/java/gregtech/integration/crafttweaker/recipe/CTRecipe.java
@@ -81,7 +81,7 @@ public class CTRecipe {
     }
 
     @ZenGetter("EUt")
-    public int getEUt() {
+    public long getEUt() {
         return this.backingRecipe.getEUt();
     }
 

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -65,7 +65,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
         if (accessor.getNBTData().hasKey("gregtech.AbstractRecipeLogic")) {
             NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.AbstractRecipeLogic");
             if (tag.getBoolean("Working")) {
-                int eut = tag.getInteger("RecipeEUt");
+                long eut = tag.getLong("RecipeEUt");
                 boolean consumer = false;
                 String endText = null;
 

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -65,16 +65,15 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
         if (accessor.getNBTData().hasKey("gregtech.AbstractRecipeLogic")) {
             NBTTagCompound tag = accessor.getNBTData().getCompoundTag("gregtech.AbstractRecipeLogic");
             if (tag.getBoolean("Working")) {
-                int EUt = tag.getInteger("RecipeEUt");
-                int absEUt = Math.abs(EUt);
-                boolean consumer = EUt > 0;
+                int eut = tag.getInteger("RecipeEUt");
+                boolean consumer = false;
                 String endText = null;
 
                 if (accessor.getTileEntity() instanceof IGregTechTileEntity gtte) {
                     MetaTileEntity mte = gtte.getMetaTileEntity();
                     if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                             mte instanceof RecipeMapSteamMultiblockController) {
-                        endText = ": " + TextFormattingUtil.formatNumbers(absEUt) + TextFormatting.RESET + " L/t " +
+                        endText = ": " + TextFormattingUtil.formatNumbers(eut) + TextFormatting.RESET + " L/t " +
                                 I18n.format(Materials.Steam.getUnlocalizedName());
                     }
                     AbstractRecipeLogic arl = mte.getRecipeLogic();
@@ -83,11 +82,11 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                     }
                 }
                 if (endText == null) {
-                    endText = ": " + TextFormattingUtil.formatNumbers(absEUt) + TextFormatting.RESET + " EU/t (" +
-                            GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.RESET + ")";
+                    endText = ": " + TextFormattingUtil.formatNumbers(eut) + TextFormatting.RESET + " EU/t (" +
+                            GTValues.VNF[GTUtility.getTierByVoltage(eut)] + TextFormatting.RESET + ")";
                 }
 
-                if (EUt == 0) return tooltip;
+                if (eut == 0) return tooltip;
 
                 if (consumer) {
                     tooltip.add(I18n.format("gregtech.top.energy_consumption") + endText);

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -48,7 +48,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
         NBTTagCompound subTag = new NBTTagCompound();
         subTag.setBoolean("Working", capability.isWorking());
         if (capability.isWorking() && !(capability instanceof PrimitiveRecipeLogic)) {
-            subTag.setInteger("RecipeEUt", capability.getInfoProviderEUt());
+            subTag.setLong("RecipeEUt", capability.getInfoProviderEUt());
         }
         tag.setTag("gregtech.AbstractRecipeLogic", subTag);
         return tag;

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -253,7 +253,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
         // Default entries
         if (drawTotalEU) {
-            long eu = Math.abs(recipe.getEUt()) * recipe.getDuration();
+            long eu = recipe.getEUt() * recipe.getDuration();
             // sadly we still need a custom override here, since computation uses duration and EU/t very differently
             if (recipe.hasProperty(TotalComputationProperty.getInstance()) &&
                     recipe.hasProperty(ComputationProperty.getInstance())) {
@@ -266,14 +266,16 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         }
         if (drawEUt) {
             minecraft.fontRenderer.drawString(
-                    I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted",
-                            Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]),
+                    I18n.format(
+                            recipeMap.getRecipeMapUI().isGenerator() ? "gregtech.recipe.eu_inverted" :
+                                    "gregtech.recipe.eu",
+                            recipe.getEUt(), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]),
                     0, yPosition += LINE_HEIGHT, 0x111111);
         }
         if (drawDuration) {
             minecraft.fontRenderer.drawString(
                     I18n.format("gregtech.recipe.duration",
-                            TextFormattingUtil.formatNumbers(recipe.getDuration() / 20d)),
+                            TextFormattingUtil.formatNumbers(recipe.getDuration() / 20.0)),
                     0, yPosition += LINE_HEIGHT, 0x111111);
         }
 

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -40,7 +40,11 @@ import mezz.jei.api.ingredients.VanillaTypes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
@@ -249,7 +253,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
         // Default entries
         if (drawTotalEU) {
-            long eu = Math.abs((long) recipe.getEUt()) * recipe.getDuration();
+            long eu = Math.abs(recipe.getEUt()) * recipe.getDuration();
             // sadly we still need a custom override here, since computation uses duration and EU/t very differently
             if (recipe.hasProperty(TotalComputationProperty.getInstance()) &&
                     recipe.hasProperty(ComputationProperty.getInstance())) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -45,8 +45,8 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             if (capability instanceof PrimitiveRecipeLogic) {
                 return; // do not show info for primitive machines, as they are supposed to appear powerless
             }
-            int EUt = capability.getInfoProviderEUt();
-            int absEUt = Math.abs(EUt);
+            long EUt = capability.getInfoProviderEUt();
+            long absEUt = Math.abs(EUt);
             String text = null;
 
             if (tileEntity instanceof IGregTechTileEntity) {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -45,8 +45,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             if (capability instanceof PrimitiveRecipeLogic) {
                 return; // do not show info for primitive machines, as they are supposed to appear powerless
             }
-            long EUt = capability.getInfoProviderEUt();
-            long absEUt = Math.abs(EUt);
+            long eut = capability.getInfoProviderEUt();
             String text = null;
 
             if (tileEntity instanceof IGregTechTileEntity) {
@@ -54,7 +53,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 MetaTileEntity mte = gtTileEntity.getMetaTileEntity();
                 if (mte instanceof SteamMetaTileEntity || mte instanceof MetaTileEntityLargeBoiler ||
                         mte instanceof RecipeMapSteamMultiblockController) {
-                    text = TextFormatting.AQUA.toString() + TextFormattingUtil.formatNumbers(absEUt) +
+                    text = TextFormatting.AQUA + TextFormattingUtil.formatNumbers(eut) +
                             TextStyleClass.INFO + " L/t {*" +
                             Materials.Steam.getUnlocalizedName() + "*}";
                 }
@@ -62,12 +61,12 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
             if (text == null) {
                 // Default behavior, if this TE is not a steam machine (or somehow not instanceof
                 // IGregTechTileEntity...)
-                text = TextFormatting.RED.toString() + TextFormattingUtil.formatNumbers(absEUt) + TextStyleClass.INFO +
+                text = TextFormatting.RED + TextFormattingUtil.formatNumbers(eut) + TextStyleClass.INFO +
                         " EU/t" + TextFormatting.GREEN +
-                        " (" + GTValues.VNF[GTUtility.getTierByVoltage(absEUt)] + TextFormatting.GREEN + ")";
+                        " (" + GTValues.VNF[GTUtility.getTierByVoltage(eut)] + TextFormatting.GREEN + ")";
             }
 
-            if (EUt == 0) return; // idk what to do for 0 eut
+            if (eut == 0) return; // do not display 0 eut
 
             if (capability.consumesEnergy()) {
                 probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);

--- a/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/FuelRecipes.java
@@ -12,91 +12,91 @@ public class FuelRecipes {
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Naphtha.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricLightFuel.getFluid(4))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Methanol.getFluid(4))
                 .duration(8)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Ethanol.getFluid(1))
                 .duration(6)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Octane.getFluid(2))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(BioDiesel.getFluid(1))
                 .duration(8)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(LightFuel.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Diesel.getFluid(1))
                 .duration(15)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(CetaneBoostedDiesel.getFluid(2))
                 .duration(45)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(RocketFuel.getFluid(16))
                 .duration(125)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Gasoline.getFluid(1))
                 .duration(50)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(HighOctaneGasoline.getFluid(1))
                 .duration(100)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Toluene.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(OilLight.getFluid(32))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(RawOil.getFluid(64))
                 .duration(15)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         // steam generator fuels
@@ -104,159 +104,159 @@ public class FuelRecipes {
                 .fluidInputs(Steam.getFluid(640))
                 .fluidOutputs(DistilledWater.getFluid(4))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         // gas turbine fuels
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(NaturalGas.getFluid(8))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(WoodGas.getFluid(8))
                 .duration(6)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricGas.getFluid(32))
                 .duration(25)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricNaphtha.getFluid(4))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(CoalGas.getFluid(1))
                 .duration(3)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Methane.getFluid(2))
                 .duration(7)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Ethylene.getFluid(1))
                 .duration(4)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(RefineryGas.getFluid(1))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Ethane.getFluid(4))
                 .duration(21)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Propene.getFluid(1))
                 .duration(6)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Butadiene.getFluid(16))
                 .duration(102)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Propane.getFluid(4))
                 .duration(29)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Butene.getFluid(1))
                 .duration(8)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Phenol.getFluid(1))
                 .duration(9)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Benzene.getFluid(1))
                 .duration(11)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(Butane.getFluid(4))
                 .duration(37)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder()
                 .fluidInputs(LPG.getFluid(1))
                 .duration(10)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.GAS_TURBINE_FUELS.recipeBuilder() // TODO Too OP pls nerf
                 .fluidInputs(Nitrobenzene.getFluid(1))
                 .duration(40)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         // semi-fluid fuels, like creosote
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Creosote.getFluid(16))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Biomass.getFluid(4))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Oil.getFluid(2))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(OilHeavy.getFluid(16))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(SulfuricHeavyFuel.getFluid(16))
                 .duration(5)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(HeavyFuel.getFluid(8))
                 .duration(15)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         RecipeMaps.SEMI_FLUID_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(FishOil.getFluid(16))
                 .duration(1)
-                .EUt((int) V[LV])
+                .EUt(V[LV])
                 .buildAndRegister();
 
         // plasma turbine
@@ -264,56 +264,56 @@ public class FuelRecipes {
                 .fluidInputs(Helium.getPlasma(1))
                 .fluidOutputs(Helium.getFluid(1))
                 .duration(40)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Oxygen.getPlasma(1))
                 .fluidOutputs(Oxygen.getFluid(1))
                 .duration(48)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Nitrogen.getPlasma(1))
                 .fluidOutputs(Nitrogen.getFluid(1))
                 .duration(64)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Argon.getPlasma(1))
                 .fluidOutputs(Argon.getFluid(1))
                 .duration(96)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Iron.getPlasma(1))
                 .fluidOutputs(Iron.getFluid(1))
                 .duration(112)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Tin.getPlasma(1))
                 .fluidOutputs(Tin.getFluid(1))
                 .duration(128)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Nickel.getPlasma(1))
                 .fluidOutputs(Nickel.getFluid(1))
                 .duration(192)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
 
         RecipeMaps.PLASMA_GENERATOR_FUELS.recipeBuilder()
                 .fluidInputs(Americium.getPlasma(1))
                 .fluidOutputs(Americium.getFluid(1))
                 .duration(320)
-                .EUt((int) V[EV])
+                .EUt(V[EV])
                 .buildAndRegister();
     }
 }

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -85,7 +85,7 @@ public class AbstractRecipeLogicTest {
         arl.setSpeedBonus(0.2);  // 20% faster than normal
 
         queryTestRecipe(arl);
-        MatcherAssert.assertThat(arl.recipeEUt, is((int) Math.round(initialEUt * 0.75)));
+        MatcherAssert.assertThat(arl.recipeEUt, is(Math.round(initialEUt * 0.75)));
         MatcherAssert.assertThat(arl.maxProgressTime, is((int) Math.round(initialDuration * 0.2)));
     }
 
@@ -105,7 +105,7 @@ public class AbstractRecipeLogicTest {
         // be able to parallel 2 times.
         MatcherAssert.assertThat(arl.parallelRecipesPerformed, is(2));
         // Because of the parallel, now the paralleled recipe EU/t should be back to 30 EU/t.
-        MatcherAssert.assertThat(arl.recipeEUt, is(30));
+        MatcherAssert.assertThat(arl.recipeEUt, is(30L));
         // Duration should be static regardless of parallels.
         MatcherAssert.assertThat(arl.maxProgressTime, is((int) Math.round(initialDuration * 0.2)));
     }

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -158,7 +158,7 @@ public class AbstractRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -194,7 +194,7 @@ public class MultiblockRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 
@@ -441,7 +441,7 @@ public class MultiblockRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 
@@ -668,7 +668,7 @@ public class MultiblockRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -525,7 +525,7 @@ public class IParallelableRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 
@@ -600,7 +600,7 @@ public class IParallelableRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 
@@ -665,7 +665,7 @@ public class IParallelableRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 
@@ -732,7 +732,7 @@ public class IParallelableRecipeLogicTest {
             }
 
             @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+            protected boolean drawEnergy(long recipeEUt, boolean simulate) {
                 return true;
             }
 

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -237,7 +237,7 @@ public class IParallelableRecipeLogicTest {
         MatcherAssert.assertThat(parallelRecipe.getParallel(), is(4));
 
         // Check that the EUt of the recipe was multiplied correctly
-        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(120));
+        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(120L));
 
         // Check if the recipe duration was not modified
         MatcherAssert.assertThat(parallelRecipe.getDuration(), is(100));
@@ -290,7 +290,7 @@ public class IParallelableRecipeLogicTest {
         MatcherAssert.assertThat(parallelRecipe.getParallel(), is(2));
 
         // Check that the EUt of the recipe was multiplied correctly
-        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(60));
+        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(60L));
 
         // Check if the recipe duration was not modified
         MatcherAssert.assertThat(parallelRecipe.getDuration(), is(100));
@@ -346,7 +346,7 @@ public class IParallelableRecipeLogicTest {
         MatcherAssert.assertThat(parallelRecipe.getParallel(), is(4));
 
         // Check that the EUt of the recipe was multiplied correctly
-        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(1920));
+        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(1920L));
 
         // Check if the recipe duration was not modified
         MatcherAssert.assertThat(parallelRecipe.getDuration(), is(10));
@@ -399,7 +399,7 @@ public class IParallelableRecipeLogicTest {
         MatcherAssert.assertThat(parallelRecipe.getParallel(), is(2));
 
         // Check that the EUt of the recipe was multiplied correctly
-        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(960));
+        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(960L));
 
         // Check if the recipe duration was not modified
         MatcherAssert.assertThat(parallelRecipe.getDuration(), is(10));
@@ -446,7 +446,7 @@ public class IParallelableRecipeLogicTest {
         MatcherAssert.assertThat(parallelRecipe.getParallel(), is(4));
 
         // Check that the EUt of the recipe was not modified
-        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(30));
+        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(30L));
 
         // Check if the recipe duration was multiplied correctly
         MatcherAssert.assertThat(parallelRecipe.getDuration(), is(400));
@@ -493,7 +493,7 @@ public class IParallelableRecipeLogicTest {
         MatcherAssert.assertThat(parallelRecipe.getParallel(), is(2));
 
         // Check that the EUt of the recipe was not modified
-        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(30));
+        MatcherAssert.assertThat(parallelRecipe.getEUt(), is(30L));
 
         // Check if the recipe duration was multiplied correctly
         MatcherAssert.assertThat(parallelRecipe.getDuration(), is(200));
@@ -568,7 +568,7 @@ public class IParallelableRecipeLogicTest {
                 exportFluidBus.getExportFluids(), 128, parallelLimit);
 
         // Check that the EUt of the recipe was multiplied correctly
-        MatcherAssert.assertThat(outputRecipe.getEUt(), is(120));
+        MatcherAssert.assertThat(outputRecipe.getEUt(), is(120L));
 
         // Check if the recipe duration was not modified
         MatcherAssert.assertThat(outputRecipe.getDuration(), is(100));
@@ -775,7 +775,7 @@ public class IParallelableRecipeLogicTest {
                 exportFluidBus.getExportFluids(), 128, parallelLimit);
 
         // Check that the EUt of the recipe was not modified
-        MatcherAssert.assertThat(outputRecipe.getEUt(), is(1));
+        MatcherAssert.assertThat(outputRecipe.getEUt(), is(1L));
 
         // Check if the recipe duration was multiplied correctly
         MatcherAssert.assertThat(outputRecipe.getDuration(), is(50));

--- a/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
@@ -143,6 +143,16 @@ class OverclockingTest {
         assertThat(oc.duration(), is(1));
         assertThat(oc.parallel(), is(2));
         assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4));
+
+        // LV recipe, EV machine
+        machineTier = EV;
+
+        oc = testSubTickParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(1));
+        assertThat(oc.parallel(), is(2 * 2));
+        assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4 * 4));
     }
 
     @Test
@@ -154,7 +164,8 @@ class OverclockingTest {
         // LV recipe, LV machine
         int machineTier = LV;
 
-        OCResult oc = testSubTickParallelPerfectOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+        OCResult oc = testSubTickParallelPerfectOC(recipeDuration, recipeTier, recipeVoltage, machineTier,
+                V[machineTier]);
 
         assertThat(oc.eut(), is(recipeVoltage));
         assertThat(oc.duration(), is(recipeDuration));
@@ -179,6 +190,16 @@ class OverclockingTest {
         assertThat(oc.duration(), is(recipeDuration));
         assertThat(oc.parallel(), is(4 * 4));
         assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4));
+
+        // LV recipe, HV machine
+        machineTier = EV;
+
+        oc = testSubTickParallelPerfectOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
+        assertThat(oc.parallel(), is(4 * 4 * 4));
+        assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4 * 4));
     }
 
     @Test
@@ -211,6 +232,15 @@ class OverclockingTest {
         oc = testSubTickNonParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         assertThat(oc.eut(), is(recipeVoltage * 4 / 2));
+        assertThat(oc.duration(), is(recipeDuration / 2));
+        assertThat(oc.parallel(), is(0));
+
+        // LV recipe, EV machine
+        machineTier = EV;
+
+        oc = testSubTickNonParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage));
         assertThat(oc.duration(), is(recipeDuration / 2));
         assertThat(oc.parallel(), is(0));
     }
@@ -254,7 +284,7 @@ class OverclockingTest {
         final long recipeVoltage = V[recipeTier];
 
         // LV recipe, HV machine
-        final int machineTier = HV;
+        int machineTier = HV;
 
         // 1800K recipe, 1800K machine
         OCResult oc = testHeatingSubtickOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800,
@@ -288,6 +318,46 @@ class OverclockingTest {
         assertThat(oc.duration(), is(1));
         assertThat(oc.parallel(), is(4));
         assertThat(oc.parallelEUt(), is((long) ((recipeVoltage * Math.pow(0.95, 4))) * 4 * 4));
+
+        // LV recipe, EV machine
+        machineTier = EV;
+
+        // 1800K recipe, 1800K machine
+        oc = testHeatingSubtickOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800,
+                1800);
+
+        // 0 EU discounts, 2 overclocks, 1 regular subtick overclock
+        assertThat(oc.eut(), is(recipeVoltage * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
+        assertThat(oc.parallel(), is(2));
+        assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4 * 4));
+
+        // 1800K recipe, 2700K machine
+        oc = testHeatingSubtickOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800, 2700);
+
+        // 1 EU discount, 2 overclocks, 1 regular subtick overclock
+        assertThat(oc.eut(), is((long) ((recipeVoltage * 0.95)) * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
+        assertThat(oc.parallel(), is(2));
+        assertThat(oc.parallelEUt(), is((long) ((recipeVoltage * 0.95)) * 4 * 4 * 4));
+
+        // 1800K recipe, 3600K machine
+        oc = testHeatingSubtickOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800, 3600);
+
+        // 2 EU discounts, 1 perfect overclock, 2 regular subtick overclock
+        assertThat(oc.eut(), is((long) ((recipeVoltage * Math.pow(0.95, 2))) * 4));
+        assertThat(oc.duration(), is(1));
+        assertThat(oc.parallel(), is(2 * 2));
+        assertThat(oc.parallelEUt(), is((long) ((recipeVoltage * Math.pow(0.95, 2))) * 4 * 4 * 4));
+
+        // 1800K recipe, 5400K machine
+        oc = testHeatingSubtickOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800, 5400);
+
+        // 4 EU discounts, 1 perfect overclock, 1 perfect subtick overclock, 1 regular subtick overclock
+        assertThat(oc.eut(), is((long) ((recipeVoltage * Math.pow(0.95, 4))) * 4));
+        assertThat(oc.duration(), is(1));
+        assertThat(oc.parallel(), is(4 * 2));
+        assertThat(oc.parallelEUt(), is((long) ((recipeVoltage * Math.pow(0.95, 4))) * 4 * 4 * 4));
     }
 
     @Test
@@ -319,6 +389,14 @@ class OverclockingTest {
 
         assertThat(oc.eut(), is(recipeVoltage * (2 * 2)));
         assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
+
+        // LuV recipe, UHV machine
+        machineTier = UHV;
+
+        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage * (2 * 2 * 2)));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2 * 2)));
     }
 
     private static @NotNull OCResult testOC(int recipeDuration, int recipeTier, long recipeVoltage, int machineTier,
@@ -364,9 +442,10 @@ class OverclockingTest {
         return ocResult;
     }
 
-    private static @NotNull OCResult testSubTickParallelPerfectOC(int recipeDuration, int recipeTier, long recipeVoltage,
-                                                           int machineTier,
-                                                           long maxVoltage) {
+    private static @NotNull OCResult testSubTickParallelPerfectOC(int recipeDuration, int recipeTier,
+                                                                  long recipeVoltage,
+                                                                  int machineTier,
+                                                                  long maxVoltage) {
         int ocAmount = machineTier - recipeTier;
         if (recipeTier == ULV) ocAmount--; // no ULV overclocking
 
@@ -381,7 +460,8 @@ class OverclockingTest {
         OCParams ocParams = new OCParams();
         ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
 
-        OverclockingLogic.subTickParallelOC(ocParams, ocResult, maxVoltage, PERFECT_DURATION_FACTOR, STD_VOLTAGE_FACTOR);
+        OverclockingLogic.subTickParallelOC(ocParams, ocResult, maxVoltage, PERFECT_DURATION_FACTOR,
+                STD_VOLTAGE_FACTOR);
 
         return ocResult;
     }
@@ -427,7 +507,8 @@ class OverclockingTest {
         OCParams ocParams = new OCParams();
         ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
 
-        OverclockingLogic.heatingCoilNonSubTickOC(ocParams, ocResult, maxVoltage, machineTemperature, recipeTemperature);
+        OverclockingLogic.heatingCoilNonSubTickOC(ocParams, ocResult, maxVoltage, machineTemperature,
+                recipeTemperature);
 
         return ocResult;
     }

--- a/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
@@ -1,226 +1,355 @@
 package gregtech.api.recipes.logic;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static gregtech.api.GTValues.*;
+import static gregtech.api.recipes.logic.OverclockingLogic.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-public class OverclockingTest {
+class OverclockingTest {
 
     @Test
-    public void testULV() {
+    void testULV() {
         final int recipeDuration = 32768;
         final int recipeTier = ULV;
-        final int recipeVoltage = (int) V[recipeTier];
+        final long recipeVoltage = V[recipeTier];
 
         // ULV recipe, LV machine
         int machineTier = LV;
 
-        int[] oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        OCResult oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         // 0 overclocks
-        assertThat(oc[0], is(recipeVoltage));
-        assertThat(oc[1], is(recipeDuration));
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
 
         // ULV recipe, MV machine
         machineTier = MV;
 
-        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         // 1 overclock
-        assertThat(oc[0], is(recipeVoltage * 4));
-        assertThat(oc[1], is(recipeDuration / 2));
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(recipeDuration / 2));
 
         // ULV recipe, HV machine
         machineTier = HV;
 
-        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         // 2 overclocks
-        assertThat(oc[0], is(recipeVoltage * ((int) Math.pow(4, 2))));
-        assertThat(oc[1], is(recipeDuration / ((int) Math.pow(2, 2))));
+        assertThat(oc.eut(), is(recipeVoltage * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
     }
 
     @Test
-    public void testULV2() {
+    void testULV2() {
         final int recipeDuration = 32768;
         final int recipeTier = ULV;
-        final int recipeVoltage = (int) V[recipeTier] * 2;
+        final long recipeVoltage = V[recipeTier] * 2;
 
         // ULV recipe, LV machine
         int machineTier = LV;
 
-        int[] oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        OCResult oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         // 0 overclocks
-        assertThat(oc[0], is(recipeVoltage));
-        assertThat(oc[1], is(recipeDuration));
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
 
         // ULV recipe, MV machine
         machineTier = MV;
 
-        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         // 1 overclock
-        assertThat(oc[0], is(recipeVoltage * 4));
-        assertThat(oc[1], is(recipeDuration / 2));
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(recipeDuration / 2));
 
         // ULV recipe, HV machine
         machineTier = HV;
 
-        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
         // 2 overclocks
-        assertThat(oc[0], is(recipeVoltage * ((int) Math.pow(4, 2))));
-        assertThat(oc[1], is(recipeDuration / ((int) Math.pow(2, 2))));
+        assertThat(oc.eut(), is(recipeVoltage * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
     }
 
     @Test
-    public void testLV() {
+    void testLV() {
         final int recipeDuration = 32768;
         final int recipeTier = LV;
-        final int recipeVoltage = (int) V[recipeTier];
+        final long recipeVoltage = V[recipeTier];
 
         // LV recipe, LV machine
         int machineTier = LV;
 
-        int[] oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        OCResult oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
-        assertThat(oc[0], is(recipeVoltage));
-        assertThat(oc[1], is(recipeDuration));
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
 
         // LV recipe, MV machine
         machineTier = MV;
 
-        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
-        assertThat(oc[0], is(recipeVoltage * 4));
-        assertThat(oc[1], is(recipeDuration / 2));
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(recipeDuration / 2));
 
         // LV recipe, HV machine
         machineTier = HV;
 
-        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
-        assertThat(oc[0], is(recipeVoltage * ((int) Math.pow(4, 2))));
-        assertThat(oc[1], is(recipeDuration / ((int) Math.pow(2, 2))));
+        assertThat(oc.eut(), is(recipeVoltage * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
     }
 
     @Test
-    public void testHeatingCoilsDiffTemp() {
+    void testSubTickParallel() {
+        final int recipeDuration = 2;
+        final int recipeTier = LV;
+        final long recipeVoltage = V[recipeTier];
+
+        // LV recipe, LV machine
+        int machineTier = LV;
+
+        OCResult oc = testSubTickParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
+        assertThat(oc.parallel(), lessThanOrEqualTo(1));
+
+        // LV recipe, MV machine
+        machineTier = MV;
+
+        oc = testSubTickParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(recipeDuration / 2));
+        assertThat(oc.parallel(), lessThanOrEqualTo(1));
+
+        // LV recipe, HV machine
+        machineTier = HV;
+
+        oc = testSubTickParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(1));
+        assertThat(oc.parallel(), is(4));
+        assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4));
+    }
+
+    @Test
+    void testSubTickNonParallel() {
+        final int recipeDuration = 2;
+        final int recipeTier = LV;
+        final long recipeVoltage = V[recipeTier];
+
+        // LV recipe, LV machine
+        int machineTier = LV;
+
+        OCResult oc = testSubTickNonParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
+        assertThat(oc.parallel(), is(0));
+
+        // LV recipe, MV machine
+        machineTier = MV;
+
+        oc = testSubTickNonParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage * 4));
+        assertThat(oc.duration(), is(recipeDuration / 2));
+        assertThat(oc.parallel(), is(0));
+
+        // LV recipe, HV machine
+        machineTier = HV;
+
+        oc = testSubTickNonParallelOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
+
+        assertThat(oc.eut(), is(recipeVoltage * 4 / 2));
+        assertThat(oc.duration(), is(recipeDuration / 2));
+        assertThat(oc.parallel(), is(0));
+    }
+
+    @Test
+    void testHeatingCoilsDiffTemp() {
         final int recipeDuration = 32768;
         final int recipeTier = LV;
-        final int recipeVoltage = (int) V[recipeTier];
+        final long recipeVoltage = V[recipeTier];
 
         // LV recipe, HV machine
         final int machineTier = HV;
 
         // 1800K recipe, 1800K machine
-        int[] oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier], 1800,
+        OCResult oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800,
                 1800);
 
         // 0 EU discounts, 2 overclocks
-        assertThat(oc[0], is(recipeVoltage * ((int) Math.pow(4, 2))));
-        assertThat(oc[1], is(recipeDuration / ((int) Math.pow(2, 2))));
+        assertThat(oc.eut(), is(recipeVoltage * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
 
         // 1800K recipe, 2700K machine
-        oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier], 1800, 2700);
+        oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800, 2700);
 
         // 1 EU discount, 2 overclocks
-        assertThat(oc[0], is(((int) (recipeVoltage * 0.95)) * ((int) Math.pow(4, 2))));
-        assertThat(oc[1], is(recipeDuration / ((int) Math.pow(2, 2))));
+        assertThat(oc.eut(), is((long) ((recipeVoltage * 0.95)) * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
 
         // 1800K recipe, 3600K machine
-        oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier], 1800, 3600);
+        oc = testHeatingOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier], 1800, 3600);
 
         // 2 EU discounts, 1 perfect overclock, 1 regular overclock
-        assertThat(oc[0], is(((int) (recipeVoltage * Math.pow(0.95, 2))) * ((int) Math.pow(4, 2))));
-        assertThat(oc[1], is(recipeDuration / 2 / 4));
+        assertThat(oc.eut(), is((long) ((recipeVoltage * Math.pow(0.95, 2))) * 4 * 4));
+        assertThat(oc.duration(), is(recipeDuration / 2 / 4));
     }
 
     @Test
-    public void testFusionReactor() {
+    void testFusionReactor() {
         final int recipeDuration = 32768;
         final int recipeTier = LuV;
-        final int recipeVoltage = (int) V[recipeTier];
+        final long recipeVoltage = V[recipeTier];
 
         // LuV recipe, LuV machine
         int machineTier = LuV;
 
-        int[] oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        OCResult oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
-        assertThat(oc[0], is(recipeVoltage));
-        assertThat(oc[1], is(recipeDuration));
+        assertThat(oc.eut(), is(recipeVoltage));
+        assertThat(oc.duration(), is(recipeDuration));
 
         // LuV recipe, ZPM machine
         machineTier = ZPM;
 
-        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
-        assertThat(oc[0], is(recipeVoltage * 2));
-        assertThat(oc[1], is(recipeDuration / 2));
+        assertThat(oc.eut(), is(recipeVoltage * 2));
+        assertThat(oc.duration(), is(recipeDuration / 2));
 
         // LuV recipe, UV machine
         machineTier = UV;
 
-        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, (int) V[machineTier]);
+        oc = testFusionOC(recipeDuration, recipeTier, recipeVoltage, machineTier, V[machineTier]);
 
-        assertThat(oc[0], is(recipeVoltage * ((int) Math.pow(2, 2))));
-        assertThat(oc[1], is(recipeDuration / ((int) Math.pow(2, 2))));
+        assertThat(oc.eut(), is(recipeVoltage * (2 * 2)));
+        assertThat(oc.duration(), is(recipeDuration / (2 * 2)));
     }
 
-    private static int[] testOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier,
-                                int maxVoltage) {
-        int numberOfOCs = machineTier - recipeTier;
-        if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
+    private static @NotNull OCResult testOC(int recipeDuration, int recipeTier, long recipeVoltage, int machineTier,
+                                            long maxVoltage) {
+        int ocAmount = machineTier - recipeTier;
+        if (recipeTier == ULV) ocAmount--; // no ULV overclocking
+
+        OCResult ocResult = new OCResult();
 
         // cannot overclock, so return the starting values
-        if (numberOfOCs <= 0) return new int[] { recipeVoltage, recipeDuration };
+        if (ocAmount <= 0) {
+            ocResult.init(recipeVoltage, recipeDuration);
+            return ocResult;
+        }
 
-        return OverclockingLogic.standardOverclockingLogic(
-                recipeVoltage,
-                maxVoltage,
-                recipeDuration,
-                numberOfOCs,
-                OverclockingLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR,
-                OverclockingLogic.STANDARD_OVERCLOCK_VOLTAGE_MULTIPLIER);
+        OCParams ocParams = new OCParams();
+        ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
+
+        OverclockingLogic.standardOC(ocParams, ocResult, maxVoltage, STD_DURATION_FACTOR, STD_VOLTAGE_FACTOR);
+
+        return ocResult;
     }
 
-    private static int[] testHeatingOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier,
-                                       int maxVoltage,
-                                       int recipeTemperature, int machineTemperature) {
-        int numberOfOCs = machineTier - recipeTier;
-        if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
+    private static @NotNull OCResult testSubTickParallelOC(int recipeDuration, int recipeTier, long recipeVoltage,
+                                                           int machineTier,
+                                                           long maxVoltage) {
+        int ocAmount = machineTier - recipeTier;
+        if (recipeTier == ULV) ocAmount--; // no ULV overclocking
+
+        OCResult ocResult = new OCResult();
+
+        // cannot overclock, so return the starting values
+        if (ocAmount <= 0) {
+            ocResult.init(recipeVoltage, recipeDuration);
+            return ocResult;
+        }
+
+        OCParams ocParams = new OCParams();
+        ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
+
+        OverclockingLogic.subTickParallelOC(ocParams, ocResult, maxVoltage, STD_DURATION_FACTOR, STD_VOLTAGE_FACTOR);
+
+        return ocResult;
+    }
+
+    private static @NotNull OCResult testSubTickNonParallelOC(int recipeDuration, int recipeTier, long recipeVoltage,
+                                                              int machineTier,
+                                                              long maxVoltage) {
+        int ocAmount = machineTier - recipeTier;
+        if (recipeTier == ULV) ocAmount--; // no ULV overclocking
+
+        OCResult ocResult = new OCResult();
+
+        // cannot overclock, so return the starting values
+        if (ocAmount <= 0) {
+            ocResult.init(recipeVoltage, recipeDuration);
+            return ocResult;
+        }
+
+        OCParams ocParams = new OCParams();
+        ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
+
+        OverclockingLogic.subTickNonParallelOC(ocParams, ocResult, maxVoltage, STD_DURATION_FACTOR, STD_VOLTAGE_FACTOR);
+
+        return ocResult;
+    }
+
+    private static @NotNull OCResult testHeatingOC(int recipeDuration, int recipeTier, long recipeVoltage,
+                                                   int machineTier, long maxVoltage, int recipeTemperature,
+                                                   int machineTemperature) {
+        int ocAmount = machineTier - recipeTier;
+        if (recipeTier == ULV) ocAmount--; // no ULV overclocking
+
+        OCResult ocResult = new OCResult();
 
         recipeVoltage = OverclockingLogic.applyCoilEUtDiscount(recipeVoltage, machineTemperature, recipeTemperature);
 
         // cannot overclock, so return the starting values
-        if (numberOfOCs <= 0) return new int[] { recipeVoltage, recipeDuration };
+        if (ocAmount <= 0) {
+            ocResult.init(recipeVoltage, recipeDuration);
+            return ocResult;
+        }
 
-        return OverclockingLogic.heatingCoilOverclockingLogic(
-                recipeVoltage,
-                maxVoltage,
-                recipeDuration,
-                numberOfOCs,
-                machineTemperature,
-                recipeTemperature);
+        OCParams ocParams = new OCParams();
+        ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
+
+        OverclockingLogic.heatingCoilOC(ocParams, ocResult, maxVoltage, machineTemperature, recipeTemperature);
+
+        return ocResult;
     }
 
-    private static int[] testFusionOC(int recipeDuration, int recipeTier, int recipeVoltage, int machineTier,
-                                      int maxVoltage) {
-        int numberOfOCs = machineTier - recipeTier;
-        if (recipeTier == ULV) numberOfOCs--; // no ULV overclocking
+    private static @NotNull OCResult testFusionOC(int recipeDuration, int recipeTier, long recipeVoltage,
+                                                  int machineTier, long maxVoltage) {
+        int ocAmount = machineTier - recipeTier;
+        if (recipeTier == ULV) ocAmount--; // no ULV overclocking
+
+        OCResult ocResult = new OCResult();
 
         // cannot overclock, so return the starting values
-        if (numberOfOCs <= 0) return new int[] { recipeVoltage, recipeDuration };
+        if (ocAmount <= 0) {
+            ocResult.init(recipeVoltage, recipeDuration);
+            return ocResult;
+        }
 
-        return OverclockingLogic.standardOverclockingLogic(
-                recipeVoltage,
-                maxVoltage,
-                recipeDuration,
-                numberOfOCs,
-                OverclockingLogic.STANDARD_OVERCLOCK_DURATION_DIVISOR,
-                2.0);
+        OCParams ocParams = new OCParams();
+        ocParams.initialize(recipeVoltage, recipeDuration, ocAmount);
+
+        OverclockingLogic.subTickParallelOC(ocParams, ocResult, maxVoltage, PERFECT_HALF_DURATION_FACTOR,
+                PERFECT_HALF_VOLTAGE_FACTOR);
+
+        return ocResult;
     }
 }

--- a/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/OverclockingTest.java
@@ -141,7 +141,7 @@ class OverclockingTest {
 
         assertThat(oc.eut(), is(recipeVoltage * 4));
         assertThat(oc.duration(), is(1));
-        assertThat(oc.parallel(), is(4));
+        assertThat(oc.parallel(), is(2));
         assertThat(oc.parallelEUt(), is(recipeVoltage * 4 * 4));
     }
 

--- a/src/test/java/gregtech/api/recipes/logic/ParallelLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/ParallelLogicTest.java
@@ -878,7 +878,7 @@ public class ParallelLogicTest {
         assertThat(testMaceratorRecipe, notNullValue());
 
         // 2 is the default EUt value assigned to macerator recipes when not specified
-        assertThat(testMaceratorRecipe.getEUt(), is(2 * parallelAmount));
+        assertThat(testMaceratorRecipe.getEUt(), is(2L * parallelAmount));
 
         // 150 is the default duration value assigned to macerator recipes when not specified
         assertThat(testMaceratorRecipe.getDuration(), is(150));


### PR DESCRIPTION
## What
This PR changes three components of recipe logic.

1. Changes eu/t to use `long` instead of `int` in `RecipeMap` and `RecipeLogic` code.
2. Removes negative eu/t values being used to denote generation part way through recipe logic. Negative eu/t is only set in `setupRecipe()` now. Otherwise it is always positive.
3. Implements sub-tick overclocking, and overhauls related overclocking code.

### Sub-Tick Overclocking

Sub-Tick Overclocking allows recipes to still gain benefits when overclocked beyond 1 tick. Previously overclocking just stopped at this point, but now it can continue and provide benefits for doing so. There are three types of overclocking behavior: standard, parallel sub-tick, and non-parallel subtick.

Standard overclocking behavior works identically to the original overclocking behavior. It overclocks as much as possible but stops once 1 tick recipe duration has been reached. This is the default logic used anywhere not covered by the following types.

Parallel Sub-Tick overclocking will overclock to 1 tick as usual. Starting with the overclock that brings the duration below 1 tick and all future overclocks, duration is kept at 1 tick, energy is increased, and parallel is increased by the amount the duration is divided by. An example would be a 4x energy and 0.5x duration overclock. When overclocking past one tick, energy is still 4x larger, but parallel is now `1 / 0.5 = 2`. After the overclock completes, the recipe will be parallelized with the `MULTIPLY` methodology. If there is not enough input to parallelize all the way, EUt is adjusted accordingly. This logic is used for standard multiblock machines.

Non-parallel Sub-Tick overclocking will overclock to 1 tick as usual. Starting with the overclock that brings duration below 1 tick and all future overclocks, duration is kept at 1 tick, and energy is divided by the duration divisor. For example, a 4x energy and 0.5x duration overclock, when overclocked past 1 tick, energy is now 0.5x smaller, and duration remains the same. This logic is used for single block machines, and the PA (since the PA runs single block machines).

## Implementation Details
Removed the arbitrary `int[]` arrays used to store overclocking values. These values now have dedicated classes and are re-used to limit allocations in recipe logic.

`AbstractRecipeLogic#subTickOC` currently is forced to copy the found recipe to override its `EUt`. I wanted to avoid modifying `ParallelLogic` if possible, so I left this current implementation. For the future if we decide to modify parallel code, we can likely get rid of the copy.

## Outcome
Moves recipe logic to use `long` instead of `int` for consistency with the energy API.
Cleans up negative eut behavior and ensure its consistency in recipe logic.
Implements sub-tick overclocking mechanics.

## Potential Compatibility Issues
Changes are fully breaking, but should not prove too difficult to resolve.
