### PR TITLE
Add stairsRecipeName

### DIFF
--- a/src/main/java/gregtech/loaders/WoodTypeEntry.java
+++ b/src/main/java/gregtech/loaders/WoodTypeEntry.java
@@ -52,6 +52,8 @@ public final class WoodTypeEntry {
     public final String fenceGateRecipeName;
     @NotNull
     public final ItemStack stairs;
+    @Nullable
+    public final String stairsRecipeName;
     public final boolean addStairsCraftingRecipe;
     @NotNull
     public final ItemStack boat;
@@ -83,13 +85,14 @@ public final class WoodTypeEntry {
                           @NotNull ItemStack slab, @Nullable String slabRecipeName, boolean addSlabCraftingRecipe,
                           @NotNull ItemStack fence, @Nullable String fenceRecipeName,
                           @NotNull ItemStack fenceGate, @Nullable String fenceGateRecipeName, @NotNull ItemStack stairs,
-                          boolean addStairsCraftingRecipe, @NotNull ItemStack boat, @Nullable String boatRecipeName,
-                          @Nullable Material material, boolean addLogOreDict, boolean addPlanksOreDict,
-                          boolean addDoorsOreDict, boolean addSlabsOreDict, boolean addFencesOreDict,
-                          boolean addFenceGatesOreDict, boolean addStairsOreDict, boolean addPlanksUnificationInfo,
-                          boolean addDoorsUnificationInfo, boolean addSlabsUnificationInfo,
-                          boolean addFencesUnificationInfo, boolean addFenceGatesUnificationInfo,
-                          boolean addStairsUnificationInfo, boolean addBoatsUnificationInfo) {
+                          @Nullable String stairsRecipeName, boolean addStairsCraftingRecipe, @NotNull ItemStack boat,
+                          @Nullable String boatRecipeName, @Nullable Material material, boolean addLogOreDict,
+                          boolean addPlanksOreDict, boolean addDoorsOreDict, boolean addSlabsOreDict,
+                          boolean addFencesOreDict, boolean addFenceGatesOreDict, boolean addStairsOreDict,
+                          boolean addPlanksUnificationInfo, boolean addDoorsUnificationInfo,
+                          boolean addSlabsUnificationInfo, boolean addFencesUnificationInfo,
+                          boolean addFenceGatesUnificationInfo, boolean addStairsUnificationInfo,
+                          boolean addBoatsUnificationInfo) {
         this.modid = modid;
         this.woodName = woodName;
         this.log = log;
@@ -107,6 +110,7 @@ public final class WoodTypeEntry {
         this.fenceGate = fenceGate;
         this.fenceGateRecipeName = fenceGateRecipeName;
         this.stairs = stairs;
+        this.stairsRecipeName = stairsRecipeName;
         this.addStairsCraftingRecipe = addStairsCraftingRecipe;
         this.boat = boat;
         this.boatRecipeName = boatRecipeName;
@@ -153,6 +157,7 @@ public final class WoodTypeEntry {
         private ItemStack fenceGate = ItemStack.EMPTY;
         private String fenceGateRecipeName;
         private ItemStack stairs = ItemStack.EMPTY;
+        private String stairsRecipeName;
         private boolean addStairsCraftingRecipe;
         private ItemStack boat = ItemStack.EMPTY;
         private String boatRecipeName;
@@ -294,11 +299,13 @@ public final class WoodTypeEntry {
         /**
          * Add an entry for stairs
          *
-         * @param stairs the stairs to add
+         * @param stairs           the stairs to add
+         * @param stairsRecipeName the recipe name for crafting the stairs
          * @return this
          */
-        public Builder stairs(@NotNull ItemStack stairs) {
+        public Builder stairs(@NotNull ItemStack stairs, @Nullable String stairsRecipeName) {
             this.stairs = stairs;
+            this.stairsRecipeName = stairsRecipeName;
             return this;
         }
 
@@ -410,12 +417,11 @@ public final class WoodTypeEntry {
             Preconditions.checkArgument(!planks.isEmpty(), "Planks cannot be empty.");
             return new WoodTypeEntry(modid, woodName, log, removeCharcoalRecipe, addCharcoalRecipe, planks,
                     planksRecipeName, door, doorRecipeName, slab, slabRecipeName, addSlabsCraftingRecipe, fence,
-                    fenceRecipeName,
-                    fenceGate, fenceGateRecipeName, stairs, addStairsCraftingRecipe, boat, boatRecipeName, material,
-                    addLogOreDict, addPlanksOreDict, addDoorsOreDict, addSlabsOreDict, addFencesOreDict,
-                    addFenceGatesOreDict, addStairsOreDict, addPlanksUnificationInfo, addDoorsUnificationInfo,
-                    addSlabsUnificationInfo, addFencesUnificationInfo, addFenceGatesUnificationInfo,
-                    addStairsUnificationInfo, addBoatsUnificationInfo);
+                    fenceRecipeName, fenceGate, fenceGateRecipeName, stairs, stairsRecipeName, addStairsCraftingRecipe,
+                    boat, boatRecipeName, material, addLogOreDict, addPlanksOreDict, addDoorsOreDict, addSlabsOreDict,
+                    addFencesOreDict, addFenceGatesOreDict, addStairsOreDict, addPlanksUnificationInfo,
+                    addDoorsUnificationInfo, addSlabsUnificationInfo, addFencesUnificationInfo,
+                    addFenceGatesUnificationInfo, addStairsUnificationInfo, addBoatsUnificationInfo);
         }
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
@@ -49,7 +49,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(Blocks.WOODEN_SLAB), "oak_wooden_slab")
                             .fence(new ItemStack(Blocks.OAK_FENCE), "fence")
                             .fenceGate(new ItemStack(Blocks.OAK_FENCE_GATE), "fence_gate")
-                            .stairs(new ItemStack(Blocks.OAK_STAIRS))
+                            .stairs(new ItemStack(Blocks.OAK_STAIRS), "oak_stairs")
                             .boat(new ItemStack(Items.BOAT), "boat")
                             .registerAllUnificationInfo()
                             .build(),
@@ -60,7 +60,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 1), "spruce_wooden_slab")
                             .fence(new ItemStack(Blocks.SPRUCE_FENCE), "spruce_fence")
                             .fenceGate(new ItemStack(Blocks.SPRUCE_FENCE_GATE), "spruce_fence_gate")
-                            .stairs(new ItemStack(Blocks.SPRUCE_STAIRS))
+                            .stairs(new ItemStack(Blocks.SPRUCE_STAIRS), "spruce_stairs")
                             .boat(new ItemStack(Items.SPRUCE_BOAT), "spruce_boat")
                             .registerAllUnificationInfo()
                             .build(),
@@ -71,7 +71,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 2), "birch_wooden_slab")
                             .fence(new ItemStack(Blocks.BIRCH_FENCE), "birch_fence")
                             .fenceGate(new ItemStack(Blocks.BIRCH_FENCE_GATE), "birch_fence_gate")
-                            .stairs(new ItemStack(Blocks.BIRCH_STAIRS))
+                            .stairs(new ItemStack(Blocks.BIRCH_STAIRS), "birch_stairs")
                             .boat(new ItemStack(Items.BIRCH_BOAT), "birch_boat")
                             .registerAllUnificationInfo()
                             .build(),
@@ -82,7 +82,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 3), "jungle_wooden_slab")
                             .fence(new ItemStack(Blocks.JUNGLE_FENCE), "jungle_fence")
                             .fenceGate(new ItemStack(Blocks.JUNGLE_FENCE_GATE), "jungle_fence_gate")
-                            .stairs(new ItemStack(Blocks.JUNGLE_STAIRS))
+                            .stairs(new ItemStack(Blocks.JUNGLE_STAIRS), "jungle_stairs")
                             .boat(new ItemStack(Items.JUNGLE_BOAT), "jungle_boat")
                             .registerAllUnificationInfo()
                             .build(),
@@ -93,7 +93,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 4), "acacia_wooden_slab")
                             .fence(new ItemStack(Blocks.ACACIA_FENCE), "acacia_fence")
                             .fenceGate(new ItemStack(Blocks.ACACIA_FENCE_GATE), "acacia_fence_gate")
-                            .stairs(new ItemStack(Blocks.ACACIA_STAIRS))
+                            .stairs(new ItemStack(Blocks.ACACIA_STAIRS), "acacia_stairs")
                             .boat(new ItemStack(Items.ACACIA_BOAT), "acacia_boat")
                             .registerAllUnificationInfo()
                             .build(),
@@ -104,7 +104,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(Blocks.WOODEN_SLAB, 1, 5), "dark_oak_wooden_slab")
                             .fence(new ItemStack(Blocks.DARK_OAK_FENCE), "dark_oak_fence")
                             .fenceGate(new ItemStack(Blocks.DARK_OAK_FENCE_GATE), "dark_oak_fence_gate")
-                            .stairs(new ItemStack(Blocks.DARK_OAK_STAIRS))
+                            .stairs(new ItemStack(Blocks.DARK_OAK_STAIRS), "dark_oak_stairs")
                             .boat(new ItemStack(Items.DARK_OAK_BOAT), "dark_oak_boat")
                             .registerAllUnificationInfo()
                             .build(),
@@ -115,7 +115,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(MetaBlocks.WOOD_SLAB), null).addSlabRecipe()
                             .fence(new ItemStack(MetaBlocks.RUBBER_WOOD_FENCE), null)
                             .fenceGate(new ItemStack(MetaBlocks.RUBBER_WOOD_FENCE_GATE), null)
-                            .stairs(new ItemStack(MetaBlocks.RUBBER_WOOD_STAIRS)).addStairsRecipe()
+                            .stairs(new ItemStack(MetaBlocks.RUBBER_WOOD_STAIRS), null).addStairsRecipe()
                             .boat(MetaItems.RUBBER_WOOD_BOAT.getStackForm(), null)
                             .registerAllOres()
                             .registerAllUnificationInfo()
@@ -126,7 +126,7 @@ public class WoodRecipeLoader {
                             .slab(new ItemStack(MetaBlocks.WOOD_SLAB, 1, 1), null).addSlabRecipe()
                             .fence(new ItemStack(MetaBlocks.TREATED_WOOD_FENCE), null)
                             .fenceGate(new ItemStack(MetaBlocks.TREATED_WOOD_FENCE_GATE), null)
-                            .stairs(new ItemStack(MetaBlocks.TREATED_WOOD_STAIRS)).addStairsRecipe()
+                            .stairs(new ItemStack(MetaBlocks.TREATED_WOOD_STAIRS), null).addStairsRecipe()
                             .boat(MetaItems.TREATED_WOOD_BOAT.getStackForm(), null)
                             .material(TreatedWood)
                             .registerAllOres()
@@ -326,8 +326,10 @@ public class WoodRecipeLoader {
 
         // stairs
         if (!entry.stairs.isEmpty()) {
+            final boolean hasStairRecipe = entry.stairsRecipeName != null;
             if (entry.addStairsCraftingRecipe) {
-                ModHandler.addShapedRecipe(name + "_stairs", GTUtility.copy(4, entry.stairs),
+                ModHandler.addShapedRecipe(hasStairRecipe ? entry.stairsRecipeName : name + "_stairs",
+                        GTUtility.copy(4, entry.stairs),
                         "P  ", "PP ", "PPP",
                         'P', entry.planks.copy());
             }


### PR DESCRIPTION
## What
When a mod that introduces many different types of wood is used for a CEu recipe, only the stairs block could not be specified by name, so this has been supported.

## Outcome
The need to list another treatment when handling wood from many different woods, such as FFM and BOP, will be avoided.

## Potential Compatibility Issues
If you use `.stairs` in `WoodTypeEntry.Builder`, you must insert `null` or string type as the second arg.
