### PR TITLE
Fix Mixin Warnings About `maxShiftBy`

### DIFF
--- a/src/main/resources/mixins.gregtech.minecraft.json
+++ b/src/main/resources/mixins.gregtech.minecraft.json
@@ -4,6 +4,9 @@
   "target": "@env(DEFAULT)",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "maxShiftBy": 10
+  },
   "mixins": [
     "BlockConcretePowderMixin",
     "DamageSourceMixin",


### PR DESCRIPTION
## What
fixes the warning thrown by mixin about `maxShiftBy` for the minecraft mixin json

## Implementation Details
`maxShiftBy` is now 10 for minecraft mixin json

## Outcome
no more warnings