### PR TITLE
Waila/Hwyla Provider Fixes

### DIFF
--- a/src/main/java/gregtech/GregTechMod.java
+++ b/src/main/java/gregtech/GregTechMod.java
@@ -27,7 +27,7 @@ import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 
 @Mod(modid = GTValues.MODID,
-     name = "GregTech",
+     name = GTValues.MOD_NAME,
      acceptedMinecraftVersions = "[1.12.2,1.13)",
      version = GTInternalTags.VERSION,
      dependencies = "required:forge@[14.23.5.2847,);" + "required-after:codechickenlib@[3.2.3,);" +

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -126,6 +126,11 @@ public class GTValues {
      */
     public static final String MODID = "gregtech";
 
+    /**
+     * GregTech Mod Name
+     */
+    public static final String MOD_NAME = "GregTech";
+
     /** @deprecated Use {@link gregtech.api.util.Mods} instead */
     @Deprecated
     @ApiStatus.ScheduledForRemoval(inVersion = "2.9")

--- a/src/main/java/gregtech/api/util/GTLog.java
+++ b/src/main/java/gregtech/api/util/GTLog.java
@@ -1,5 +1,7 @@
 package gregtech.api.util;
 
+import gregtech.api.GTValues;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -9,7 +11,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class GTLog {
 
-    public static Logger logger = LogManager.getLogger("GregTech");
+    public static Logger logger = LogManager.getLogger(GTValues.MOD_NAME);
 
     private GTLog() {}
 }

--- a/src/main/java/gregtech/api/util/input/KeyBind.java
+++ b/src/main/java/gregtech/api/util/input/KeyBind.java
@@ -1,5 +1,6 @@
 package gregtech.api.util.input;
 
+import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.util.GTLog;
 import gregtech.core.network.packets.PacketKeysPressed;
@@ -99,14 +100,14 @@ public enum KeyBind {
 
     KeyBind(String langKey, int button) {
         if (FMLCommonHandler.instance().getSide().isClient()) {
-            this.keybinding = new KeyBinding(langKey, button, "GregTech");
+            this.keybinding = new KeyBinding(langKey, button, GTValues.MOD_NAME);
             ClientRegistry.registerKeyBinding(this.keybinding);
         }
     }
 
     KeyBind(String langKey, IKeyConflictContext ctx, int button) {
         if (FMLCommonHandler.instance().getSide().isClient()) {
-            this.keybinding = new KeyBinding(langKey, ctx, button, "GregTech");
+            this.keybinding = new KeyBinding(langKey, ctx, button, GTValues.MOD_NAME);
             ClientRegistry.registerKeyBinding(this.keybinding);
         }
     }

--- a/src/main/java/gregtech/integration/forestry/bees/GTBeeDefinition.java
+++ b/src/main/java/gregtech/integration/forestry/bees/GTBeeDefinition.java
@@ -18,7 +18,12 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.fml.common.Optional;
 
 import appeng.core.Api;
-import forestry.api.apiculture.*;
+import forestry.api.apiculture.BeeManager;
+import forestry.api.apiculture.EnumBeeType;
+import forestry.api.apiculture.IAlleleBeeSpecies;
+import forestry.api.apiculture.IBee;
+import forestry.api.apiculture.IBeeGenome;
+import forestry.api.apiculture.IBeeMutationBuilder;
 import forestry.api.core.EnumHumidity;
 import forestry.api.core.EnumTemperature;
 import forestry.api.genetics.IAllele;
@@ -1206,7 +1211,7 @@ public enum GTBeeDefinition implements IBeeDefinition {
         String name = "for.bees.species." + lowercaseName;
 
         this.branch = branch;
-        this.species = new GTAlleleBeeSpecies(GTValues.MODID, uid, name, "GregTech", description, dominant,
+        this.species = new GTAlleleBeeSpecies(GTValues.MODID, uid, name, GTValues.MOD_NAME, description, dominant,
                 branch.getBranch(), binomial, primary, secondary);
         this.generationCondition = generationCondition;
     }

--- a/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
@@ -223,7 +223,7 @@ public class GroovyScriptModule extends IntegrationSubmodule implements GroovyPl
 
     @Override
     public @NotNull String getContainerName() {
-        return "GregTech";
+        return GTValues.MOD_NAME;
     }
 
     @Optional.Method(modid = Mods.Names.GROOVY_SCRIPT)

--- a/src/main/java/gregtech/integration/hwyla/provider/BlockOreDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/BlockOreDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.unification.ore.StoneType;
 import gregtech.common.blocks.BlockOre;
 import gregtech.integration.hwyla.HWYLAModule;
@@ -21,7 +22,7 @@ public class BlockOreDataProvider implements IWailaDataProvider {
 
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, BlockOre.class);
-        registrar.addConfig("GregTech", "gregtech.block_ore");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.block_ore");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/BlockOreDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/BlockOreDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.unification.ore.StoneType;
 import gregtech.common.blocks.BlockOre;
 import gregtech.integration.hwyla.HWYLAModule;
@@ -8,7 +7,10 @@ import gregtech.integration.hwyla.HWYLAModule;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
-import mcp.mobius.waila.api.*;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.IWailaRegistrar;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -19,7 +21,7 @@ public class BlockOreDataProvider implements IWailaDataProvider {
 
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, BlockOre.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.block_ore");
+        registrar.addConfig("GregTech", "gregtech.block_ore");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/ControllableDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ControllableDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 
@@ -25,7 +26,7 @@ public class ControllableDataProvider extends CapabilityDataProvider<IControllab
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.controllable");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.controllable");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/ControllableDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ControllableDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 
@@ -26,7 +25,7 @@ public class ControllableDataProvider extends CapabilityDataProvider<IControllab
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.controllable");
+        registrar.addConfig("GregTech", "gregtech.controllable");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
@@ -30,7 +30,7 @@ public class ConverterDataProvider extends CapabilityDataProvider<ConverterTrait
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.converter");
+        registrar.addConfig("GregTech", "gregtech.converter");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ConverterDataProvider.java
@@ -30,7 +30,7 @@ public class ConverterDataProvider extends CapabilityDataProvider<ConverterTrait
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.converter");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.converter");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.TextFormattingUtil;
@@ -26,7 +27,7 @@ public class DiodeDataProvider extends ElectricContainerDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.diode");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.diode");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/DiodeDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.util.TextFormattingUtil;
@@ -27,7 +26,7 @@ public class DiodeDataProvider extends ElectricContainerDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.diode");
+        registrar.addConfig("GregTech", "gregtech.diode");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/ElectricContainerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ElectricContainerDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 
@@ -24,7 +25,7 @@ public class ElectricContainerDataProvider extends CapabilityDataProvider<IEnerg
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.energy");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.energy");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/ElectricContainerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ElectricContainerDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 
@@ -25,7 +24,7 @@ public class ElectricContainerDataProvider extends CapabilityDataProvider<IEnerg
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.energy");
+        registrar.addConfig("GregTech", "gregtech.energy");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/LampDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/LampDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.common.blocks.BlockLamp;
 
 import net.minecraft.block.state.IBlockState;
@@ -20,7 +21,7 @@ public class LampDataProvider implements IWailaDataProvider {
 
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, BlockLamp.class);
-        registrar.addConfig("GregTech", "gregtech.block_lamp");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.block_lamp");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/LampDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/LampDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.common.blocks.BlockLamp;
 
 import net.minecraft.block.state.IBlockState;
@@ -21,7 +20,7 @@ public class LampDataProvider implements IWailaDataProvider {
 
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, BlockLamp.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.block_lamp");
+        registrar.addConfig("GregTech", "gregtech.block_lamp");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/MaintenanceDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/MaintenanceDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMultiblockController;
@@ -37,7 +36,7 @@ public class MaintenanceDataProvider extends CapabilityDataProvider<IMaintenance
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.maintenance");
+        registrar.addConfig("GregTech", "gregtech.maintenance");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/MaintenanceDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/MaintenanceDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMultiblockController;
@@ -36,7 +37,7 @@ public class MaintenanceDataProvider extends CapabilityDataProvider<IMaintenance
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.maintenance");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.maintenance");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/MultiRecipeMapDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/MultiRecipeMapDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMultipleRecipeMaps;
 
@@ -24,7 +25,7 @@ public class MultiRecipeMapDataProvider extends CapabilityDataProvider<IMultiple
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.multi_recipemap");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.multi_recipemap");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/MultiRecipeMapDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/MultiRecipeMapDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMultipleRecipeMaps;
 
@@ -25,7 +24,7 @@ public class MultiRecipeMapDataProvider extends CapabilityDataProvider<IMultiple
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.multi_recipemap");
+        registrar.addConfig("GregTech", "gregtech.multi_recipemap");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/MultiblockDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/MultiblockDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IMultiblockController;
 
@@ -26,7 +25,7 @@ public class MultiblockDataProvider extends CapabilityDataProvider<IMultiblockCo
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.multiblock");
+        registrar.addConfig("GregTech", "gregtech.multiblock");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/MultiblockDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/MultiblockDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IMultiblockController;
 
@@ -25,7 +26,7 @@ public class MultiblockDataProvider extends CapabilityDataProvider<IMultiblockCo
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.multiblock");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.multiblock");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IPrimitivePump;
 import gregtech.api.util.TextFormattingUtil;
@@ -28,7 +29,7 @@ public class PrimitivePumpDataProvider implements IWailaDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, IGregTechTileEntity.class);
         registrar.registerNBTProvider(this, IGregTechTileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.primitive_pump");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.primitive_pump");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/PrimitivePumpDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IPrimitivePump;
 import gregtech.api.util.TextFormattingUtil;
@@ -29,7 +28,7 @@ public class PrimitivePumpDataProvider implements IWailaDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, IGregTechTileEntity.class);
         registrar.registerNBTProvider(this, IGregTechTileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.primitive_pump");
+        registrar.addConfig("GregTech", "gregtech.primitive_pump");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -35,7 +35,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.recipe_logic");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.recipe_logic");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -3,6 +3,7 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
+import gregtech.api.capability.impl.PrimitiveRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
@@ -46,7 +47,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
     protected NBTTagCompound getNBTData(AbstractRecipeLogic capability, NBTTagCompound tag) {
         NBTTagCompound subTag = new NBTTagCompound();
         subTag.setBoolean("Working", capability.isWorking());
-        if (capability.isWorking()) {
+        if (capability.isWorking() && !(capability instanceof PrimitiveRecipeLogic)) {
             subTag.setInteger("RecipeEUt", capability.getInfoProviderEUt());
         }
         tag.setTag("gregtech.AbstractRecipeLogic", subTag);

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -34,7 +34,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.recipe_logic");
+        registrar.addConfig("GregTech", "gregtech.recipe_logic");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.TextFormattingUtil;
@@ -28,7 +29,7 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, IGregTechTileEntity.class);
         registrar.registerNBTProvider(this, IGregTechTileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.steam_boiler");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.steam_boiler");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/SteamBoilerDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.TextFormattingUtil;
@@ -29,7 +28,7 @@ public class SteamBoilerDataProvider implements IWailaDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, IGregTechTileEntity.class);
         registrar.registerNBTProvider(this, IGregTechTileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.steam_boiler");
+        registrar.addConfig("GregTech", "gregtech.steam_boiler");
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/hwyla/provider/TransformerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/TransformerDataProvider.java
@@ -29,7 +29,7 @@ public class TransformerDataProvider extends ElectricContainerDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.transformer");
+        registrar.addConfig("GregTech", "gregtech.transformer");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/TransformerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/TransformerDataProvider.java
@@ -29,7 +29,7 @@ public class TransformerDataProvider extends ElectricContainerDataProvider {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.transformer");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.transformer");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/WorkableDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/WorkableDataProvider.java
@@ -1,6 +1,5 @@
 package gregtech.integration.hwyla.provider;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.ComputationRecipeLogic;
@@ -26,7 +25,7 @@ public class WorkableDataProvider extends CapabilityDataProvider<IWorkable> {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig(GTValues.MODID, "gregtech.workable");
+        registrar.addConfig("GregTech", "gregtech.workable");
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/WorkableDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/WorkableDataProvider.java
@@ -1,5 +1,6 @@
 package gregtech.integration.hwyla.provider;
 
+import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.ComputationRecipeLogic;
@@ -25,7 +26,7 @@ public class WorkableDataProvider extends CapabilityDataProvider<IWorkable> {
     public void register(@NotNull IWailaRegistrar registrar) {
         registrar.registerBodyProvider(this, TileEntity.class);
         registrar.registerNBTProvider(this, TileEntity.class);
-        registrar.addConfig("GregTech", "gregtech.workable");
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.workable");
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -104,6 +104,21 @@ gregtech.top.ld_pipe_output=Output
 gregtech.top.ld_pipe_input_endpoint=Input Endpoint:
 gregtech.top.ld_pipe_output_endpoint=Output Endpoint:
 
+option.gregtech.block_ore=Ore Blocks
+option.gregtech.controllable=Controllable Machines
+option.gregtech.converter=Energy Converters
+option.gregtech.diode=Diodes
+option.gregtech.energy=Energy Containers
+option.gregtech.block_lamp=Lamp Blocks
+option.gregtech.maintenance=Maintenance Problems
+option.gregtech.multi_recipemap=Machine Modes
+option.gregtech.multiblock=Multiblocks
+option.gregtech.primitive_pump=Primitive Pump
+option.gregtech.recipe_logic=Recipes
+option.gregtech.steam_boiler=Steam Boilers
+option.gregtech.transformer=Transformers
+option.gregtech.workable=Workable Machines
+
 gregtech.waila.energy_stored=Energy: %d EU / %d EU
 gregtech.waila.progress_idle=Idle
 gregtech.waila.progress_tick=Progress: %d t / %d t


### PR DESCRIPTION
## What
1. Fixes the category name for GT Waila Modules being all lowercase. The API intends that you specify the mod name instead of the modid.
2. Fixes GT Waila Modules showing an unlocalized name in the config UI. This PR adds localization for these modules.
3. Fixes the Recipe Logic provider showing EU consumption on PrimitiveRecipeLogic instances. This PR fixes this to keep the Waila provider equivalent with the TOP one.


## Outcome
Fixes assorted Waila/Hwyla data provider issues.
