### PR TITLE
Port passthrough hatches to MUI2 and allow them to be togged

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -40,7 +40,6 @@ import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
-import com.cleanroommc.modularui.widgets.layout.Column;
 import com.cleanroommc.modularui.widgets.layout.Grid;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -141,9 +140,7 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     public ModularPanel buildUI(PosGuiData guiData, PanelSyncManager guiSyncManager) {
         int rowSize = (int) Math.sqrt(getTier() + 1);
 
-        int backgroundWidth = Math.max(
-                9 * 18 + 18 + 14 + 5,   // Player Inv width
-                rowSize * 18 + 14); // Bus Inv width
+        int backgroundWidth = 9 * 18 + 14;
         int backgroundHeight = 18 + 18 * rowSize + 94;
 
         List<List<IWidget>> widgets = new ArrayList<>();
@@ -161,25 +158,21 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
                 .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
                 .child(SlotGroupWidget.playerInventory().left(7).bottom(7))
-                .child(new Column()
-                        .pos(backgroundWidth - 7 - 18, backgroundHeight - 18 * 4 - 7 - 5)
-                        .width(18).height(18 * 4 + 5)
-                        .child(GTGuiTextures.getLogo(getUITheme()).asWidget().size(17).top(18 * 3 + 5))
-                        .child(new ToggleButton()
-                                .top(18 * 2)
-                                .value(new BoolValue.Dynamic(workingStateValue::getBoolValue,
-                                        workingStateValue::setBoolValue))
-                                .overlay(GTGuiTextures.BUTTON_FLUID_OUTPUT)
-                                .tooltipBuilder(t -> t.setAutoUpdate(true)
-                                        .addLine(workingStateValue.getBoolValue() ?
-                                                IKey.lang("gregtech.gui.fluid_passthrough.enabled") :
-                                                IKey.lang("gregtech.gui.fluid_passthrough.disabled")))))
                 .child(new Grid()
                         .top(18).height(rowSize * 18)
                         .minElementMargin(0, 0)
                         .minColWidth(18).minRowHeight(18)
                         .alignX(0.5f)
-                        .matrix(widgets));
+                        .matrix(widgets))
+                .child(new ToggleButton()
+                        .top(18 * 2).left(18 * 8 + 7)
+                        .value(new BoolValue.Dynamic(workingStateValue::getBoolValue,
+                                workingStateValue::setBoolValue))
+                        .overlay(GTGuiTextures.BUTTON_FLUID_OUTPUT)
+                        .tooltipBuilder(t -> t.setAutoUpdate(true)
+                                .addLine(workingStateValue.getBoolValue() ?
+                                        IKey.lang("gregtech.gui.fluid_passthrough.enabled") :
+                                        IKey.lang("gregtech.gui.fluid_passthrough.disabled"))));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -1,5 +1,7 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
+import com.cleanroommc.modularui.widgets.FluidSlot;
+
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
@@ -15,6 +17,7 @@ import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.mui.GTGuiTextures;
 import gregtech.api.mui.GTGuis;
 import gregtech.client.renderer.texture.Textures;
+import gregtech.common.mui.widget.GTFluidSlot;
 
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -37,7 +40,6 @@ import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.value.BoolValue;
 import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.widgets.FluidSlot;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Column;
@@ -150,12 +152,11 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         for (int i = 0; i < rowSize; i++) {
             widgets.add(new ArrayList<>());
             for (int j = 0; j < rowSize; j++) {
-                widgets.get(i)
-                        .add(new FluidSlot().syncHandler(fluidTankList.getTankAt(i * rowSize + j))
-                                .background(GTGuiTextures.FLUID_SLOT)
-                                .alwaysShowFull(true));
+                widgets.get(i).add(new GTFluidSlot().syncHandler(fluidTankList.getTankAt(i * rowSize + j))
+                        .background(GTGuiTextures.FLUID_SLOT));
             }
         }
+
         BooleanSyncValue workingStateValue = new BooleanSyncValue(() -> workingEnabled, val -> workingEnabled = val);
         guiSyncManager.syncValue("working_state", workingStateValue);
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -166,10 +166,10 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
                         .top(18 * 2).left(18 * 8 + 7)
                         .value(workingStateValue)
                         .overlay(GTGuiTextures.BUTTON_FLUID_OUTPUT)
-                        .tooltipBuilder(t -> t.setAutoUpdate(true)
-                                .addLine(workingStateValue.getBoolValue() ?
-                                        IKey.lang("gregtech.gui.fluid_passthrough.enabled") :
-                                        IKey.lang("gregtech.gui.fluid_passthrough.disabled"))));
+                        .tooltip(t -> t.setAutoUpdate(true))
+                        .tooltipBuilder(t -> t.addLine(workingStateValue.getBoolValue() ?
+                                IKey.lang("gregtech.gui.fluid_passthrough.enabled") :
+                                IKey.lang("gregtech.gui.fluid_passthrough.disabled"))));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -155,6 +155,7 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         BooleanSyncValue workingStateValue = new BooleanSyncValue(() -> workingEnabled, val -> workingEnabled = val);
         guiSyncManager.syncValue("working_state", workingStateValue);
 
+        // TODO: Change the position of the name when it's standardized.
         return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
                 .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
                 .child(SlotGroupWidget.playerInventory().left(7).bottom(7))

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -87,8 +87,8 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     @Override
     public void update() {
         super.update();
-        if (workingEnabled) {
-            if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
+        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
+            if (workingEnabled) {
                 pushFluidsIntoNearbyHandlers(getFrontFacing().getOpposite()); // outputs to back
                 pullFluidsFromNearbyHandlers(getFrontFacing()); // inputs from front
             }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -1,21 +1,21 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
+import gregtech.api.capability.GregtechDataCodes;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IControllable;
 import gregtech.api.capability.impl.FilteredFluidHandler;
 import gregtech.api.capability.impl.FluidHandlerProxy;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
-import gregtech.api.gui.GuiTextures;
-import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.mui.GTGuis;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -29,13 +29,19 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import com.cleanroommc.modularui.api.drawable.IKey;
+import com.cleanroommc.modularui.factory.PosGuiData;
+import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.value.sync.GuiSyncManager;
+import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultiblockPart implements IPassthroughHatch,
-                                                 IMultiblockAbilityPart<IPassthroughHatch> {
+                                                 IMultiblockAbilityPart<IPassthroughHatch>,
+                                                 IControllable {
 
     private static final int TANK_SIZE = 16_000;
 
@@ -44,8 +50,11 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     private IFluidHandler importHandler;
     private IFluidHandler exportHandler;
 
+    private boolean workingEnabled;
+
     public MetaTileEntityPassthroughHatchFluid(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
+        this.workingEnabled = true;
         initializeInventory();
     }
 
@@ -69,10 +78,24 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
-            pushFluidsIntoNearbyHandlers(getFrontFacing().getOpposite()); // outputs to back
-            pullFluidsFromNearbyHandlers(getFrontFacing()); // inputs from front
+        if (workingEnabled) {
+            if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
+                pushFluidsIntoNearbyHandlers(getFrontFacing().getOpposite()); // outputs to back
+                pullFluidsFromNearbyHandlers(getFrontFacing()); // inputs from front
+            }
         }
+    }
+
+    public void setWorkingEnabled(boolean workingEnabled) {
+        this.workingEnabled = workingEnabled;
+        World world = getWorld();
+        if (world != null && !world.isRemote) {
+            writeCustomData(GregtechDataCodes.WORKING_ENABLED, buf -> buf.writeBoolean(workingEnabled));
+        }
+    }
+
+    public boolean isWorkingEnabled() {
+        return this.workingEnabled;
     }
 
     @Override
@@ -100,34 +123,55 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         return new NotifiableItemStackHandler(this, TANK_SIZE, getController(), false);
     }
 
+    /*
+     * @Override
+     * protected ModularUI createUI(EntityPlayer entityPlayer) {
+     * int rowSize = (int) Math.sqrt(getTier() + 1);
+     * return createUITemplate(entityPlayer, rowSize)
+     * .build(getHolder(), entityPlayer);
+     * }
+     *
+     * private ModularUI.Builder createUITemplate(EntityPlayer player, int rowSize) {
+     * ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 18 + 18 * rowSize + 94)
+     * .label(6, 6, getMetaFullName());
+     *
+     * for (int y = 0; y < rowSize; y++) {
+     * for (int x = 0; x < rowSize; x++) {
+     * int index = y * rowSize + x;
+     * builder.widget(
+     * new TankWidget(fluidTankList.getTankAt(index), 89 - rowSize * 9 + x * 18, 18 + y * 18, 18, 18)
+     * .setBackgroundTexture(GuiTextures.FLUID_SLOT)
+     * .setContainerClicking(true, true)
+     * .setAlwaysShowFull(true));
+     * }
+     * }
+     * return builder.bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 18 + 18 * rowSize + 12);
+     * }
+     */
+
     @Override
-    protected ModularUI createUI(EntityPlayer entityPlayer) {
-        int rowSize = (int) Math.sqrt(getTier() + 1);
-        return createUITemplate(entityPlayer, rowSize)
-                .build(getHolder(), entityPlayer);
+    public boolean usesMui2() {
+        return true;
     }
 
-    private ModularUI.Builder createUITemplate(EntityPlayer player, int rowSize) {
-        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 18 + 18 * rowSize + 94)
-                .label(6, 6, getMetaFullName());
+    @Override
+    public ModularPanel buildUI(PosGuiData guiData, GuiSyncManager guiSyncManager) {
+        int rowSize = (int) Math.sqrt(getTier() + 1);
+        int backgroundWidth = Math.max(
+                9 * 18 + 18 + 14 + 5,   // Player Inv width
+                rowSize * 18 + 14); // Bus Inv width
+        int backgroundHeight = 18 + 18 * rowSize + 94;
 
-        for (int y = 0; y < rowSize; y++) {
-            for (int x = 0; x < rowSize; x++) {
-                int index = y * rowSize + x;
-                builder.widget(
-                        new TankWidget(fluidTankList.getTankAt(index), 89 - rowSize * 9 + x * 18, 18 + y * 18, 18, 18)
-                                .setBackgroundTexture(GuiTextures.FLUID_SLOT)
-                                .setContainerClicking(true, true)
-                                .setAlwaysShowFull(true));
-            }
-        }
-        return builder.bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 18 + 18 * rowSize + 12);
+        return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
+                .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
+                .child(SlotGroupWidget.playerInventory().left(7).bottom(7));
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound tag) {
         super.writeToNBT(tag);
         tag.setTag("FluidInventory", fluidTankList.serializeNBT());
+        tag.setBoolean("workingEnabled", workingEnabled);
         return tag;
     }
 
@@ -135,6 +179,10 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     public void readFromNBT(NBTTagCompound tag) {
         super.readFromNBT(tag);
         this.fluidTankList.deserializeNBT(tag.getCompoundTag("FluidInventory"));
+        // Passthrough hatches before this change won't have workingEnabled at all, so we need to check if it exists
+        if (tag.hasKey("workingEnabled")) {
+            this.workingEnabled = tag.getBoolean("workingEnabled");
+        }
     }
 
     @Override
@@ -174,6 +222,8 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
             } else if (side == getFrontFacing().getOpposite()) {
                 return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(exportHandler);
             } else return null;
+        } else if (capability == GregtechTileCapabilities.CAPABILITY_CONTROLLABLE) {
+            return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE.cast(this);
         }
         return super.getCapability(capability, side);
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -1,7 +1,5 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
-import com.cleanroommc.modularui.widgets.FluidSlot;
-
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
@@ -188,7 +186,7 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     public NBTTagCompound writeToNBT(NBTTagCompound tag) {
         super.writeToNBT(tag);
         tag.setTag("FluidInventory", fluidTankList.serializeNBT());
-        tag.setBoolean("workingEnabled", workingEnabled);
+        tag.setBoolean("WorkingEnabled", workingEnabled);
         return tag;
     }
 
@@ -196,10 +194,10 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     public void readFromNBT(NBTTagCompound tag) {
         super.readFromNBT(tag);
         this.fluidTankList.deserializeNBT(tag.getCompoundTag("FluidInventory"));
-        // Passthrough hatches before this change won't have workingEnabled at all, so we need to check if it exists
-        if (tag.hasKey("workingEnabled")) {
-            this.workingEnabled = tag.getBoolean("workingEnabled");
-        } else if (!tag.hasKey("workingEnabled")) {
+        // Passthrough hatches before this change won't have WorkingEnabled at all, so we need to check if it exists
+        if (tag.hasKey("WorkingEnabled")) {
+            this.workingEnabled = tag.getBoolean("WorkingEnabled");
+        } else {
             this.workingEnabled = true;
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -132,32 +132,6 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         return new NotifiableItemStackHandler(this, TANK_SIZE, getController(), false);
     }
 
-    /*
-     * @Override
-     * protected ModularUI createUI(EntityPlayer entityPlayer) {
-     * int rowSize = (int) Math.sqrt(getTier() + 1);
-     * return createUITemplate(entityPlayer, rowSize)
-     * .build(getHolder(), entityPlayer);
-     * }
-     *
-     * private ModularUI.Builder createUITemplate(EntityPlayer player, int rowSize) {
-     * ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 18 + 18 * rowSize + 94)
-     * .label(6, 6, getMetaFullName());
-     *
-     * for (int y = 0; y < rowSize; y++) {
-     * for (int x = 0; x < rowSize; x++) {
-     * int index = y * rowSize + x;
-     * builder.widget(
-     * new TankWidget(fluidTankList.getTankAt(index), 89 - rowSize * 9 + x * 18, 18 + y * 18, 18, 18)
-     * .setBackgroundTexture(GuiTextures.FLUID_SLOT)
-     * .setContainerClicking(true, true)
-     * .setAlwaysShowFull(true));
-     * }
-     * }
-     * return builder.bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 18 + 18 * rowSize + 12);
-     * }
-     */
-
     @Override
     public boolean usesMui2() {
         return true;
@@ -224,6 +198,8 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
         // Passthrough hatches before this change won't have workingEnabled at all, so we need to check if it exists
         if (tag.hasKey("workingEnabled")) {
             this.workingEnabled = tag.getBoolean("workingEnabled");
+        } else if (!tag.hasKey("workingEnabled")) {
+            this.workingEnabled = true;
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchFluid.java
@@ -36,7 +36,7 @@ import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.value.BoolValue;
 import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
-import com.cleanroommc.modularui.value.sync.GuiSyncManager;
+import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.widgets.FluidSlot;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
@@ -138,7 +138,7 @@ public class MetaTileEntityPassthroughHatchFluid extends MetaTileEntityMultibloc
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData guiData, GuiSyncManager guiSyncManager) {
+    public ModularPanel buildUI(PosGuiData guiData, PanelSyncManager guiSyncManager) {
         int rowSize = (int) Math.sqrt(getTier() + 1);
 
         int backgroundWidth = Math.max(

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -162,6 +162,7 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         BooleanSyncValue workingStateValue = new BooleanSyncValue(() -> workingEnabled, val -> workingEnabled = val);
         guiSyncManager.syncValue("working_state", workingStateValue);
 
+        // TODO: Change the position of the name when it's standardized.
         return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
                 .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
                 .child(SlotGroupWidget.playerInventory().left(7).bottom(7))

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -1,6 +1,8 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
 import gregtech.api.capability.GregtechDataCodes;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IControllable;
 import gregtech.api.capability.impl.ItemHandlerProxy;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.items.itemhandlers.GTItemStackHandler;
@@ -48,7 +50,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblockPart implements IPassthroughHatch,
-                                                IMultiblockAbilityPart<IPassthroughHatch> {
+                                                IMultiblockAbilityPart<IPassthroughHatch>,
+                                                IControllable {
 
     private ItemStackHandler itemStackHandler;
 
@@ -92,6 +95,12 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         }
     }
 
+    @Override
+    public boolean isWorkingEnabled() {
+        return this.workingEnabled;
+    }
+
+    @Override
     public void setWorkingEnabled(boolean workingEnabled) {
         this.workingEnabled = workingEnabled;
         World world = getWorld();
@@ -240,6 +249,8 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
             } else if (side == getFrontFacing().getOpposite()) {
                 return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(exportHandler);
             } else return null;
+        } else if (capability == GregtechTileCapabilities.CAPABILITY_CONTROLLABLE) {
+            return GregtechTileCapabilities.CAPABILITY_CONTROLLABLE.cast(this);
         }
         return super.getCapability(capability, side);
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -36,7 +36,7 @@ import com.cleanroommc.modularui.factory.PosGuiData;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.value.BoolValue;
 import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
-import com.cleanroommc.modularui.value.sync.GuiSyncManager;
+import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.value.sync.SyncHandlers;
 import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
@@ -140,7 +140,7 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     }
 
     @Override
-    public ModularPanel buildUI(PosGuiData guiData, GuiSyncManager guiSyncManager) {
+    public ModularPanel buildUI(PosGuiData guiData, PanelSyncManager guiSyncManager) {
         int rowSize = (int) Math.sqrt(getInventorySize());
 
         guiSyncManager.registerSlotGroup("item_inv", rowSize);

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -125,30 +125,6 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         return new NotifiableItemStackHandler(this, getInventorySize(), getController(), false);
     }
 
-    /*
-     * @Override
-     * protected ModularUI createUI(EntityPlayer entityPlayer) {
-     * int rowSize = (int) Math.sqrt(getInventorySize());
-     * return createUITemplate(entityPlayer, rowSize)
-     * .build(getHolder(), entityPlayer);
-     * }
-     * 
-     * private ModularUI.Builder createUITemplate(EntityPlayer player, int rowSize) {
-     * ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 18 + 18 * rowSize + 94)
-     * .label(6, 6, getMetaFullName());
-     * 
-     * for (int y = 0; y < rowSize; y++) {
-     * for (int x = 0; x < rowSize; x++) {
-     * int index = y * rowSize + x;
-     * builder.widget(new SlotWidget(itemStackHandler, index,
-     * (88 - rowSize * 9 + x * 18), 18 + y * 18, true, true)
-     * .setBackgroundTexture(GuiTextures.SLOT));
-     * }
-     * }
-     * return builder.bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 18 + 18 * rowSize + 12);
-     * }
-     */
-
     @Override
     public boolean usesMui2() {
         return true;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -41,7 +41,6 @@ import com.cleanroommc.modularui.value.sync.SyncHandlers;
 import com.cleanroommc.modularui.widgets.ItemSlot;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
-import com.cleanroommc.modularui.widgets.layout.Column;
 import com.cleanroommc.modularui.widgets.layout.Grid;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -145,9 +144,7 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
 
         guiSyncManager.registerSlotGroup("item_inv", rowSize);
 
-        int backgroundWidth = Math.max(
-                9 * 18 + 18 + 14 + 5,   // Player Inv width
-                rowSize * 18 + 14); // Bus Inv width
+        int backgroundWidth = 9 * 18 + 14;
         int backgroundHeight = 18 + 18 * rowSize + 94;
 
         List<List<IWidget>> widgets = new ArrayList<>();
@@ -168,25 +165,21 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
                 .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
                 .child(SlotGroupWidget.playerInventory().left(7).bottom(7))
-                .child(new Column()
-                        .pos(backgroundWidth - 7 - 18, backgroundHeight - 18 * 4 - 7 - 5)
-                        .width(18).height(18 * 4 + 5)
-                        .child(GTGuiTextures.getLogo(getUITheme()).asWidget().size(17).top(18 * 3 + 5))
-                        .child(new ToggleButton()
-                                .top(18 * 2)
-                                .value(new BoolValue.Dynamic(workingStateValue::getBoolValue,
-                                        workingStateValue::setBoolValue))
-                                .overlay(GTGuiTextures.BUTTON_ITEM_OUTPUT)
-                                .tooltipBuilder(t -> t.setAutoUpdate(true)
-                                        .addLine(workingStateValue.getBoolValue() ?
-                                                IKey.lang("gregtech.gui.item_passthrough.enabled") :
-                                                IKey.lang("gregtech.gui.item_passthrough.disabled")))))
                 .child(new Grid()
                         .top(18).height(rowSize * 18)
                         .minElementMargin(0, 0)
                         .minColWidth(18).minRowHeight(18)
                         .alignX(0.5f)
-                        .matrix(widgets));
+                        .matrix(widgets))
+                .child(new ToggleButton()
+                        .top(18 * 4).left(18 * 8 + 7)
+                        .value(new BoolValue.Dynamic(workingStateValue::getBoolValue,
+                                workingStateValue::setBoolValue))
+                        .overlay(GTGuiTextures.BUTTON_ITEM_OUTPUT)
+                        .tooltipBuilder(t -> t.setAutoUpdate(true)
+                                .addLine(workingStateValue.getBoolValue() ?
+                                        IKey.lang("gregtech.gui.item_passthrough.enabled") :
+                                        IKey.lang("gregtech.gui.item_passthrough.disabled"))));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -193,7 +193,7 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     public NBTTagCompound writeToNBT(NBTTagCompound tag) {
         super.writeToNBT(tag);
         tag.setTag("Inventory", itemStackHandler.serializeNBT());
-        tag.setBoolean("workingEnabled", workingEnabled);
+        tag.setBoolean("WorkingEnabled", workingEnabled);
         return tag;
     }
 
@@ -201,10 +201,10 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     public void readFromNBT(NBTTagCompound tag) {
         super.readFromNBT(tag);
         this.itemStackHandler.deserializeNBT(tag.getCompoundTag("Inventory"));
-        // Passthrough hatches before this change won't have workingEnabled at all, so we need to check if it exists
-        if (tag.hasKey("workingEnabled")) {
-            this.workingEnabled = tag.getBoolean("workingEnabled");
-        } else if (!tag.hasKey("workingEnabled")) {
+        // Passthrough hatches before this change won't have WorkingEnabled at all, so we need to check if it exists
+        if (tag.hasKey("WorkingEnabled")) {
+            this.workingEnabled = tag.getBoolean("WorkingEnabled");
+        } else {
             this.workingEnabled = true;
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -173,10 +173,10 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
                         .top(18 * 4).left(18 * 8 + 7)
                         .value(workingStateValue)
                         .overlay(GTGuiTextures.BUTTON_ITEM_OUTPUT)
-                        .tooltipBuilder(t -> t.setAutoUpdate(true)
-                                .addLine(workingStateValue.getBoolValue() ?
-                                        IKey.lang("gregtech.gui.item_passthrough.enabled") :
-                                        IKey.lang("gregtech.gui.item_passthrough.disabled"))));
+                        .tooltip(t -> t.setAutoUpdate(true))
+                        .tooltipBuilder(t -> t.addLine(workingStateValue.getBoolValue() ?
+                                IKey.lang("gregtech.gui.item_passthrough.enabled") :
+                                IKey.lang("gregtech.gui.item_passthrough.disabled"))));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -168,12 +168,6 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
                 .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
                 .child(SlotGroupWidget.playerInventory().left(7).bottom(7))
-                .child(new Grid()
-                        .top(18).height(rowSize * 18)
-                        .minElementMargin(0, 0)
-                        .minColWidth(18).minRowHeight(18)
-                        .alignX(0.5f)
-                        .matrix(widgets))
                 .child(new Column()
                         .pos(backgroundWidth - 7 - 18, backgroundHeight - 18 * 4 - 7 - 5)
                         .width(18).height(18 * 4 + 5)
@@ -186,7 +180,13 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
                                 .tooltipBuilder(t -> t.setAutoUpdate(true)
                                         .addLine(workingStateValue.getBoolValue() ?
                                                 IKey.lang("gregtech.gui.item_passthrough.enabled") :
-                                                IKey.lang("gregtech.gui.item_passthrough.disabled")))));
+                                                IKey.lang("gregtech.gui.item_passthrough.disabled")))))
+                .child(new Grid()
+                        .top(18).height(rowSize * 18)
+                        .minElementMargin(0, 0)
+                        .minColWidth(18).minRowHeight(18)
+                        .alignX(0.5f)
+                        .matrix(widgets));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -87,8 +87,8 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     @Override
     public void update() {
         super.update();
-        if (workingEnabled) {
-            if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
+        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
+            if (workingEnabled) {
                 pushItemsIntoNearbyHandlers(getFrontFacing().getOpposite()); // outputs to back
                 pullItemsFromNearbyHandlers(getFrontFacing()); // inputs from front
             }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -1,20 +1,19 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
+import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.impl.ItemHandlerProxy;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
-import gregtech.api.gui.GuiTextures;
-import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.items.itemhandlers.GTItemStackHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.mui.GTGuiTextures;
+import gregtech.api.mui.GTGuis;
 import gregtech.client.renderer.texture.Textures;
 
 import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -29,9 +28,23 @@ import net.minecraftforge.items.ItemStackHandler;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
+import com.cleanroommc.modularui.api.drawable.IKey;
+import com.cleanroommc.modularui.api.widget.IWidget;
+import com.cleanroommc.modularui.factory.PosGuiData;
+import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.value.BoolValue;
+import com.cleanroommc.modularui.value.sync.BooleanSyncValue;
+import com.cleanroommc.modularui.value.sync.GuiSyncManager;
+import com.cleanroommc.modularui.value.sync.SyncHandlers;
+import com.cleanroommc.modularui.widgets.ItemSlot;
+import com.cleanroommc.modularui.widgets.SlotGroupWidget;
+import com.cleanroommc.modularui.widgets.ToggleButton;
+import com.cleanroommc.modularui.widgets.layout.Column;
+import com.cleanroommc.modularui.widgets.layout.Grid;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblockPart implements IPassthroughHatch,
@@ -42,8 +55,11 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     private IItemHandler importHandler;
     private IItemHandler exportHandler;
 
+    private boolean workingEnabled;
+
     public MetaTileEntityPassthroughHatchItem(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
+        this.workingEnabled = true;
         initializeInventory();
     }
 
@@ -68,9 +84,19 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
-            pushItemsIntoNearbyHandlers(getFrontFacing().getOpposite()); // outputs to back
-            pullItemsFromNearbyHandlers(getFrontFacing()); // inputs from front
+        if (workingEnabled) {
+            if (!getWorld().isRemote && getOffsetTimer() % 5 == 0) {
+                pushItemsIntoNearbyHandlers(getFrontFacing().getOpposite()); // outputs to back
+                pullItemsFromNearbyHandlers(getFrontFacing()); // inputs from front
+            }
+        }
+    }
+
+    public void setWorkingEnabled(boolean workingEnabled) {
+        this.workingEnabled = workingEnabled;
+        World world = getWorld();
+        if (world != null && !world.isRemote) {
+            writeCustomData(GregtechDataCodes.WORKING_ENABLED, buf -> buf.writeBoolean(workingEnabled));
         }
     }
 
@@ -99,32 +125,90 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         return new NotifiableItemStackHandler(this, getInventorySize(), getController(), false);
     }
 
+    /*
+     * @Override
+     * protected ModularUI createUI(EntityPlayer entityPlayer) {
+     * int rowSize = (int) Math.sqrt(getInventorySize());
+     * return createUITemplate(entityPlayer, rowSize)
+     * .build(getHolder(), entityPlayer);
+     * }
+     * 
+     * private ModularUI.Builder createUITemplate(EntityPlayer player, int rowSize) {
+     * ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 18 + 18 * rowSize + 94)
+     * .label(6, 6, getMetaFullName());
+     * 
+     * for (int y = 0; y < rowSize; y++) {
+     * for (int x = 0; x < rowSize; x++) {
+     * int index = y * rowSize + x;
+     * builder.widget(new SlotWidget(itemStackHandler, index,
+     * (88 - rowSize * 9 + x * 18), 18 + y * 18, true, true)
+     * .setBackgroundTexture(GuiTextures.SLOT));
+     * }
+     * }
+     * return builder.bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 18 + 18 * rowSize + 12);
+     * }
+     */
+
     @Override
-    protected ModularUI createUI(EntityPlayer entityPlayer) {
-        int rowSize = (int) Math.sqrt(getInventorySize());
-        return createUITemplate(entityPlayer, rowSize)
-                .build(getHolder(), entityPlayer);
+    public boolean usesMui2() {
+        return true;
     }
 
-    private ModularUI.Builder createUITemplate(EntityPlayer player, int rowSize) {
-        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND, 176, 18 + 18 * rowSize + 94)
-                .label(6, 6, getMetaFullName());
+    @Override
+    public ModularPanel buildUI(PosGuiData guiData, GuiSyncManager guiSyncManager) {
+        int rowSize = (int) Math.sqrt(getInventorySize());
 
-        for (int y = 0; y < rowSize; y++) {
-            for (int x = 0; x < rowSize; x++) {
-                int index = y * rowSize + x;
-                builder.widget(new SlotWidget(itemStackHandler, index,
-                        (88 - rowSize * 9 + x * 18), 18 + y * 18, true, true)
-                                .setBackgroundTexture(GuiTextures.SLOT));
+        guiSyncManager.registerSlotGroup("item_inv", rowSize);
+
+        int backgroundWidth = Math.max(
+                9 * 18 + 18 + 14 + 5,   // Player Inv width
+                rowSize * 18 + 14); // Bus Inv width
+        int backgroundHeight = 18 + 18 * rowSize + 94;
+
+        List<List<IWidget>> widgets = new ArrayList<>();
+        for (int i = 0; i < rowSize; i++) {
+            widgets.add(new ArrayList<>());
+            for (int j = 0; j < rowSize; j++) {
+                widgets.get(i)
+                        .add(new ItemSlot()
+                                .slot(SyncHandlers.itemSlot(itemStackHandler, i * rowSize + j)
+                                        .slotGroup("item_inv")
+                                        .accessibility(true, true)));
             }
         }
-        return builder.bindPlayerInventory(player.inventory, GuiTextures.SLOT, 7, 18 + 18 * rowSize + 12);
+
+        BooleanSyncValue workingStateValue = new BooleanSyncValue(() -> workingEnabled, val -> workingEnabled = val);
+        guiSyncManager.syncValue("working_state", workingStateValue);
+
+        return GTGuis.createPanel(this, backgroundWidth, backgroundHeight)
+                .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
+                .child(SlotGroupWidget.playerInventory().left(7).bottom(7))
+                .child(new Grid()
+                        .top(18).height(rowSize * 18)
+                        .minElementMargin(0, 0)
+                        .minColWidth(18).minRowHeight(18)
+                        .alignX(0.5f)
+                        .matrix(widgets))
+                .child(new Column()
+                        .pos(backgroundWidth - 7 - 18, backgroundHeight - 18 * 4 - 7 - 5)
+                        .width(18).height(18 * 4 + 5)
+                        .child(GTGuiTextures.getLogo(getUITheme()).asWidget().size(17).top(18 * 3 + 5))
+                        .child(new ToggleButton()
+                                .top(18 * 2)
+                                .value(new BoolValue.Dynamic(workingStateValue::getBoolValue,
+                                        workingStateValue::setBoolValue))
+                                .overlay(GTGuiTextures.BUTTON_ITEM_OUTPUT)
+                                .tooltipBuilder(t -> t.setAutoUpdate(true)
+                                        .addLine(workingStateValue.getBoolValue() ?
+                                                IKey.lang("gregtech.gui.item_passthrough.enabled") :
+                                                IKey.lang("gregtech.gui.item_passthrough.disabled")))));
     }
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound tag) {
         super.writeToNBT(tag);
         tag.setTag("Inventory", itemStackHandler.serializeNBT());
+        tag.setBoolean("workingEnabled", workingEnabled);
         return tag;
     }
 
@@ -132,6 +216,10 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
     public void readFromNBT(NBTTagCompound tag) {
         super.readFromNBT(tag);
         this.itemStackHandler.deserializeNBT(tag.getCompoundTag("Inventory"));
+        // Passthrough hatches before this change won't have workingEnabled at all, so we need to check if it exists
+        if (tag.hasKey("workingEnabled")) {
+            this.workingEnabled = tag.getBoolean("workingEnabled");
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchItem.java
@@ -204,6 +204,8 @@ public class MetaTileEntityPassthroughHatchItem extends MetaTileEntityMultiblock
         // Passthrough hatches before this change won't have workingEnabled at all, so we need to check if it exists
         if (tag.hasKey("workingEnabled")) {
             this.workingEnabled = tag.getBoolean("workingEnabled");
+        } else if (!tag.hasKey("workingEnabled")) {
+            this.workingEnabled = true;
         }
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5533,6 +5533,10 @@ gregtech.gui.config_slot.auto_pull_managed=§4Disabled:§7 Managed by Auto-Pull
 gregtech.gui.me_bus.extra_slot=Extra Slot/n§7Put extra items for recipes here, like Molds or Lenses
 gregtech.gui.me_bus.auto_pull_button=Click to toggle automatic item pulling from ME
 gregtech.gui.alarm.radius=Radius:
+gregtech.gui.item_passthrough.enabled=Item Passthough Enabled
+gregtech.gui.item_passthrough.disabled=Item Passthough Disabled
+gregtech.gui.fluid_passthrough.enabled=Fluid Passthough Enabled
+gregtech.gui.fluid_passthrough.disabled=Fluid Passthough Disabled
 
 
 ore.spawnlocation.name=Ore Spawn Information


### PR DESCRIPTION
## What
To resolve #2490

## Implementation Details
I migrated them to MUI2 and added logic in `update()` to only move stuff when active.

## Outcome
Passthrough hatches can be toggled in their GUIs and controller covers can be attached.

## Potential Compatibility Issues
Passthrough hatches which were placed before this change should be set to working when loaded for the first time because of a check in `readFromNBT`.

~~I'm not satisfied with the outcome of the fluid passthrough hatch's new UI, so I'll have to keep working on that. *Please don't merge until the FluitSlot from MUI2 matches how it works in MUI~~ no idea when this will be changed so oh well.