### PR TITLE
Make drums no longer require a Material

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -54,26 +54,58 @@ import static gregtech.api.capability.GregtechDataCodes.UPDATE_AUTO_OUTPUT;
 
 public class MetaTileEntityDrum extends MetaTileEntity {
 
+    private final IPropertyFluidFilter fluidFilter;
+    private final boolean isWood;
+    private final int color;
     private final int tankSize;
-    private final Material material;
+
     private FilteredFluidHandler fluidTank;
     private boolean isAutoOutput = false;
 
-    public MetaTileEntityDrum(ResourceLocation metaTileEntityId, Material material, int tankSize) {
+    /**
+     * @param metaTileEntityId the id for the MTE
+     * @param material         the material the drum is made of, must have {@link gregtech.api.unification.material.properties.FluidProperty}.
+     * @param tankSize         the size of the storage tank
+     */
+    public MetaTileEntityDrum(ResourceLocation metaTileEntityId, @NotNull Material material, int tankSize) {
         super(metaTileEntityId);
+        IPropertyFluidFilter filter = material.getProperty(PropertyKey.FLUID_PIPE);
+        if (filter == null) {
+            throw new IllegalArgumentException("Material " + material + " requires FluidPipeProperty for Drums");
+        }
+        this.fluidFilter = filter;
+        this.isWood = ModHandler.isMaterialWood(material);
+        this.color = material.getMaterialRGB();
         this.tankSize = tankSize;
-        this.material = material;
+        initializeInventory();
+    }
+
+    /**
+     *
+     * @param metaTileEntityId the id for the MTE
+     * @param fluidFilter      the filter for which fluids can be stored
+     * @param isWood           if the drum is made of wood
+     * @param color            the color of the drum in RGB format
+     * @param tankSize         the size of the storage tank
+     */
+    public MetaTileEntityDrum(ResourceLocation metaTileEntityId, @NotNull IPropertyFluidFilter fluidFilter,
+                              boolean isWood, int color, int tankSize) {
+        super(metaTileEntityId);
+        this.fluidFilter = fluidFilter;
+        this.isWood = isWood;
+        this.color = color;
+        this.tankSize = tankSize;
         initializeInventory();
     }
 
     @Override
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
-        return new MetaTileEntityDrum(metaTileEntityId, material, tankSize);
+        return new MetaTileEntityDrum(metaTileEntityId, fluidFilter, isWood, color, tankSize);
     }
 
     @Override
     public String getHarvestTool() {
-        return ModHandler.isMaterialWood(material) ? ToolClasses.AXE : ToolClasses.WRENCH;
+        return isWood ? ToolClasses.AXE : ToolClasses.WRENCH;
     }
 
     @Override
@@ -83,14 +115,14 @@ public class MetaTileEntityDrum extends MetaTileEntity {
 
     @Override
     protected void initializeInventory() {
-        if (this.material == null) return; // call before field initialization, should be called later with fields set
-        super.initializeInventory();
-        IPropertyFluidFilter filter = this.material.getProperty(PropertyKey.FLUID_PIPE);
-        if (filter == null) {
-            throw new IllegalArgumentException(
-                    String.format("Material %s requires FluidPipeProperty for Drums", material));
+        // call before field initialization, should be called later with fields set
+        if (this.fluidFilter == null) {
+            return;
         }
-        this.fluidInventory = this.fluidTank = new FilteredFluidHandler(tankSize).setFilter(filter);
+
+        super.initializeInventory();
+        this.fluidTank = new FilteredFluidHandler(tankSize).setFilter(this.fluidFilter);
+        this.fluidInventory = this.fluidTank;
     }
 
     @Override
@@ -203,27 +235,26 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     @Override
     @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
-        if (ModHandler.isMaterialWood(material)) {
+        if (isWood) {
             return Pair.of(Textures.WOODEN_DRUM.getParticleTexture(), getPaintingColorForRendering());
         } else {
-            int color = ColourRGBA.multiply(
-                    GTUtility.convertRGBtoOpaqueRGBA_CL(material.getMaterialRGB()),
-                    GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()));
-            color = GTUtility.convertOpaqueRGBA_CLtoRGB(color);
+            int color =  GTUtility.convertOpaqueRGBA_CLtoRGB(ColourRGBA.multiply(
+                    GTUtility.convertRGBtoOpaqueRGBA_CL(this.color),
+                    GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering())));
             return Pair.of(Textures.DRUM.getParticleTexture(), color);
         }
     }
 
     @Override
     public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
-        if (ModHandler.isMaterialWood(material)) {
+        if (isWood) {
             ColourMultiplier multiplier = new ColourMultiplier(
                     GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()));
             Textures.WOODEN_DRUM.render(renderState, translation, ArrayUtils.add(pipeline, multiplier),
                     getFrontFacing());
         } else {
             ColourMultiplier multiplier = new ColourMultiplier(
-                    ColourRGBA.multiply(GTUtility.convertRGBtoOpaqueRGBA_CL(material.getMaterialRGB()),
+                    ColourRGBA.multiply(GTUtility.convertRGBtoOpaqueRGBA_CL(this.color),
                             GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering())));
             Textures.DRUM.render(renderState, translation, ArrayUtils.add(pipeline, multiplier), getFrontFacing());
             Textures.DRUM_OVERLAY.render(renderState, translation, pipeline);
@@ -243,8 +274,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.universal.tooltip.fluid_storage_capacity", tankSize));
-        FluidPipeProperties pipeProperties = material.getProperty(PropertyKey.FLUID_PIPE);
-        pipeProperties.appendTooltips(tooltip, true, true);
+        this.fluidFilter.appendTooltips(tooltip, true, true);
 
         if (TooltipHelper.isShiftDown()) {
             tooltip.add(I18n.format("gregtech.tool_action.screwdriver.access_covers"));

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -9,7 +9,6 @@ import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.Material;
-import gregtech.api.unification.material.properties.FluidPipeProperties;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.texture.Textures;
@@ -64,7 +63,8 @@ public class MetaTileEntityDrum extends MetaTileEntity {
 
     /**
      * @param metaTileEntityId the id for the MTE
-     * @param material         the material the drum is made of, must have {@link gregtech.api.unification.material.properties.FluidProperty}.
+     * @param material         the material the drum is made of, must have
+     *                         {@link gregtech.api.unification.material.properties.FluidProperty}.
      * @param tankSize         the size of the storage tank
      */
     public MetaTileEntityDrum(ResourceLocation metaTileEntityId, @NotNull Material material, int tankSize) {
@@ -238,7 +238,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
         if (isWood) {
             return Pair.of(Textures.WOODEN_DRUM.getParticleTexture(), getPaintingColorForRendering());
         } else {
-            int color =  GTUtility.convertOpaqueRGBA_CLtoRGB(ColourRGBA.multiply(
+            int color = GTUtility.convertOpaqueRGBA_CLtoRGB(ColourRGBA.multiply(
                     GTUtility.convertRGBtoOpaqueRGBA_CL(this.color),
                     GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering())));
             return Pair.of(Textures.DRUM.getParticleTexture(), color);


### PR DESCRIPTION
## What
Makes drums no longer require a material object.

`PropertyFluidFilter` can now be used as an alternative to `FluidPipeProperties` as an `IPropertyFluidFilter` instance.

## Outcome
Allows more freedom when creating drums.
