### PR TITLE
cleanup stacktrace logging for recipe errors

### DIFF
--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -49,7 +49,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -752,6 +757,6 @@ public final class ModHandler {
     }
 
     public static void logInvalidRecipe(@NotNull String message) {
-        GTLog.logger.warn("Invalid Recipe Found", new IllegalArgumentException(message));
+        GTLog.logger.warn("Invalid Recipe Found: {}", message, new Throwable());
     }
 }

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -225,8 +225,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public R input(GTRecipeInput input) {
         if (input.getAmount() < 0) {
-            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount(), new Throwable());
         } else {
             this.inputs.add(input);
         }
@@ -295,18 +294,15 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public R inputNBT(GTRecipeInput input, NBTMatcher matcher, NBTCondition condition) {
         if (input.getAmount() < 0) {
-            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount(), new Throwable());
             return (R) this;
         }
         if (matcher == null) {
-            GTLog.logger.error("NBTMatcher must not be null");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("NBTMatcher must not be null", new Throwable());
             return (R) this;
         }
         if (condition == null) {
-            GTLog.logger.error("NBTCondition must not be null");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("NBTCondition must not be null", new Throwable());
             return (R) this;
         }
         this.inputs.add(input.setNBTMatchingCondition(matcher, condition));
@@ -389,8 +385,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public R inputs(ItemStack input) {
         if (input == null || input.isEmpty()) {
-            GTLog.logger.error("Input cannot be null or empty. Input: {}", input);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Input cannot be null or empty. Input: {}", input, new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         } else {
             this.inputs.add(new GTRecipeItemInput(input));
@@ -401,8 +396,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R inputs(ItemStack... inputs) {
         for (ItemStack input : inputs) {
             if (input == null || input.isEmpty()) {
-                GTLog.logger.error("Inputs cannot contain null or empty ItemStacks. Inputs: {}", input);
-                GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                GTLog.logger.error("Inputs cannot contain null or empty ItemStacks. Inputs: {}", input,
+                        new Throwable());
                 recipeStatus = EnumValidationResult.INVALID;
                 continue;
             }
@@ -414,8 +409,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R inputStacks(Collection<ItemStack> inputs) {
         for (ItemStack input : inputs) {
             if (input == null || input.isEmpty()) {
-                GTLog.logger.error("Input cannot contain null or empty ItemStacks. Inputs: {}", input);
-                GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                GTLog.logger.error("Input cannot contain null or empty ItemStacks. Inputs: {}", input, new Throwable());
                 recipeStatus = EnumValidationResult.INVALID;
                 continue;
             }
@@ -426,8 +420,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public R inputs(GTRecipeInput input) {
         if (input.getAmount() < 0) {
-            GTLog.logger.error("Input count cannot be less than 0. Actual: {}.", input.getAmount());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Input count cannot be less than 0. Actual: {}.", input.getAmount(), new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         } else {
             this.inputs.add(input);
@@ -438,8 +431,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R inputs(GTRecipeInput... inputs) {
         for (GTRecipeInput input : inputs) {
             if (input.getAmount() < 0) {
-                GTLog.logger.error("Input count cannot be less than 0. Actual: {}.", input.getAmount());
-                GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                GTLog.logger.error("Input count cannot be less than 0. Actual: {}.", input.getAmount(),
+                        new Throwable());
                 recipeStatus = EnumValidationResult.INVALID;
                 continue;
             }
@@ -451,8 +444,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R inputIngredients(Collection<GTRecipeInput> inputs) {
         for (GTRecipeInput input : inputs) {
             if (input.getAmount() < 0) {
-                GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount());
-                GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                GTLog.logger.error("Count cannot be less than 0. Actual: {}.", input.getAmount(), new Throwable());
                 recipeStatus = EnumValidationResult.INVALID;
                 continue;
             }
@@ -501,8 +493,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     public R circuitMeta(int circuitNumber) {
         if (IntCircuitIngredient.CIRCUIT_MIN > circuitNumber || circuitNumber > IntCircuitIngredient.CIRCUIT_MAX) {
             GTLog.logger.error("Integrated Circuit Number cannot be less than {} and more than {}",
-                    IntCircuitIngredient.CIRCUIT_MIN, IntCircuitIngredient.CIRCUIT_MAX);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid Integrated Circuit Number"));
+                    IntCircuitIngredient.CIRCUIT_MIN, IntCircuitIngredient.CIRCUIT_MAX, new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
             return (R) this;
         }
@@ -590,8 +581,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         if (input != null && input.amount > 0) {
             this.fluidInputs.add(new GTRecipeFluidInput(input));
         } else if (input != null) {
-            GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", input.amount);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", input.amount, new Throwable());
         } else {
             GTLog.logger.error("FluidStack cannot be null.");
         }
@@ -604,8 +594,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             if (fluidStack != null && fluidStack.amount > 0) {
                 fluidIngredients.add(new GTRecipeFluidInput(fluidStack));
             } else if (fluidStack != null) {
-                GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", fluidStack.amount);
-                GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", fluidStack.amount,
+                        new Throwable());
             } else {
                 GTLog.logger.error("FluidStack cannot be null.");
             }
@@ -648,8 +638,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         }
         if (0 >= chance || chance > ChancedOutputLogic.getMaxChancedValue()) {
             GTLog.logger.error("Chance cannot be less or equal to 0 or more than {}. Actual: {}.",
-                    ChancedOutputLogic.getMaxChancedValue(), chance);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                    ChancedOutputLogic.getMaxChancedValue(), chance, new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
             return (R) this;
         }
@@ -696,8 +685,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         }
         if (0 >= chance || chance > ChancedOutputLogic.getMaxChancedValue()) {
             GTLog.logger.error("Chance cannot be less or equal to 0 or more than {}. Actual: {}.",
-                    ChancedOutputLogic.getMaxChancedValue(), chance);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+                    ChancedOutputLogic.getMaxChancedValue(), chance, new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
             return (R) this;
         }
@@ -934,31 +922,31 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             return msg.postIfNotEmpty() ? EnumValidationResult.SKIP : EnumValidationResult.VALID;
         }
         if (EUt == 0) {
-            GTLog.logger.error("EU/t cannot be equal to 0", new IllegalArgumentException());
+            GTLog.logger.error("EU/t cannot be equal to 0", new Throwable());
             if (isCTRecipe) {
-                CraftTweakerAPI.logError("EU/t cannot be equal to 0", new IllegalArgumentException());
+                CraftTweakerAPI.logError("EU/t cannot be equal to 0", new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (duration <= 0) {
-            GTLog.logger.error("Duration cannot be less or equal to 0", new IllegalArgumentException());
+            GTLog.logger.error("Duration cannot be less or equal to 0", new Throwable());
             if (isCTRecipe) {
-                CraftTweakerAPI.logError("Duration cannot be less or equal to 0", new IllegalArgumentException());
+                CraftTweakerAPI.logError("Duration cannot be less or equal to 0", new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
         if (recipeMap != null) { // recipeMap can be null in tests
             if (category == null) {
-                GTLog.logger.error("Recipes must have a category", new IllegalArgumentException());
+                GTLog.logger.error("Recipes must have a category", new Throwable());
                 if (isCTRecipe) {
-                    CraftTweakerAPI.logError("Recipes must have a category", new IllegalArgumentException());
+                    CraftTweakerAPI.logError("Recipes must have a category", new Throwable());
                 }
                 recipeStatus = EnumValidationResult.INVALID;
             } else if (category.getRecipeMap() != this.recipeMap) {
-                GTLog.logger.error("Cannot apply Category with incompatible RecipeMap", new IllegalArgumentException());
+                GTLog.logger.error("Cannot apply Category with incompatible RecipeMap", new Throwable());
                 if (isCTRecipe) {
                     CraftTweakerAPI.logError("Cannot apply Category with incompatible RecipeMap",
-                            new IllegalArgumentException());
+                            new Throwable());
                 }
                 recipeStatus = EnumValidationResult.INVALID;
             }

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -462,11 +462,9 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
         boolean emptyInputs = recipe.getInputs().isEmpty() && recipe.getFluidInputs().isEmpty();
         if (emptyInputs) {
-            GTLog.logger.error("Invalid amount of recipe inputs. Recipe inputs are empty.");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+            GTLog.logger.error("Invalid amount of recipe inputs. Recipe inputs are empty.", new Throwable());
             if (recipe.getIsCTRecipe()) {
-                CraftTweakerAPI.logError("Invalid amount of recipe inputs. Recipe inputs are empty.");
-                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+                CraftTweakerAPI.logError("Invalid amount of recipe inputs. Recipe inputs are empty.", new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
@@ -474,11 +472,10 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 recipe.getFluidOutputs().isEmpty() && recipe.getChancedOutputs().getChancedEntries().isEmpty() &&
                 recipe.getChancedFluidOutputs().getChancedEntries().isEmpty();
         if (emptyOutputs) {
-            GTLog.logger.error("Invalid amount of recipe outputs. Recipe outputs are empty.");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+            GTLog.logger.error("Invalid amount of recipe outputs. Recipe outputs are empty.", new Throwable());
             if (recipe.getIsCTRecipe()) {
-                CraftTweakerAPI.logError("Invalid amount of outputs inputs. Recipe outputs are empty.");
-                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+                CraftTweakerAPI.logError("Invalid amount of outputs inputs. Recipe outputs are empty.",
+                        new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
@@ -486,12 +483,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         int amount = recipe.getInputs().size();
         if (amount > getMaxInputs()) {
             GTLog.logger.error("Invalid amount of recipe inputs. Actual: {}. Should be at most {}.", amount,
-                    getMaxInputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+                    getMaxInputs(), new Throwable());
             if (recipe.getIsCTRecipe()) {
                 CraftTweakerAPI.logError(String.format(
-                        "Invalid amount of recipe inputs. Actual: %s. Should be at most %s.", amount, getMaxInputs()));
-                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Inputs"));
+                        "Invalid amount of recipe inputs. Actual: %s. Should be at most %s.", amount, getMaxInputs()),
+                        new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
@@ -499,13 +495,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         amount = recipe.getOutputs().size() + recipe.getChancedOutputs().getChancedEntries().size();
         if (amount > getMaxOutputs()) {
             GTLog.logger.error("Invalid amount of recipe outputs. Actual: {}. Should be at most {}.", amount,
-                    getMaxOutputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+                    getMaxOutputs(), new Throwable());
             if (recipe.getIsCTRecipe()) {
                 CraftTweakerAPI
                         .logError(String.format("Invalid amount of recipe outputs. Actual: %s. Should be at most %s.",
-                                amount, getMaxOutputs()));
-                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Outputs"));
+                                amount, getMaxOutputs()), new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
@@ -513,13 +507,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         amount = recipe.getFluidInputs().size();
         if (amount > getMaxFluidInputs()) {
             GTLog.logger.error("Invalid amount of recipe fluid inputs. Actual: {}. Should be at most {}.", amount,
-                    getMaxFluidInputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Inputs"));
+                    getMaxFluidInputs(), new Throwable());
             if (recipe.getIsCTRecipe()) {
                 CraftTweakerAPI.logError(
                         String.format("Invalid amount of recipe fluid inputs. Actual: %s. Should be at most %s.",
-                                amount, getMaxFluidInputs()));
-                CraftTweakerAPI.logError("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Inputs"));
+                                amount, getMaxFluidInputs()),
+                        new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
@@ -527,14 +520,12 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         amount = recipe.getFluidOutputs().size() + recipe.getChancedFluidOutputs().getChancedEntries().size();
         if (amount > getMaxFluidOutputs()) {
             GTLog.logger.error("Invalid amount of recipe fluid outputs. Actual: {}. Should be at most {}.", amount,
-                    getMaxFluidOutputs());
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException("Invalid number of Fluid Outputs"));
+                    getMaxFluidOutputs(), new Throwable());
             if (recipe.getIsCTRecipe()) {
                 CraftTweakerAPI.logError(
                         String.format("Invalid amount of recipe fluid outputs. Actual: %s. Should be at most %s.",
-                                amount, getMaxFluidOutputs()));
-                CraftTweakerAPI.logError("Stacktrace:",
-                        new IllegalArgumentException("Invalid number of Fluid Outputs"));
+                                amount, getMaxFluidOutputs()),
+                        new Throwable());
             }
             recipeStatus = EnumValidationResult.INVALID;
         }
@@ -1008,7 +999,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                                              @NotNull Branch branchMap, int index, int count) {
         if (count >= ingredients.size()) return true;
         if (index >= ingredients.size()) {
-            throw new RuntimeException("Index out of bounds for recurseItemTreeAdd, should not happen");
+            throw new IllegalStateException("Index out of bounds for recurseItemTreeAdd, should not happen");
         }
         // Loop through NUMBER_OF_INGREDIENTS times.
 

--- a/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
@@ -58,14 +58,14 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
     private boolean applyResearchProperty(ResearchPropertyData.ResearchEntry researchEntry) {
         if (!ConfigHolder.machines.enableResearch) return false;
         if (researchEntry == null) {
-            GTLog.logger.error("Assembly Line Research Entry cannot be empty.", new IllegalArgumentException());
+            GTLog.logger.error("Assembly Line Research Entry cannot be empty.", new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
             return false;
         }
 
         if (!generatingRecipes) {
             GTLog.logger.error("Cannot generate recipes when using researchWithoutRecipe()",
-                    new IllegalArgumentException());
+                    new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
             return false;
         }

--- a/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/BlastRecipeBuilder.java
@@ -39,7 +39,7 @@ public class BlastRecipeBuilder extends RecipeBuilder<BlastRecipeBuilder> {
     public BlastRecipeBuilder blastFurnaceTemp(int blastFurnaceTemp) {
         if (blastFurnaceTemp <= 0) {
             GTLog.logger.error("Blast Furnace Temperature cannot be less than or equal to 0",
-                    new IllegalArgumentException());
+                    new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.applyProperty(TemperatureProperty.getInstance(), blastFurnaceTemp);

--- a/src/main/java/gregtech/api/recipes/builders/CircuitAssemblerRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/CircuitAssemblerRecipeBuilder.java
@@ -31,8 +31,8 @@ public class CircuitAssemblerRecipeBuilder extends RecipeBuilder<CircuitAssemble
 
     public CircuitAssemblerRecipeBuilder solderMultiplier(int multiplier) {
         if (1 > GTValues.L * multiplier || GTValues.L * multiplier > 64000) {
-            GTLog.logger.error("Fluid multiplier cannot exceed 64000mb total. Multiplier: {}", multiplier);
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("Fluid multiplier cannot exceed 64000mb total. Multiplier: {}", multiplier,
+                    new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.solderMultiplier = multiplier;

--- a/src/main/java/gregtech/api/recipes/builders/ComputationRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ComputationRecipeBuilder.java
@@ -42,7 +42,7 @@ public class ComputationRecipeBuilder extends RecipeBuilder<ComputationRecipeBui
 
     public ComputationRecipeBuilder CWUt(int cwut) {
         if (cwut < 0) {
-            GTLog.logger.error("CWU/t cannot be less than 0", new IllegalArgumentException());
+            GTLog.logger.error("CWU/t cannot be less than 0", new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.applyProperty(ComputationProperty.getInstance(), cwut);
@@ -54,7 +54,7 @@ public class ComputationRecipeBuilder extends RecipeBuilder<ComputationRecipeBui
      */
     public ComputationRecipeBuilder totalCWU(int totalCWU) {
         if (totalCWU < 0) {
-            GTLog.logger.error("Total CWU cannot be less than 0", new IllegalArgumentException());
+            GTLog.logger.error("Total CWU cannot be less than 0", new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.applyProperty(TotalComputationProperty.getInstance(), totalCWU);

--- a/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FusionRecipeBuilder.java
@@ -38,7 +38,7 @@ public class FusionRecipeBuilder extends RecipeBuilder<FusionRecipeBuilder> {
 
     public FusionRecipeBuilder EUToStart(long EUToStart) {
         if (EUToStart <= 0) {
-            GTLog.logger.error("EU to start cannot be less than or equal to 0", new IllegalArgumentException());
+            GTLog.logger.error("EU to start cannot be less than or equal to 0", new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.applyProperty(FusionEUToStartProperty.getInstance(), EUToStart);

--- a/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
@@ -49,7 +49,7 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
     @ZenMethod
     public ImplosionRecipeBuilder explosivesAmount(int explosivesAmount) {
         if (1 > explosivesAmount || explosivesAmount > 64) {
-            GTLog.logger.error("Amount of explosives should be from 1 to 64 inclusive", new IllegalArgumentException());
+            GTLog.logger.error("Amount of explosives should be from 1 to 64 inclusive", new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.applyProperty(ImplosionExplosiveProperty.getInstance(), new ItemStack(Blocks.TNT, explosivesAmount));
@@ -59,7 +59,7 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
     @ZenMethod
     public ImplosionRecipeBuilder explosivesType(ItemStack explosivesType) {
         if (1 > explosivesType.getCount() || explosivesType.getCount() > 64) {
-            GTLog.logger.error("Amount of explosives should be from 1 to 64 inclusive", new IllegalArgumentException());
+            GTLog.logger.error("Amount of explosives should be from 1 to 64 inclusive", new Throwable());
             recipeStatus = EnumValidationResult.INVALID;
         }
         this.applyProperty(ImplosionExplosiveProperty.getInstance(), explosivesType);

--- a/src/main/java/gregtech/api/recipes/ingredients/nbtmatch/ListNBTCondition.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/nbtmatch/ListNBTCondition.java
@@ -19,8 +19,7 @@ public class ListNBTCondition extends NBTCondition {
         super(NBTTagType.LIST, nbtKey, value);
         this.listTagType = listTagType;
         if (listTagType == null) {
-            GTLog.logger.error("ListNBTCondition must not have null parameters.");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("ListNBTCondition must not have null parameters.", new Throwable());
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/ingredients/nbtmatch/NBTCondition.java
+++ b/src/main/java/gregtech/api/recipes/ingredients/nbtmatch/NBTCondition.java
@@ -37,8 +37,7 @@ public class NBTCondition {
         this.nbtKey = nbtKey;
         this.value = value;
         if (tagType == null || nbtKey == null || value == null) {
-            GTLog.logger.error("NBTCondition must not have null parameters.");
-            GTLog.logger.error("Stacktrace:", new IllegalArgumentException());
+            GTLog.logger.error("NBTCondition must not have null parameters.", new Throwable());
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/IRecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/IRecipePropertyStorage.java
@@ -5,8 +5,6 @@ import java.util.Set;
 
 public interface IRecipePropertyStorage {
 
-    String STACKTRACE = "Stacktrace:";
-
     /**
      * Stores new {@link RecipeProperty} with value
      *

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipePropertyStorage.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipePropertyStorage.java
@@ -45,16 +45,15 @@ public class RecipePropertyStorage implements IRecipePropertyStorage {
 
         try {
             recipeProperty.castValue(value);
-        } catch (ClassCastException ex) {
-            GTLog.logger.warn("Provided incorrect value for RecipeProperty with key {}", key);
-            GTLog.logger.warn("Full exception:", ex);
+        } catch (ClassCastException e) {
+            GTLog.logger.warn("Provided incorrect value for RecipeProperty with key {}", key, e);
             success = false;
         }
 
         if (success) {
             recipeProperties.put(recipeProperty, value);
         } else {
-            GTLog.logger.warn(STACKTRACE, new IllegalArgumentException());
+            GTLog.logger.warn("RecipePropertyStorage error found", new Throwable());
         }
 
         return success;


### PR DESCRIPTION
## What
Cleans up the code for stacktrace logging for recipe errors. When an object `instanceof Throwable` is passed as the last format argument in a log message, and there is no format location specified for it in the message string, it will be logged automatically on the subsequent line. This means we can simplify the logging code by quite a bit.

## Outcome
Cleans up recipe error logging code.
