### PR TITLE
Fix Miner Pipe Deleting TileEntities

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -157,8 +157,9 @@ public class MinerLogic {
         // drill a hole beneath the miner and extend the pipe downwards by one
         WorldServer world = (WorldServer) metaTileEntity.getWorld();
         if (mineY.get() < pipeY.get()) {
-            world.destroyBlock(
-                    new BlockPos(metaTileEntity.getPos().getX(), pipeY.get(), metaTileEntity.getPos().getZ()), false);
+            var pipePos = new BlockPos(metaTileEntity.getPos().getX(), pipeY.get(), metaTileEntity.getPos().getZ());
+            if (world.getTileEntity(pipePos) == null)
+                world.destroyBlock(pipePos, false);
             pipeY.decrementAndGet();
             incrementPipeLength();
         }

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -158,7 +158,8 @@ public class MinerLogic {
         WorldServer world = (WorldServer) metaTileEntity.getWorld();
         if (mineY.get() < pipeY.get()) {
             var pipePos = new BlockPos(metaTileEntity.getPos().getX(), pipeY.get(), metaTileEntity.getPos().getZ());
-            if (world.getTileEntity(pipePos) == null && world.getBlockState(pipePos).getBlockHardness(world, pipePos) >= 0)
+            if (world.getTileEntity(pipePos) == null &&
+                    world.getBlockState(pipePos).getBlockHardness(world, pipePos) >= 0)
                 world.destroyBlock(pipePos, false);
             pipeY.decrementAndGet();
             incrementPipeLength();

--- a/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/miner/MinerLogic.java
@@ -158,7 +158,7 @@ public class MinerLogic {
         WorldServer world = (WorldServer) metaTileEntity.getWorld();
         if (mineY.get() < pipeY.get()) {
             var pipePos = new BlockPos(metaTileEntity.getPos().getX(), pipeY.get(), metaTileEntity.getPos().getZ());
-            if (world.getTileEntity(pipePos) == null)
+            if (world.getTileEntity(pipePos) == null && world.getBlockState(pipePos).getBlockHardness(world, pipePos) >= 0)
                 world.destroyBlock(pipePos, false);
             pipeY.decrementAndGet();
             incrementPipeLength();


### PR DESCRIPTION
## What
prevents the miner pipe from deleting TEs

## Implementation Details
check for TE at the next pipe pos, and only deleting if null

## Outcome
TEs are no longer afraid of miners
