### PR TITLE
Fix blocks not being able to choose preferred meta values in previews

### DIFF
--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -527,7 +527,12 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
                 stack = ((IGregTechTileEntity) tileEntity).getMetaTileEntity().getStackForm();
             }
             if (stack.isEmpty()) {
-                // try the itemstack constructor if we're not a GT machine
+                // first, see what the block has to say for itself before forcing it to use a particular meta value
+                stack = block.getPickBlock(state, new RayTraceResult(Vec3d.ZERO, EnumFacing.UP, pos), world, pos,
+                        new GregFakePlayer(world));
+            }
+            if (stack.isEmpty()) {
+                // try the default itemstack constructor if we're not a GT machine
                 stack = GTUtility.toItem(state);
             }
             if (stack.isEmpty()) {
@@ -540,11 +545,6 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
                         stack = is;
                     }
                 }
-            }
-            if (stack.isEmpty()) {
-                // if everything else doesn't work, try the not great getPickBlock() with some dummy values
-                stack = block.getPickBlock(state, new RayTraceResult(Vec3d.ZERO, EnumFacing.UP, pos), world, pos,
-                        new GregFakePlayer(world));
             }
 
             // if we got a stack, add it to the set and map


### PR DESCRIPTION
## What
Previously, in Supersymmetry, there were several blocks in JEI previews that were rotated variants of the original block shown in JEI searches. However, the `toItem` method used to retrieve the stack for the item requirement list did not take this into account, and used the rotated variant rather than the normal item. For example, if rotated wooden logs were placed into a multiblock structure, missing item textures would appear:

![image](https://github.com/GregTechCEu/GregTech/assets/80226372/0fc66fde-965c-471c-a045-7ae0dd2693f3)

## Implementation Details
I've mitigated this issue by prioritizing the `pickBlock` method within the stack retrieval algorithm, allowing blocks such as wooden logs to have more of a "say" in what meta is applied.
Although the original comment states that `pickBlock` is "not great," analyzing the code shows that it has nearly the same method calls as GTUtility's `toItem`, with the GregFakePlayer call being cached after its first use. 

## Outcome
Allows blocks from addons to return the correct item stack for multiblock previews.

## Potential Compatibility Issues
In the case that a specific multiblock from an addon added special code to pickBlock that wouldn't apply to multiblock previews for some reason, that might cause a problem, but I find it unlikely.