### PR TITLE
Improvement to DT hatch logic

### DIFF
--- a/src/main/java/gregtech/api/capability/IDistillationTower.java
+++ b/src/main/java/gregtech/api/capability/IDistillationTower.java
@@ -1,0 +1,22 @@
+package gregtech.api.capability;
+
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+
+import net.minecraft.util.math.BlockPos;
+
+import java.util.List;
+
+/**
+ * intended for use in conjunction with {@link gregtech.api.capability.impl.DistillationTowerLogicHandler}
+ * use with distillation tower type multiblocks
+ */
+public interface IDistillationTower {
+
+    List<IMultiblockPart> getMultiblockParts();
+
+    BlockPos getPos();
+
+    void invalidateStructure();
+
+    boolean allowSameFluidFillForOutputs();
+}

--- a/src/main/java/gregtech/api/capability/impl/DistillationTowerLogicHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/DistillationTowerLogicHandler.java
@@ -15,7 +15,6 @@ import net.minecraftforge.fluids.capability.FluidTankProperties;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 
-import com.cleanroommc.modularui.utils.FluidTankHandler;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.NotNull;
 
@@ -96,9 +95,7 @@ public class DistillationTowerLogicHandler {
                 List<IFluidTank> hatchTanks = new ObjectArrayList<>();
                 // noinspection unchecked
                 ((IMultiblockAbilityPart<IFluidTank>) part).registerAbilities(hatchTanks);
-                if (hatchTanks.size() == 1)
-                    orderedHandlerList.add(FluidTankHandler.getTankFluidHandler(hatchTanks.get(0)));
-                else orderedHandlerList.add(new FluidTankList(false, hatchTanks));
+                orderedHandlerList.add(new FluidTankList(false, hatchTanks));
                 tankList.addAll(hatchTanks);
                 exportIndex++;
             } else if (part.getPos().getY() > y) {

--- a/src/main/java/gregtech/api/capability/impl/DistillationTowerLogicHandler.java
+++ b/src/main/java/gregtech/api/capability/impl/DistillationTowerLogicHandler.java
@@ -1,0 +1,184 @@
+package gregtech.api.capability.impl;
+
+import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.IMultiblockPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.api.pattern.BlockPattern;
+import gregtech.api.recipes.Recipe;
+import gregtech.api.util.GTLog;
+import gregtech.api.util.GTTransferUtils;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import com.cleanroommc.modularui.utils.FluidTankHandler;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DistillationTowerLogicHandler {
+
+    protected final AbstractRecipeLogic workable;
+    protected final IDistillationTower tower;
+
+    public int layerCount;
+    public List<IFluidHandler> orderedFluidOutputs;
+
+    public DistillationTowerLogicHandler(IDistillationTower tower, AbstractRecipeLogic workable) {
+        this.tower = tower;
+        this.workable = workable;
+    }
+
+    protected boolean applyFluidToOutputs(List<FluidStack> fluids, boolean doFill) {
+        boolean valid = true;
+        for (int i = 0; i < fluids.size(); i++) {
+            IFluidHandler handler = orderedFluidOutputs.get(i);
+            int accepted = handler.fill(fluids.get(i), doFill);
+            if (accepted != fluids.get(i).amount) valid = false;
+            if (!doFill && !valid) break;
+        }
+        return valid;
+    }
+
+    public void outputRecipeOutputs() {
+        GTTransferUtils.addItemsToItemHandler(workable.getOutputInventory(), false, workable.itemOutputs);
+        this.applyFluidToOutputs(workable.fluidOutputs, true);
+    }
+
+    public boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
+                                               @NotNull IItemHandlerModifiable importInventory,
+                                               @NotNull IMultipleTankHandler importFluids) {
+        workable.overclockResults = workable.calculateOverclock(recipe);
+
+        workable.modifyOverclockPost(workable.overclockResults, recipe.getRecipePropertyStorage());
+
+        if (!workable.hasEnoughPower(workable.overclockResults)) {
+            return false;
+        }
+
+        IItemHandlerModifiable exportInventory = workable.getOutputInventory();
+
+        // We have already trimmed outputs and chanced outputs at this time
+        // Attempt to merge all outputs + chanced outputs into the output bus, to prevent voiding chanced outputs
+        if (!workable.getMetaTileEntity().canVoidRecipeItemOutputs() &&
+                !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
+            workable.isOutputsFull = true;
+            return false;
+        }
+
+        // Perform layerwise fluid checks
+        if (!workable.getMetaTileEntity().canVoidRecipeFluidOutputs() &&
+                !this.applyFluidToOutputs(recipe.getAllFluidOutputs(), false)) {
+            workable.isOutputsFull = true;
+
+            return false;
+        }
+
+        workable.isOutputsFull = false;
+        if (recipe.matches(true, importInventory, importFluids)) {
+            workable.getMetaTileEntity().addNotifiedInput(importInventory);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
+     *
+     * @param structurePattern the structure pattern
+     */
+    public void determineLayerCount(@NotNull BlockPattern structurePattern) {
+        this.layerCount = structurePattern.formedRepetitionCount[1] + 1;
+    }
+
+    /**
+     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
+     */
+    public void determineOrderedFluidOutputs() {
+        // noinspection SimplifyStreamApiCallChains
+        List<MetaTileEntityMultiblockPart> fluidExportParts = tower.getMultiblockParts().stream()
+                .filter(iMultiblockPart -> iMultiblockPart instanceof IMultiblockAbilityPart<?>abilityPart &&
+                        abilityPart.getAbility() == MultiblockAbility.EXPORT_FLUIDS &&
+                        abilityPart instanceof MetaTileEntityMultiblockPart)
+                .map(iMultiblockPart -> (MetaTileEntityMultiblockPart) iMultiblockPart)
+                .collect(Collectors.toList());
+        // the fluidExportParts should come sorted in smallest Y first, largest Y last.
+        List<IFluidHandler> orderedHandlerList = new ObjectArrayList<>();
+        int firstY = tower.getPos().getY() + 1;
+        int exportIndex = 0;
+        for (int y = firstY; y < firstY + this.layerCount; y++) {
+            if (fluidExportParts.size() <= exportIndex) {
+                orderedHandlerList.add(null);
+                continue;
+            }
+            MetaTileEntityMultiblockPart part = fluidExportParts.get(exportIndex);
+            if (part.getPos().getY() == y) {
+                List<IFluidTank> hatchTanks = new ObjectArrayList<>();
+                // noinspection unchecked
+                ((IMultiblockAbilityPart<IFluidTank>) part).registerAbilities(hatchTanks);
+                if (hatchTanks.size() == 1)
+                    orderedHandlerList.add(FluidTankHandler.getTankFluidHandler(hatchTanks.get(0)));
+                else orderedHandlerList.add(new FluidTankList(false, hatchTanks));
+                exportIndex++;
+            } else if (part.getPos().getY() > y) {
+                orderedHandlerList.add(FakeFluidHandler.INSTANCE);
+            } else {
+                GTLog.logger.error("The Distillation Tower at " + tower.getPos() +
+                        " had a fluid export hatch with an unexpected Y position.");
+                tower.invalidateStructure();
+                this.orderedFluidOutputs = new ObjectArrayList<>();
+            }
+        }
+        this.orderedFluidOutputs = orderedHandlerList;
+    }
+
+    public void invalidate() {
+        this.layerCount = 0;
+        this.orderedFluidOutputs = null;
+    }
+
+    public interface IDistillationTower {
+
+        List<IMultiblockPart> getMultiblockParts();
+
+        BlockPos getPos();
+
+        void invalidateStructure();
+    }
+
+    // an endless void devouring any fluid sent to it
+    protected static class FakeFluidHandler implements IFluidHandler {
+
+        protected static final FakeFluidHandler INSTANCE = new FakeFluidHandler();
+
+        private static final IFluidTankProperties[] ARRAY = new IFluidTankProperties[0];
+
+        @Override
+        public IFluidTankProperties[] getTankProperties() {
+            return ARRAY;
+        }
+
+        @Override
+        public int fill(FluidStack resource, boolean doFill) {
+            return resource.amount;
+        }
+
+        @Override
+        public FluidStack drain(FluidStack resource, boolean doDrain) {
+            return null;
+        }
+
+        @Override
+        public FluidStack drain(int maxDrain, boolean doDrain) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -136,7 +136,7 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     }
 
     @Override
-    protected boolean allowSameFluidFillForOutputs() {
+    public boolean allowSameFluidFillForOutputs() {
         return false;
     }
 
@@ -184,6 +184,11 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
                                                       @NotNull IItemHandlerModifiable importInventory,
                                                       @NotNull IMultipleTankHandler importFluids) {
             return handler.setupAndConsumeRecipeInputs(recipe, importInventory, importFluids);
+        }
+
+        @Override
+        protected IMultipleTankHandler getOutputTank() {
+            return handler.fluidTanks;
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityDistillationTower.java
@@ -1,11 +1,10 @@
 package gregtech.common.metatileentities.multi.electric;
 
 import gregtech.api.capability.IMultipleTankHandler;
-import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.capability.impl.DistillationTowerLogicHandler;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
-import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.IMultiblockPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -14,8 +13,6 @@ import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
-import gregtech.api.util.GTLog;
-import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.RelativeDirection;
 import gregtech.api.util.TextComponentUtil;
@@ -23,7 +20,6 @@ import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.blocks.BlockMetalCasing.MetalCasingType;
 import gregtech.common.blocks.MetaBlocks;
-import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.core.sound.GTSoundEvents;
 
 import net.minecraft.block.state.IBlockState;
@@ -33,46 +29,48 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.IFluidTank;
-import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import com.cleanroommc.modularui.utils.FluidTankHandler;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static gregtech.api.util.RelativeDirection.*;
 
-public class MetaTileEntityDistillationTower extends RecipeMapMultiblockController {
+public class MetaTileEntityDistillationTower extends RecipeMapMultiblockController
+                                             implements DistillationTowerLogicHandler.IDistillationTower {
 
-    private final boolean useAdvHatchLogic;
+    protected DistillationTowerLogicHandler handler;
 
-    protected int layerCount;
-    protected List<IFluidHandler> orderedFluidOutputs;
-
+    @SuppressWarnings("unused") // backwards compatibility
     public MetaTileEntityDistillationTower(ResourceLocation metaTileEntityId) {
         this(metaTileEntityId, false);
     }
 
     public MetaTileEntityDistillationTower(ResourceLocation metaTileEntityId, boolean useAdvHatchLogic) {
         super(metaTileEntityId, RecipeMaps.DISTILLATION_RECIPES);
-        this.useAdvHatchLogic = useAdvHatchLogic;
         if (useAdvHatchLogic) {
-            this.recipeMapWorkable = new DistillationTowerRecipeLogic(this);
-        }
+            DistillationTowerRecipeLogic logic = new DistillationTowerRecipeLogic(this);
+            this.recipeMapWorkable = logic;
+            this.handler = new DistillationTowerLogicHandler(this, logic);
+        } else this.handler = null;
     }
 
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
-        return new MetaTileEntityDistillationTower(metaTileEntityId, this.useAdvHatchLogic);
+        return new MetaTileEntityDistillationTower(metaTileEntityId, this.handler != null);
     }
 
+    /**
+     * Used if MultiblockPart Abilities need to be sorted a certain way, like
+     * Distillation Tower and Assembly Line. <br>
+     * <br>
+     * There will be <i>consequences</i> if this is changed. Make sure to set the logic handler to one with
+     * a properly overriden {@link DistillationTowerLogicHandler#determineOrderedFluidOutputs()}
+     */
     @Override
     protected Function<BlockPos, Integer> multiblockPartSorter() {
         return RelativeDirection.UP.getSorter(getFrontFacing(), getUpwardsFacing(), isFlipped());
@@ -80,7 +78,9 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
 
     /**
      * Whether this multi can be rotated or face upwards. <br>
-     * There will be <i>consequences</i> if this returns true. Go override {@link #determineOrderedFluidOutputs()}
+     * <br>
+     * There will be <i>consequences</i> if this returns true. Make sure to set the logic handler to one with
+     * a properly overriden {@link DistillationTowerLogicHandler#determineOrderedFluidOutputs()}
      */
     @Override
     public boolean allowsExtendedFacing() {
@@ -106,68 +106,15 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
     @Override
     protected void formStructure(PatternMatchContext context) {
         super.formStructure(context);
-        if (!useAdvHatchLogic || this.structurePattern == null) return;
-        this.layerCount = determineLayerCount(this.structurePattern);
-        this.orderedFluidOutputs = determineOrderedFluidOutputs();
-    }
-
-    /**
-     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
-     * 
-     * @param structurePattern the structure pattern
-     * @return the number of layers that <b>could</b> hold output hatches
-     */
-    protected int determineLayerCount(@NotNull BlockPattern structurePattern) {
-        return structurePattern.formedRepetitionCount[1] + 1;
-    }
-
-    /**
-     * Needs to be overriden for multiblocks that have different assemblies than the standard distillation tower.
-     * 
-     * @return the fluid hatches of the multiblock, in order, with null entries for layers that do not have hatches.
-     */
-    protected List<IFluidHandler> determineOrderedFluidOutputs() {
-        List<MetaTileEntityMultiblockPart> fluidExportParts = this.getMultiblockParts().stream()
-                .filter(iMultiblockPart -> iMultiblockPart instanceof IMultiblockAbilityPart<?>abilityPart &&
-                        abilityPart.getAbility() == MultiblockAbility.EXPORT_FLUIDS &&
-                        abilityPart instanceof MetaTileEntityMultiblockPart)
-                .map(iMultiblockPart -> (MetaTileEntityMultiblockPart) iMultiblockPart)
-                .collect(Collectors.toList());
-        // the fluidExportParts should come sorted in smallest Y first, largest Y last.
-        List<IFluidHandler> orderedHandlerList = new ObjectArrayList<>();
-        int firstY = this.getPos().getY() + 1;
-        int exportIndex = 0;
-        for (int y = firstY; y < firstY + this.layerCount; y++) {
-            if (fluidExportParts.size() <= exportIndex) {
-                orderedHandlerList.add(null);
-                continue;
-            }
-            MetaTileEntityMultiblockPart part = fluidExportParts.get(exportIndex);
-            if (part.getPos().getY() == y) {
-                List<IFluidTank> hatchTanks = new ObjectArrayList<>();
-                // noinspection unchecked
-                ((IMultiblockAbilityPart<IFluidTank>) part).registerAbilities(hatchTanks);
-                if (hatchTanks.size() == 1)
-                    orderedHandlerList.add(FluidTankHandler.getTankFluidHandler(hatchTanks.get(0)));
-                else orderedHandlerList.add(new FluidTankList(false, hatchTanks));
-                exportIndex++;
-            } else if (part.getPos().getY() > y) {
-                orderedHandlerList.add(null);
-            } else {
-                GTLog.logger.error("The Distillation Tower at " + this.getPos() +
-                        " had a fluid export hatch with an unexpected Y position.");
-                this.invalidateStructure();
-                return new ObjectArrayList<>();
-            }
-        }
-        return orderedHandlerList;
+        if (this.handler == null || this.structurePattern == null) return;
+        handler.determineLayerCount(this.structurePattern);
+        handler.determineOrderedFluidOutputs();
     }
 
     @Override
     public void invalidateStructure() {
         super.invalidateStructure();
-        this.layerCount = 0;
-        this.orderedFluidOutputs = null;
+        if (this.handler != null) handler.invalidate();
     }
 
     @Override
@@ -217,7 +164,8 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
 
     @Override
     public int getFluidOutputLimit() {
-        return this.layerCount;
+        if (this.handler != null) return this.handler.layerCount;
+        else return super.getFluidOutputLimit();
     }
 
     protected class DistillationTowerRecipeLogic extends MultiblockRecipeLogic {
@@ -226,61 +174,16 @@ public class MetaTileEntityDistillationTower extends RecipeMapMultiblockControll
             super(tileEntity);
         }
 
-        protected boolean applyFluidToOutputs(List<FluidStack> fluids, boolean doFill) {
-            boolean valid = true;
-            for (int i = 0; i < fluids.size(); i++) {
-                IFluidHandler handler = orderedFluidOutputs.get(i);
-                // void if no hatch is found on that fluid's layer
-                // this is considered trimming and thus ignores canVoid
-                if (handler == null) continue;
-                int accepted = handler.fill(fluids.get(i), doFill);
-                if (accepted != fluids.get(i).amount) valid = false;
-                if (!doFill && !valid) break;
-            }
-            return valid;
-        }
-
         @Override
         protected void outputRecipeOutputs() {
-            GTTransferUtils.addItemsToItemHandler(getOutputInventory(), false, itemOutputs);
-            this.applyFluidToOutputs(fluidOutputs, true);
+            handler.outputRecipeOutputs();
         }
 
         @Override
         protected boolean setupAndConsumeRecipeInputs(@NotNull Recipe recipe,
                                                       @NotNull IItemHandlerModifiable importInventory,
                                                       @NotNull IMultipleTankHandler importFluids) {
-            this.overclockResults = calculateOverclock(recipe);
-
-            modifyOverclockPost(overclockResults, recipe.getRecipePropertyStorage());
-
-            if (!hasEnoughPower(overclockResults)) {
-                return false;
-            }
-
-            IItemHandlerModifiable exportInventory = getOutputInventory();
-
-            // We have already trimmed outputs and chanced outputs at this time
-            // Attempt to merge all outputs + chanced outputs into the output bus, to prevent voiding chanced outputs
-            if (!metaTileEntity.canVoidRecipeItemOutputs() &&
-                    !GTTransferUtils.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs())) {
-                this.isOutputsFull = true;
-                return false;
-            }
-
-            // Perform layerwise fluid checks
-            if (!metaTileEntity.canVoidRecipeFluidOutputs() &&
-                    !this.applyFluidToOutputs(recipe.getAllFluidOutputs(), false)) {
-                this.isOutputsFull = true;
-                return false;
-            }
-
-            this.isOutputsFull = false;
-            if (recipe.matches(true, importInventory, importFluids)) {
-                this.metaTileEntity.addNotifiedInput(importInventory);
-                return true;
-            }
-            return false;
+            return handler.setupAndConsumeRecipeInputs(recipe, importInventory, importFluids);
         }
     }
 }


### PR DESCRIPTION
## What
(Probably) makes the new DT hatch scan logic compatible with recipe parallelization, and abstracts the logic so any class can use it.

## Implementation Details
Uses fake fluid handlers instead of null, and redirects output tank fetches to a list with the fake handlers. Also moves the logic to an independent class.

## Outcome
Compatibility with GCYM fractioning distillery
Also fix #2525 because I'm a fool and used a mui2 class