### PR TITLE
fix crash with Forestry integration

### DIFF
--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -219,9 +219,9 @@ public class OreDictUnifier {
 
     public static @NotNull List<@NotNull ItemStack> getAllWithOreDictionaryName(@NotNull String oreDictionaryName) {
         var stacks = oreDictNameStacks.get(oreDictionaryName);
-        // if (stacks == null) {
-        // return Collections.emptyList();
-        // }
+        if (stacks == null) {
+            return Collections.emptyList();
+        }
 
         return stacks.stream()
                 .map(ItemStack::copy)

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -219,9 +219,9 @@ public class OreDictUnifier {
 
     public static @NotNull List<@NotNull ItemStack> getAllWithOreDictionaryName(@NotNull String oreDictionaryName) {
         var stacks = oreDictNameStacks.get(oreDictionaryName);
-//        if (stacks == null) {
-//            return Collections.emptyList();
-//        }
+        // if (stacks == null) {
+        // return Collections.emptyList();
+        // }
 
         return stacks.stream()
                 .map(ItemStack::copy)

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -217,8 +217,13 @@ public class OreDictUnifier {
         return wildcardNames != null && wildcardNames != names && wildcardNames.contains(oreDictName);
     }
 
-    public static List<ItemStack> getAllWithOreDictionaryName(String oreDictionaryName) {
-        return oreDictNameStacks.get(oreDictionaryName).stream()
+    public static @NotNull List<@NotNull ItemStack> getAllWithOreDictionaryName(@NotNull String oreDictionaryName) {
+        var stacks = oreDictNameStacks.get(oreDictionaryName);
+//        if (stacks == null) {
+//            return Collections.emptyList();
+//        }
+
+        return stacks.stream()
                 .map(ItemStack::copy)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gregtech/integration/forestry/mutation/MaterialMutationCondition.java
+++ b/src/main/java/gregtech/integration/forestry/mutation/MaterialMutationCondition.java
@@ -47,7 +47,8 @@ public class MaterialMutationCondition implements IMutationCondition {
     }
 
     @Override
-    public float getChance(@NotNull World world, @NotNull BlockPos pos, @NotNull IAllele allele0, @NotNull IAllele allele1, @NotNull IGenome genome0,
+    public float getChance(@NotNull World world, @NotNull BlockPos pos, @NotNull IAllele allele0,
+                           @NotNull IAllele allele1, @NotNull IGenome genome0,
                            @NotNull IGenome genome1, @NotNull IClimateProvider climate) {
         TileEntity tile;
         do {

--- a/src/main/java/gregtech/integration/forestry/mutation/MaterialMutationCondition.java
+++ b/src/main/java/gregtech/integration/forestry/mutation/MaterialMutationCondition.java
@@ -2,6 +2,8 @@ package gregtech.integration.forestry.mutation;
 
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.LocalizationUtils;
 
 import net.minecraft.block.Block;
@@ -19,22 +21,21 @@ import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IGenome;
 import forestry.api.genetics.IMutationCondition;
 import forestry.core.tiles.TileUtil;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
-
 public class MaterialMutationCondition implements IMutationCondition {
 
-    private final Set<IBlockState> acceptedBlocks = new HashSet();
+    private final Set<IBlockState> acceptedBlocks = new HashSet<>();
     private final String displayName;
 
-    public MaterialMutationCondition(Material material) {
+    public MaterialMutationCondition(@NotNull Material material) {
         this.displayName = LocalizationUtils.format("gregtech.mutation.block_of", material.getLocalizedName());
-        String oredictName = "block" + capitalize(material.getName());
+        String oreDictName = new UnificationEntry(OrePrefix.block, material).toString();
 
-        for (ItemStack ore : OreDictUnifier.getAllWithOreDictionaryName(oredictName)) {
+        for (ItemStack ore : OreDictUnifier.getAllWithOreDictionaryName(oreDictName)) {
             if (!ore.isEmpty()) {
                 Item oreItem = ore.getItem();
                 Block oreBlock = Block.getBlockFromItem(oreItem);
@@ -45,8 +46,9 @@ public class MaterialMutationCondition implements IMutationCondition {
         }
     }
 
-    public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0,
-                           IGenome genome1, IClimateProvider climate) {
+    @Override
+    public float getChance(@NotNull World world, @NotNull BlockPos pos, @NotNull IAllele allele0, @NotNull IAllele allele1, @NotNull IGenome genome0,
+                           @NotNull IGenome genome1, @NotNull IClimateProvider climate) {
         TileEntity tile;
         do {
             pos = pos.down();
@@ -57,7 +59,8 @@ public class MaterialMutationCondition implements IMutationCondition {
         return this.acceptedBlocks.contains(blockState) ? 1.0F : 0.0F;
     }
 
-    public String getDescription() {
+    @Override
+    public @NotNull String getDescription() {
         return LocalizationUtils.format("for.mutation.condition.resource", this.displayName);
     }
 }


### PR DESCRIPTION
## What
Fixes crash in Forestry integration caused by a missing null check in `OreDictUnifier`. Also fixes case where logic will fail due to improperly converting a material name and prefix into an oredict name.

## Outcome
Fixes crash with Forestry integration.
