### PR TITLE
Add Polybenzimidazole Block Conversion Recipes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/OrganicChemistryMaterials.java
@@ -97,7 +97,7 @@ public class OrganicChemistryMaterials {
                 .polymer()
                 .liquid(new FluidBuilder().temperature(1450))
                 .color(0x2D2D2D)
-                .flags(EXCLUDE_BLOCK_CRAFTING_RECIPES, GENERATE_FOIL)
+                .flags(GENERATE_FOIL)
                 .components(Carbon, 20, Hydrogen, 12, Nitrogen, 4)
                 .fluidPipeProperties(1000, 350, true)
                 .build();


### PR DESCRIPTION
## What
Adds back Polybenzimidazole Block -> Ingot and Ingot -> Block Crafting Recipes. First reported in https://github.com/Nomi-CEu/Nomi-CEu/issues/748.

Also makes GTCEu more consistent (although it could be argued that all higher tier materials should have these recipes removed, but that seems pointless).

## Implementation Details
None

## Outcome
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/748.

## Additional Information
None

## Potential Compatibility Issues
Perhaps conflicts with modpacks adding PBI conversion recipes manually.

**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**
