### PR TITLE
Add a faster recipe for drilling fluid with distilled water

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/MixerRecipes.java
@@ -102,6 +102,13 @@ public class MixerRecipes {
                 .fluidOutputs(DrillingFluid.getFluid(5000))
                 .duration(64).EUt(16).buildAndRegister();
 
+        MIXER_RECIPES.recipeBuilder()
+                .input(dust, Stone)
+                .fluidInputs(Lubricant.getFluid(20))
+                .fluidInputs(DistilledWater.getFluid(4980))
+                .fluidOutputs(DrillingFluid.getFluid(5000))
+                .duration(48).EUt(16).buildAndRegister();
+
         MIXER_RECIPES.recipeBuilder().duration(160).EUt(VA[HV])
                 .input(dust, Beryllium)
                 .input(dust, Potassium, 4)


### PR DESCRIPTION
## What
Adds another recipe for drilling fluid that uses distilled water and is 0.75x the duration, same as a cutting machine's water to distilled water speed.