### PR TITLE
Fix liquid and gas registry key functions overlapping

### DIFF
--- a/src/main/java/gregtech/api/fluids/FluidBuilder.java
+++ b/src/main/java/gregtech/api/fluids/FluidBuilder.java
@@ -390,7 +390,7 @@ public class FluidBuilder {
     private void determineName(@Nullable Material material, @Nullable FluidStorageKey key) {
         if (name != null) return;
         if (material == null || key == null) throw new IllegalArgumentException("Fluid must have a name");
-        name = key.getRegistryNameFor(material.getName());
+        name = key.getRegistryNameFor(material);
     }
 
     private void determineTextures(@Nullable Material material, @Nullable FluidStorageKey key, @NotNull String modid) {

--- a/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
+++ b/src/main/java/gregtech/api/fluids/GTFluidRegistration.java
@@ -82,7 +82,7 @@ public class GTFluidRegistration {
         for (Material material : GregTechAPI.materialManager.getRegisteredMaterials()) {
             FluidProperty property = material.getProperty(PropertyKey.FLUID);
             if (property != null) {
-                property.getStorage().registerFluids(material);
+                property.registerFluids(material);
             }
         }
     }

--- a/src/main/java/gregtech/api/fluids/store/FluidStorage.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorage.java
@@ -1,27 +1,13 @@
 package gregtech.api.fluids.store;
 
 import gregtech.api.fluids.FluidBuilder;
-import gregtech.api.unification.material.Material;
-import gregtech.api.util.GTLog;
 
 import net.minecraftforge.fluids.Fluid;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Comparator;
-import java.util.Map;
-
-public final class FluidStorage {
-
-    private final Map<FluidStorageKey, Fluid> map = new Object2ObjectOpenHashMap<>();
-    private Map<FluidStorageKey, FluidBuilder> toRegister = new Object2ObjectOpenHashMap<>();
-
-    private boolean registered = false;
-
-    public FluidStorage() {}
+public interface FluidStorage {
 
     /**
      * Enqueue a fluid for registration
@@ -29,81 +15,19 @@ public final class FluidStorage {
      * @param key     the key corresponding with the fluid
      * @param builder the FluidBuilder to build
      */
-    public void enqueueRegistration(@NotNull FluidStorageKey key, @NotNull FluidBuilder builder) {
-        if (registered) {
-            throw new IllegalStateException("Cannot enqueue a builder after registration");
-        }
-
-        if (toRegister.containsKey(key)) {
-            throw new IllegalArgumentException("FluidStorageKey " + key + " is already queued");
-        }
-        toRegister.put(key, builder);
-    }
+    void enqueueRegistration(@NotNull FluidStorageKey key, @NotNull FluidBuilder builder);
 
     /**
      * @param key the key corresponding with the FluidBuilder
      * @return the fluid builder queued to be registered
      */
-    public @Nullable FluidBuilder getQueuedBuilder(@NotNull FluidStorageKey key) {
-        if (registered) {
-            throw new IllegalArgumentException("FluidStorage has already been registered");
-        }
-        return toRegister.get(key);
-    }
-
-    /**
-     * Register the enqueued fluids
-     *
-     * @param material the material the fluid is based off of
-     */
-    @ApiStatus.Internal
-    public void registerFluids(@NotNull Material material) {
-        if (registered) {
-            throw new IllegalStateException("FluidStorage has already been registered");
-        }
-
-        // If nothing is queued for registration and nothing is manually stored,
-        // we need something for the registry to handle this will prevent cases
-        // of a material having a fluid property but no fluids actually created
-        // for the material.
-        if (toRegister.isEmpty() && map.isEmpty()) {
-            enqueueRegistration(FluidStorageKeys.LIQUID, new FluidBuilder());
-        }
-
-        toRegister.entrySet().stream()
-                .sorted(Comparator.comparingInt(e -> -e.getKey().getRegistrationPriority()))
-                .forEach(entry -> {
-                    Fluid fluid = entry.getValue().build(material.getModid(), material, entry.getKey());
-                    if (!storeNoOverwrites(entry.getKey(), fluid)) {
-                        GTLog.logger.error("{} already has an associated fluid for material {}", material);
-                    }
-                });
-        toRegister = null;
-        registered = true;
-    }
+    @Nullable FluidBuilder getQueuedBuilder(@NotNull FluidStorageKey key);
 
     /**
      * @param key the key corresponding with the fluid
      * @return the fluid associated with the key
      */
-    public @Nullable Fluid get(@NotNull FluidStorageKey key) {
-        return map.get(key);
-    }
-
-    /**
-     * Will do nothing if an existing fluid association would be overwritten.
-     *
-     * @param key   the key to associate with the fluid
-     * @param fluid the fluid to associate with the key
-     * @return if the associations were successfully updated
-     */
-    public boolean storeNoOverwrites(@NotNull FluidStorageKey key, @NotNull Fluid fluid) {
-        if (map.containsKey(key)) {
-            return false;
-        }
-        store(key, fluid);
-        return true;
-    }
+    @Nullable Fluid get(@NotNull FluidStorageKey key);
 
     /**
      * Will overwrite existing fluid associations.
@@ -111,7 +35,5 @@ public final class FluidStorage {
      * @param key   the key to associate with the fluid
      * @param fluid the fluid to associate with the key
      */
-    public void store(@NotNull FluidStorageKey key, @NotNull Fluid fluid) {
-        map.put(key, fluid);
-    }
+    void store(@NotNull FluidStorageKey key, @NotNull Fluid fluid);
 }

--- a/src/main/java/gregtech/api/fluids/store/FluidStorage.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorage.java
@@ -21,13 +21,15 @@ public interface FluidStorage {
      * @param key the key corresponding with the FluidBuilder
      * @return the fluid builder queued to be registered
      */
-    @Nullable FluidBuilder getQueuedBuilder(@NotNull FluidStorageKey key);
+    @Nullable
+    FluidBuilder getQueuedBuilder(@NotNull FluidStorageKey key);
 
     /**
      * @param key the key corresponding with the fluid
      * @return the fluid associated with the key
      */
-    @Nullable Fluid get(@NotNull FluidStorageKey key);
+    @Nullable
+    Fluid get(@NotNull FluidStorageKey key);
 
     /**
      * Will overwrite existing fluid associations.

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageImpl.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageImpl.java
@@ -1,0 +1,101 @@
+package gregtech.api.fluids.store;
+
+import gregtech.api.fluids.FluidBuilder;
+import gregtech.api.unification.material.Material;
+import gregtech.api.util.GTLog;
+
+import net.minecraftforge.fluids.Fluid;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Comparator;
+import java.util.Map;
+
+public final class FluidStorageImpl implements FluidStorage {
+
+    private final Map<FluidStorageKey, Fluid> map = new Object2ObjectOpenHashMap<>();
+    private Map<FluidStorageKey, FluidBuilder> toRegister = new Object2ObjectOpenHashMap<>();
+
+    private boolean registered = false;
+
+    public FluidStorageImpl() {}
+
+    @Override
+    public void enqueueRegistration(@NotNull FluidStorageKey key, @NotNull FluidBuilder builder) {
+        if (registered) {
+            throw new IllegalStateException("Cannot enqueue a builder after registration");
+        }
+
+        if (toRegister.containsKey(key)) {
+            throw new IllegalArgumentException("FluidStorageKey " + key + " is already queued");
+        }
+        toRegister.put(key, builder);
+    }
+
+    @Override
+    public @Nullable FluidBuilder getQueuedBuilder(@NotNull FluidStorageKey key) {
+        if (registered) {
+            throw new IllegalArgumentException("FluidStorageImpl has already been registered");
+        }
+        return toRegister.get(key);
+    }
+
+    /**
+     * Register the enqueued fluids
+     *
+     * @param material the material the fluid is based off of
+     */
+    @ApiStatus.Internal
+    public void registerFluids(@NotNull Material material) {
+        if (registered) {
+            throw new IllegalStateException("FluidStorageImpl has already been registered");
+        }
+
+        // If nothing is queued for registration and nothing is manually stored,
+        // we need something for the registry to handle this will prevent cases
+        // of a material having a fluid property but no fluids actually created
+        // for the material.
+        if (toRegister.isEmpty() && map.isEmpty()) {
+            enqueueRegistration(FluidStorageKeys.LIQUID, new FluidBuilder());
+        }
+
+        toRegister.entrySet().stream()
+                .sorted(Comparator.comparingInt(e -> -e.getKey().getRegistrationPriority()))
+                .forEach(entry -> {
+                    Fluid fluid = entry.getValue().build(material.getModid(), material, entry.getKey());
+                    if (!storeNoOverwrites(entry.getKey(), fluid)) {
+                        GTLog.logger.error("{} already has an associated fluid for material {}", material);
+                    }
+                });
+        toRegister = null;
+        registered = true;
+    }
+
+    @Override
+    public @Nullable Fluid get(@NotNull FluidStorageKey key) {
+        return map.get(key);
+    }
+
+    /**
+     * Will do nothing if an existing fluid association would be overwritten.
+     *
+     * @param key   the key to associate with the fluid
+     * @param fluid the fluid to associate with the key
+     * @return if the associations were successfully updated
+     */
+    private boolean storeNoOverwrites(@NotNull FluidStorageKey key, @NotNull Fluid fluid) {
+        if (map.containsKey(key)) {
+            return false;
+        }
+        store(key, fluid);
+        return true;
+    }
+
+    @Override
+    public void store(@NotNull FluidStorageKey key, @NotNull Fluid fluid) {
+        map.put(key, fluid);
+    }
+}

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKey.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 
 public final class FluidStorageKey {
 
@@ -20,32 +19,32 @@ public final class FluidStorageKey {
 
     private final ResourceLocation resourceLocation;
     private final MaterialIconType iconType;
-    private final UnaryOperator<String> registryNameOperator;
+    private final Function<Material, String> registryNameFunction;
     private final Function<Material, String> translationKeyFunction;
     private final int hashCode;
     private final FluidState defaultFluidState;
     private final int registrationPriority;
 
     public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
-                           @NotNull UnaryOperator<@NotNull String> registryNameOperator,
+                           @NotNull Function<@NotNull Material, @NotNull String> registryNameFunction,
                            @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction) {
-        this(resourceLocation, iconType, registryNameOperator, translationKeyFunction, null);
+        this(resourceLocation, iconType, registryNameFunction, translationKeyFunction, null);
     }
 
     public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
-                           @NotNull UnaryOperator<@NotNull String> registryNameOperator,
+                           @NotNull Function<@NotNull Material, @NotNull String> registryNameFunction,
                            @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction,
                            @Nullable FluidState defaultFluidState) {
-        this(resourceLocation, iconType, registryNameOperator, translationKeyFunction, defaultFluidState, 0);
+        this(resourceLocation, iconType, registryNameFunction, translationKeyFunction, defaultFluidState, 0);
     }
 
     public FluidStorageKey(@NotNull ResourceLocation resourceLocation, @NotNull MaterialIconType iconType,
-                           @NotNull UnaryOperator<@NotNull String> registryNameOperator,
+                           @NotNull Function<@NotNull Material, @NotNull String> registryNameFunction,
                            @NotNull Function<@NotNull Material, @NotNull String> translationKeyFunction,
                            @Nullable FluidState defaultFluidState, int registrationPriority) {
         this.resourceLocation = resourceLocation;
         this.iconType = iconType;
-        this.registryNameOperator = registryNameOperator;
+        this.registryNameFunction = registryNameFunction;
         this.translationKeyFunction = translationKeyFunction;
         this.hashCode = resourceLocation.hashCode();
         this.defaultFluidState = defaultFluidState;
@@ -72,8 +71,8 @@ public final class FluidStorageKey {
      * @param baseName the base name of the fluid
      * @return the registry name to use
      */
-    public @NotNull String getRegistryNameFor(@NotNull String baseName) {
-        return registryNameOperator.apply(baseName);
+    public @NotNull String getRegistryNameFor(@NotNull Material baseName) {
+        return registryNameFunction.apply(baseName);
     }
 
     /**

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -2,11 +2,8 @@ package gregtech.api.fluids.store;
 
 import gregtech.api.fluids.FluidState;
 import gregtech.api.unification.material.info.MaterialIconType;
+import gregtech.api.unification.material.properties.FluidProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
-
-import net.minecraftforge.fluids.FluidRegistry;
-
-import java.util.function.UnaryOperator;
 
 import static gregtech.api.util.GTUtility.gregtechId;
 
@@ -14,20 +11,32 @@ public final class FluidStorageKeys {
 
     public static final FluidStorageKey LIQUID = new FluidStorageKey(gregtechId("liquid"),
             MaterialIconType.liquid,
-            UnaryOperator.identity(),
+            m -> {
+                FluidProperty property = m.getProperty(PropertyKey.FLUID);
+                if (property != null && property.getPrimaryKey() != FluidStorageKeys.LIQUID) {
+                    return "liquid." + m.getName();
+                }
+                return m.getName();
+            },
             m -> m.hasProperty(PropertyKey.DUST) ? "gregtech.fluid.liquid_generic" : "gregtech.fluid.generic",
             FluidState.LIQUID);
 
     public static final FluidStorageKey GAS = new FluidStorageKey(gregtechId("gas"),
             MaterialIconType.gas,
-            s -> FluidRegistry.getFluid(s) == null ? s : "gas." + s,
+            m -> {
+                FluidProperty property = m.getProperty(PropertyKey.FLUID);
+                if (property != null && property.getPrimaryKey() != FluidStorageKeys.GAS) {
+                    return "gas." + m.getName();
+                }
+                return m.getName();
+            },
             m -> {
                 if (m.hasProperty(PropertyKey.DUST)) {
                     return "gregtech.fluid.gas_vapor";
                 }
-                if (m.isElement() || (m.hasProperty(PropertyKey.FLUID) &&
-                        m.getProperty(PropertyKey.FLUID).getStorage().getQueuedBuilder(FluidStorageKeys.LIQUID) !=
-                                null)) {
+
+                FluidProperty property = m.getProperty(PropertyKey.FLUID);
+                if (m.isElement() || (property != null && property.getPrimaryKey() != FluidStorageKeys.LIQUID)) {
                     return "gregtech.fluid.gas_generic";
                 }
                 return "gregtech.fluid.generic";
@@ -36,7 +45,8 @@ public final class FluidStorageKeys {
 
     public static final FluidStorageKey PLASMA = new FluidStorageKey(gregtechId("plasma"),
             MaterialIconType.plasma,
-            s -> "plasma." + s, m -> "gregtech.fluid.plasma",
+            m -> "plasma." + m.getName(),
+            m -> "gregtech.fluid.plasma",
             FluidState.PLASMA, -1);
 
     private FluidStorageKeys() {}

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -4,6 +4,8 @@ import gregtech.api.fluids.FluidState;
 import gregtech.api.unification.material.info.MaterialIconType;
 import gregtech.api.unification.material.properties.PropertyKey;
 
+import net.minecraftforge.fluids.FluidRegistry;
+
 import java.util.function.UnaryOperator;
 
 import static gregtech.api.util.GTUtility.gregtechId;
@@ -18,12 +20,14 @@ public final class FluidStorageKeys {
 
     public static final FluidStorageKey GAS = new FluidStorageKey(gregtechId("gas"),
             MaterialIconType.gas,
-            UnaryOperator.identity(),
+            s -> FluidRegistry.getFluid(s) == null ? s : "gas." + s,
             m -> {
                 if (m.hasProperty(PropertyKey.DUST)) {
                     return "gregtech.fluid.gas_vapor";
                 }
-                if (m.isElement()) {
+                if (m.isElement() || (m.hasProperty(PropertyKey.FLUID) &&
+                        m.getProperty(PropertyKey.FLUID).getStorage().getQueuedBuilder(FluidStorageKeys.LIQUID) !=
+                                null)) {
                     return "gregtech.fluid.gas_generic";
                 }
                 return "gregtech.fluid.generic";

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -1,9 +1,12 @@
 package gregtech.api.fluids.store;
 
 import gregtech.api.fluids.FluidState;
+import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.info.MaterialIconType;
 import gregtech.api.unification.material.properties.FluidProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
+
+import org.jetbrains.annotations.NotNull;
 
 import static gregtech.api.util.GTUtility.gregtechId;
 
@@ -11,25 +14,13 @@ public final class FluidStorageKeys {
 
     public static final FluidStorageKey LIQUID = new FluidStorageKey(gregtechId("liquid"),
             MaterialIconType.liquid,
-            m -> {
-                FluidProperty property = m.getProperty(PropertyKey.FLUID);
-                if (property != null && property.getPrimaryKey() != FluidStorageKeys.LIQUID) {
-                    return "liquid." + m.getName();
-                }
-                return m.getName();
-            },
+            m -> prefixedRegistryName("liquid.", FluidStorageKeys.LIQUID, m),
             m -> m.hasProperty(PropertyKey.DUST) ? "gregtech.fluid.liquid_generic" : "gregtech.fluid.generic",
             FluidState.LIQUID);
 
     public static final FluidStorageKey GAS = new FluidStorageKey(gregtechId("gas"),
             MaterialIconType.gas,
-            m -> {
-                FluidProperty property = m.getProperty(PropertyKey.FLUID);
-                if (property != null && property.getPrimaryKey() != FluidStorageKeys.GAS) {
-                    return "gas." + m.getName();
-                }
-                return m.getName();
-            },
+            m -> prefixedRegistryName("gas.", FluidStorageKeys.GAS, m),
             m -> {
                 if (m.hasProperty(PropertyKey.DUST)) {
                     return "gregtech.fluid.gas_vapor";
@@ -50,4 +41,19 @@ public final class FluidStorageKeys {
             FluidState.PLASMA, -1);
 
     private FluidStorageKeys() {}
+
+    /**
+     * @param prefix   the prefix string for the registry name
+     * @param key      the key which does not require the prefix
+     * @param material the material to create a registry name for
+     * @return the registry name
+     */
+    private static @NotNull String prefixedRegistryName(@NotNull String prefix, @NotNull FluidStorageKey key,
+                                                        @NotNull Material material) {
+        FluidProperty property = material.getProperty(PropertyKey.FLUID);
+        if (property != null && property.getPrimaryKey() != key) {
+            return prefix + material.getName();
+        }
+        return material.getName();
+    }
 }

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -209,10 +209,7 @@ public class Material implements Comparable<Material> {
             throw new IllegalArgumentException("Material " + getResourceLocation() + " does not have a Fluid!");
         }
 
-        FluidStorageKey key = prop.getPrimaryKey();
-        Fluid fluid = null;
-
-        if (key != null) fluid = prop.getStorage().get(key);
+        Fluid fluid = prop.getStorage().get(prop.getPrimaryKey());
         if (fluid != null) return fluid;
 
         fluid = getFluid(FluidStorageKeys.LIQUID);
@@ -523,6 +520,10 @@ public class Material implements Comparable<Material> {
             properties.ensureSet(PropertyKey.FLUID);
             FluidProperty property = properties.getProperty(PropertyKey.FLUID);
             property.getStorage().enqueueRegistration(key, builder);
+            if (property.getPrimaryKey() == null) {
+                property.setPrimaryKey(key);
+            }
+
             return this;
         }
 
@@ -536,6 +537,10 @@ public class Material implements Comparable<Material> {
             properties.ensureSet(PropertyKey.FLUID);
             FluidProperty property = properties.getProperty(PropertyKey.FLUID);
             property.getStorage().store(key, fluid);
+            if (property.getPrimaryKey() == null) {
+                property.setPrimaryKey(key);
+            }
+
             postProcessors.add(
                     m -> FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createFluidTooltip(m, fluid, state)));
             return this;

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -209,7 +209,7 @@ public class Material implements Comparable<Material> {
             throw new IllegalArgumentException("Material " + getResourceLocation() + " does not have a Fluid!");
         }
 
-        Fluid fluid = prop.getStorage().get(prop.getPrimaryKey());
+        Fluid fluid = prop.get(prop.getPrimaryKey());
         if (fluid != null) return fluid;
 
         fluid = getFluid(FluidStorageKeys.LIQUID);
@@ -228,7 +228,7 @@ public class Material implements Comparable<Material> {
             throw new IllegalArgumentException("Material " + getResourceLocation() + " does not have a Fluid!");
         }
 
-        return prop.getStorage().get(key);
+        return prop.get(key);
     }
 
     /**
@@ -519,10 +519,7 @@ public class Material implements Comparable<Material> {
         public Builder fluid(@NotNull FluidStorageKey key, @NotNull FluidBuilder builder) {
             properties.ensureSet(PropertyKey.FLUID);
             FluidProperty property = properties.getProperty(PropertyKey.FLUID);
-            property.getStorage().enqueueRegistration(key, builder);
-            if (property.getPrimaryKey() == null) {
-                property.setPrimaryKey(key);
-            }
+            property.enqueueRegistration(key, builder);
 
             return this;
         }
@@ -536,10 +533,7 @@ public class Material implements Comparable<Material> {
         public Builder fluid(@NotNull Fluid fluid, @NotNull FluidStorageKey key, @NotNull FluidState state) {
             properties.ensureSet(PropertyKey.FLUID);
             FluidProperty property = properties.getProperty(PropertyKey.FLUID);
-            property.getStorage().store(key, fluid);
-            if (property.getPrimaryKey() == null) {
-                property.setPrimaryKey(key);
-            }
+            property.store(key, fluid);
 
             postProcessors.add(
                     m -> FluidTooltipUtil.registerTooltip(fluid, FluidTooltipUtil.createFluidTooltip(m, fluid, state)));

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -1204,7 +1204,7 @@ public class FirstDegreeMaterials {
                 .build();
 
         Iron3Chloride = new Material.Builder(411, gregtechId("iron_iii_chloride"))
-                .fluid()
+                .liquid().gas()
                 .color(0x060B0B)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Iron, 1, Chlorine, 3)

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -1204,7 +1204,7 @@ public class FirstDegreeMaterials {
                 .build();
 
         Iron3Chloride = new Material.Builder(411, gregtechId("iron_iii_chloride"))
-                .liquid().gas()
+                .liquid()
                 .color(0x060B0B)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Iron, 1, Chlorine, 3)

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -5,7 +5,6 @@ import gregtech.api.fluids.store.FluidStorage;
 import gregtech.api.fluids.store.FluidStorageImpl;
 import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.fluids.store.FluidStorageKeys;
-
 import gregtech.api.unification.material.Material;
 
 import net.minecraftforge.fluids.Fluid;

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -1,35 +1,92 @@
 package gregtech.api.unification.material.properties;
 
+import gregtech.api.fluids.FluidBuilder;
 import gregtech.api.fluids.store.FluidStorage;
+import gregtech.api.fluids.store.FluidStorageImpl;
 import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.fluids.store.FluidStorageKeys;
+
+import gregtech.api.unification.material.Material;
 
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 
-public class FluidProperty implements IMaterialProperty {
+public class FluidProperty implements IMaterialProperty, FluidStorage {
 
-    private final FluidStorage storage = new FluidStorage();
+    private final FluidStorageImpl storage = new FluidStorageImpl();
     private FluidStorageKey primaryKey = null;
     private @Nullable Fluid solidifyingFluid = null;
 
     public FluidProperty() {}
 
-    public @NotNull FluidStorage getStorage() {
-        return this.storage;
+    /**
+     * Helper constructor which automatically calls {@link #enqueueRegistration(FluidStorageKey, FluidBuilder)} for a
+     * builder.
+     * <p>
+     * This is primarily useful for adding FluidProperties to materials after they are registered with a single fluid
+     * stored.
+     *
+     * @param key     the fluid storage key to store the builder with
+     * @param builder the builder to enqueue
+     */
+    public FluidProperty(@NotNull FluidStorageKey key, @NotNull FluidBuilder builder) {
+        enqueueRegistration(key, builder);
     }
 
     /**
-     * This is only {@code Nullable} internally during the Material creation process.
-     * All external use should assume this is {@code Nonnull}.
+     * Obsolete method, FluidProperty now contains this functionality.
      *
-     * @return the FluidStorageKey fluid is stored as primarily
+     * @deprecated {@link FluidStorage}
      */
-    public @UnknownNullability FluidStorageKey getPrimaryKey() {
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
+    @Deprecated
+    public @NotNull FluidStorage getStorage() {
+        return this;
+    }
+
+    /**
+     * @see FluidStorageImpl#registerFluids(Material)
+     */
+    @ApiStatus.Internal
+    public void registerFluids(@NotNull Material material) {
+        this.storage.registerFluids(material);
+    }
+
+    @Override
+    public void enqueueRegistration(@NotNull FluidStorageKey key, @NotNull FluidBuilder builder) {
+        storage.enqueueRegistration(key, builder);
+        if (primaryKey == null) {
+            primaryKey = key;
+        }
+    }
+
+    @Override
+    public void store(@NotNull FluidStorageKey key, @NotNull Fluid fluid) {
+        storage.store(key, fluid);
+        if (primaryKey == null) {
+            primaryKey = key;
+        }
+    }
+
+    @Override
+    public @Nullable Fluid get(@NotNull FluidStorageKey key) {
+        return storage.get(key);
+    }
+
+    @Override
+    public @Nullable FluidBuilder getQueuedBuilder(@NotNull FluidStorageKey key) {
+        return storage.getQueuedBuilder(key);
+    }
+
+    /**
+     *
+     * @return the key the fluid is stored with primarily
+     */
+    public @NotNull FluidStorageKey getPrimaryKey() {
         return primaryKey;
     }
 
@@ -43,7 +100,7 @@ public class FluidProperty implements IMaterialProperty {
     @Override
     public void verifyProperty(MaterialProperties properties) {
         if (this.primaryKey == null) {
-            throw new IllegalStateException("PrimaryKey cannot be null after property verification");
+            throw new IllegalStateException("FluidProperty cannot be empty");
         }
     }
 
@@ -52,7 +109,7 @@ public class FluidProperty implements IMaterialProperty {
      */
     public @Nullable Fluid solidifiesFrom() {
         if (this.solidifyingFluid == null) {
-            return getStorage().get(FluidStorageKeys.LIQUID);
+            return storage.get(FluidStorageKeys.LIQUID);
         }
         return solidifyingFluid;
     }

--- a/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/FluidProperty.java
@@ -9,11 +9,12 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 public class FluidProperty implements IMaterialProperty {
 
     private final FluidStorage storage = new FluidStorage();
-    private @Nullable FluidStorageKey primaryKey = null;
+    private FluidStorageKey primaryKey = null;
     private @Nullable Fluid solidifyingFluid = null;
 
     public FluidProperty() {}
@@ -23,27 +24,33 @@ public class FluidProperty implements IMaterialProperty {
     }
 
     /**
+     * This is only {@code Nullable} internally during the Material creation process.
+     * All external use should assume this is {@code Nonnull}.
+     *
      * @return the FluidStorageKey fluid is stored as primarily
      */
-    public @Nullable FluidStorageKey getPrimaryKey() {
+    public @UnknownNullability FluidStorageKey getPrimaryKey() {
         return primaryKey;
     }
 
     /**
      * @param primaryKey the key to use primarily
      */
-    public void setPrimaryKey(@Nullable FluidStorageKey primaryKey) {
+    public void setPrimaryKey(@NotNull FluidStorageKey primaryKey) {
         this.primaryKey = primaryKey;
     }
 
     @Override
-    public void verifyProperty(MaterialProperties properties) {}
+    public void verifyProperty(MaterialProperties properties) {
+        if (this.primaryKey == null) {
+            throw new IllegalStateException("PrimaryKey cannot be null after property verification");
+        }
+    }
 
     /**
      * @return the Fluid which solidifies into the material.
      */
-
-    public Fluid solidifiesFrom() {
+    public @Nullable Fluid solidifiesFrom() {
         if (this.solidifyingFluid == null) {
             return getStorage().get(FluidStorageKeys.LIQUID);
         }

--- a/src/main/java/gregtech/integration/crafttweaker/material/MaterialExpansion.java
+++ b/src/main/java/gregtech/integration/crafttweaker/material/MaterialExpansion.java
@@ -60,7 +60,7 @@ public class MaterialExpansion {
     @ZenGetter
     public static boolean isGaseous(Material m) {
         FluidProperty prop = m.getProperty(PropertyKey.FLUID);
-        return prop != null && prop.getStorage().get(FluidStorageKeys.GAS) != null;
+        return prop != null && prop.get(FluidStorageKeys.GAS) != null;
     }
 
     // TODO May need to move this to Material

--- a/src/main/java/gregtech/integration/crafttweaker/material/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/integration/crafttweaker/material/MaterialPropertyExpansion.java
@@ -3,7 +3,6 @@ package gregtech.integration.crafttweaker.material;
 import gregtech.api.fluids.FluidBuilder;
 import gregtech.api.fluids.FluidState;
 import gregtech.api.fluids.attribute.FluidAttributes;
-import gregtech.api.fluids.store.FluidStorage;
 import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.properties.*;
@@ -147,7 +146,7 @@ public class MaterialPropertyExpansion {
         if (checkFrozen("add a Fluid to a material")) return;
         if (!m.hasProperty(PropertyKey.FLUID)) {
             FluidProperty property = new FluidProperty();
-            property.getStorage().enqueueRegistration(FluidStorageKeys.LIQUID, new FluidBuilder());
+            property.enqueueRegistration(FluidStorageKeys.LIQUID, new FluidBuilder());
             m.setProperty(PropertyKey.FLUID, property);
         }
     }
@@ -162,18 +161,17 @@ public class MaterialPropertyExpansion {
             m.setProperty(PropertyKey.FLUID, property);
         }
 
-        FluidStorage storage = property.getStorage();
         FluidBuilder builder = switch (type) {
-            case LIQUID -> storage.getQueuedBuilder(FluidStorageKeys.LIQUID);
-            case GAS -> storage.getQueuedBuilder(FluidStorageKeys.GAS);
-            case PLASMA -> storage.getQueuedBuilder(FluidStorageKeys.PLASMA);
+            case LIQUID -> property.getQueuedBuilder(FluidStorageKeys.LIQUID);
+            case GAS -> property.getQueuedBuilder(FluidStorageKeys.GAS);
+            case PLASMA -> property.getQueuedBuilder(FluidStorageKeys.PLASMA);
         };
         if (builder == null) {
             builder = new FluidBuilder();
             switch (type) {
-                case LIQUID -> storage.enqueueRegistration(FluidStorageKeys.LIQUID, builder);
-                case GAS -> storage.enqueueRegistration(FluidStorageKeys.GAS, builder.state(FluidState.GAS));
-                case PLASMA -> storage.enqueueRegistration(FluidStorageKeys.PLASMA, builder.state(FluidState.PLASMA));
+                case LIQUID -> property.enqueueRegistration(FluidStorageKeys.LIQUID, builder);
+                case GAS -> property.enqueueRegistration(FluidStorageKeys.GAS, builder.state(FluidState.GAS));
+                case PLASMA -> property.enqueueRegistration(FluidStorageKeys.PLASMA, builder.state(FluidState.PLASMA));
             }
         }
         if (hasBlock) builder.block();
@@ -218,7 +216,7 @@ public class MaterialPropertyExpansion {
         if (checkFrozen("add a Plasma to a material")) return;
         if (!m.hasProperty(PropertyKey.FLUID)) {
             FluidProperty property = new FluidProperty();
-            property.getStorage().enqueueRegistration(FluidStorageKeys.PLASMA,
+            property.enqueueRegistration(FluidStorageKeys.PLASMA,
                     new FluidBuilder().state(FluidState.PLASMA));
             m.setProperty(PropertyKey.FLUID, property);
         }

--- a/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
+++ b/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
@@ -53,7 +53,7 @@ public class MaterialExpansion {
 
     public static boolean isGaseous(Material m) {
         FluidProperty prop = m.getProperty(PropertyKey.FLUID);
-        return prop != null && prop.getStorage().get(FluidStorageKeys.GAS) != null;
+        return prop != null && prop.get(FluidStorageKeys.GAS) != null;
     }
 
     ///////////////////////////////////

--- a/src/main/java/gregtech/integration/groovy/MaterialPropertyExpansion.java
+++ b/src/main/java/gregtech/integration/groovy/MaterialPropertyExpansion.java
@@ -174,7 +174,7 @@ public class MaterialPropertyExpansion {
             property = new FluidProperty();
             m.setProperty(PropertyKey.FLUID, property);
         }
-        property.getStorage().enqueueRegistration(key, builder);
+        property.enqueueRegistration(key, builder);
     }
 
     public static void addLiquid(Material m, FluidBuilder builder) {


### PR DESCRIPTION
## What
This PR fixes an issue where materials that had both a gas and a liquid registered would end up only having a liquid:
![image](https://github.com/GregTechCEu/GregTech/assets/80226372/142c96dc-24ca-41f7-b7c7-22034f62f03e)

## Implementation Details
If there is a better way to write lines 29-30 to more efficiently get the liquid version of the material, that would be appreciated.

## Outcome
Materials now properly support having both liquid and gas forms.

## Potential Compatibility Issues
It is possible (although unlikely) that some fluid IDs in some addons may get remapped by this change.