### PR TITLE
bump GHA versions

### DIFF
--- a/.github/actions/build_setup/action.yml
+++ b/.github/actions/build_setup/action.yml
@@ -18,7 +18,7 @@ runs:
       java-version: 17
 
   - name: Setup Gradle
-    uses: gradle/gradle-build-action@v2
+    uses: gradle/actions/setup-gradle@v3
     with:
       cache-write-only: ${{ inputs.update-cache }}
       generate-job-summary: false

--- a/.github/workflows/publish_project.yml
+++ b/.github/workflows/publish_project.yml
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew build --warning-mode all --build-cache
 
       - name: Publish to GitHub
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: "build/libs/*.jar"
           generate_release_notes: true

--- a/.github/workflows/update_buildscript.yml
+++ b/.github/workflows/update_buildscript.yml
@@ -35,13 +35,11 @@ jobs:
 
       - name: Create Pull Request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.BUILDSCRIPT_UPDATER_TOKEN }}
         with:
           token: ${{ secrets.BUILDSCRIPT_UPDATER_TOKEN }}
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit-message: 'update build script version to ${{ steps.version-check.outputs.NEW_VERSION }}'
           branch: gha-update-buildscript
           title: Update build script version to ${{ steps.version-check.outputs.NEW_VERSION }}

--- a/.github/workflows/validate_gradle_wrapper.yml
+++ b/.github/workflows/validate_gradle_wrapper.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation


### PR DESCRIPTION
Some standard routine maintenance. 

Just bumps the action versions to latest and removes things that should be no longer needed according to the changelogs.
