### PR TITLE
Fix the lighter behaviour

### DIFF
--- a/src/main/java/gregtech/common/items/behaviors/LighterBehaviour.java
+++ b/src/main/java/gregtech/common/items/behaviors/LighterBehaviour.java
@@ -133,9 +133,11 @@ public class LighterBehaviour implements IItemBehaviour, IItemDurabilityManager,
             }
 
             BlockPos offset = pos.offset(side);
-            world.setBlockState(offset, Blocks.FIRE.getDefaultState(), 11);
-            if (!world.isRemote) {
-                CriteriaTriggers.PLACED_BLOCK.trigger((EntityPlayerMP) player, offset, stack);
+            if (world.isAirBlock(offset)) {
+                world.setBlockState(offset, Blocks.FIRE.getDefaultState(), 11);
+                if (!world.isRemote) {
+                    CriteriaTriggers.PLACED_BLOCK.trigger((EntityPlayerMP) player, offset, stack);
+                }
             }
             return EnumActionResult.SUCCESS;
         }


### PR DESCRIPTION
## What
Before this fix, setting fires with ceu lighters will not check whether there's alr a block at the position. This PR syncs ceu lighters' behaviour with vanilla Flint and Steel so that it won't void non-full blocks.


## Implementation Details
Simply adds `isAirBlock` check before setting a block to fire.

## Potential Compatibility Issues
None that I could think of.