### PR TITLE
fix MTE data fixer registry conflicts

### DIFF
--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -405,7 +405,9 @@ public class CommonProxy {
 
     public void onPreLoad() {}
 
-    public void onLoad() {}
+    public void onLoad() {
+        GTDataFixers.init();
+    }
 
     public void onPostLoad() {
         TerminalRegistry.init();
@@ -416,9 +418,6 @@ public class CommonProxy {
     }
 
     public void onLoadComplete() {
-        // Need to initialize data fixers in LoadComplete in order to ensure GroovyScript is covered
-        GTDataFixers.init();
-
         GTRecipeInputCache.disableCache();
 
         // If JEI and GS is not loaded, refresh ore dict ingredients

--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -405,9 +405,7 @@ public class CommonProxy {
 
     public void onPreLoad() {}
 
-    public void onLoad() {
-        GTDataFixers.init();
-    }
+    public void onLoad() {}
 
     public void onPostLoad() {
         TerminalRegistry.init();
@@ -418,6 +416,9 @@ public class CommonProxy {
     }
 
     public void onLoadComplete() {
+        // Need to initialize data fixers in LoadComplete in order to ensure GroovyScript is covered
+        GTDataFixers.init();
+
         GTRecipeInputCache.disableCache();
 
         // If JEI and GS is not loaded, refresh ore dict ingredients

--- a/src/main/java/gregtech/datafix/GTDataFixers.java
+++ b/src/main/java/gregtech/datafix/GTDataFixers.java
@@ -2,13 +2,11 @@ package gregtech.datafix;
 
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
-import gregtech.api.metatileentity.registry.MTERegistry;
 import gregtech.datafix.migration.impl.MigrateMTEBlockTE;
 import gregtech.datafix.migration.impl.MigrateMTEItems;
 import gregtech.datafix.migration.lib.MTERegistriesMigrator;
 import gregtech.datafix.walker.WalkItemStackLike;
 
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.datafix.FixTypes;
 import net.minecraft.util.datafix.IDataWalker;
 import net.minecraftforge.common.util.CompoundDataFixer;

--- a/src/main/java/gregtech/datafix/GTDataFixers.java
+++ b/src/main/java/gregtech/datafix/GTDataFixers.java
@@ -67,9 +67,10 @@ public final class GTDataFixers {
      */
     private static void migrateMTERegistries() {
         MTERegistriesMigrator migrator = GregTechAPI.MIGRATIONS.registriesMigrator();
-        MTERegistry registry = GregTechAPI.mteManager.getRegistry(GTValues.MODID);
-        for (ResourceLocation key : registry.getKeys()) {
-            migrator.migrate(key.getNamespace(), (short) registry.getIdByObjectName(key));
+        for (MTERegistry registry : GregTechAPI.mteManager.getRegistries()) {
+            for (ResourceLocation key : registry.getKeys()) {
+                migrator.migrate(key.getNamespace(), (short) registry.getIdByObjectName(key));
+            }
         }
     }
 }

--- a/src/main/java/gregtech/datafix/GTDataFixers.java
+++ b/src/main/java/gregtech/datafix/GTDataFixers.java
@@ -19,6 +19,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.stream.IntStream;
+
 public final class GTDataFixers {
 
     public static final Logger LOGGER = LogManager.getLogger("GregTech DataFixers");
@@ -63,14 +65,10 @@ public final class GTDataFixers {
     }
 
     /**
-     * Migrate all MTEs to the new blocks automatically
+     * Migrate GT's own MTEs to the new blocks automatically
      */
     private static void migrateMTERegistries() {
         MTERegistriesMigrator migrator = GregTechAPI.MIGRATIONS.registriesMigrator();
-        for (MTERegistry registry : GregTechAPI.mteManager.getRegistries()) {
-            for (ResourceLocation key : registry.getKeys()) {
-                migrator.migrate(key.getNamespace(), (short) registry.getIdByObjectName(key));
-            }
-        }
+        migrator.migrate(GTValues.MODID, IntStream.range(0, 2000));
     }
 }

--- a/src/main/java/gregtech/datafix/migration/lib/MTERegistriesMigrator.java
+++ b/src/main/java/gregtech/datafix/migration/lib/MTERegistriesMigrator.java
@@ -15,6 +15,8 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.stream.IntStream;
+
 /**
  * Performs migration to an independent MTE registry.
  * <p>
@@ -48,14 +50,28 @@ public final class MTERegistriesMigrator extends AbstractMTEMigrator {
     }
 
     /**
-     * Register a data fix entry for the multiple MTE registry transition.
+     * Register a single data fix entry for the multiple MTE registry transition.
+     * <p>
+     * Callers will probably prefer {@link #migrate(String, IntStream)}.
      *
      * @param modid the registry's modid
      * @param meta  the metadata value to migrate
      */
-    @ApiStatus.Internal
     public void migrate(@NotNull String modid, short meta) {
         metaModidMap.put(meta, modid);
+    }
+
+    /**
+     * Register data fix entries for the multiple MTE registry transition.
+     * <p>
+     * Register the range of values allocated to the modid using {@link IntStream#range(int, int)} or
+     * {@link IntStream#builder()}.
+     *
+     * @param modid      the registry's modid
+     * @param metaValues the metadata values to migrate
+     */
+    public void migrate(@NotNull String modid, @NotNull IntStream metaValues) {
+        metaValues.forEach(i -> metaModidMap.put((short) i, modid));
     }
 
     @Override

--- a/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 @Optional.Interface(modid = Mods.Names.GROOVY_SCRIPT,
                     iface = "com.cleanroommc.groovyscript.api.GroovyPlugin",
@@ -100,7 +101,8 @@ public class GroovyScriptModule extends IntegrationSubmodule implements GroovyPl
     @SubscribeEvent
     public static void onMTERegistries(MTEManager.MTERegistryEvent event) {
         // automatically create a registry for groovyscript to store its MTEs
-        GregTechAPI.mteManager.createRegistry(GroovyScriptModule.getPackId());
+        GregTechAPI.mteManager.createRegistry(getPackId());
+        GregTechAPI.MIGRATIONS.registriesMigrator().migrate(getPackId(), IntStream.rangeClosed(32000, Short.MAX_VALUE));
     }
 
     public static boolean isCurrentlyRunning() {


### PR DESCRIPTION
## What
Fixes some issues introduced by #2505.

GT is actually unable to automatically associate metadata values with modids. In scenarios where two mods with separate registries both register an MTE with the same meta value, GT will not be able to associate the pre-migration metadata with the correct post-migration modid. Instead, mods will have to specify their own metadata to modid associations:

```java
public void preInit(FMLPreInitializationEvent event) {
    MTERegistriesMigrator migrator = GregTechAPI.MIGRATIONS.registriesMigrator();
    migrator.migrate(MODID, OLD_OWNED_META_1);
    migrator.migrate(MODID, OLD_OWNED_META_2);
    migrator.migrate(MODID, IntStream.range(ID_RANGE_START, ID_RANGE_END));
}
```

This can be done at any point before `FMLLoadCompleteEvent` and after GT experiences its `FMLPreInitializationEvent`.

Mods are strongly encouraged to use the method utilizing an `IntStream` in conjunction with `IntStream.range` and `IntStream.builder` in order to vastly simplify this association process. Most projects already have their own soft-reserved ID ranges, so it should be simple to register the required associations.

## Outcome
Fixes important issue with MTE data fixers.
