### PR TITLE
Add JEI text-button to see JEI Recipes ran at higher tiers

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -99,7 +99,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     public ChanceBoostFunction chanceFunction = DEFAULT_CHANCE_FUNCTION;
 
     public final String unlocalizedName;
-
+    private boolean jeiOverclockButton = true;
     private final R recipeBuilderSample;
     private int maxInputs;
     private int maxOutputs;
@@ -363,6 +363,15 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     public RecipeMap<? extends RecipeBuilder<?>> getSmallRecipeMap() {
         return smallRecipeMap;
+    }
+
+    public RecipeMap<R> disableJeiOverclockButton() {
+        this.jeiOverclockButton = false;
+        return this;
+    }
+
+    public boolean JeiOverclockButtonEnabled() {
+        return this.jeiOverclockButton;
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -370,7 +370,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return this;
     }
 
-    public boolean JeiOverclockButtonEnabled() {
+    public boolean jeiOverclockButtonEnabled() {
         return this.jeiOverclockButton;
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
@@ -33,7 +33,7 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     private boolean modifyFluidInputs = true;
     private int fluidOutputs;
     private boolean modifyFluidOutputs = true;
-
+    private boolean jeiOverclockButton = true;
     private @Nullable TextureArea progressBar;
     private @Nullable ProgressWidget.MoveType moveType;
 
@@ -253,6 +253,11 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
         return this;
     }
 
+    public @NotNull RecipeMapBuilder<B> disableJeiOverclockButton() {
+        this.jeiOverclockButton = false;
+        return this;
+    }
+
     /**
      * Add a recipe build action to be performed upon this RecipeMap's builder's recipe registration.
      *
@@ -285,6 +290,9 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
         }
         if (buildActions != null) {
             recipeMap.onRecipeBuild(buildActions);
+        }
+        if (!jeiOverclockButton) {
+            recipeMap.disableJeiOverclockButton();
         }
         return recipeMap;
     }

--- a/src/main/java/gregtech/api/recipes/RecipeMaps.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMaps.java
@@ -525,6 +525,7 @@ public final class RecipeMaps {
                     .fluidOutputs(1)
                     .ui(CokeOvenUI::new)
                     .sound(GTSoundEvents.FIRE)
+                    .disableJeiOverclockButton()
                     .build();
 
     /**
@@ -1287,6 +1288,7 @@ public final class RecipeMaps {
                     .modifyFluidInputs(false)
                     .modifyFluidOutputs(false)
                     .sound(GTSoundEvents.FIRE)
+                    .disableJeiOverclockButton()
                     .build();
 
     /**
@@ -1336,7 +1338,7 @@ public final class RecipeMaps {
 
     @ZenProperty
     public static final RecipeMap<ComputationRecipeBuilder> RESEARCH_STATION_RECIPES = new RecipeMapResearchStation<>(
-            "research_station", new ComputationRecipeBuilder(), ResearchStationUI::new);
+            "research_station", new ComputationRecipeBuilder(), ResearchStationUI::new).disableJeiOverclockButton();
 
     @ZenProperty
     public static final RecipeMap<SimpleRecipeBuilder> ROCK_BREAKER_RECIPES = new RecipeMapBuilder<>("rock_breaker",
@@ -1483,6 +1485,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTSoundEvents.COMBUSTION)
                     .allowEmptyOutputs()
+                    .disableJeiOverclockButton()
                     .build();
 
     @ZenProperty
@@ -1493,6 +1496,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
+                    .disableJeiOverclockButton()
                     .build();
 
     @ZenProperty
@@ -1504,6 +1508,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
+                    .disableJeiOverclockButton()
                     .build();
 
     @ZenProperty
@@ -1514,6 +1519,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_ARROW_MULTIPLE)
                     .sound(GTSoundEvents.COMBUSTION)
                     .allowEmptyOutputs()
+                    .disableJeiOverclockButton()
                     .build();
 
     @ZenProperty
@@ -1525,6 +1531,7 @@ public final class RecipeMaps {
                     .progressBar(GuiTextures.PROGRESS_BAR_GAS_COLLECTOR)
                     .sound(GTSoundEvents.TURBINE)
                     .allowEmptyOutputs()
+                    .disableJeiOverclockButton()
                     .build();
 
     private RecipeMaps() {}

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -317,9 +317,9 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
     @Override
     public void initExtras() {
-        // recipe is null on the first call of this method, so load the tweaker recipe remove button here
-        if (recipe == null) {
-            if (!RecipeCompatUtil.isTweakerLoaded()) return;
+        // recipe is null on the first call of this method
+        if (recipe == null) return;
+        if (RecipeCompatUtil.isTweakerLoaded()) {
             BooleanSupplier creativePlayerCtPredicate = () -> Minecraft.getMinecraft().player != null &&
                     Minecraft.getMinecraft().player.isCreative();
             buttons.add(new JeiButton(166, 2, 10, 10)
@@ -339,7 +339,8 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                         return true;
                     })
                     .setActiveSupplier(creativePlayerCtPredicate));
-        } else if (recipeMap.JeiOverclockButtonEnabled()) {
+        }
+        if (recipeMap.JeiOverclockButtonEnabled()) {
             // on second call recipe != null, so add this instead
             int recipeTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
 

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -283,7 +283,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
             minecraft.fontRenderer.drawString(
                     I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted",
                             eut,
-                            GTValues.VN[GTUtility.getTierByVoltage(eut)]),
+                            GTValues.VNF[GTUtility.getTierByVoltage(eut)]),
                     0, yPosition += LINE_HEIGHT, color);
         }
         if (drawDuration) {
@@ -345,7 +345,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         if (recipeMap.JeiOverclockButtonEnabled()) {
             int recipeTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
 
-            jeiTexts.add(new JeiInteractableText(0, 0, GTValues.VN[recipeTier], GTValues.VC[recipeTier], recipeTier)
+            jeiTexts.add(new JeiInteractableText(0, 0, GTValues.VNF[recipeTier], 0x111111, recipeTier)
                     .setClickAction((minecraft, text, mouseX, mouseY, mouseButton) -> {
                         int maxTier = GregTechAPI.isHighTier() ? GTValues.UIV : GTValues.MAX;
                         int minTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
@@ -360,8 +360,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                             state = text.getState() - 1;
                             if (state < minTier) state = maxTier;
                         }
-                        text.setColor(GTValues.VC[state]);
-                        text.setCurrentText(GTValues.VN[state]);
+                        text.setCurrentText(GTValues.VNF[state]);
                         text.setState(state);
                         return true;
                     }));

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -29,7 +29,6 @@ import gregtech.client.utils.TooltipHelper;
 import gregtech.integration.RecipeCompatUtil;
 import gregtech.integration.jei.utils.AdvancedRecipeWrapper;
 import gregtech.integration.jei.utils.JeiButton;
-
 import gregtech.integration.jei.utils.JeiInteractableText;
 
 import net.minecraft.client.Minecraft;
@@ -270,13 +269,16 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                 minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.max_eu", eu / minimumCWUt), 0, yPosition,
                         0x111111);
             } else {
-                minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total", (int) (eu * Math.pow(2, tierDifference))), 0, yPosition, color);
+                minecraft.fontRenderer.drawString(
+                        I18n.format("gregtech.recipe.total", (int) (eu * Math.pow(2, tierDifference))), 0, yPosition,
+                        color);
             }
         }
         if (drawEUt) {
             minecraft.fontRenderer.drawString(
                     I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted",
-                            (int) (Math.abs(recipe.getEUt()) * Math.pow(4, tierDifference)), GTValues.VN[tierDifference + recipeTier]),
+                            (int) (Math.abs(recipe.getEUt()) * Math.pow(4, tierDifference)),
+                            GTValues.VN[tierDifference + recipeTier]),
                     0, yPosition += LINE_HEIGHT, color);
         }
         if (drawDuration) {
@@ -337,14 +339,13 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
         jeiTexts.add(new JeiInteractableText(0, 0, GTValues.VN[GTValues.ULV], 0x111111)
                 .setClickAction((minecraft, text, mouseX, mouseY, mouseButton) -> {
-                    final int maxTier = GregTechAPI.isHighTier() ? GTValues.UIV + 1: GTValues.OpV + 1;
+                    final int maxTier = GregTechAPI.isHighTier() ? GTValues.UIV + 1 : GTValues.OpV + 1;
                     final int state = (text.getState() + 1) % maxTier;
                     text.setColor(GTValues.VC[state]);
                     text.setCurrentText(GTValues.VN[state]);
                     text.setState(state);
                     return true;
-                })
-        );
+                }));
     }
 
     public ChancedItemOutput getOutputChance(int slot) {

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -323,17 +323,17 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         int recipeTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
 
         jeiTexts.add(new JeiInteractableText(0, 0, GTValues.VN[recipeTier], GTValues.VC[recipeTier], recipeTier)
-                        .setClickAction((minecraft, text, mouseX, mouseY, mouseButton) -> {
-                            int maxTier = GregTechAPI.isHighTier() ? GTValues.UIV + 1 : GTValues.OpV + 1;
-                            int minTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
-                            int state = (text.getState() + 1) % maxTier;
-                            // ULV isnt real sorry
-                            state = Math.max(state, minTier);
-                            text.setColor(GTValues.VC[state]);
-                            text.setCurrentText(GTValues.VN[state]);
-                            text.setState(state);
-                            return true;
-                        }));
+                .setClickAction((minecraft, text, mouseX, mouseY, mouseButton) -> {
+                    int maxTier = GregTechAPI.isHighTier() ? GTValues.UIV + 1 : GTValues.OpV + 1;
+                    int minTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
+                    int state = (text.getState() + 1) % maxTier;
+                    // ULV isnt real sorry
+                    state = Math.max(state, minTier);
+                    text.setColor(GTValues.VC[state]);
+                    text.setCurrentText(GTValues.VN[state]);
+                    text.setState(state);
+                    return true;
+                }));
 
         // do not add the X button if no tweaker mod is present, or the button is already added(initExtras is called
         // twice because of the comment above)

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -344,26 +344,34 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         }
         if (recipeMap.JeiOverclockButtonEnabled()) {
             int recipeTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
-
-            jeiTexts.add(new JeiInteractableText(0, 0, GTValues.VNF[recipeTier], 0x111111, recipeTier)
-                    .setClickAction((minecraft, text, mouseX, mouseY, mouseButton) -> {
-                        int maxTier = GregTechAPI.isHighTier() ? GTValues.UIV : GTValues.MAX;
-                        int minTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
-                        // ULV isn't real sorry
-                        int state = minTier;
-                        if (mouseButton == 0) {
-                            // increment tier if left click
-                            state = text.getState() + 1;
-                            if (state > maxTier) state = minTier;
-                        } else if (mouseButton == 1) {
-                            // decrement tier if right click
-                            state = text.getState() - 1;
-                            if (state < minTier) state = maxTier;
-                        }
-                        text.setCurrentText(GTValues.VNF[state]);
-                        text.setState(state);
-                        return true;
-                    }));
+            // seems like recipeHeight is always 120
+            jeiTexts.add(
+                    new JeiInteractableText(0, 120 - LINE_HEIGHT, GTValues.VNF[recipeTier], 0x111111, recipeTier, true)
+                            .setTooltipBuilder((state, tooltip) -> {
+                                tooltip.add(I18n.format("gregtech.jei.overclock_button", GTValues.VNF[state]));
+                                tooltip.add(TooltipHelper.BLINKING_CYAN + I18n.format("gregtech.jei.overclock_warn"));
+                            })
+                            .setClickAction((minecraft, text, mouseX, mouseY, mouseButton) -> {
+                                // just here because if highTier is disabled, if a recipe is (incorrectly) registering
+                                // UIV+ recipes, this allows it to go up to the recipe tier for that recipe
+                                int maxTier = Math.max(recipeTier,
+                                        GregTechAPI.isHighTier() ? GTValues.UIV : GTValues.MAX);
+                                int minTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
+                                // ULV isn't real sorry
+                                int state = minTier;
+                                if (mouseButton == 0) {
+                                    // increment tier if left click
+                                    state = text.getState() + 1;
+                                    if (state > maxTier) state = minTier;
+                                } else if (mouseButton == 1) {
+                                    // decrement tier if right click
+                                    state = text.getState() - 1;
+                                    if (state < minTier) state = maxTier;
+                                }
+                                text.setCurrentText(GTValues.VNF[state]);
+                                text.setState(state);
+                                return true;
+                            }));
         }
     }
 

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -259,13 +259,12 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         tierDifference = Math.max(0, tierDifference);
         // if duration is less than 0.5, that means even with one less overclock, the recipe would still 1 tick
         // so add the yellow warning
-        double duration = (Math.floor(recipe.getDuration() / Math.pow(2, tierDifference)));
+        double duration = Math.floor(recipe.getDuration() / Math.pow(2, tierDifference));
         int color = duration <= 0.5 ? 0xFFFF55 : 0x111111;
         long eut = (long) Math.abs(recipe.getEUt()) * (int) Math.pow(4, tierDifference);
         duration = Math.max(1, duration);
         // Default entries
         if (drawTotalEU) {
-
             // sadly we still need a custom override here, since computation uses duration and EU/t very differently
             if (recipe.hasProperty(TotalComputationProperty.getInstance()) &&
                     recipe.hasProperty(ComputationProperty.getInstance())) {
@@ -276,7 +275,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
             } else {
                 // duration is in sec
                 minecraft.fontRenderer.drawString(
-                        I18n.format("gregtech.recipe.total", (int) (eut * duration)), 0, yPosition,
+                        I18n.format("gregtech.recipe.total", (long) (eut * duration)), 0, yPosition,
                         color);
             }
         }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -257,7 +257,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         int tierDifference = getDisplayOCTier() - recipeTier;
         // if duration is less than 0.5, that means even with one less overclock, the recipe would still 1 tick
         // so add the yellow warning
-        double duration = Math.floor(recipe.getDuration() / Math.pow(2, tierDifference));
+        double duration = Math.floor(recipe.getDuration() / Math.pow(recipeMap == RecipeMaps.LARGE_CHEMICAL_RECIPES ? 4 : 2, tierDifference));
         int color = duration <= 0.5 ? 0xFFFF55 : 0x111111;
         // currently manual override for fusion's 2x EU/t instead of 4x, maybe custom multiplier per recipeMap soontm?
         long eut = (long) Math.abs(recipe.getEUt()) *

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -335,9 +335,9 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         if (recipeMap.jeiOverclockButtonEnabled()) {
             int recipeTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
             int maxTier = Math.max(recipeTier, GregTechAPI.isHighTier() ? GTValues.UIV : GTValues.MAX);
-            // seems like recipeHeight is always 120
+            // scuffed positioning because we can't have good ui(until mui soontm)
             jeiTexts.add(
-                    new JeiInteractableText(0, 120 - LINE_HEIGHT, GTValues.VNF[recipeTier], 0x111111, recipeTier, true)
+                    new JeiInteractableText(0, 90 - LINE_HEIGHT, GTValues.VNF[recipeTier], 0x111111, recipeTier, true)
                             .setTooltipBuilder((state, tooltip) -> {
                                 tooltip.add(I18n.format("gregtech.jei.overclock_button", GTValues.VNF[state]));
                                 tooltip.add(TooltipHelper.BLINKING_CYAN + I18n.format("gregtech.jei.overclock_warn"));
@@ -363,8 +363,11 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
     }
 
     public long[] calculateJeiOverclock() {
-        long[] result = new long[3];
+        // simple case
+        if (!recipeMap.jeiOverclockButtonEnabled())
+            return new long[] { recipe.getEUt(), recipe.getDuration(), 0x111111 };
 
+        long[] result = new long[3];
         int recipeTier = GTUtility.getTierByVoltage(recipe.getEUt());
         // ULV doesn't overclock to LV, so treat ULV recipes as LV
         recipeTier += recipeTier == GTValues.ULV ? 1 : 0;

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -252,8 +252,9 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
 
         int recipeTier = GTUtility.getTierByVoltage(recipe.getEUt());
         // ULV doesn't overclock to LV, so treat ULV recipes as LV
-        // tier difference can be negative here
-        int tierDifference = Math.max(0, getDisplayOCTier() - recipeTier - (recipeTier == GTValues.ULV ? 1 : 0));
+        recipeTier += recipeTier == GTValues.ULV ? 1 : 0;
+        // tier difference *should* not be negative here since at least displayOCTier() == recipeTier
+        int tierDifference = getDisplayOCTier() - recipeTier;
         // if duration is less than 0.5, that means even with one less overclock, the recipe would still 1 tick
         // so add the yellow warning
         double duration = Math.floor(recipe.getDuration() / Math.pow(2, tierDifference));
@@ -270,7 +271,6 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                 minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.max_eu", eu / minimumCWUt), 0, yPosition,
                         0x111111);
             } else {
-                // duration is in sec
                 minecraft.fontRenderer.drawString(
                         I18n.format("gregtech.recipe.total", (long) (eut * duration)), 0, yPosition,
                         color);
@@ -341,7 +341,6 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
                     .setActiveSupplier(creativePlayerCtPredicate));
         }
         if (recipeMap.JeiOverclockButtonEnabled()) {
-            // on second call recipe != null, so add this instead
             int recipeTier = Math.max(GTValues.LV, GTUtility.getTierByVoltage(recipe.getEUt()));
 
             jeiTexts.add(new JeiInteractableText(0, 0, GTValues.VN[recipeTier], GTValues.VC[recipeTier], recipeTier)

--- a/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
@@ -51,7 +51,7 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
                 if (tooltip.isEmpty()) continue;
                 int width = (int) (minecraft.displayWidth / 2f + recipeWidth / 2f);
                 GuiUtils.drawHoveringText(tooltip, mouseX, mouseY, width, minecraft.displayHeight,
-                        Math.min(200, width - mouseX - 5), minecraft.fontRenderer);
+                        Math.min(150, width - mouseX - 5), minecraft.fontRenderer);
                 GlStateManager.disableLighting();
             }
         }

--- a/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
@@ -50,7 +50,8 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
                 text.buildTooltip(tooltip);
                 if (tooltip.isEmpty()) continue;
                 int width = (int) (minecraft.displayWidth / 2f + recipeWidth / 2f);
-                GuiUtils.drawHoveringText(tooltip, mouseX, mouseY, width, minecraft.displayHeight, Math.min(200, width - mouseX - 5), minecraft.fontRenderer);
+                GuiUtils.drawHoveringText(tooltip, mouseX, mouseY, width, minecraft.displayHeight,
+                        Math.min(200, width - mouseX - 5), minecraft.fontRenderer);
                 GlStateManager.disableLighting();
             }
         }
@@ -67,7 +68,8 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
             }
         }
         for (JeiInteractableText text : jeiTexts) {
-            if (text.isHovering(mouseX, mouseY) && text.getTextClickAction().click(minecraft, text, mouseX, mouseY, mouseButton)) {
+            if (text.isHovering(mouseX, mouseY) &&
+                    text.getTextClickAction().click(minecraft, text, mouseX, mouseY, mouseButton)) {
                 Minecraft.getMinecraft().getSoundHandler()
                         .playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;

--- a/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/utils/AdvancedRecipeWrapper.java
@@ -16,6 +16,7 @@ import java.util.List;
 public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
 
     protected final List<JeiButton> buttons = new ArrayList<>();
+    protected final List<JeiInteractableText> jeiTexts = new ArrayList<>();
 
     public AdvancedRecipeWrapper() {
         initExtras();
@@ -41,6 +42,18 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
                 GlStateManager.disableLighting();
             }
         }
+
+        for (JeiInteractableText text : jeiTexts) {
+            text.render(minecraft, recipeWidth, recipeHeight, mouseX, mouseY);
+            if (text.isHovering(mouseX, mouseY)) {
+                List<String> tooltip = new ArrayList<>();
+                text.buildTooltip(tooltip);
+                if (tooltip.isEmpty()) continue;
+                int width = (int) (minecraft.displayWidth / 2f + recipeWidth / 2f);
+                GuiUtils.drawHoveringText(tooltip, mouseX, mouseY, width, minecraft.displayHeight, Math.min(200, width - mouseX - 5), minecraft.fontRenderer);
+                GlStateManager.disableLighting();
+            }
+        }
     }
 
     @Override
@@ -48,6 +61,13 @@ public abstract class AdvancedRecipeWrapper implements IRecipeWrapper {
         for (JeiButton button : buttons) {
             if (button.isHovering(mouseX, mouseY) &&
                     button.getClickAction().click(minecraft, mouseX, mouseY, mouseButton)) {
+                Minecraft.getMinecraft().getSoundHandler()
+                        .playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+                return true;
+            }
+        }
+        for (JeiInteractableText text : jeiTexts) {
+            if (text.isHovering(mouseX, mouseY) && text.getTextClickAction().click(minecraft, text, mouseX, mouseY, mouseButton)) {
                 Minecraft.getMinecraft().getSoundHandler()
                         .playSound(PositionedSoundRecord.getMasterRecord(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -49,6 +49,7 @@ public class JeiInteractableText {
 
     /**
      * This is overriden by in-text formatting codes!
+     * 
      * @param color The color to set the text to
      */
     public void setColor(int color) {

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -9,6 +9,7 @@ public class JeiInteractableText {
 
     private final int x;
     private final int y;
+    private final boolean invertX;
     private int color;
     private String currentText;
     private int textWidth;
@@ -16,9 +17,22 @@ public class JeiInteractableText {
     private BiConsumer<Integer, List<String>> tooltipBuilder;
     private int state;
 
-    public JeiInteractableText(int x, int y, String defaultText, int color, int baseState) {
+    /**
+     * Creates a new text object when can handle clicks and update state when clicked
+     * 
+     * @param x           x value, 0 on the left border, increases moving right.
+     * @param y           x value, 0 on the top border, increases moving down.
+     * @param defaultText the text that should be initially displayed(without any clicks)
+     * @param color       the default color of the text, overridden by in-text formatting codes
+     * @param baseState   the default state of the button, it is used for tooltip and general information storage
+     * @param invertX     instead defines x as the distance from the right border,
+     *                    * this takes into account the text width,
+     *                    ensuring the rightmost part of the text is always aligned
+     */
+    public JeiInteractableText(int x, int y, String defaultText, int color, int baseState, boolean invertX) {
         this.x = x;
         this.y = y;
+        this.invertX = invertX;
         this.currentText = defaultText;
         this.textWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(defaultText);
         this.color = color;
@@ -26,7 +40,7 @@ public class JeiInteractableText {
     }
 
     public void render(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
-        minecraft.fontRenderer.drawString(currentText, x, y, color);
+        minecraft.fontRenderer.drawString(currentText, invertX ? recipeWidth - x - textWidth : x, y, color);
     }
 
     public JeiInteractableText setTooltipBuilder(BiConsumer<Integer, List<String>> builder) {
@@ -35,7 +49,10 @@ public class JeiInteractableText {
     }
 
     public boolean isHovering(int mouseX, int mouseY) {
-        return mouseX >= x && mouseY >= y && mouseX <= x + textWidth && mouseY <= y + 10;
+        if (!(mouseY >= y && mouseY <= y + 10)) return false;
+        // seems like recipeWidth is always 176
+        if (invertX) return 176 - textWidth - x <= mouseX && mouseX <= 176 - x;
+        return mouseX >= x && mouseX <= x + textWidth;
     }
 
     public void setCurrentText(String text) {

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -47,6 +47,10 @@ public class JeiInteractableText {
         return this.currentText;
     }
 
+    /**
+     * This is overriden by in-text formatting codes!
+     * @param color The color to set the text to
+     */
     public void setColor(int color) {
         this.color = color;
     }

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -4,17 +4,18 @@ import net.minecraft.client.Minecraft;
 
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 public class JeiInteractableText {
+
     private final int x;
     private final int y;
     private int color;
-    private String currentText = "null";
+    private String currentText;
     private int textWidth;
     private TextClickAction textClickAction;
     private BiConsumer<String, List<String>> tooltipBuilder;
     private int state;
+
     public JeiInteractableText(int x, int y, String defaultText, int color) {
         this.x = x;
         this.y = y;
@@ -27,12 +28,10 @@ public class JeiInteractableText {
         minecraft.fontRenderer.drawString(currentText, x, y, color);
     }
 
-
     public JeiInteractableText setTooltipBuilder(BiConsumer<String, List<String>> builder) {
         this.tooltipBuilder = builder;
         return this;
     }
-
 
     public boolean isHovering(int mouseX, int mouseY) {
         return mouseX >= x && mouseY >= y && mouseX <= x + textWidth && mouseY <= y + 10;
@@ -76,8 +75,10 @@ public class JeiInteractableText {
         if (tooltipBuilder == null) return;
         tooltipBuilder.accept(currentText, baseTooltip);
     }
+
     @FunctionalInterface
     public interface TextClickAction {
+
         boolean click(Minecraft minecraft, JeiInteractableText text, int mouseX, int mouseY, int mouseButton);
     }
 }

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -26,7 +26,7 @@ public class JeiInteractableText {
      * @param color       the default color of the text, overridden by in-text formatting codes
      * @param baseState   the default state of the button, it is used for tooltip and general information storage
      * @param invertX     instead defines x as the distance from the right border,
-     *                    * this takes into account the text width,
+     *                    this takes into account the text width,
      *                    ensuring the rightmost part of the text is always aligned
      */
     public JeiInteractableText(int x, int y, String defaultText, int color, int baseState, boolean invertX) {

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -16,12 +16,13 @@ public class JeiInteractableText {
     private BiConsumer<String, List<String>> tooltipBuilder;
     private int state;
 
-    public JeiInteractableText(int x, int y, String defaultText, int color) {
+    public JeiInteractableText(int x, int y, String defaultText, int color, int baseState) {
         this.x = x;
         this.y = y;
         this.currentText = defaultText;
         this.textWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(defaultText);
         this.color = color;
+        this.state = baseState;
     }
 
     public void render(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -13,7 +13,7 @@ public class JeiInteractableText {
     private String currentText;
     private int textWidth;
     private TextClickAction textClickAction;
-    private BiConsumer<String, List<String>> tooltipBuilder;
+    private BiConsumer<Integer, List<String>> tooltipBuilder;
     private int state;
 
     public JeiInteractableText(int x, int y, String defaultText, int color, int baseState) {
@@ -29,7 +29,7 @@ public class JeiInteractableText {
         minecraft.fontRenderer.drawString(currentText, x, y, color);
     }
 
-    public JeiInteractableText setTooltipBuilder(BiConsumer<String, List<String>> builder) {
+    public JeiInteractableText setTooltipBuilder(BiConsumer<Integer, List<String>> builder) {
         this.tooltipBuilder = builder;
         return this;
     }
@@ -79,7 +79,7 @@ public class JeiInteractableText {
 
     public void buildTooltip(List<String> baseTooltip) {
         if (tooltipBuilder == null) return;
-        tooltipBuilder.accept(currentText, baseTooltip);
+        tooltipBuilder.accept(this.state, baseTooltip);
     }
 
     @FunctionalInterface

--- a/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
+++ b/src/main/java/gregtech/integration/jei/utils/JeiInteractableText.java
@@ -1,0 +1,83 @@
+package gregtech.integration.jei.utils;
+
+import net.minecraft.client.Minecraft;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class JeiInteractableText {
+    private final int x;
+    private final int y;
+    private int color;
+    private String currentText = "null";
+    private int textWidth;
+    private TextClickAction textClickAction;
+    private BiConsumer<String, List<String>> tooltipBuilder;
+    private int state;
+    public JeiInteractableText(int x, int y, String defaultText, int color) {
+        this.x = x;
+        this.y = y;
+        this.currentText = defaultText;
+        this.textWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(defaultText);
+        this.color = color;
+    }
+
+    public void render(Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+        minecraft.fontRenderer.drawString(currentText, x, y, color);
+    }
+
+
+    public JeiInteractableText setTooltipBuilder(BiConsumer<String, List<String>> builder) {
+        this.tooltipBuilder = builder;
+        return this;
+    }
+
+
+    public boolean isHovering(int mouseX, int mouseY) {
+        return mouseX >= x && mouseY >= y && mouseX <= x + textWidth && mouseY <= y + 10;
+    }
+
+    public void setCurrentText(String text) {
+        this.currentText = text;
+        this.textWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(currentText);
+    }
+
+    public String getCurrentText() {
+        return this.currentText;
+    }
+
+    public void setColor(int color) {
+        this.color = color;
+    }
+
+    public int getColor() {
+        return this.color;
+    }
+
+    public JeiInteractableText setClickAction(TextClickAction action) {
+        this.textClickAction = action;
+        return this;
+    }
+
+    public TextClickAction getTextClickAction() {
+        return this.textClickAction;
+    }
+
+    public void setState(int state) {
+        this.state = state;
+    }
+
+    public int getState() {
+        return this.state;
+    }
+
+    public void buildTooltip(List<String> baseTooltip) {
+        if (tooltipBuilder == null) return;
+        tooltipBuilder.accept(currentText, baseTooltip);
+    }
+    @FunctionalInterface
+    public interface TextClickAction {
+        boolean click(Minecraft minecraft, JeiInteractableText text, int mouseX, int mouseY, int mouseButton);
+    }
+}

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5499,6 +5499,9 @@ gregtech.jei.fluid.dep_chance_hover=The percentage chance for the vein to be dep
 gregtech.jei.fluid.dep_amount_hover=The amount the vein will be depleted by
 gregtech.jei.fluid.dep_yield_hover=The maximum yield of the vein when it is fully depleted
 
+gregtech.jei.overclock_button=§rThe speed of the recipe at %s
+gregtech.jei.overclock_warn=Results may not be fully accurate for some recipes!
+
 gregtech.jei.materials.average_mass=Average mass: %,d
 gregtech.jei.materials.average_protons=Average protons: %,d
 gregtech.jei.materials.average_neutrons=Average neutrons: %,d


### PR DESCRIPTION
## What
Adds an interactable overclock text in JEI to see recipe EU/t and speed at different voltage tiers, clicking on the text changes the overclock tier. 
Left clicking on the text increases the OC tier, while right clicking decreases it. 
Both wrap around as necessary, with the max tier being specified below and min tier being the lowest tier the recipe will run at. 
This PR also adds voltage colors to the JEI EU/t display.

## Implementation Details
Adds a ``JeiInteractableText`` to handle the interactable text. RecipeMaps can disable this overclock button(such as research recipemaps or generator recipemaps) with the ``.disableJeiOverclockButton()`` method on both ``RecipeMapBuilder`` and ``RecipeMap``. 

This PR currently only assumes 4xEUt/2xSpeed overclocking, with the exception of:

- fusion RecipeMap - 2xEUt/2xSpeed
- LCR RecipeMap - 4xEUt/4xSpeed

Currently this button only goes up to UIV if ``highTier`` is disabled, and MAX if it is enabled(maybe like "MAX+1" if MAX+ OC was implemented?)
An exception is if ``highTier`` is disabled, but there is a recipe which is incorrectly registered as UXV or above, then for that recipe only the max overclocking button tier is the tier of the recipe(so you cannot change the overclocking tier at all, since min tier equals max tier in this case)

## Outcome
There is now a JEI button to "calculate" overclocks.
Currently the tooltip builder in ``JeiInteractableButton`` renders the tooltip below the ingredients, I currently don't know of any way to fix this. This should be fine for this PR since the button is at the bottom right, so no ingredients should overlay.
![image](https://github.com/GregTechCEu/GregTech/assets/113960896/02824ae7-085a-442c-885e-0a212d5b9f9a)


These screenshots are with highTier enabled, without it, the max tier would be UIV

The position of the text is very sus because during click handling you aren't given the recipe height and width, which makes it impossible to align with respect to the south border(afaik ``recipeWidth`` is always 176, while ``recipeHeight`` is variable), since different ``RecipeMaps`` have different ``recipeHeight``s. The spot avoids all recipes, while being far enough away from the south border than it is inside the border for all ``RecipeMaps``(top left has conflicts with assembly line, top right has conflicts with arc furnace)

The base recipe
![image](https://github.com/GregTechCEu/GregTech/assets/113960896/77ac5d08-c573-4b13-a394-dd7edca77fca)
The recipe now only takes one tick
![image](https://github.com/GregTechCEu/GregTech/assets/113960896/a345e0da-bd0a-483f-a4b5-7ee52724a501)
Because the UXV recipe took one tick, this is yellow since you are not gaining speed from the overclock(s)
![image](https://github.com/GregTechCEu/GregTech/assets/113960896/30ad477f-9cda-4f42-ba2b-bca5dc419059)
After another click reaching MAX tier, the next left click will wrap around to LuV tier.


## Potential Compatibility Issues
This has conflicts with #2432 . Don't think it would be too bad, just changing some ints to longs for this PR, only questionable one is ``GTRecipeWrapper`` though. Also likely ``NonParallelSubtickOC`` will be the default, instead of just yellow text.
