### PR TITLE
Allow recipe logic to set EU/t and speed discounts

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -537,10 +537,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      *
      * @param discount The discount, must be greater than 0 and less than 1.
      *                 If discount == 0.75, then the recipe will only require 75% of the listed power to run.
+     *                 If discount is > 1, then the recipe will require more than the listed power to run.
+     *                 <strong>Be careful as this may not always be possible within the EU/t maximums of the machine!
+     *                 </strong>
      */
     public void setEUDiscount(double discount) {
-        if (discount <= 0 || discount >= 1) {
-            GTLog.logger.warn("Cannot set EU discount for recipe logic to {}, discount must be 0<x<1", discount);
+        if (discount <= 0) {
+            GTLog.logger.warn("Cannot set EU discount for recipe logic to {}, discount must be > 0", discount);
             return;
         }
         euDiscount = discount;
@@ -559,10 +562,11 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      *
      * @param bonus The bonus, must be greater than 0.
      *              If bonus == 0.2, then the recipe will be 20% of the normal duration.
+     *              If bonus is > 1, then the recipe will be slower than the normal duration.
      */
     public void setSpeedBonus(double bonus) {
-        if (bonus <= 0 || bonus >= 1) {
-            GTLog.logger.warn("Cannot set speed bonus for recipe logic to {}, bonus must be 0<x<1", bonus);
+        if (bonus <= 0) {
+            GTLog.logger.warn("Cannot set speed bonus for recipe logic to {}, bonus must be > 0", bonus);
             return;
         }
         speedBonus = bonus;

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -13,11 +13,13 @@ import gregtech.api.metatileentity.multiblock.ICleanroomProvider;
 import gregtech.api.metatileentity.multiblock.ICleanroomReceiver;
 import gregtech.api.metatileentity.multiblock.ParallelLogicType;
 import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.logic.IParallelableRecipeLogic;
 import gregtech.api.recipes.recipeproperties.CleanroomProperty;
 import gregtech.api.recipes.recipeproperties.DimensionProperty;
 import gregtech.api.recipes.recipeproperties.IRecipePropertyStorage;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
@@ -49,6 +51,9 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     private static final String OVERCLOCK_VOLTAGE = "OverclockVoltage";
 
     private final RecipeMap<?> recipeMap;
+
+    private double euDiscount = -1;
+    private double speedBonus = -1;
 
     protected Recipe previousRecipe;
     private boolean allowOverclocking = true;
@@ -457,6 +462,23 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         recipe = Recipe.trimRecipeOutputs(recipe, getRecipeMap(), metaTileEntity.getItemOutputLimit(),
                 metaTileEntity.getFluidOutputLimit());
 
+        // apply EU/speed discount (if any) before parallel
+        if (euDiscount > 0 || speedBonus > 0) { // if-statement to avoid unnecessarily creating RecipeBuilder object
+            RecipeBuilder<?> builder = new RecipeBuilder<>(recipe, recipeMap);
+            if (euDiscount > 0) {
+                int newEUt = (int) (recipe.getEUt() * euDiscount);
+                if (newEUt <= 0) newEUt = 1;
+                builder.EUt(newEUt);
+            }
+            if (speedBonus > 0) {
+                int duration = recipe.getDuration();
+                int newDuration = (int) (duration - (duration * speedBonus));
+                if (newDuration <= 0) newDuration = 1;
+                builder.duration(newDuration);
+            }
+            recipe = builder.build().getResult();
+        }
+
         // Pass in the trimmed recipe to the parallel logic
         recipe = findParallelRecipe(
                 recipe,
@@ -506,6 +528,48 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      */
     public void setParallelLimit(int amount) {
         parallelLimit = amount;
+    }
+
+    /**
+     * Sets an EU/t discount to apply to a machine when running recipes.<br>
+     * This does NOT affect recipe lookup voltage, even if the discount drops it to a lower voltage tier.<br>
+     * This discount is applied pre-parallel.
+     *
+     * @param discount The discount, must be greater than 0 and less than 1.
+     *                 If discount == 0.75, then the recipe will only require 75% of the listed power to run.
+     */
+    public void setEUDiscount(double discount) {
+        if (discount <= 0 || discount >= 1) {
+            GTLog.logger.warn("Cannot set EU discount for recipe logic to {}, discount must be 0<x<1", discount);
+            return;
+        }
+        euDiscount = discount;
+    }
+
+    /**
+     * @return the EU/t discount, or -1 if no discount.
+     */
+    public double getEUtDiscount() {
+        return euDiscount;
+    }
+
+    /**
+     *
+     * @param bonus
+     */
+    public void setSpeedBonus(double bonus) {
+        if (bonus <= 0 || bonus >= 1) {
+            GTLog.logger.warn("Cannot set speed bonus for recipe logic to {}, bonus must be 0<x<1", bonus);
+            return;
+        }
+        speedBonus = bonus;
+    }
+
+    /**
+     * @return the speed bonus, or -1 if no bonus.
+     */
+    public double getSpeedBonus() {
+        return speedBonus;
     }
 
     /**

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -466,13 +466,13 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
         if (euDiscount > 0 || speedBonus > 0) { // if-statement to avoid unnecessarily creating RecipeBuilder object
             RecipeBuilder<?> builder = new RecipeBuilder<>(recipe, recipeMap);
             if (euDiscount > 0) {
-                int newEUt = (int) (recipe.getEUt() * euDiscount);
+                int newEUt = (int) Math.round(recipe.getEUt() * euDiscount);
                 if (newEUt <= 0) newEUt = 1;
                 builder.EUt(newEUt);
             }
             if (speedBonus > 0) {
                 int duration = recipe.getDuration();
-                int newDuration = (int) (duration * speedBonus);
+                int newDuration = (int) Math.round(duration * speedBonus);
                 if (newDuration <= 0) newDuration = 1;
                 builder.duration(newDuration);
             }

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -472,7 +472,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
             }
             if (speedBonus > 0) {
                 int duration = recipe.getDuration();
-                int newDuration = (int) (duration - (duration * speedBonus));
+                int newDuration = (int) (duration * speedBonus);
                 if (newDuration <= 0) newDuration = 1;
                 builder.duration(newDuration);
             }
@@ -533,7 +533,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     /**
      * Sets an EU/t discount to apply to a machine when running recipes.<br>
      * This does NOT affect recipe lookup voltage, even if the discount drops it to a lower voltage tier.<br>
-     * This discount is applied pre-parallel.
+     * This discount is applied pre-parallel/pre-overclock.
      *
      * @param discount The discount, must be greater than 0 and less than 1.
      *                 If discount == 0.75, then the recipe will only require 75% of the listed power to run.
@@ -554,8 +554,11 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     }
 
     /**
+     * Sets a speed multiplier to apply to a machine when running recipes.<br>
+     * This discount is applied pre-parallel/pre-overclock.
      *
-     * @param bonus
+     * @param bonus The bonus, must be greater than 0.
+     *              If bonus == 0.2, then the recipe will be 20% of the normal duration.
      */
     public void setSpeedBonus(double bonus) {
         if (bonus <= 0 || bonus >= 1) {

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -116,7 +116,7 @@ public class AbstractRecipeLogicTest {
         World world = DummyWorld.INSTANCE;
 
         // Create an empty recipe map to work with
-        RecipeMap<SimpleRecipeBuilder> map = new RecipeMap<>("test_reactor_"+TEST_ID,
+        RecipeMap<SimpleRecipeBuilder> map = new RecipeMap<>("test_reactor_" + TEST_ID,
                 2,
                 2,
                 3,
@@ -126,7 +126,7 @@ public class AbstractRecipeLogicTest {
 
         MetaTileEntity at = MetaTileEntities.registerMetaTileEntity(TEST_ID,
                 new SimpleMachineMetaTileEntity(
-                        GTUtility.gregtechId("chemical_reactor.lv_"+TEST_ID),
+                        GTUtility.gregtechId("chemical_reactor.lv_" + TEST_ID),
                         map,
                         null,
                         1, false));

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -30,61 +30,7 @@ public class AbstractRecipeLogicTest {
 
     @Test
     public void trySearchNewRecipe() {
-        World world = DummyWorld.INSTANCE;
-
-        // Create an empty recipe map to work with
-        RecipeMap<SimpleRecipeBuilder> map = new RecipeMap<>("test_reactor",
-                2,
-                2,
-                3,
-                2,
-                new SimpleRecipeBuilder().EUt(30),
-                false);
-
-        MetaTileEntity at = MetaTileEntities.registerMetaTileEntity(190,
-                new SimpleMachineMetaTileEntity(
-                        GTUtility.gregtechId("chemical_reactor.lv"),
-                        map,
-                        null,
-                        1, false));
-        MetaTileEntity atte = new MetaTileEntityHolder().setMetaTileEntity(at);
-        ((MetaTileEntityHolder) atte.getHolder()).setWorld(world);
-        map.recipeBuilder()
-                .inputs(new ItemStack(Blocks.COBBLESTONE))
-                .outputs(new ItemStack(Blocks.STONE))
-                .EUt(1).duration(1)
-                .buildAndRegister();
-
-        AbstractRecipeLogic arl = new AbstractRecipeLogic(atte, map) {
-
-            @Override
-            protected long getEnergyInputPerSecond() {
-                return Long.MAX_VALUE;
-            }
-
-            @Override
-            protected long getEnergyStored() {
-                return Long.MAX_VALUE;
-            }
-
-            @Override
-            protected long getEnergyCapacity() {
-                return Long.MAX_VALUE;
-            }
-
-            @Override
-            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
-                return true;
-            }
-
-            @Override
-            public long getMaxVoltage() {
-                return 32;
-            }
-        };
-
-        arl.isOutputsFull = false;
-        arl.invalidInputsForRecipes = false;
+        AbstractRecipeLogic arl = createTestLogic(1, 1);
         arl.trySearchNewRecipe();
 
         // no recipe found
@@ -92,11 +38,7 @@ public class AbstractRecipeLogicTest {
         MatcherAssert.assertThat(arl.isActive, is(false));
         MatcherAssert.assertThat(arl.previousRecipe, nullValue());
 
-        // put an item in the inventory that will trigger recipe recheck
-        arl.getInputInventory().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
-        // Inputs change. did we detect it ?
-        MatcherAssert.assertThat(arl.hasNotifiedInputs(), is(true));
-        arl.trySearchNewRecipe();
+        queryTestRecipe(arl);
         MatcherAssert.assertThat(arl.invalidInputsForRecipes, is(false));
         MatcherAssert.assertThat(arl.previousRecipe, notNullValue());
         MatcherAssert.assertThat(arl.isActive, is(true));
@@ -131,5 +73,106 @@ public class AbstractRecipeLogicTest {
         MatcherAssert.assertThat(arl.isOutputsFull, is(false));
         MatcherAssert.assertThat(AbstractRecipeLogic.areItemStacksEqual(arl.getOutputInventory().getStackInSlot(0),
                 new ItemStack(Blocks.STONE, 1)), is(true));
+    }
+
+    @Test
+    public void euAndSpeedBonus() {
+        final int initialEUt = 30;
+        final int initialDuration = 100;
+
+        AbstractRecipeLogic arl = createTestLogic(initialEUt, initialDuration);
+        arl.setEUDiscount(0.75); // 75% EU cost required
+        arl.setSpeedBonus(0.2);  // 20% faster than normal
+
+        queryTestRecipe(arl);
+        MatcherAssert.assertThat(arl.recipeEUt, is((int) (initialEUt * 0.75)));
+        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration - (initialDuration * 0.2))));
+    }
+
+    @Test
+    public void euAndSpeedBonusParallel() {
+        final int initialEUt = 30;
+        final int initialDuration = 100;
+
+        AbstractRecipeLogic arl = createTestLogic(initialEUt, initialDuration);
+        arl.setEUDiscount(0.5);  // 50% EU cost required
+        arl.setSpeedBonus(0.2);  // 20% faster than normal
+        arl.setParallelLimit(4); // Allow parallels
+
+        queryTestRecipe(arl);
+
+        // The EU discount should drop the EU/t of this recipe to 15 EU/t. As a result, this should now
+        // be able to parallel 2 times.
+        MatcherAssert.assertThat(arl.parallelRecipesPerformed, is(2));
+        // Because of the parallel, now the paralleled recipe EU/t should be back to 30 EU/t.
+        MatcherAssert.assertThat(arl.recipeEUt, is(30));
+        // Duration should be static regardless of parallels.
+        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration - (initialDuration * 0.2))));
+    }
+
+    private static AbstractRecipeLogic createTestLogic(int testRecipeEUt, int testRecipeDuration) {
+        World world = DummyWorld.INSTANCE;
+
+        // Create an empty recipe map to work with
+        RecipeMap<SimpleRecipeBuilder> map = new RecipeMap<>("test_reactor",
+                2,
+                2,
+                3,
+                2,
+                new SimpleRecipeBuilder().EUt(30),
+                false);
+
+        MetaTileEntity at = MetaTileEntities.registerMetaTileEntity(190,
+                new SimpleMachineMetaTileEntity(
+                        GTUtility.gregtechId("chemical_reactor.lv"),
+                        map,
+                        null,
+                        1, false));
+        MetaTileEntity atte = new MetaTileEntityHolder().setMetaTileEntity(at);
+        ((MetaTileEntityHolder) atte.getHolder()).setWorld(world);
+        map.recipeBuilder()
+                .inputs(new ItemStack(Blocks.COBBLESTONE))
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(testRecipeEUt).duration(testRecipeDuration)
+                .buildAndRegister();
+
+        AbstractRecipeLogic arl = new AbstractRecipeLogic(atte, map) {
+
+            @Override
+            protected long getEnergyInputPerSecond() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected long getEnergyStored() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected long getEnergyCapacity() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected boolean drawEnergy(int recipeEUt, boolean simulate) {
+                return true;
+            }
+
+            @Override
+            public long getMaxVoltage() {
+                return 32;
+            }
+        };
+
+        arl.isOutputsFull = false;
+        arl.invalidInputsForRecipes = false;
+        return arl;
+    }
+
+    private static void queryTestRecipe(AbstractRecipeLogic arl) {
+        // put an item in the inventory that will trigger recipe recheck
+        arl.getInputInventory().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
+        MatcherAssert.assertThat(arl.hasNotifiedInputs(), is(true));
+        arl.trySearchNewRecipe();
     }
 }

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -110,11 +110,13 @@ public class AbstractRecipeLogicTest {
         MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration * 0.2)));
     }
 
+    private static int TEST_ID = 190;
+
     private static AbstractRecipeLogic createTestLogic(int testRecipeEUt, int testRecipeDuration) {
         World world = DummyWorld.INSTANCE;
 
         // Create an empty recipe map to work with
-        RecipeMap<SimpleRecipeBuilder> map = new RecipeMap<>("test_reactor",
+        RecipeMap<SimpleRecipeBuilder> map = new RecipeMap<>("test_reactor_"+TEST_ID,
                 2,
                 2,
                 3,
@@ -122,9 +124,9 @@ public class AbstractRecipeLogicTest {
                 new SimpleRecipeBuilder().EUt(30),
                 false);
 
-        MetaTileEntity at = MetaTileEntities.registerMetaTileEntity(190,
+        MetaTileEntity at = MetaTileEntities.registerMetaTileEntity(TEST_ID,
                 new SimpleMachineMetaTileEntity(
-                        GTUtility.gregtechId("chemical_reactor.lv"),
+                        GTUtility.gregtechId("chemical_reactor.lv_"+TEST_ID),
                         map,
                         null,
                         1, false));
@@ -135,6 +137,8 @@ public class AbstractRecipeLogicTest {
                 .outputs(new ItemStack(Blocks.STONE))
                 .EUt(testRecipeEUt).duration(testRecipeDuration)
                 .buildAndRegister();
+
+        TEST_ID++;
 
         AbstractRecipeLogic arl = new AbstractRecipeLogic(atte, map) {
 

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -86,7 +86,7 @@ public class AbstractRecipeLogicTest {
 
         queryTestRecipe(arl);
         MatcherAssert.assertThat(arl.recipeEUt, is((int) (initialEUt * 0.75)));
-        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration - (initialDuration * 0.2))));
+        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration * 0.2)));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class AbstractRecipeLogicTest {
         // Because of the parallel, now the paralleled recipe EU/t should be back to 30 EU/t.
         MatcherAssert.assertThat(arl.recipeEUt, is(30));
         // Duration should be static regardless of parallels.
-        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration - (initialDuration * 0.2))));
+        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration * 0.2)));
     }
 
     private static AbstractRecipeLogic createTestLogic(int testRecipeEUt, int testRecipeDuration) {

--- a/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/AbstractRecipeLogicTest.java
@@ -85,8 +85,8 @@ public class AbstractRecipeLogicTest {
         arl.setSpeedBonus(0.2);  // 20% faster than normal
 
         queryTestRecipe(arl);
-        MatcherAssert.assertThat(arl.recipeEUt, is((int) (initialEUt * 0.75)));
-        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration * 0.2)));
+        MatcherAssert.assertThat(arl.recipeEUt, is((int) Math.round(initialEUt * 0.75)));
+        MatcherAssert.assertThat(arl.maxProgressTime, is((int) Math.round(initialDuration * 0.2)));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class AbstractRecipeLogicTest {
         // Because of the parallel, now the paralleled recipe EU/t should be back to 30 EU/t.
         MatcherAssert.assertThat(arl.recipeEUt, is(30));
         // Duration should be static regardless of parallels.
-        MatcherAssert.assertThat(arl.maxProgressTime, is((int) (initialDuration * 0.2)));
+        MatcherAssert.assertThat(arl.maxProgressTime, is((int) Math.round(initialDuration * 0.2)));
     }
 
     private static int TEST_ID = 190;


### PR DESCRIPTION
## What
Adds a new API for recipe logic implementations to set an EU/t discount and speed bonus for recipe processing. These are multipliers applied onto a recipe after lookup but before parallel. This means that recipe voltage requirements are unaffected, but potential for overclocking or paralleling further than "normal" is possible. Currently no multiblocks enable this feature, but this may change in the future and can be used by modpacks and/or addons.
