### PR TITLE
Reduce allocations in RecipeBuilder

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -389,7 +389,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public R inputs(ItemStack input) {
         if (input == null || input.isEmpty()) {
-            GTLog.logger.error("Input cannot contain null or empty ItemStacks. Inputs: {}", input);
+            GTLog.logger.error("Input cannot be null or empty. Input: {}", input);
             GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
             recipeStatus = EnumValidationResult.INVALID;
         } else {
@@ -401,7 +401,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R inputs(ItemStack... inputs) {
         for (ItemStack input : inputs) {
             if (input == null || input.isEmpty()) {
-                GTLog.logger.error("Input cannot contain null or empty ItemStacks. Inputs: {}", input);
+                GTLog.logger.error("Inputs cannot contain null or empty ItemStacks. Inputs: {}", input);
                 GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
                 recipeStatus = EnumValidationResult.INVALID;
                 continue;
@@ -426,7 +426,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public R inputs(GTRecipeInput input) {
         if (input.getAmount() < 0) {
-            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount());
+            GTLog.logger.error("Input count cannot be less than 0. Actual: {}.", input.getAmount());
             GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
             recipeStatus = EnumValidationResult.INVALID;
         } else {
@@ -438,7 +438,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R inputs(GTRecipeInput... inputs) {
         for (GTRecipeInput input : inputs) {
             if (input.getAmount() < 0) {
-                GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount());
+                GTLog.logger.error("Input count cannot be less than 0. Actual: {}.", input.getAmount());
                 GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
                 recipeStatus = EnumValidationResult.INVALID;
                 continue;
@@ -590,7 +590,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         if (input != null && input.amount > 0) {
             this.fluidInputs.add(new GTRecipeFluidInput(input));
         } else if (input != null) {
-            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.amount);
+            GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", input.amount);
             GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
         } else {
             GTLog.logger.error("FluidStack cannot be null.");
@@ -604,7 +604,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             if (fluidStack != null && fluidStack.amount > 0) {
                 fluidIngredients.add(new GTRecipeFluidInput(fluidStack));
             } else if (fluidStack != null) {
-                GTLog.logger.error("Count cannot be less than 0. Actual: {}.", fluidStack.amount);
+                GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", fluidStack.amount);
                 GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
             } else {
                 GTLog.logger.error("FluidStack cannot be null.");

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -57,7 +57,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @see Recipe
@@ -388,6 +387,17 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return inputNBT(new GTRecipeItemInput(stack), matcher, condition);
     }
 
+    public R inputs(ItemStack input) {
+        if (input == null || input.isEmpty()) {
+            GTLog.logger.error("Input cannot contain null or empty ItemStacks. Inputs: {}", input);
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            recipeStatus = EnumValidationResult.INVALID;
+        } else {
+            this.inputs.add(new GTRecipeItemInput(input));
+        }
+        return (R) this;
+    }
+
     public R inputs(ItemStack... inputs) {
         for (ItemStack input : inputs) {
             if (input == null || input.isEmpty()) {
@@ -410,6 +420,17 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
                 continue;
             }
             this.inputs.add(new GTRecipeItemInput(input));
+        }
+        return (R) this;
+    }
+
+    public R inputs(GTRecipeInput input) {
+        if (input.getAmount() < 0) {
+            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount());
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            recipeStatus = EnumValidationResult.INVALID;
+        } else {
+            this.inputs.add(input);
         }
         return (R) this;
     }
@@ -532,6 +553,13 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return outputs(mte.getStackForm(amount));
     }
 
+    public R outputs(ItemStack output) {
+        if (output != null && !output.isEmpty()) {
+            this.outputs.add(output);
+        }
+        return (R) this;
+    }
+
     public R outputs(ItemStack... outputs) {
         return outputs(Arrays.asList(outputs));
     }
@@ -558,6 +586,18 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
+    public R fluidInputs(FluidStack input) {
+        if (input != null && input.amount > 0) {
+            this.fluidInputs.add(new GTRecipeFluidInput(input));
+        } else if (input != null) {
+            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.amount);
+            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+        } else {
+            GTLog.logger.error("FluidStack cannot be null.");
+        }
+        return (R) this;
+    }
+
     public R fluidInputs(FluidStack... fluidStacks) {
         ArrayList<GTRecipeInput> fluidIngredients = new ArrayList<>();
         for (FluidStack fluidStack : fluidStacks) {
@@ -579,13 +619,20 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
+    public R fluidOutputs(FluidStack output) {
+        if (output != null && output.amount > 0) {
+            this.fluidOutputs.add(output);
+        }
+        return (R) this;
+    }
+
     public R fluidOutputs(FluidStack... outputs) {
         return fluidOutputs(Arrays.asList(outputs));
     }
 
     public R fluidOutputs(Collection<FluidStack> outputs) {
         outputs = new ArrayList<>(outputs);
-        outputs.removeIf(Objects::isNull);
+        outputs.removeIf(o -> o == null || o.amount <= 0);
         this.fluidOutputs.addAll(outputs);
         return (R) this;
     }


### PR DESCRIPTION
## What
We very rarely actually utilize the varargs aspect of `RecipeBuilder` method, causing a lot of wasted allocations for single item arrays. This PR adds non-varargs methods for a single input, which is our most common case. This should reduce array allocations significantly.

## Outcome
Reduces memory allocations in recipe registration and recipe logic code.
