### PR TITLE
Fusion bloom fix & other bloom effect API modifications

### DIFF
--- a/src/main/java/gregtech/client/event/ClientEventHandler.java
+++ b/src/main/java/gregtech/client/event/ClientEventHandler.java
@@ -11,6 +11,7 @@ import gregtech.client.particle.GTParticleManager;
 import gregtech.client.renderer.handler.BlockPosHighlightRenderer;
 import gregtech.client.renderer.handler.MultiblockPreviewRenderer;
 import gregtech.client.renderer.handler.TerminalARRenderer;
+import gregtech.client.utils.BloomEffectUtil;
 import gregtech.client.utils.DepthTextureUtil;
 import gregtech.client.utils.TooltipHelper;
 import gregtech.common.ConfigHolder;
@@ -24,6 +25,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.*;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -156,5 +158,10 @@ public class ClientEventHandler {
                 }
             }
         }
+    }
+
+    @SubscribeEvent
+    public static void onWorldUnload(WorldEvent.Unload event) {
+        BloomEffectUtil.invalidateWorldTickets(event.getWorld());
     }
 }

--- a/src/main/java/gregtech/client/particle/GTOverheatParticle.java
+++ b/src/main/java/gregtech/client/particle/GTOverheatParticle.java
@@ -251,7 +251,15 @@ public class GTOverheatParticle extends GTBloomParticle {
 
     @Override
     public boolean shouldRenderBloomEffect(@NotNull EffectRenderContext context) {
-        return !this.insulated;
+        if (this.insulated) return false;
+        for (Cuboid6 cuboid : pipeBoxes) {
+            if (!context.camera().isBoxInFrustum(
+                    cuboid.min.x + posX, cuboid.min.y + posY, cuboid.min.z + posZ,
+                    cuboid.max.x + posX, cuboid.max.y + posY, cuboid.max.z + posZ)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static final IRenderSetup SETUP = new IRenderSetup() {

--- a/src/main/java/gregtech/client/utils/BloomEffectUtil.java
+++ b/src/main/java/gregtech/client/utils/BloomEffectUtil.java
@@ -81,7 +81,7 @@ public class BloomEffectUtil {
      * disabled, {@link BlockRenderLayer#CUTOUT} is returned instead.
      *
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@link BlockRenderLayer#CUTOUT} if bloom
-     *         layer is disabled
+     * layer is disabled
      * @see #getEffectiveBloomLayer(BlockRenderLayer)
      */
     @NotNull
@@ -96,7 +96,7 @@ public class BloomEffectUtil {
      *
      * @param fallback Block render layer to be returned when bloom layer is disabled
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@code fallback} if bloom layer is
-     *         disabled
+     * disabled
      * @see #getEffectiveBloomLayer(boolean, BlockRenderLayer)
      */
     @Contract("null -> _; !null -> !null")
@@ -112,7 +112,7 @@ public class BloomEffectUtil {
      * @param isBloomActive Whether bloom layer should be active. If this value is {@code false}, {@code fallback} layer
      *                      will be returned. Has no effect if Optifine is present.
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@link BlockRenderLayer#CUTOUT} if bloom
-     *         layer is disabled
+     * layer is disabled
      * @see #getEffectiveBloomLayer(boolean, BlockRenderLayer)
      */
     @NotNull
@@ -129,7 +129,7 @@ public class BloomEffectUtil {
      *                      will be returned. Has no effect if Optifine is present.
      * @param fallback      Block render layer to be returned when bloom layer is disabled
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@code fallback} if bloom layer is
-     *         disabled
+     * disabled
      */
     @Contract("_, null -> _; _, !null -> !null")
     public static BlockRenderLayer getEffectiveBloomLayer(boolean isBloomActive, BlockRenderLayer fallback) {
@@ -168,7 +168,9 @@ public class BloomEffectUtil {
                                                         @NotNull IBloomEffect render,
                                                         @NotNull MetaTileEntity metaTileEntity) {
         Objects.requireNonNull(metaTileEntity, "metaTileEntity == null");
-        return registerBloomRender(setup, bloomType, render, t -> metaTileEntity.isValid());
+        return registerBloomRender(setup, bloomType, render, t ->
+                metaTileEntity.isValid() && metaTileEntity.getWorld() != null &&
+                        metaTileEntity.getWorld() == Minecraft.getMinecraft().world);
     }
 
     /**
@@ -473,7 +475,7 @@ public class BloomEffectUtil {
     }
 
     private static void postDraw() {
-        for (var it = BLOOM_RENDERS.values().iterator(); it.hasNext();) {
+        for (var it = BLOOM_RENDERS.values().iterator(); it.hasNext(); ) {
             List<BloomRenderTicket> list = it.next();
 
             if (!list.isEmpty()) {
@@ -545,12 +547,12 @@ public class BloomEffectUtil {
          * Custom Bloom Style.
          *
          * @return 0 - Simple Gaussian Blur Bloom
-         *         <p>
-         *         1 - Unity Bloom
-         *         </p>
-         *         <p>
-         *         2 - Unreal Bloom
-         *         </p>
+         * <p>
+         * 1 - Unity Bloom
+         * </p>
+         * <p>
+         * 2 - Unreal Bloom
+         * </p>
          */
         int customBloomStyle();
     }

--- a/src/main/java/gregtech/client/utils/BloomEffectUtil.java
+++ b/src/main/java/gregtech/client/utils/BloomEffectUtil.java
@@ -86,7 +86,7 @@ public class BloomEffectUtil {
      * disabled, {@link BlockRenderLayer#CUTOUT} is returned instead.
      *
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@link BlockRenderLayer#CUTOUT} if bloom
-     * layer is disabled
+     *         layer is disabled
      * @see #getEffectiveBloomLayer(BlockRenderLayer)
      */
     @NotNull
@@ -101,7 +101,7 @@ public class BloomEffectUtil {
      *
      * @param fallback Block render layer to be returned when bloom layer is disabled
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@code fallback} if bloom layer is
-     * disabled
+     *         disabled
      * @see #getEffectiveBloomLayer(boolean, BlockRenderLayer)
      */
     @Contract("null -> _; !null -> !null")
@@ -117,7 +117,7 @@ public class BloomEffectUtil {
      * @param isBloomActive Whether bloom layer should be active. If this value is {@code false}, {@code fallback} layer
      *                      will be returned. Has no effect if Optifine is present.
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@link BlockRenderLayer#CUTOUT} if bloom
-     * layer is disabled
+     *         layer is disabled
      * @see #getEffectiveBloomLayer(boolean, BlockRenderLayer)
      */
     @NotNull
@@ -134,7 +134,7 @@ public class BloomEffectUtil {
      *                      will be returned. Has no effect if Optifine is present.
      * @param fallback      Block render layer to be returned when bloom layer is disabled
      * @return {@link BlockRenderLayer} instance for the bloom render layer, or {@code fallback} if bloom layer is
-     * disabled
+     *         disabled
      */
     @Contract("_, null -> _; _, !null -> !null")
     public static BlockRenderLayer getEffectiveBloomLayer(boolean isBloomActive, BlockRenderLayer fallback) {
@@ -572,7 +572,7 @@ public class BloomEffectUtil {
     }
 
     private static void postDraw() {
-        for (var it = BLOOM_RENDERS.values().iterator(); it.hasNext(); ) {
+        for (var it = BLOOM_RENDERS.values().iterator(); it.hasNext();) {
             List<BloomRenderTicket> list = it.next();
 
             if (!list.isEmpty()) {
@@ -659,12 +659,12 @@ public class BloomEffectUtil {
          * Custom Bloom Style.
          *
          * @return 0 - Simple Gaussian Blur Bloom
-         * <p>
-         * 1 - Unity Bloom
-         * </p>
-         * <p>
-         * 2 - Unreal Bloom
-         * </p>
+         *         <p>
+         *         1 - Unity Bloom
+         *         </p>
+         *         <p>
+         *         2 - Unreal Bloom
+         *         </p>
          */
         int customBloomStyle();
     }

--- a/src/main/java/gregtech/client/utils/BloomEffectUtil.java
+++ b/src/main/java/gregtech/client/utils/BloomEffectUtil.java
@@ -147,12 +147,12 @@ public class BloomEffectUtil {
     /**
      * <p>
      * Register a custom bloom render callback for subsequent world render. The render call persists until the
-     * {@code metaTileEntity} is invalidated, or the ticket is manually freed by calling
+     * {@code metaTileEntity} is invalidated, or the world associated with {@code metaTileEntity}  or the ticket is manually freed by calling
      * {@link BloomRenderTicket#invalidate()}.
      * </p>
      * <p>
-     * This method does not register bloom render ticket when Optifine is present, and {@code null} will be returned
-     * instead of a ticket instance.
+     * This method does not register bloom render ticket when Optifine is present, and an invalid ticket will be
+     * returned instead.
      * </p>
      *
      * @param setup          Render setup, if exists
@@ -162,7 +162,7 @@ public class BloomEffectUtil {
      * @return Ticket for the registered bloom render callback
      * @throws NullPointerException if {@code bloomType == null || render == null || metaTileEntity == null}
      */
-    @Nullable
+    @NotNull
     public static BloomRenderTicket registerBloomRender(@Nullable IRenderSetup setup,
                                                         @NotNull BloomType bloomType,
                                                         @NotNull IBloomEffect render,
@@ -180,8 +180,8 @@ public class BloomEffectUtil {
      * {@link BloomRenderTicket#invalidate()}.
      * </p>
      * <p>
-     * This method does not register bloom render ticket when Optifine is present, and {@code null} will be returned
-     * instead of a ticket instance.
+     * This method does not register bloom render ticket when Optifine is present, and an invalid ticket will be
+     * returned instead.
      * </p>
      *
      * @param setup     Render setup, if exists
@@ -191,7 +191,7 @@ public class BloomEffectUtil {
      * @return Ticket for the registered bloom render callback
      * @throws NullPointerException if {@code bloomType == null || render == null || metaTileEntity == null}
      */
-    @Nullable
+    @NotNull
     public static BloomRenderTicket registerBloomRender(@Nullable IRenderSetup setup,
                                                         @NotNull BloomType bloomType,
                                                         @NotNull IBloomEffect render,
@@ -206,8 +206,8 @@ public class BloomEffectUtil {
      * manually freed by calling {@link BloomRenderTicket#invalidate()}, or invalidated by validity checker.
      * </p>
      * <p>
-     * This method does not register bloom render ticket when Optifine is present, and {@code null} will be returned
-     * instead of a ticket instance.
+     * This method does not register bloom render ticket when Optifine is present, and an invalid ticket will be
+     * returned instead.
      * </p>
      *
      * @param setup           Render setup, if exists
@@ -217,13 +217,15 @@ public class BloomEffectUtil {
      *                        Checked on both pre/post render each frame.
      * @return Ticket for the registered bloom render callback
      * @throws NullPointerException if {@code bloomType == null || render == null}
+     * @see #registerBloomRender(IRenderSetup, BloomType, IBloomEffect, MetaTileEntity)
+     * @see #registerBloomRender(IRenderSetup, BloomType, IBloomEffect, GTParticle)
      */
-    @Nullable
+    @NotNull
     public static BloomRenderTicket registerBloomRender(@Nullable IRenderSetup setup,
                                                         @NotNull BloomType bloomType,
                                                         @NotNull IBloomEffect render,
                                                         @Nullable Predicate<BloomRenderTicket> validityChecker) {
-        if (Mods.Optifine.isModLoaded()) return null;
+        if (Mods.Optifine.isModLoaded()) return BloomRenderTicket.INVALID;
         BloomRenderTicket ticket = new BloomRenderTicket(setup, bloomType, render, validityChecker);
         SCHEDULED_BLOOM_RENDERS.add(ticket);
         return ticket;
@@ -494,6 +496,8 @@ public class BloomEffectUtil {
 
     public static final class BloomRenderTicket {
 
+        public static final BloomRenderTicket INVALID = new BloomRenderTicket();
+
         @Nullable
         private final IRenderSetup renderSetup;
         private final BloomType bloomType;
@@ -502,6 +506,11 @@ public class BloomEffectUtil {
         private final Predicate<BloomRenderTicket> validityChecker;
 
         private boolean invalidated;
+
+        BloomRenderTicket() {
+            this(null, BloomType.DISABLED, (b, c) -> {}, null);
+            this.invalidated = true;
+        }
 
         BloomRenderTicket(@Nullable IRenderSetup renderSetup, @NotNull BloomType bloomType,
                           @NotNull IBloomEffect render, @Nullable Predicate<BloomRenderTicket> validityChecker) {
@@ -512,11 +521,15 @@ public class BloomEffectUtil {
         }
 
         @Nullable
+        @Deprecated
+        @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
         public IRenderSetup getRenderSetup() {
             return this.renderSetup;
         }
 
         @NotNull
+        @Deprecated
+        @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
         public BloomType getBloomType() {
             return this.bloomType;
         }

--- a/src/main/java/gregtech/client/utils/EffectRenderContext.java
+++ b/src/main/java/gregtech/client/utils/EffectRenderContext.java
@@ -1,6 +1,8 @@
 package gregtech.client.utils;
 
 import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.renderer.culling.ClippingHelperImpl;
+import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Vec3d;
 
@@ -19,6 +21,9 @@ public final class EffectRenderContext {
     public static EffectRenderContext getInstance() {
         return instance;
     }
+
+    private final ClippingHelperImpl clippingHelper = new ClippingHelperImpl();
+    private final Frustum camera = new Frustum(this.clippingHelper);
 
     @Nullable
     private Entity renderViewEntity;
@@ -52,6 +57,9 @@ public final class EffectRenderContext {
         this.rotationYZ = ActiveRenderInfo.getRotationYZ();
         this.rotationXY = ActiveRenderInfo.getRotationXY();
         this.rotationXZ = ActiveRenderInfo.getRotationXZ();
+
+        this.clippingHelper.init();
+        this.camera.setPosition(this.cameraX, this.cameraY, this.cameraZ);
 
         return this;
     }
@@ -133,5 +141,13 @@ public final class EffectRenderContext {
      */
     public float rotationXZ() {
         return rotationXZ;
+    }
+
+    /**
+     * @return camera
+     */
+    @NotNull
+    public Frustum camera() {
+        return camera;
     }
 }

--- a/src/main/java/gregtech/client/utils/IBloomEffect.java
+++ b/src/main/java/gregtech/client/utils/IBloomEffect.java
@@ -9,8 +9,11 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.function.Predicate;
+
 /**
- * Render callback interface for {@link BloomEffectUtil#registerBloomRender(IRenderSetup, BloomType, IBloomEffect)}.
+ * Render callback interface for
+ * {@link BloomEffectUtil#registerBloomRender(IRenderSetup, BloomType, IBloomEffect, Predicate)}.
  */
 @FunctionalInterface
 public interface IBloomEffect {
@@ -26,8 +29,8 @@ public interface IBloomEffect {
 
     /**
      * @param context render context
-     * @return if this effect should be rendered; returning {@code false} skips {@link #renderBloomEffect(BufferBuilder,
-     *         EffectRenderContext)} call.
+     * @return if this effect should be rendered; returning {@code false} skips
+     * {@link #renderBloomEffect(BufferBuilder, EffectRenderContext)} call.
      */
     @SideOnly(Side.CLIENT)
     default boolean shouldRenderBloomEffect(@NotNull EffectRenderContext context) {

--- a/src/main/java/gregtech/client/utils/IBloomEffect.java
+++ b/src/main/java/gregtech/client/utils/IBloomEffect.java
@@ -30,7 +30,7 @@ public interface IBloomEffect {
     /**
      * @param context render context
      * @return if this effect should be rendered; returning {@code false} skips
-     * {@link #renderBloomEffect(BufferBuilder, EffectRenderContext)} call.
+     *         {@link #renderBloomEffect(BufferBuilder, EffectRenderContext)} call.
      */
     @SideOnly(Side.CLIENT)
     default boolean shouldRenderBloomEffect(@NotNull EffectRenderContext context) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -704,7 +704,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
     @Override
     @SideOnly(Side.CLIENT)
     public boolean shouldRenderBloomEffect(@NotNull EffectRenderContext context) {
-        return this.hasFusionRingColor();
+        return this.hasFusionRingColor() && context.camera().isBoundingBoxInFrustum(getRenderBoundingBox());
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -691,12 +691,14 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
         EnumFacing.Axis axis = RelativeDirection.UP.getRelativeFacing(getFrontFacing(), getUpwardsFacing(), isFlipped())
                 .getAxis();
 
+        buffer.begin(GL11.GL_QUAD_STRIP, DefaultVertexFormats.POSITION_COLOR);
         RenderBufferHelper.renderRing(buffer,
                 getPos().getX() - context.cameraX() + relativeBack.getXOffset() * 7 + 0.5,
                 getPos().getY() - context.cameraY() + relativeBack.getYOffset() * 7 + 0.5,
                 getPos().getZ() - context.cameraZ() + relativeBack.getZOffset() * 7 + 0.5,
                 6, 0.2, 10, 20,
                 r, g, b, a, axis);
+        Tessellator.getInstance().draw();
     }
 
     @Override
@@ -753,14 +755,10 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
             GlStateManager.color(1, 1, 1, 1);
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
             GlStateManager.disableTexture2D();
-
-            buffer.begin(GL11.GL_QUAD_STRIP, DefaultVertexFormats.POSITION_COLOR);
         }
 
         @Override
         public void postDraw(@NotNull BufferBuilder buffer) {
-            Tessellator.getInstance().draw();
-
             GlStateManager.enableTexture2D();
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX, lastBrightnessY);
         }


### PR DESCRIPTION
## What
This PR is a fix for the rendering issues found on fusion rings: (1) multiple fusion rings getting linked together, and (2) fusion rings getting rendered on another dimensions. This PR also contains number of small changes to bloom effect API.

## Implementation Details
* Fixed a dumb stupid idiocy from the last guy that tried to """rewrite bloom api""" by rubbing his greasy fat finger all over his keyboard with his cerebral cortex turned off and pass it as an improvement.
* Added world context to bloom tickets, with automatic invalidation system that removes all tickets associated to the world on world unload event. For externally managed worlds which does not utilize world unload event, a method is available for manual removal.
* Added bounding box based visibility check on existing bloom effects, which could improve performance by a minuscule amount.

## Outcome
Renders

## Additional Information
Did you know that e

## Potential Compatibility Issues
* Virtually all methods on `BloomEffectUtil` that uses bloom render tickets are now made thread-safe, which can incur some amount of performance loss. Hopefully not that much.
* `BloomEffectUtil.BloomRenderTicket#getRenderSetup` and `BloomEffectUtil.BloomRenderTicket#getBloomType` is deprecated and marked for removal.
* `BloomEffectUtil#registerBloomRender` has a minor contract change; now it returns an invalid ticket instead of `null` if optinotfine is present. This might affect API users so idk if I should revert this one or not.