### PR TITLE
fix pyrolyse speed

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -180,8 +180,12 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
                 return;
 
             if (coilTier == 0) {
-                resultOverclock[1] *= 5.0 / 4; // 25% slower with cupronickel (coilTier = 0)
-            } else resultOverclock[1] *= 2.0f / (coilTier + 1); // each coil above kanthal (coilTier = 1) is 50% faster
+                // 75% speed with cupronickel (coilTier = 0)
+                resultOverclock[1] = 4 * resultOverclock[1] / 3;
+            } else {
+                // each coil above kanthal (coilTier = 1) is 50% faster
+                resultOverclock[1] = resultOverclock[1] * 2 / (coilTier + 1);
+            }
 
             resultOverclock[1] = Math.max(1, resultOverclock[1]);
         }


### PR DESCRIPTION
## What
Fixes the Pyrolyse Oven running faster than it was supposed to with Cupronickel Coils. It previously multiplied duration by `1.2` but it should have been by `1.33` for being reduced to 75% speed. This makes the speed in-line with what the tooltip describes.

## Outcome
Fixes the Pyrolyse Oven running too fast with Cupronickel Coils.
