### PR TITLE
Allow laser hatches on multis

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.EnergyContainerList;
 import gregtech.api.capability.impl.MultiblockFuelRecipeLogic;
+import gregtech.api.pattern.TraceabilityPredicate;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextComponentUtil;
@@ -34,7 +35,26 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
     @Override
     protected void initializeAbilities() {
         super.initializeAbilities();
-        this.energyContainer = new EnergyContainerList(getAbilities(MultiblockAbility.OUTPUT_ENERGY));
+        List<IEnergyContainer> inputEnergy = new ArrayList<>(getAbilities(MultiblockAbility.OUTPUT_ENERGY));
+        if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
+            inputEnergy.addAll(getAbilities(MultiblockAbility.OUTPUT_LASER));
+        }
+        this.energyContainer = new EnergyContainerList(inputEnergy);
+    }
+
+    public TraceabilityPredicate autoAbilityEnergyOut() {
+        TraceabilityPredicate predicate = new TraceabilityPredicate();
+
+        if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
+            predicate = predicate.or(abilities(MultiblockAbility.OUTPUT_ENERGY, MultiblockAbility.OUTPUT_LASER)
+                    .setExactLimit(1));
+        }
+        else {
+            predicate = predicate.or(abilities(MultiblockAbility.OUTPUT_ENERGY)
+                    .setExactLimit(1));
+        }
+
+        return predicate;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -48,8 +48,7 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
         if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
             predicate = predicate.or(abilities(MultiblockAbility.OUTPUT_ENERGY, MultiblockAbility.OUTPUT_LASER)
                     .setExactLimit(1));
-        }
-        else {
+        } else {
             predicate = predicate.or(abilities(MultiblockAbility.OUTPUT_ENERGY)
                     .setExactLimit(1));
         }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
@@ -100,8 +100,7 @@ public abstract class MultiMapMultiblockController extends RecipeMapMultiblockCo
         boolean checkedItemIn = false, checkedItemOut = false, checkedFluidIn = false, checkedFluidOut = false;
 
         TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler)
-                .or(checkEnergyIn ? abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1)
-                        .setMaxGlobalLimited(3).setPreviewCount(1) : new TraceabilityPredicate());
+                .or(checkEnergyIn ? autoAbilityEnergyIn() : new TraceabilityPredicate());
 
         for (RecipeMap<?> recipeMap : getAvailableRecipeMaps()) {
             if (!checkedItemIn && checkItemIn) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -338,7 +338,7 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     }
 
     public TraceabilityPredicate autoAbilities() {
-        return autoAbilities(true, true, true, 2);
+        return autoAbilities(true, true, true, ConfigHolder.machines.energyHatchCount);
     }
 
     public TraceabilityPredicate autoAbilities(boolean checkMaintenance, boolean checkMuffler, boolean checkEnergyIn, int maxHatchCount) {
@@ -376,7 +376,7 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     }
 
     public TraceabilityPredicate autoAbilityEnergyIn() {
-        return autoAbilities(false, false, true, 2);
+        return autoAbilities(false, false, true, ConfigHolder.machines.energyHatchCount);
     }
 
     protected TraceabilityPredicate maintenancePredicate() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -338,10 +338,10 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     }
 
     public TraceabilityPredicate autoAbilities() {
-        return autoAbilities(true, true);
+        return autoAbilities(true, true, true, 2);
     }
 
-    public TraceabilityPredicate autoAbilities(boolean checkMaintenance, boolean checkMuffler) {
+    public TraceabilityPredicate autoAbilities(boolean checkMaintenance, boolean checkMuffler, boolean checkEnergyIn, int maxHatchCount) {
         TraceabilityPredicate predicate = new TraceabilityPredicate();
         if (checkMaintenance && hasMaintenanceMechanics()) {
             predicate = predicate.or(maintenancePredicate());
@@ -350,7 +350,33 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
             predicate = predicate
                     .or(abilities(MultiblockAbility.MUFFLER_HATCH).setMinGlobalLimited(1).setMaxGlobalLimited(1));
         }
+        if (checkEnergyIn) {
+            if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
+                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY, MultiblockAbility.INPUT_LASER)
+                        .setMinGlobalLimited(1)
+                        .setMaxGlobalLimited(maxHatchCount)
+                        .setPreviewCount(1));
+            }
+            else {
+                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY)
+                        .setMinGlobalLimited(1)
+                        .setMaxGlobalLimited(maxHatchCount)
+                        .setPreviewCount(1));
+            }
+        }
         return predicate;
+    }
+
+    public TraceabilityPredicate autoAbilities(boolean checkMaintenance, boolean checkMuffler) {
+        return autoAbilities(checkMaintenance, checkMuffler, false, 0);
+    }
+
+    public TraceabilityPredicate autoAbilityEnergyIn(int maxHatchCount) {
+        return autoAbilities(false, false, true, maxHatchCount);
+    }
+
+    public TraceabilityPredicate autoAbilityEnergyIn() {
+        return autoAbilities(false, false, true, 2);
     }
 
     protected TraceabilityPredicate maintenancePredicate() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -341,7 +341,8 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
         return autoAbilities(true, true, true, ConfigHolder.machines.energyHatchCount);
     }
 
-    public TraceabilityPredicate autoAbilities(boolean checkMaintenance, boolean checkMuffler, boolean checkEnergyIn, int maxHatchCount) {
+    public TraceabilityPredicate autoAbilities(boolean checkMaintenance, boolean checkMuffler, boolean checkEnergyIn,
+                                               int maxHatchCount) {
         TraceabilityPredicate predicate = new TraceabilityPredicate();
         if (checkMaintenance && hasMaintenanceMechanics()) {
             predicate = predicate.or(maintenancePredicate());
@@ -356,8 +357,7 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
                         .setMinGlobalLimited(1)
                         .setMaxGlobalLimited(maxHatchCount)
                         .setPreviewCount(1));
-            }
-            else {
+            } else {
                 predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY)
                         .setMinGlobalLimited(1)
                         .setMaxGlobalLimited(maxHatchCount)

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -125,8 +125,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
         this.outputFluidInventory = new FluidTankList(allowSameFluidFillForOutputs(),
                 getAbilities(MultiblockAbility.EXPORT_FLUIDS));
         List<IEnergyContainer> inputEnergy = new ArrayList<>(getAbilities(MultiblockAbility.INPUT_ENERGY));
-        if (ConfigHolder.machines.allowLaserHatches) {
-            inputEnergy.addAll(getAbilities(MultiblockAbility.SUBSTATION_INPUT_ENERGY));
+        if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
             inputEnergy.addAll(getAbilities(MultiblockAbility.INPUT_LASER));
         }
         this.energyContainer = new EnergyContainerList(inputEnergy);
@@ -176,11 +175,11 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                                                boolean checkMuffler) {
         TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler);
 
+
+
         if (checkEnergyIn) {
-            if (ConfigHolder.machines.allowLaserHatches) {
-                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY,
-                        MultiblockAbility.INPUT_LASER,
-                        MultiblockAbility.SUBSTATION_INPUT_ENERGY)
+            if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
+                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY, MultiblockAbility.INPUT_LASER)
                         .setMinGlobalLimited(1)
                         .setMaxGlobalLimited(2)
                         .setPreviewCount(1));

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -173,7 +173,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                                                boolean checkFluidIn,
                                                boolean checkFluidOut,
                                                boolean checkMuffler) {
-        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, checkEnergyIn, 2);
+        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, checkEnergyIn, ConfigHolder.machines.energyHatchCount);
 
         if (checkItemIn) {
             if (recipeMap.getMaxInputs() > 0) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -173,7 +173,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                                                boolean checkFluidIn,
                                                boolean checkFluidOut,
                                                boolean checkMuffler) {
-        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, true, 2);
+        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, checkEnergyIn, 2);
 
         if (checkItemIn) {
             if (recipeMap.getMaxInputs() > 0) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -173,24 +173,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                                                boolean checkFluidIn,
                                                boolean checkFluidOut,
                                                boolean checkMuffler) {
-        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler);
-
-
-
-        if (checkEnergyIn) {
-            if (ConfigHolder.machines.allowLaserHatchesOnMultis) {
-                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY, MultiblockAbility.INPUT_LASER)
-                        .setMinGlobalLimited(1)
-                        .setMaxGlobalLimited(2)
-                        .setPreviewCount(1));
-            }
-            else {
-                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY)
-                        .setMinGlobalLimited(1)
-                        .setMaxGlobalLimited(2)
-                        .setPreviewCount(1));
-            }
-        }
+        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, true, 2);
 
         if (checkItemIn) {
             if (recipeMap.getMaxInputs() > 0) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -124,7 +124,12 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
         this.outputInventory = new ItemHandlerList(getAbilities(MultiblockAbility.EXPORT_ITEMS));
         this.outputFluidInventory = new FluidTankList(allowSameFluidFillForOutputs(),
                 getAbilities(MultiblockAbility.EXPORT_FLUIDS));
-        this.energyContainer = new EnergyContainerList(getAbilities(MultiblockAbility.INPUT_ENERGY));
+        List<IEnergyContainer> inputEnergy = new ArrayList<>(getAbilities(MultiblockAbility.INPUT_ENERGY));
+        if (ConfigHolder.machines.allowLaserHatches) {
+            inputEnergy.addAll(getAbilities(MultiblockAbility.SUBSTATION_INPUT_ENERGY));
+            inputEnergy.addAll(getAbilities(MultiblockAbility.INPUT_LASER));
+        }
+        this.energyContainer = new EnergyContainerList(inputEnergy);
     }
 
     private void resetTileAbilities() {
@@ -172,9 +177,20 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
         TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler);
 
         if (checkEnergyIn) {
-            predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1)
-                    .setMaxGlobalLimited(2)
-                    .setPreviewCount(1));
+            if (ConfigHolder.machines.allowLaserHatches) {
+                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY,
+                        MultiblockAbility.INPUT_LASER,
+                        MultiblockAbility.SUBSTATION_INPUT_ENERGY)
+                        .setMinGlobalLimited(1)
+                        .setMaxGlobalLimited(2)
+                        .setPreviewCount(1));
+            }
+            else {
+                predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY)
+                        .setMinGlobalLimited(1)
+                        .setMaxGlobalLimited(2)
+                        .setPreviewCount(1));
+            }
         }
 
         if (checkItemIn) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -173,7 +173,8 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                                                boolean checkFluidIn,
                                                boolean checkFluidOut,
                                                boolean checkMuffler) {
-        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, checkEnergyIn, ConfigHolder.machines.energyHatchCount);
+        TraceabilityPredicate predicate = super.autoAbilities(checkMaintenance, checkMuffler, checkEnergyIn,
+                ConfigHolder.machines.energyHatchCount);
 
         if (checkItemIn) {
             if (recipeMap.getMaxInputs() > 0) {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -166,6 +166,12 @@ public class ConfigHolder {
                 "Default: false" })
         @Config.RequiresMcRestart
         public boolean allowLaserHatchesOnMultis = false;
+
+        @Config.Comment({ "Maximum number of allowed energy hatches on multiblocks.",
+                "Default: 2" })
+        @Config.RequiresMcRestart
+        @Config.RangeInt(min = 1, max = 5)
+        public int energyHatchCount = 2;
     }
 
     public static class WorldGenOptions {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -165,7 +165,7 @@ public class ConfigHolder {
         @Config.Comment({ "If laser target hatches should be allowed on multiblocks.",
                 "Default: false" })
         @Config.RequiresMcRestart
-        public boolean allowLaserHatches = false;
+        public boolean allowLaserHatchesOnMultis = false;
     }
 
     public static class WorldGenOptions {

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -161,6 +161,11 @@ public class ConfigHolder {
                 "This does NOT apply to the World Accelerator, but to external effects like Time in a Bottle.",
                 "Default: true" })
         public boolean allowTickAcceleration = true;
+
+        @Config.Comment({ "If laser target hatches should be allowed on multiblocks.",
+                "Default: false" })
+        @Config.RequiresMcRestart
+        public boolean allowLaserHatches = false;
     }
 
     public static class WorldGenOptions {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
@@ -88,10 +88,7 @@ public class MetaTileEntityAssemblyLine extends RecipeMapMultiblockController {
                         .or(fluidInputPredicate()))
                 .where('O', abilities(MultiblockAbility.EXPORT_ITEMS)
                         .addTooltips("gregtech.multiblock.pattern.location_end"))
-                .where('Y', states(getCasingState())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY)
-                                .setMinGlobalLimited(1)
-                                .setMaxGlobalLimited(3)))
+                .where('Y', states(getCasingState()).or(autoAbilityEnergyIn()))
                 .where('I', metaTileEntities(MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV]))
                 .where('G', states(getGrateState()))
                 .where('A',

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -364,8 +364,7 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
         }
 
         TraceabilityPredicate wallPredicate = states(getCasingState(), getGlassState());
-        TraceabilityPredicate basePredicate = autoAbilities().or(abilities(MultiblockAbility.INPUT_ENERGY)
-                .setMinGlobalLimited(1).setMaxGlobalLimited(3));
+        TraceabilityPredicate basePredicate = autoAbilities();
 
         // layer the slices one behind the next
         return FactoryBlockPattern.start()

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDataBank.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDataBank.java
@@ -172,8 +172,7 @@ public class MetaTileEntityDataBank extends MultiblockWithDisplayBase implements
                 .where('C', states(getFrontState())
                         .setMinGlobalLimited(4)
                         .or(autoAbilities())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY)
-                                .setMinGlobalLimited(1).setMaxGlobalLimited(2).setPreviewCount(1)))
+                        .or(autoAbilityEnergyIn()))
                 .build();
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -82,7 +82,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
                 .where('S', selfPredicate())
                 .where('Y', states(getCasingState())
                         .or(abilities(MultiblockAbility.EXPORT_ITEMS).setMaxGlobalLimited(1))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(3))
+                        .or(autoAbilityEnergyIn())
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setExactLimit(1)))
                 .where('X', states(getCasingState())
                         .or(metaTileEntities(MultiblockAbility.REGISTRY.get(MultiblockAbility.EXPORT_FLUIDS).stream()
@@ -90,7 +90,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
                                         !(mte instanceof MetaTileEntityMEOutputHatch))
                                 .toArray(MetaTileEntity[]::new))
                                         .setMinLayerLimited(1).setMaxLayerLimited(1))
-                        .or(autoAbilities()))
+                        .or(autoAbilities(true, false)))
                 .where('#', air())
                 .build();
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -90,7 +90,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
                                         !(mte instanceof MetaTileEntityMEOutputHatch))
                                 .toArray(MetaTileEntity[]::new))
                                         .setMinLayerLimited(1).setMaxLayerLimited(1))
-                        .or(autoAbilities(true, false)))
+                        .or(autoAbilities()))
                 .where('#', air())
                 .build();
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityHPCA.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityHPCA.java
@@ -208,7 +208,7 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
                 .where('X', abilities(MultiblockAbility.HPCA_COMPONENT))
                 .where('C', states(getCasingState()).setMinGlobalLimited(5)
                         .or(maintenancePredicate())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1))
+                        .or(autoAbilityEnergyIn())
                         .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMaxGlobalLimited(1))
                         .or(abilities(MultiblockAbility.COMPUTATION_DATA_TRANSMISSION).setExactLimit(1)))
                 .build();

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityNetworkSwitch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityNetworkSwitch.java
@@ -107,7 +107,7 @@ public class MetaTileEntityNetworkSwitch extends MetaTileEntityDataBank implemen
                 .where('S', selfPredicate())
                 .where('A', states(getAdvancedState()))
                 .where('X', states(getCasingState()).setMinGlobalLimited(7)
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1, 1))
+                        .or(autoAbilityEnergyIn())
                         .or(maintenancePredicate())
                         .or(abilities(MultiblockAbility.COMPUTATION_DATA_RECEPTION).setMinGlobalLimited(1, 2))
                         .or(abilities(MultiblockAbility.COMPUTATION_DATA_TRANSMISSION).setMinGlobalLimited(1, 1)))

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -87,7 +87,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                 .where('X', states(getCasingState())
                         .setMinGlobalLimited(tier == 0 ? 11 : 4)
                         .or(autoAbilities(false, true, true, true, true, true, true))
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(4))
+                        .or(autoAbilityEnergyIn(4))
                         .or(abilities(MultiblockAbility.MACHINE_HATCH).setExactLimit(1)))
                 .where('#', air())
                 .build();

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityResearchStation.java
@@ -134,7 +134,7 @@ public class MetaTileEntityResearchStation extends RecipeMapMultiblockController
                 .where('V', states(getVentState()))
                 .where('A', states(getAdvancedState()))
                 .where('P', states(getCasingState())
-                        .or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1))
+                        .or(autoAbilityEnergyIn())
                         .or(maintenancePredicate())
                         .or(abilities(MultiblockAbility.COMPUTATION_DATA_RECEPTION).setExactLimit(1)))
                 .where('H', abilities(MultiblockAbility.OBJECT_HOLDER))

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/MetaTileEntityLargeTurbine.java
@@ -199,7 +199,7 @@ public class MetaTileEntityLargeTurbine extends FuelMultiblockController
                                 .addTooltips("gregtech.multiblock.pattern.clear_amount_3")
                                 .addTooltip("gregtech.multiblock.pattern.error.limited.1", GTValues.VN[tier])
                                 .setExactLimit(1)
-                                .or(abilities(MultiblockAbility.OUTPUT_ENERGY)).setExactLimit(1))
+                                .or(autoAbilityEnergyOut()).setExactLimit(1))
                 .where('H', states(getCasingState()).or(autoAbilities(false, true, false, false, true, true, true)))
                 .build();
     }


### PR DESCRIPTION
## What
Allows laser target hatches to be used on multiblocks for increased overclock capabilities.

## Implementation Details
I introduced a new function `autoAbilitiesEnergyIn` for multiblocks like the assembly line where the energy input is set in a different part of `createStructurePattern`, since it would normally only affect mulitblocks that use autoAbilities with energyIn set to true. I did not change fluid and item drilling rigs since they have an overclocking limit. Same for fusion reactors because they have special overclocking rules.

## Additional Information
This would allow 2 laser targets on multiblocks. Does that make sense? I'm leaning to only 1.

## Outcome
Multiblocks can use laser target hatches

## Potential Compatibility Issues
Speaking of the assembly line, this would change it to only have a maximum of 2 energy inputs. (Why did it still allow 3?)

This also touched more spots in the code than I'm really comfortable with changing, so I'm very open to better ways of achieving this.