### PR TITLE
fix MTE block opacity

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -482,7 +482,7 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
     public int getLightOpacity(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos) {
         // since it is called on neighbor blocks
         MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
-        return metaTileEntity == null ? 0 : metaTileEntity.getLightOpacity();
+        return metaTileEntity == null ? 255 : metaTileEntity.getLightOpacity();
     }
 
     @Override

--- a/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
+++ b/src/main/java/gregtech/api/block/machines/MachineItemBlock.java
@@ -92,7 +92,7 @@ public class MachineItemBlock extends ItemBlock {
         // prevent rendering glitch before meta tile entity sync to client, but after block placement
         // set opaque property on the placing on block, instead during set of meta tile entity
         boolean superVal = super.placeBlockAt(stack, player, world, pos, side, hitX, hitY, hitZ,
-                newState.withProperty(BlockMachine.OPAQUE, metaTileEntity != null && metaTileEntity.isOpaqueCube()));
+                newState.withProperty(BlockMachine.OPAQUE, metaTileEntity == null || metaTileEntity.isOpaqueCube()));
         if (superVal && !world.isRemote) {
             BlockPos possiblePipe = pos.offset(side.getOpposite());
             Block block = world.getBlockState(possiblePipe).getBlock();

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCrate.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static gregtech.api.capability.GregtechDataCodes.IS_TAPED;
-import static gregtech.api.capability.GregtechDataCodes.TAG_KEY_PAINTING_COLOR;
 
 public class MetaTileEntityCrate extends MetaTileEntity {
 
@@ -73,11 +72,6 @@ public class MetaTileEntityCrate extends MetaTileEntity {
     @Override
     public boolean hasFrontFacing() {
         return false;
-    }
-
-    @Override
-    public int getLightOpacity() {
-        return 1;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -72,16 +72,6 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     }
 
     @Override
-    public int getLightOpacity() {
-        return 1;
-    }
-
-    @Override
-    public boolean isOpaqueCube() {
-        return false;
-    }
-
-    @Override
     public String getHarvestTool() {
         return ModHandler.isMaterialWood(material) ? ToolClasses.AXE : ToolClasses.WRENCH;
     }


### PR DESCRIPTION
## What
Fixes the block opacity of MTEs by making the default "fully opaque" instead of "fully transparent." Previously, the default opacity was `0` for MTEs, which means it acts like air blocks. This PR changes the default to `255`, which means "fully opaque," as per the javadoc in `Block#getLightOpacity(IBlockState, IBlockAccess, BlockPos)`.

A consequence of this bug was that any MTE block can be placed on top of things like solar boilers or solar panel covers, and allowed them to stack on top of each other while all still having access to the sun to continue producing output. This is now fixed.

This PR also fixes strange opacity overrides in `MetaTileEntityDrum` and `MetaTileEntityCrate` which should not have been there.

## Outcome
Fixes MTE block opacity.
