### PR TITLE
Allow all input bus variants on assembly line

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -145,6 +145,11 @@ public class ConfigHolder {
         @Config.RequiresMcRestart
         public boolean orderedFluidAssembly = false;
 
+        @Config.Comment({ "Whether the Assembly Line should check every permutation of inputs for a valid recipe.",
+                "Prevents the Assembly Line from locking up due to bad hatch stocking, but can cause significant lag during recipe search.",
+                "Default: true" })
+        public boolean advancedAssemblyRecipeSearch = true;
+
         /**
          * <strong>Addons mods should not reference this config directly.</strong>
          * Use {@link GregTechAPI#isHighTier()} instead.


### PR DESCRIPTION
## What
Revamps assembly line logic to allow larger than ULV item inputs, while still respecting the '1 item variant per input' rule (and the ordered inputs rule, if that is enabled)

## Implementation Details
Mostly just adds expanded checks, but if a new config option (defaulting to true) is set to true, then a recursive search of every possible permutation happens. This has the benefit of preventing the assembly line from locking if, for example, the ingredients for a LuV motor were all present but improperly distributed, and the ingredients for a LuV conveyor were properly distributed. The downside is, of course, rapidly inflating performance impact. Thus config option.

## Additional Information
Am I just the advanced multiblock logic guy now?
