### PR TITLE
Allow dynamic hatch placement on Distillation Tower

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -683,7 +683,7 @@ public class MetaTileEntities {
                 new MetaTileEntityImplosionCompressor(gregtechId("implosion_compressor")));
         PYROLYSE_OVEN = registerMetaTileEntity(1004, new MetaTileEntityPyrolyseOven(gregtechId("pyrolyse_oven")));
         DISTILLATION_TOWER = registerMetaTileEntity(1005,
-                new MetaTileEntityDistillationTower(gregtechId("distillation_tower")));
+                new MetaTileEntityDistillationTower(gregtechId("distillation_tower"), true));
         MULTI_FURNACE = registerMetaTileEntity(1006, new MetaTileEntityMultiSmelter(gregtechId("multi_furnace")));
         LARGE_COMBUSTION_ENGINE = registerMetaTileEntity(1007,
                 new MetaTileEntityLargeCombustionEngine(gregtechId("large_combustion_engine"), GTValues.EV));

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -159,6 +159,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     public void invalidateStructure() {
         super.invalidateStructure();
         this.layerCount = 0;
+        this.orderedFluidOutputs = null;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -23,9 +23,7 @@ import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockMetalCasing.MetalCasingType;
 import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiFluidHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
-import gregtech.common.metatileentities.multi.multiblockpart.appeng.MetaTileEntityMEOutputHatch;
 import gregtech.core.sound.GTSoundEvents;
 
 import net.minecraft.block.state.IBlockState;

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -118,7 +118,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
      * @return the number of layers that <b>could</b> hold output hatches
      */
     protected int determineLayerCount(@NotNull BlockPattern structurePattern) {
-        return structurePattern.formedRepetitionCount[1];
+        return structurePattern.formedRepetitionCount[1] + 1;
     }
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -1,13 +1,20 @@
 package gregtech.common.metatileentities.multi.electric;
 
+import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
+import gregtech.api.pattern.PatternMatchContext;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.util.GTLog;
+import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.RelativeDirection;
 import gregtech.api.util.TextComponentUtil;
@@ -16,6 +23,7 @@ import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockMetalCasing.MetalCasingType;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiFluidHatch;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.common.metatileentities.multi.multiblockpart.appeng.MetaTileEntityMEOutputHatch;
 import gregtech.core.sound.GTSoundEvents;
 
@@ -26,20 +34,28 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static gregtech.api.util.RelativeDirection.*;
 
 public class MetaTileEntityDistillationTower extends RecipeMapMultiblockController {
 
+    protected int layerCount;
+    protected List<IFluidTank> orderedFluidOutputs;
+
     public MetaTileEntityDistillationTower(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.DISTILLATION_RECIPES);
+        this.recipeMapWorkable = new DistillationTowerRecipeLogic(this);
     }
 
     @Override
@@ -52,6 +68,10 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
         return RelativeDirection.UP.getSorter(getFrontFacing(), getUpwardsFacing(), isFlipped());
     }
 
+    /**
+     * Whether this multi can be rotated or face upwards. <br>
+     * There will be <i>consequences</i> if this returns true. Go override {@link #determineOrderedFluidOutputs()}
+     */
     @Override
     public boolean allowsExtendedFacing() {
         return false;
@@ -74,7 +94,66 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     }
 
     @Override
-    protected BlockPattern createStructurePattern() {
+    protected void formStructure(PatternMatchContext context) {
+        super.formStructure(context);
+        if (this.structurePattern == null) return;
+        this.layerCount = determineLayerCount(this.structurePattern);
+        this.orderedFluidOutputs = determineOrderedFluidOutputs();
+    }
+
+    /**
+     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
+     * 
+     * @param structurePattern the structure pattern
+     * @return the number of layers that <b>could</b> hold output hatches
+     */
+    protected int determineLayerCount(@NotNull BlockPattern structurePattern) {
+        return structurePattern.formedRepetitionCount[1];
+    }
+
+    /**
+     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
+     * 
+     * @return the fluid hatches of the multiblock, in order, with null entries for layers that do not have hatches.
+     */
+    protected List<IFluidTank> determineOrderedFluidOutputs() {
+        List<MetaTileEntityMultiblockPart> fluidExportParts = this.getMultiblockParts().stream()
+                .filter(iMultiblockPart -> iMultiblockPart instanceof IMultiblockAbilityPart<?>abilityPart &&
+                        abilityPart.getAbility() == MultiblockAbility.EXPORT_FLUIDS &&
+                        abilityPart instanceof MetaTileEntityMultiblockPart)
+                .map(iMultiblockPart -> (MetaTileEntityMultiblockPart) iMultiblockPart)
+                .collect(Collectors.toList());
+        // the fluidExportParts should come sorted in smallest Y first, largest Y last.
+        List<IFluidTank> orderedTankList = new ObjectArrayList<>();
+        int firstY = this.getPos().getY() + 1;
+        int exportIndex = 0;
+        for (int y = firstY; y < firstY + this.layerCount; y++) {
+            if (fluidExportParts.size() <= exportIndex) break;
+            MetaTileEntityMultiblockPart first = fluidExportParts.get(exportIndex);
+            if (first.getPos().getY() == y) {
+                // noinspection unchecked
+                ((IMultiblockAbilityPart<IFluidTank>) first).registerAbilities(orderedTankList);
+                exportIndex++;
+            } else if (first.getPos().getY() > y) {
+                orderedTankList.add(null);
+            } else {
+                GTLog.logger.error("The Distillation Tower at " + this.getPos() +
+                        " had a fluid export hatch with an unexpected Y position.");
+                this.invalidateStructure();
+                return new ObjectArrayList<>();
+            }
+        }
+        return orderedTankList;
+    }
+
+    @Override
+    public void invalidateStructure() {
+        super.invalidateStructure();
+        this.layerCount = 0;
+    }
+
+    @Override
+    protected @NotNull BlockPattern createStructurePattern() {
         return FactoryBlockPattern.start(RIGHT, FRONT, UP)
                 .aisle("YSY", "YYY", "YYY")
                 .aisle("XXX", "X#X", "XXX").setRepeatable(1, 11)
@@ -88,8 +167,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
                         .or(metaTileEntities(MultiblockAbility.REGISTRY.get(MultiblockAbility.EXPORT_FLUIDS).stream()
                                 .filter(mte -> !(mte instanceof MetaTileEntityMultiFluidHatch) &&
                                         !(mte instanceof MetaTileEntityMEOutputHatch))
-                                .toArray(MetaTileEntity[]::new))
-                                        .setMinLayerLimited(1).setMaxLayerLimited(1))
+                                .toArray(MetaTileEntity[]::new)).setMaxLayerLimited(1, 1))
                         .or(autoAbilities(true, false)))
                 .where('#', air())
                 .build();
@@ -124,6 +202,70 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
 
     @Override
     public int getFluidOutputLimit() {
-        return getOutputFluidInventory().getTanks();
+        return this.layerCount;
+    }
+
+    protected class DistillationTowerRecipeLogic extends MultiblockRecipeLogic {
+
+        public DistillationTowerRecipeLogic(MetaTileEntityDistillationTower tileEntity) {
+            super(tileEntity);
+        }
+
+        protected boolean applyFluidToOutputs(List<FluidStack> fluids, boolean doFill) {
+            boolean valid = true;
+            for (int i = 0; i < fluids.size(); i++) {
+                IFluidTank tank = orderedFluidOutputs.get(i);
+                // void if no hatch is found on that fluid's layer
+                // this is considered trimming and thus ignores canVoid
+                if (tank == null) continue;
+                int accepted = tank.fill(fluids.get(i), doFill);
+                if (accepted != fluids.get(i).amount) valid = false;
+                if (!doFill && !valid) break;
+            }
+            return valid;
+        }
+
+        @Override
+        protected void outputRecipeOutputs() {
+            GTTransferUtils.addItemsToItemHandler(getOutputInventory(), false, itemOutputs);
+            this.applyFluidToOutputs(fluidOutputs, true);
+        }
+
+        @Override
+        protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
+                                                      @NotNull IItemHandlerModifiable importInventory,
+                                                      @NotNull IMultipleTankHandler importFluids) {
+            this.overclockResults = calculateOverclock(recipe);
+
+            modifyOverclockPost(overclockResults, recipe.getRecipePropertyStorage());
+
+            if (!hasEnoughPower(overclockResults)) {
+                return false;
+            }
+
+            IItemHandlerModifiable exportInventory = getOutputInventory();
+
+            // We have already trimmed outputs and chanced outputs at this time
+            // Attempt to merge all outputs + chanced outputs into the output bus, to prevent voiding chanced outputs
+            if (!metaTileEntity.canVoidRecipeItemOutputs() &&
+                    !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
+                this.isOutputsFull = true;
+                return false;
+            }
+
+            // Perform layerwise fluid checks
+            if (!metaTileEntity.canVoidRecipeFluidOutputs() &&
+                    !this.applyFluidToOutputs(recipe.getAllFluidOutputs(), false)) {
+                this.isOutputsFull = true;
+                return false;
+            }
+
+            this.isOutputsFull = false;
+            if (recipe.matches(true, importInventory, importFluids)) {
+                this.metaTileEntity.addNotifiedInput(importInventory);
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -69,7 +69,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
 
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
-        return new MetaTileEntityDistillationTower(metaTileEntityId);
+        return new MetaTileEntityDistillationTower(metaTileEntityId, this.useAdvHatchLogic);
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -138,17 +138,20 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
         int firstY = this.getPos().getY() + 1;
         int exportIndex = 0;
         for (int y = firstY; y < firstY + this.layerCount; y++) {
-            if (fluidExportParts.size() <= exportIndex) break;
-            MetaTileEntityMultiblockPart first = fluidExportParts.get(exportIndex);
-            if (first.getPos().getY() == y) {
+            if (fluidExportParts.size() <= exportIndex) {
+                orderedHandlerList.add(null);
+                continue;
+            }
+            MetaTileEntityMultiblockPart part = fluidExportParts.get(exportIndex);
+            if (part.getPos().getY() == y) {
                 List<IFluidTank> hatchTanks = new ObjectArrayList<>();
                 // noinspection unchecked
-                ((IMultiblockAbilityPart<IFluidTank>) first).registerAbilities(hatchTanks);
+                ((IMultiblockAbilityPart<IFluidTank>) part).registerAbilities(hatchTanks);
                 if (hatchTanks.size() == 1)
                     orderedHandlerList.add(FluidTankHandler.getTankFluidHandler(hatchTanks.get(0)));
                 else orderedHandlerList.add(new FluidTankList(false, hatchTanks));
                 exportIndex++;
-            } else if (first.getPos().getY() > y) {
+            } else if (part.getPos().getY() > y) {
                 orderedHandlerList.add(null);
             } else {
                 GTLog.logger.error("The Distillation Tower at " + this.getPos() +

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -50,12 +50,21 @@ import static gregtech.api.util.RelativeDirection.*;
 
 public class MetaTileEntityDistillationTower extends RecipeMapMultiblockController {
 
+    private final boolean useAdvHatchLogic;
+
     protected int layerCount;
     protected List<IFluidTank> orderedFluidOutputs;
 
     public MetaTileEntityDistillationTower(ResourceLocation metaTileEntityId) {
+        this(metaTileEntityId, false);
+    }
+
+    public MetaTileEntityDistillationTower(ResourceLocation metaTileEntityId, boolean useAdvHatchLogic) {
         super(metaTileEntityId, RecipeMaps.DISTILLATION_RECIPES);
-        this.recipeMapWorkable = new DistillationTowerRecipeLogic(this);
+        this.useAdvHatchLogic = useAdvHatchLogic;
+        if (useAdvHatchLogic) {
+            this.recipeMapWorkable = new DistillationTowerRecipeLogic(this);
+        }
     }
 
     @Override
@@ -96,7 +105,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     @Override
     protected void formStructure(PatternMatchContext context) {
         super.formStructure(context);
-        if (this.structurePattern == null) return;
+        if (!useAdvHatchLogic || this.structurePattern == null) return;
         this.layerCount = determineLayerCount(this.structurePattern);
         this.orderedFluidOutputs = determineOrderedFluidOutputs();
     }


### PR DESCRIPTION
## What
Allows hatches to be optional on any layer of the distillation tower, with automatic fluid voiding performed based on what hatches are left off.

## Implementation Details
Adds two new information gathering methods, determineLayerCount and determineOrderedFluidOutputs, to the MetaTileEntityDistillationTower class. The information gathered through these methods is then used to smart distribute fluids among output hatches, skipping over absent hatches.

## Additional Information
You're welcome sereni

## Potential Compatibility Issues
~~Literally any addon (I'm looking at you GCYM) that extends the distillation tower mte class is going to need to add overrides for the two new information-gathering methods or they are going to implode.~~
None, the new logic is opt-in.
