### PR TITLE
Fix failing builds due to Vintagium

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,22 +56,8 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:baubles-227083:2518667") // Baubles 1.5.2
     compileOnly rfg.deobf("curse.maven:forestry-59751:2684780") // Forestry 5.8.2.387
     compileOnly rfg.deobf("curse.maven:chisel-235279:2915375") // Chisel 1.0.2.45
-
-    // Special Vintagium Hackery
-    // Vintagium is currently only distributed as a .zip containing the reobf and -dev jars on Github Actions, which is not ideal
-    // Using a fake Ivy repo to download it does not work, as nightly.link does not support http HEAD requests, which Gradle wants
-    mkdir("libs")
-    // Using Gradle's Ant integration seems to be the least hacky way to download an arbitrary file without a plugin
-    ant.get(src: "https://nightly.link/Asek3/sodium-1.12/workflows/gradle/12.x%2Fforge/Vintagium.zip",
-            dest: "libs",
-            skipexisting: 'true')
-    ant.unzip(src: "libs/Vintagium.zip",
-              dest: "libs")
-    compileOnly(files("libs/vintagium-mc1.12.2-0.1-dev.jar"))
-
     compileOnly rfg.deobf("curse.maven:littletiles-257818:4750222") // LittleTiles 1.5.82-1.12.2
     compileOnly rfg.deobf("curse.maven:creativecore-257814:4722163") // Creative Core 1.10.71
-
 
     // Mods with Soft compat but which have no need to be in code, such as isModLoaded() checks and getModItem() recipes.
     // Uncomment any of these to test them in-game.

--- a/src/api/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
+++ b/src/api/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
@@ -1,0 +1,11 @@
+package me.jellysquid.mods.sodium.client.render.chunk.passes;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/Asek3/sodium-1.12/blob/12.x/forge/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java">BlockRenderPass.java</a>
+ */
+public enum BlockRenderPass {
+    ;
+
+    public static BlockRenderPass[] VALUES;
+    public static int COUNT;
+}

--- a/src/api/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPassManager.java
+++ b/src/api/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPassManager.java
@@ -1,0 +1,19 @@
+package me.jellysquid.mods.sodium.client.render.chunk.passes;
+
+import net.minecraft.util.BlockRenderLayer;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/Asek3/sodium-1.12/blob/12.x/forge/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPassManager.java">BlockRenderPassManager.java</a>
+ */
+public class BlockRenderPassManager {
+
+    private void addMapping(BlockRenderLayer layer, BlockRenderPass type) {}
+
+    /**
+     * Creates a set of render pass mappings to vanilla render layers which closely mirrors the rendering
+     * behavior of vanilla.
+     */
+    public static BlockRenderPassManager createDefaultMappings() {
+        return new BlockRenderPassManager();
+    }
+}

--- a/src/api/java/me/jellysquid/mods/sodium/client/util/BufferSizeUtil.java
+++ b/src/api/java/me/jellysquid/mods/sodium/client/util/BufferSizeUtil.java
@@ -1,0 +1,14 @@
+package me.jellysquid.mods.sodium.client.util;
+
+import net.minecraft.util.BlockRenderLayer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/Asek3/sodium-1.12/blob/12.x/forge/src/main/java/me/jellysquid/mods/sodium/client/util/BufferSizeUtil.java">BufferSizeUtil.java</a>
+ */
+public class BufferSizeUtil {
+
+    public static final Map<BlockRenderLayer, Integer> BUFFER_SIZES = new HashMap<>();
+}

--- a/src/api/java/me/jellysquid/mods/sodium/client/util/EnumUtil.java
+++ b/src/api/java/me/jellysquid/mods/sodium/client/util/EnumUtil.java
@@ -1,0 +1,12 @@
+package me.jellysquid.mods.sodium.client.util;
+
+import net.minecraft.util.BlockRenderLayer;
+
+/**
+ * Adapted and minimized from <a href="https://github.com/Asek3/sodium-1.12/blob/12.x/forge/src/main/java/me/jellysquid/mods/sodium/client/util/EnumUtil.java">EnumUtil.java</a>
+ */
+public class EnumUtil {
+
+    public static BlockRenderLayer[] LAYERS = BlockRenderLayer.values();
+
+}

--- a/src/main/java/gregtech/mixins/vintagium/BlockRenderManagerMixin.java
+++ b/src/main/java/gregtech/mixins/vintagium/BlockRenderManagerMixin.java
@@ -10,7 +10,6 @@ import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.passes.BlockRenderPassManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;

--- a/src/main/java/gregtech/mixins/vintagium/BlockRenderManagerMixin.java
+++ b/src/main/java/gregtech/mixins/vintagium/BlockRenderManagerMixin.java
@@ -21,7 +21,7 @@ public abstract class BlockRenderManagerMixin {
     @Shadow(remap = false)
     protected abstract void addMapping(BlockRenderLayer layer, BlockRenderPass type);
 
-    @Unique
+    @SuppressWarnings("UnresolvedMixinReference")
     @Inject(method = "createDefaultMappings",
             at = @At(value = "RETURN"),
             remap = false)

--- a/src/main/java/gregtech/mixins/vintagium/BlockRenderPassMixin.java
+++ b/src/main/java/gregtech/mixins/vintagium/BlockRenderPassMixin.java
@@ -30,6 +30,7 @@ public abstract class BlockRenderPassMixin {
     @Shadow(remap = false)
     public static int COUNT;
 
+    @SuppressWarnings("UnresolvedMixinReference")
     @Inject(method = "<clinit>",
             at = @At(value = "TAIL"),
             remap = false)


### PR DESCRIPTION
## What
Fixes failing builds due to the latest Vintagium artifact expiring from GitHub Actions. This moves all of the files we utilized in our compat mixins to `src/api/` and minimizes them.

Mixin and the MC Dev Intellij Plugin are both unable to find the actual `@Inject` target so I suppressed the warnings. This also means they do not show in the log and Intellij will not pick them up at runtime either.

According to the mixin log, the `@Unique` annotation in `BlockRenderPassMixin` was redundant, so I removed it.

## Outcome
Fixes failing builds.

## Additional Information
I only briefly tested this, but I do not encounter any noticeable issues and bloom is still visible as expected.
