### PR TITLE
Add config options to prevent wallsharing and extended facing

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -330,7 +330,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
         PatternMatchContext context = structurePattern.checkPatternFastAt(getWorld(), getPos(),
                 getFrontFacing().getOpposite(), getUpwardsFacing(), allowsFlip());
         if (context != null && !structureFormed) {
-            if (!ConfigHolder.machines.allowWallsharing) {
+            if (!this.allowsWallsharing()) {
                 Set<Long> keySet = this.structurePattern.cache.keySet();
                 for (long pos : keySet) {
                     if (checkIfLocationReserved(pos)) return;
@@ -614,6 +614,15 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     public @Nullable Integer getDimensionID() {
         if (this.getWorld() != null) return this.getWorld().provider.getDimension();
         return null;
+    }
+
+    // todo tooltip on multis saying if this is enabled or disabled?
+    /**
+     * Whether this multi allows wallsharing.
+     * This is an OR-y operation; only if both multis disallow wallsharing will wallsharing be prevented.
+     */
+    public boolean allowsWallsharing() {
+        return ConfigHolder.machines.allowWallsharing;
     }
 
     protected static Map<Long, Set<Long>> getReservedLocationsForDimension(int dim) {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -161,6 +161,19 @@ public class ConfigHolder {
                 "This does NOT apply to the World Accelerator, but to external effects like Time in a Bottle.",
                 "Default: true" })
         public boolean allowTickAcceleration = true;
+
+        @Config.Comment({ "Whether to allow wallsharing for multiblocks.",
+                "Warning - disabling this requires extra checks to be performed, impacting performance.",
+                "Default: true" })
+        @Config.RequiresWorldRestart
+        public boolean allowWallsharing = true;
+
+        @Config.Comment({ "Whether to allow extended facing for multiblocks as default behavior.",
+                "Disabling this prevents multiblocks from facing vertically or rotating.",
+                "Does not apply to all multiblocks.",
+                "Default: true" })
+        @Config.RequiresWorldRestart
+        public boolean allowExtendedFacing = true;
     }
 
     public static class WorldGenOptions {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -162,7 +162,7 @@ public class ConfigHolder {
                 "Default: true" })
         public boolean allowTickAcceleration = true;
 
-        @Config.Comment({ "Whether to allow wallsharing for multiblocks.",
+        @Config.Comment({ "Whether to allow wallsharing for multiblocks as default behavior.",
                 "Warning - disabling this requires extra checks to be performed, impacting performance.",
                 "Default: true" })
         @Config.RequiresWorldRestart

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -11,6 +11,7 @@ import gregtech.api.fluids.GTFluidRegistration;
 import gregtech.api.gui.UIFactory;
 import gregtech.api.items.gui.PlayerInventoryUIFactory;
 import gregtech.api.metatileentity.MetaTileEntityUIFactory;
+import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.modules.GregTechModule;
 import gregtech.api.modules.IGregTechModule;
 import gregtech.api.mui.GTGuiTextures;
@@ -324,6 +325,7 @@ public class CoreModule implements IGregTechModule {
 
     @Override
     public void serverStopped(FMLServerStoppedEvent event) {
+        MultiblockControllerBase.clearReservedLocations();
         VirtualTankRegistry.clearMaps();
         CapesRegistry.clearMaps();
     }


### PR DESCRIPTION
## What
Adds a pair of config options, one to change the default wallsharing behavior, and the other to change the default extended facing behavior to false.
Also adds a system to prevent wallsharing.

## Implementation Details
For extended facing, simply changes the default return from 'true' to the config option.
For wallsharing, when a multiblock that disallows wallsharing is formed, it 'reserves' block positions in its dimension inside a map. When a multiblock that disallows wallsharing is trying to form, it checks the reserved positions in its dimension and prevents formation if it overlaps a reserved position. When a multiblock is invalidated, it unreserves its locations.

## Outcome
Resolves #2436 

## Additional Information
When wallsharing is allowed, the extra checks are never performed and the maps never populated, so the overhead should be basically unnoticeable. For this reason, even though wallsharing and extended facing are intended behaviors, adding these as config options won't impact performance for those who leave them set to true.