### PR TITLE
Fix excessive packets & re-renders with AEHostable parts

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -40,6 +40,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
     private AENetworkProxy aeProxy;
     private int meUpdateTick;
     protected boolean isOnline;
+    protected boolean lastOnline;
 
     public MetaTileEntityAEHostablePart(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch,
                                         Class<? extends IStorageChannel<T>> storageChannel) {
@@ -149,8 +150,9 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
         } else {
             this.isOnline = false;
         }
-        if (!getWorld().isRemote) {
+        if (!getWorld().isRemote && this.isOnline != this.lastOnline) {
             writeCustomData(UPDATE_ONLINE_STATUS, buf -> buf.writeBoolean(this.isOnline));
+            this.lastOnline = this.isOnline;
         }
         return this.isOnline;
     }


### PR DESCRIPTION
## What
Prevent an online status sync packet from being sent every tick from AEHostable multiblock parts, causing them to rerender _every. Tick._

## Implementation Details
adds a lastOnline field which is compared with isOnline to determine if isOnline has changed; update packets are only sent if it has changed.

## Outcome
Less lag 👍 

## Additional Information
RIP Gregmeister
