### PR TITLE
Fix EUt usage of HPCA with custom higher tier Components

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityHPCA.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityHPCA.java
@@ -167,7 +167,7 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
     }
 
     private void consumeEnergy() {
-        int energyToConsume = hpcaHandler.getCurrentEUt();
+        long energyToConsume = hpcaHandler.getCurrentEUt();
         boolean hasMaintenance = ConfigHolder.machines.enableMaintenance && hasMaintenanceMechanics();
         if (hasMaintenance) {
             // 10% more energy per maintenance problem
@@ -377,7 +377,7 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
     protected void addDisplayText(List<ITextComponent> textList) {
         MultiblockDisplayText.builder(textList, isStructureFormed())
                 .setWorkingStatus(true, hpcaHandler.getAllocatedCWUt() > 0) // transform into two-state system for
-                                                                            // display
+                // display
                 .setWorkingStatusKeys(
                         "gregtech.multiblock.idling",
                         "gregtech.multiblock.idling",
@@ -580,7 +580,7 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
 
         // cached gui info
         // holding these values past the computation clear because GUI is too "late" to read the state in time
-        private int cachedEUt;
+        private long cachedEUt;
         private int cachedCWUt;
 
         public HPCAGridHandler(@Nullable MetaTileEntityHPCA controller) {
@@ -760,10 +760,10 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
         }
 
         /** The current EU/t this HPCA should use, considering passive drain, current computation, etc.. */
-        public int getCurrentEUt() {
+        public long getCurrentEUt() {
             int maximumCWUt = Math.max(1, getMaxCWUt()); // behavior is no different setting this to 1 if it is 0
-            int maximumEUt = getMaxEUt();
-            int upkeepEUt = getUpkeepEUt();
+            long maximumEUt = getMaxEUt();
+            long upkeepEUt = getUpkeepEUt();
 
             if (maximumEUt == upkeepEUt) {
                 return maximumEUt;
@@ -775,8 +775,8 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
         }
 
         /** The amount of EU/t this HPCA uses just to stay on with 0 output computation. */
-        public int getUpkeepEUt() {
-            int upkeepEUt = 0;
+        public long getUpkeepEUt() {
+            long upkeepEUt = 0;
             for (var component : components) {
                 upkeepEUt += component.getUpkeepEUt();
             }
@@ -784,8 +784,8 @@ public class MetaTileEntityHPCA extends MultiblockWithDisplayBase
         }
 
         /** The maximum EU/t that this HPCA could ever use with the given configuration. */
-        public int getMaxEUt() {
-            int maximumEUt = 0;
+        public long getMaxEUt() {
+            long maximumEUt = 0;
             for (var component : components) {
                 maximumEUt += component.getMaxEUt();
             }

--- a/src/test/java/gregtech/common/metatileentities/multiblock/hpca/HPCATest.java
+++ b/src/test/java/gregtech/common/metatileentities/multiblock/hpca/HPCATest.java
@@ -30,8 +30,8 @@ public class HPCATest {
                         .coolingAmount(4)));
 
         final int maxCWUt = handler.getMaxCWUt();
-        final int upkeepEUt = handler.getUpkeepEUt();
-        final int maxEUt = handler.getMaxEUt();
+        final long upkeepEUt = handler.getUpkeepEUt();
+        final long maxEUt = handler.getMaxEUt();
         final int maxCoolingDemand = handler.getMaxCoolantDemand();
         final int maxCoolingAmount = handler.getMaxCoolingAmount();
         int allocated;
@@ -69,8 +69,8 @@ public class HPCATest {
                         .coolingAmount(2)));
 
         final int maxCWUt = handler.getMaxCWUt();
-        final int upkeepEUt = handler.getUpkeepEUt();
-        final int maxEUt = handler.getMaxEUt();
+        final long upkeepEUt = handler.getUpkeepEUt();
+        final long maxEUt = handler.getMaxEUt();
         final int maxCoolingDemand = handler.getMaxCoolingDemand();
         final int maxCoolingAmount = handler.getMaxCoolingAmount();
         int allocated, requested;
@@ -115,12 +115,13 @@ public class HPCATest {
                             .EUt(() -> r.nextInt(128))
                             .coolingAmount(() -> r.nextInt(128))));
 
-            final int maxEUt = handler.getMaxEUt();
-            final int upkeepEUt = handler.getUpkeepEUt();
+            final long maxEUt = handler.getMaxEUt();
+            final long upkeepEUt = handler.getUpkeepEUt();
             final int maxCWUt = handler.getMaxCWUt();
             final int maxCoolingDemand = handler.getMaxCoolingDemand();
             final int maxCoolingAmount = handler.getMaxCoolingAmount();
-            int allocated, requested, currentEUt;
+            int allocated, requested;
+            long currentEUt;
             double temperatureChange;
 
             // exit, we unit test these edge cases elsewhere

--- a/src/test/java/gregtech/common/metatileentities/multiblock/hpca/HPCATest.java
+++ b/src/test/java/gregtech/common/metatileentities/multiblock/hpca/HPCATest.java
@@ -38,8 +38,8 @@ public class HPCATest {
         double temperatureChange;
 
         assertThat(maxCWUt, is(0));
-        assertThat(upkeepEUt, is(32 * 4));
-        assertThat(maxEUt, is(128 * 4));
+        assertThat(upkeepEUt, is(32L * 4L));
+        assertThat(maxEUt, is(128L * 4L));
         assertThat(maxCoolingDemand, is(0));
         assertThat(maxCoolingAmount, is(4 * 4));
 
@@ -76,7 +76,7 @@ public class HPCATest {
         int allocated, requested;
         double temperatureChange;
 
-        final int FIXED_EUT = 32 * 8;
+        final long FIXED_EUT = 32 * 8;
         assertThat(maxCWUt, is(4 * 4));
         assertThat(upkeepEUt, is(FIXED_EUT));
         assertThat(maxEUt, is(FIXED_EUT));


### PR DESCRIPTION
## What
Fixes the HPCA energy usage with higher tier components.

## Implementation Details
Changed the data types of EUt to long.

## Outcome
Allows custom HPCA components to not bug out the EUt usage after a certain point. I'm not sure why it was breaking well below integer max value anyways.

## Additional Information
None

## Potential Compatibility Issues
None to my knowledge