### PR TITLE
Various Cleanroom Improvements

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -1,6 +1,7 @@
 package gregtech.api;
 
 import gregtech.api.advancement.IAdvancementManager;
+import gregtech.api.block.ICleanroomFilter;
 import gregtech.api.block.IHeatingCoilBlockStats;
 import gregtech.api.block.machines.BlockMachine;
 import gregtech.api.command.ICommandManager;
@@ -68,6 +69,7 @@ public class GregTechAPI {
     public static final Map<Material, Map<StoneType, IBlockOre>> oreBlockTable = new HashMap<>();
     public static final Object2ObjectMap<IBlockState, IHeatingCoilBlockStats> HEATING_COILS = new Object2ObjectOpenHashMap<>();
     public static final Object2ObjectMap<IBlockState, IBatteryData> PSS_BATTERIES = new Object2ObjectOpenHashMap<>();
+    public static final Object2ObjectMap<IBlockState, ICleanroomFilter> CLEANROOM_FILTERS = new Object2ObjectOpenHashMap<>();
 
     /** Will be available at the Pre-Initialization stage */
     public static boolean isHighTier() {

--- a/src/main/java/gregtech/api/block/ICleanroomFilter.java
+++ b/src/main/java/gregtech/api/block/ICleanroomFilter.java
@@ -3,11 +3,15 @@ package gregtech.api.block;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.multiblock.CleanroomType;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface ICleanroomFilter {
 
     /**
-     * @return The {@link CleanroomType} this filter should provide
+     * @return The {@link CleanroomType} this filter should provide,
+     * can be <code>null</code> if the block isn't a filter
      */
+    @Nullable
     CleanroomType getCleanroomType();
 
     /**

--- a/src/main/java/gregtech/api/block/ICleanroomFilter.java
+++ b/src/main/java/gregtech/api/block/ICleanroomFilter.java
@@ -1,0 +1,17 @@
+package gregtech.api.block;
+
+import gregtech.api.metatileentity.multiblock.CleanroomType;
+
+public interface ICleanroomFilter {
+
+    /**
+     * @return The name of the cleanroom this filter should provide, for lookup using
+     *         {@link CleanroomType#getByName(String)}
+     */
+    String getCleanroomName();
+
+    /**
+     * @return The "tier" of the filter, for use in JEI previews
+     */
+    int getTier();
+}

--- a/src/main/java/gregtech/api/block/ICleanroomFilter.java
+++ b/src/main/java/gregtech/api/block/ICleanroomFilter.java
@@ -9,7 +9,7 @@ public interface ICleanroomFilter {
 
     /**
      * @return The {@link CleanroomType} this filter should provide,
-     * can be <code>null</code> if the block isn't a filter
+     *         can be <code>null</code> if the block isn't a filter
      */
     @Nullable
     CleanroomType getCleanroomType();

--- a/src/main/java/gregtech/api/block/ICleanroomFilter.java
+++ b/src/main/java/gregtech/api/block/ICleanroomFilter.java
@@ -1,17 +1,24 @@
 package gregtech.api.block;
 
+import gregtech.api.GTValues;
 import gregtech.api.metatileentity.multiblock.CleanroomType;
 
 public interface ICleanroomFilter {
 
     /**
-     * @return The name of the cleanroom this filter should provide, for lookup using
-     *         {@link CleanroomType#getByName(String)}
+     * @return The {@link CleanroomType} this filter should provide
      */
-    String getCleanroomName();
+    CleanroomType getCleanroomType();
 
     /**
      * @return The "tier" of the filter, for use in JEI previews
      */
     int getTier();
+
+    /**
+     * @return The minimum voltage tier a cleanroom with this filter will accept
+     */
+    default int getMinTier() {
+        return GTValues.LV;
+    }
 }

--- a/src/main/java/gregtech/api/capability/impl/CleanroomLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/CleanroomLogic.java
@@ -48,6 +48,9 @@ public class CleanroomLogic {
         // all maintenance problems not fixed means the machine does not run
         if (hasMaintenance && ((IMaintenance) metaTileEntity).getNumMaintenanceProblems() > 5) return;
 
+        // if the energy tier is below min tier then do nothing
+        if (minEnergyTier > ((ICleanroomProvider) metaTileEntity).getEnergyTier()) return;
+
         // drain the energy
         if (consumeEnergy(true)) {
             consumeEnergy(false);

--- a/src/main/java/gregtech/api/capability/impl/CleanroomLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/CleanroomLogic.java
@@ -19,7 +19,7 @@ public class CleanroomLogic {
     private int maxProgress = 0;
     private int progressTime = 0;
 
-    private final int minEnergyTier;
+    private int minEnergyTier;
 
     private final MetaTileEntity metaTileEntity;
     private final boolean hasMaintenance;
@@ -49,7 +49,7 @@ public class CleanroomLogic {
         if (hasMaintenance && ((IMaintenance) metaTileEntity).getNumMaintenanceProblems() > 5) return;
 
         // if the energy tier is below min tier then do nothing
-        if (minEnergyTier > ((ICleanroomProvider) metaTileEntity).getEnergyTier()) return;
+        if (!isVoltageHighEnough()) return;
 
         // drain the energy
         if (consumeEnergy(true)) {
@@ -131,6 +131,10 @@ public class CleanroomLogic {
         }
     }
 
+    public boolean isVoltageHighEnough() {
+        return minEnergyTier <= ((ICleanroomProvider) metaTileEntity).getEnergyTier();
+    }
+
     /**
      * @return whether working is enabled for the logic
      */
@@ -166,6 +170,10 @@ public class CleanroomLogic {
 
     protected int getTierDifference() {
         return ((ICleanroomProvider) metaTileEntity).getEnergyTier() - minEnergyTier;
+    }
+
+    public void setMinEnergyTier(int energyTier) {
+        this.minEnergyTier = energyTier;
     }
 
     /**

--- a/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
@@ -67,6 +67,7 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
         }
 
         @Override
+        @Nullable
         public CleanroomType getCleanroomType() {
             return cleanroomType;
         }

--- a/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
@@ -4,6 +4,7 @@ import gregtech.api.block.ICleanroomFilter;
 import gregtech.api.block.IStateHarvestLevel;
 import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
+import gregtech.api.metatileentity.multiblock.CleanroomType;
 
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -42,13 +43,13 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
     public enum CasingType implements IStringSerializable, ICleanroomFilter {
 
         PLASCRETE("plascrete", null),
-        FILTER_CASING("filter_casing", "cleanroom"),
-        FILTER_CASING_STERILE("filter_casing_sterile", "sterile_cleanroom");
+        FILTER_CASING("filter_casing", CleanroomType.CLEANROOM),
+        FILTER_CASING_STERILE("filter_casing_sterile", CleanroomType.STERILE_CLEANROOM);
 
         private final String name;
-        private final String cleanroomType;
+        private final CleanroomType cleanroomType;
 
-        CasingType(String name, String cleanroomType) {
+        CasingType(String name, CleanroomType cleanroomType) {
             this.name = name;
             this.cleanroomType = cleanroomType;
         }
@@ -66,7 +67,7 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
         }
 
         @Override
-        public String getCleanroomName() {
+        public CleanroomType getCleanroomType() {
             return cleanroomType;
         }
 

--- a/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
+++ b/src/main/java/gregtech/common/blocks/BlockCleanroomCasing.java
@@ -1,5 +1,6 @@
 package gregtech.common.blocks;
 
+import gregtech.api.block.ICleanroomFilter;
 import gregtech.api.block.IStateHarvestLevel;
 import gregtech.api.block.VariantBlock;
 import gregtech.api.items.toolitem.ToolClasses;
@@ -38,16 +39,18 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
         return false;
     }
 
-    public enum CasingType implements IStringSerializable {
+    public enum CasingType implements IStringSerializable, ICleanroomFilter {
 
-        PLASCRETE("plascrete"),
-        FILTER_CASING("filter_casing"),
-        FILTER_CASING_STERILE("filter_casing_sterile");
+        PLASCRETE("plascrete", null),
+        FILTER_CASING("filter_casing", "cleanroom"),
+        FILTER_CASING_STERILE("filter_casing_sterile", "sterile_cleanroom");
 
         private final String name;
+        private final String cleanroomType;
 
-        CasingType(String name) {
+        CasingType(String name, String cleanroomType) {
             this.name = name;
+            this.cleanroomType = cleanroomType;
         }
 
         @NotNull
@@ -60,6 +63,16 @@ public class BlockCleanroomCasing extends VariantBlock<BlockCleanroomCasing.Casi
         @Override
         public String toString() {
             return getName();
+        }
+
+        @Override
+        public String getCleanroomName() {
+            return cleanroomType;
+        }
+
+        @Override
+        public int getTier() {
+            return this.ordinal() - 1;
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -586,7 +586,8 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation(
-                isClean() ? "gregtech.multiblock.cleanroom.clean_state" : "gregtech.multiblock.cleanroom.dirty_state", this.cleanAmount));
+                isClean() ? "gregtech.multiblock.cleanroom.clean_state" : "gregtech.multiblock.cleanroom.dirty_state",
+                this.cleanAmount));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -134,7 +134,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
         super.formStructure(context);
         initializeAbilities();
         this.cleanroomFilter = context.get("FilterType");
-        this.cleanroomType = CleanroomType.getByName(cleanroomFilter.getCleanroomType().getName());
+        this.cleanroomType = cleanroomFilter.getCleanroomType();
 
         // max progress is based on the dimensions of the structure: (x^3)-(x^2)
         // taller cleanrooms take longer than wider ones

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -503,6 +503,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
                                 cleanState));
                     }
                 })
+                .addEnergyUsageExactLine(isClean() ? 4 : GTValues.VA[getEnergyTier()])
                 .addWorkingStatusLine()
                 .addProgressLine(getProgressPercent() / 100.0);
     }
@@ -585,7 +586,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
     @Override
     public List<ITextComponent> getDataInfo() {
         return Collections.singletonList(new TextComponentTranslation(
-                isClean() ? "gregtech.multiblock.cleanroom.clean_state" : "gregtech.multiblock.cleanroom.dirty_state"));
+                isClean() ? "gregtech.multiblock.cleanroom.clean_state" : "gregtech.multiblock.cleanroom.dirty_state", this.cleanAmount));
     }
 
     @Override
@@ -631,7 +632,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
     }
 
     public boolean drainEnergy(boolean simulate) {
-        long energyToDrain = isClean() ? (long) Math.min(4, Math.pow(4, getEnergyTier())) :
+        long energyToDrain = isClean() ? 4 :
                 GTValues.VA[getEnergyTier()];
         long resultEnergy = energyContainer.getEnergyStored() - energyToDrain;
         if (resultEnergy >= 0L && resultEnergy <= energyContainer.getEnergyCapacity()) {

--- a/src/main/java/gregtech/core/CoreModule.java
+++ b/src/main/java/gregtech/core/CoreModule.java
@@ -36,6 +36,7 @@ import gregtech.common.CommonProxy;
 import gregtech.common.ConfigHolder;
 import gregtech.common.MetaEntities;
 import gregtech.common.blocks.BlockBatteryPart;
+import gregtech.common.blocks.BlockCleanroomCasing;
 import gregtech.common.blocks.BlockWireCoil;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.command.CommandHand;
@@ -206,6 +207,9 @@ public class CoreModule implements IGregTechModule {
         }
         for (BlockBatteryPart.BatteryPartType type : BlockBatteryPart.BatteryPartType.values()) {
             PSS_BATTERIES.put(MetaBlocks.BATTERY_BLOCK.getState(type), type);
+        }
+        for (BlockCleanroomCasing.CasingType type : BlockCleanroomCasing.CasingType.values()) {
+            CLEANROOM_FILTERS.put(MetaBlocks.CLEANROOM_CASING.getState(type), type);
         }
         /* End API Block Registration */
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4831,6 +4831,7 @@ gregtech.multiblock.cleanroom.clean_status=Status: %s
 gregtech.multiblock.cleanroom.clean_state=Clean (%s%%)
 gregtech.multiblock.cleanroom.dirty_state=Contaminated (%s%%)
 gregtech.multiblock.cleanroom.warning_contaminated=Contaminated!
+gregtech.multiblock.cleanroom.low_tier=Energy tier too low, minimum of %s!
 
 gregtech.machine.charcoal_pile.name=Charcoal Pile Igniter
 gregtech.machine.charcoal_pile.tooltip.1=Turns Logs into §aCharcoal§7 when §cignited§7.


### PR DESCRIPTION
## What
Improves the cleanroom GUI, structure code, and allows addons to define cleanroom filters to use in the cleanroom without extending the ``MetaTileEntityCleanroom`` class and overriding the structure code. Cleanroom filters can additionally specify minimum energy tiers that the cleanroom must run at(although this is just a possibility and the current filters work with all energy tiers). Oh and also using the scanner on the cleanroom actually has correct formatting.

## Implementation Details
Adds interface ``ICleanroomFilter``, which ``BlockCleanroomCasing`` implements, to signify a cleanroom filter. Note that plascrete is not moved elsewhere for compatability reasons, thus there are null checks in the code. 

## Outcome
Cleanroom GUI shows EU/t used, addons can add custom cleanroom filters easily, cleanroom filters can have a min energy tier, scanner on cleanroom shows the percent cleaned

**NOTE**: I'm not sure if this is intended, but cleanroom always uses 4 EU/t when cleaned regardless of energy hatch tier, while the 30 EU/t cleaning cost does overclock. Since ``getEnergyTier()`` returns at minimum ``GTValues.LV``(1), thus the ``(long) Math.min(4, Math.pow(4, getEnergyTier()))`` always returns 4. If this is unintended I can add default overclocking logic for the 4 EU/t as well.
![image](https://github.com/GregTechCEu/GregTech/assets/113960896/72b3f34d-3b12-45cf-b087-a9e699952485)

## Additional Information
For some forsaken reason these 2 blocks don't render both before and after I made this change, and I can't figure out why.
![image](https://github.com/GregTechCEu/GregTech/assets/113960896/1a47c0cb-b7f9-454e-8c73-ba48022b28f4)

## Potential Compatibility Issues
None, since I *think* any addons with custom cleanrooms had to override the structure methods changed here already with custom filters.
