### PR TITLE
Brute-force Fix of RAM Usage Problem When Using Alfheim

### DIFF
--- a/src/main/java/gregtech/api/util/Mods.java
+++ b/src/main/java/gregtech/api/util/Mods.java
@@ -69,6 +69,7 @@ public enum Mods {
     VoxelMap(Names.VOXEL_MAP),
     XaerosMinimap(Names.XAEROS_MINIMAP),
     Vintagium(Names.VINTAGIUM),
+    Alfheim(Names.ALFHEIM),
 
     // Special Optifine handler, but consolidated here for simplicity
     Optifine(null) {
@@ -137,6 +138,7 @@ public enum Mods {
         public static final String VOXEL_MAP = "voxelmap";
         public static final String XAEROS_MINIMAP = "xaerominimap";
         public static final String VINTAGIUM = "vintagium";
+        public static final String ALFHEIM = "alfheim";
     }
 
     private final String ID;

--- a/src/main/java/gregtech/api/util/world/DummyWorld.java
+++ b/src/main/java/gregtech/api/util/world/DummyWorld.java
@@ -1,5 +1,7 @@
 package gregtech.api.util.world;
 
+import gregtech.api.util.Mods;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.profiler.Profiler;
@@ -10,6 +12,7 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 
 import org.jetbrains.annotations.NotNull;
@@ -37,6 +40,12 @@ public class DummyWorld extends World {
         // De-allocate lightUpdateBlockList, checkLightFor uses this
         ObfuscationReflectionHelper.setPrivateValue(World.class, this, null,
                 FMLLaunchHandler.isDeobfuscatedEnvironment() ? "lightUpdateBlockList" : "field_72994_J");
+
+        // De-allocate alfheim lighting engine
+        if (Mods.Alfheim.isModLoaded()) {
+            ObfuscationReflectionHelper.setPrivateValue(World.class, this, null,
+                    "alfheim$lightingEngine");
+        }
     }
 
     @Override
@@ -89,5 +98,22 @@ public class DummyWorld extends World {
     // De-allocated lightUpdateBlockList, default return
     public boolean checkLightFor(@NotNull EnumSkyBlock lightType, @NotNull BlockPos pos) {
         return true;
+    }
+
+    @Override
+    @Method(modid = Mods.Names.ALFHEIM)
+    public World init() {
+        return this;
+    }
+
+    @Override
+    @Method(modid = Mods.Names.ALFHEIM)
+    public int getLightFromNeighborsFor(EnumSkyBlock type, BlockPos pos) {
+        return 15;
+    }
+
+    @Method(modid = Mods.Names.ALFHEIM)
+    public int alfheim$getLight(BlockPos pos, boolean checkNeighbors) {
+        return 15;
     }
 }


### PR DESCRIPTION
## What
This PR fixes the huge amount of ram usage when using Alfheim Lighting Engine mod by overwriting some methods in  DummyWorlds class, pretty much the same as how ceu deals with vanllia lighting.

## Implementation Details
This PR overwrites these methods in DummyWorld class:

- `init` to cancel Alfheim Lighting Engine initialization.
- `alfheim$getLight` to always return light level of `15`.
- `getLightFromNeighborsFor` to always return light level of `15`.
- and a ObfuscationReflectionHelper to make sure `alfheim$lightingEngine` field is null.

It's just a few lines of change so if I haven't make it clear (probably), you might just read the code.

## Outcome
Fixes #2465 

## Potential Compatibility Issues
None hopefully?