### PR TITLE
Fix possible NPE from MultiblockDisplayText

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
@@ -456,7 +456,7 @@ public class MultiblockDisplayText {
          * Added if structure is formed, the machine is active, and the passed fuelName parameter is not null.
          */
         public Builder addFuelNeededLine(String fuelName, int previousRecipeDuration) {
-            if (!isStructureFormed || !isActive) return this;
+            if (!isStructureFormed || !isActive || fuelName == null) return this;
             ITextComponent fuelNeeded = TextComponentUtil.stringWithColor(TextFormatting.RED, fuelName);
             ITextComponent numTicks = TextComponentUtil.stringWithColor(TextFormatting.AQUA,
                     TextFormattingUtil.formatNumbers(previousRecipeDuration));


### PR DESCRIPTION
## What
fixes a rare NPE

## Implementation Details
null check

## Outcome
no longer NPE

## Additional Information
see [here](https://github.com/GregTechCEu/GregTech/blob/e9b942561e3b4aeee4cf0850352928cd382308c7/src/main/java/gregtech/api/capability/impl/MultiblockFuelRecipeLogic.java#L134)
The NPE that is fixed can be reproduced by:
1. Build and fuel a large turbine
2. When a recipe starts, quickly drain the fuel input hatch.
3. Before the current recipe ends, log out and re-enter the world
4. Try to open the GUI on the current recipe, it won't open and will NPE. This gets automatically fixed when the next recipe starts

## Potential Compatibility Issues
none
