### PR TITLE
Fix potential MetaTileEntity NPE when calling a server side method on client

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -39,7 +39,6 @@ import gregtech.common.creativetab.GTCreativeTabs;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
@@ -812,19 +811,21 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     }
 
     public void update() {
+        if (!getWorld().isRemote && !allowTickAcceleration()) {
+            int currentTick = FMLCommonHandler.instance().getMinecraftServerInstance().getTickCounter();
+            if (currentTick == lastTick) {
+                return;
+            }
+            lastTick = currentTick;
+        }
+
         for (MTETrait mteTrait : this.mteTraits.values()) {
             if (shouldUpdate(mteTrait)) {
                 mteTrait.update();
             }
         }
+
         if (!getWorld().isRemote) {
-            if (!allowTickAcceleration()) {
-                int currentTick = FMLCommonHandler.instance().getMinecraftServerInstance().getTickCounter();
-                if (currentTick == lastTick) {
-                    return;
-                }
-                lastTick = currentTick;
-            }
             updateCovers();
         } else {
             updateSound();

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -39,6 +39,7 @@ import gregtech.common.creativetab.GTCreativeTabs;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.creativetab.CreativeTabs;
@@ -811,19 +812,19 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     }
 
     public void update() {
-        if (!allowTickAcceleration()) {
-            int currentTick = FMLCommonHandler.instance().getMinecraftServerInstance().getTickCounter();
-            if (currentTick == lastTick) {
-                return;
-            }
-            lastTick = currentTick;
-        }
         for (MTETrait mteTrait : this.mteTraits.values()) {
             if (shouldUpdate(mteTrait)) {
                 mteTrait.update();
             }
         }
         if (!getWorld().isRemote) {
+            if (!allowTickAcceleration()) {
+                int currentTick = FMLCommonHandler.instance().getMinecraftServerInstance().getTickCounter();
+                if (currentTick == lastTick) {
+                    return;
+                }
+                lastTick = currentTick;
+            }
             updateCovers();
         } else {
             updateSound();


### PR DESCRIPTION
## What
fixes a potential NPE when calling `getMinecraftServerInstance()` on the client side.
notably only affects the world accelerator by default.

## Implementation Details
moves the method call into a sided if check so it won't be called on client

## Outcome
no more NPE