### PR TITLE
More nuclear fission stuff

### DIFF
--- a/src/main/java/gregtech/api/cover/ICustomEnergyCover.java
+++ b/src/main/java/gregtech/api/cover/ICustomEnergyCover.java
@@ -1,7 +1,8 @@
 package gregtech.api.cover;
 
 /**
- * Simple interface specifying that an attached energy detector(advanced or not) cover reads custom EU values from the MTE
+ * Simple interface specifying that an attached energy detector(advanced or not) cover reads custom EU values from the
+ * MTE
  */
 public interface ICustomEnergyCover {
 

--- a/src/main/java/gregtech/api/cover/ICustomEnergyCover.java
+++ b/src/main/java/gregtech/api/cover/ICustomEnergyCover.java
@@ -1,0 +1,17 @@
+package gregtech.api.cover;
+
+/**
+ * Simple interface specifying that an attached energy detector(advanced or not) cover reads custom EU values from the MTE
+ */
+public interface ICustomEnergyCover {
+
+    /**
+     * @return The total EU capacity
+     */
+    long getCoverCapacity();
+
+    /**
+     * @return The stored EU capacity
+     */
+    long getCoverStored();
+}

--- a/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
+++ b/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
@@ -52,9 +52,6 @@ public class FissionReactor {
     private double avgPressure;
 
     /**
-     * Thresholds important for determining the evolution of the reactor ^^^ This is a very epic comment
-     */
-    /**
      * Integers used on variables with direct player control for easier adjustments (normalize this to 0,1)
      */
     public double controlRodInsertion = 1;

--- a/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
+++ b/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
@@ -49,8 +49,6 @@ public class FissionReactor {
 
     public double kEff; // criticality value, based on k
 
-    private double avgPressure;
-
     /**
      * Integers used on variables with direct player control for easier adjustments (normalize this to 0,1)
      */
@@ -400,7 +398,6 @@ public class FissionReactor {
     public void prepareInitialConditions() {
         coolantBaseTemperature = 0;
         coolantBoilingPointStandardPressure = 0;
-        avgPressure = 0;
         coolantHeatOfVaporization = 0;
         maxFuelDepletion = 0;
         for (FuelRod rod : fuelRods) {
@@ -418,17 +415,12 @@ public class FissionReactor {
                     channel.getWeight();
             coolantBoilingPointStandardPressure += prop.getBoilingPoint() *
                     channel.getWeight();
-            avgPressure += prop.getPressure() *
-                    channel.getWeight();
             coolantHeatOfVaporization += prop.getHeatOfVaporization() *
                     channel.getWeight();
         }
 
         if (coolantBaseTemperature == 0) {
             coolantBaseTemperature = envTemperature;
-        }
-        if (avgPressure == 0) {
-            avgPressure = standardPressure;
         }
         if (coolantBoilingPointStandardPressure == 0) {
             coolantBoilingPointStandardPressure = airBoilingPoint;

--- a/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
+++ b/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
@@ -87,7 +87,6 @@ public class FissionReactor {
     public double coolantBaseTemperature;
     public double maxFuelDepletion = 1;
     public double fuelDepletion = -1;
-    public double prevFuelDepletion;
     public double neutronPoisonAmount; // can kill reactor if power is lowered and this value is high
     public double decayProductsAmount;
     public double envTemperature = roomTemperature; // maybe gotten from config per dim
@@ -564,7 +563,6 @@ public class FissionReactor {
             this.kEff = 1 / ((1 / this.kEff) + powerDefectCoefficient * (this.power / this.maxPower) +
                     neutronPoisonAmount * crossSectionRatio / surfaceArea + controlRodFactor);
             this.kEff = Math.max(0, this.kEff);
-            this.prevFuelDepletion = this.fuelDepletion;
             // maps (1, 1.1) to (1, 15); this value basically sets how quickly kEff operates
             double generationTime = Math.max(1, Math.min(15, (kEff - 1) * 150.));
 
@@ -576,7 +574,7 @@ public class FissionReactor {
             }
             this.fuelDepletion += this.power;
 
-            this.decayProductsAmount += Math.max(this.fuelDepletion - this.prevFuelDepletion, 0.) / 1000;
+            this.decayProductsAmount += Math.max(power, 0.) / 1000;
         } else {
             this.power = responseFunction(Math.min(this.realMaxPower(), this.power * kEff), this.power,
                     1);

--- a/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
+++ b/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
@@ -54,7 +54,7 @@ public class FissionReactor {
     /**
      * Integers used on variables with direct player control for easier adjustments (normalize this to 0,1)
      */
-    public double controlRodInsertion = 1;
+    public double controlRodInsertion;
     public int reactorDepth;
     public double reactorRadius;
 
@@ -227,8 +227,8 @@ public class FissionReactor {
             for (int j = 0; j < i; j++) {
                 double mij = 0;
                 boolean pathIsClear = true;
-                ArrayList<ControlRod> controlRodsHit = new ArrayList<ControlRod>();
-                ArrayList<CoolantChannel> coolantChannelsHit = new ArrayList<CoolantChannel>();
+                ArrayList<ControlRod> controlRodsHit = new ArrayList<>();
+                ArrayList<CoolantChannel> coolantChannelsHit = new ArrayList<>();
 
                 /*
                  * Geometric factor calculation is done by (rough) numerical integration along a straight path between

--- a/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
+++ b/src/main/java/gregtech/api/nuclear/fission/FissionReactor.java
@@ -521,9 +521,14 @@ public class FissionReactor {
     }
 
     public void updateTemperature(int flowRate) {
+        double oldTemp = this.temperature;
+        // simulate heat based only on the reactor power
+        this.temperature = responseFunctionTemperature(envTemperature, this.temperature, this.power * 1e6, 0);
+        // prevent temperature from going above meltdown temp, to stop coolant from absorbing more heat than it should
+        this.temperature = Math.min(maxTemperature, temperature);
         double heatRemoved = this.makeCoolantFlow(flowRate);
-        this.temperature = responseFunctionTemperature(envTemperature, this.temperature, this.power * 1000000,
-                heatRemoved);
+        // calculate the actual temperature based on the reactor power and the heat removed
+        this.temperature = responseFunctionTemperature(envTemperature, oldTemp, this.power * 1e6, heatRemoved);
         this.temperature = Math.max(this.temperature, this.coolantBaseTemperature);
     }
 

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.cover.CoverDefinition;
 import gregtech.api.cover.CoverableView;
+import gregtech.api.cover.ICustomEnergyCover;
 import gregtech.api.util.RedstoneUtil;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityPowerSubstation;
@@ -28,12 +29,12 @@ public class CoverDetectorEnergy extends CoverDetectorBase implements ITickable 
     @Override
     public boolean canAttach(@NotNull CoverableView coverable, @NotNull EnumFacing side) {
         return coverable.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null) != null ||
-                coverable instanceof MetaTileEntityPowerSubstation; // todo check this
+                coverable instanceof ICustomEnergyCover; // todo check this
     }
 
     public long getCoverHolderCapacity() {
-        if (getCoverableView() instanceof MetaTileEntityPowerSubstation pss) {
-            return pss.getCapacityLong();
+        if (getCoverableView() instanceof ICustomEnergyCover custom) {
+            return custom.getCoverCapacity();
         } else {
             IEnergyContainer energyContainer = getCoverableView()
                     .getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);
@@ -43,8 +44,8 @@ public class CoverDetectorEnergy extends CoverDetectorBase implements ITickable 
     }
 
     public long getCoverHolderStored() {
-        if (getCoverableView() instanceof MetaTileEntityPowerSubstation pss) {
-            return pss.getStoredLong();
+        if (getCoverableView() instanceof ICustomEnergyCover custom) {
+            return custom.getCoverStored();
         } else {
             IEnergyContainer energyContainer = getCoverableView()
                     .getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, null);

--- a/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
+++ b/src/main/java/gregtech/common/covers/detector/CoverDetectorEnergy.java
@@ -7,7 +7,6 @@ import gregtech.api.cover.CoverableView;
 import gregtech.api.cover.ICustomEnergyCover;
 import gregtech.api.util.RedstoneUtil;
 import gregtech.client.renderer.texture.Textures;
-import gregtech.common.metatileentities.multi.electric.MetaTileEntityPowerSubstation;
 
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -209,6 +209,9 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
                         .setTooltipText("gregtech.gui.fission.helper");
     }
 
+    /**
+     * Public for OC integration, use it if you want ig
+     */
     public void toggleControlRodRegulation(boolean b) {
         if (fissionReactor != null) {
             this.fissionReactor.controlRodRegulationOn = b;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -79,6 +79,7 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -209,13 +210,13 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
                         .setTooltipText("gregtech.gui.fission.helper");
     }
 
-    private void toggleControlRodRegulation(boolean b) {
+    public void toggleControlRodRegulation(boolean b) {
         if (fissionReactor != null) {
             this.fissionReactor.controlRodRegulationOn = b;
         }
     }
 
-    private boolean areControlRodsRegulated() {
+    public boolean areControlRodsRegulated() {
         return fissionReactor != null && this.fissionReactor.controlRodRegulationOn;
     }
 
@@ -238,7 +239,7 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
         if (flowRate < 1) flowRate = 1;
     }
 
-    private void setControlRodInsertionValue(float value) {
+    public void setControlRodInsertionValue(float value) {
         this.controlRodInsertionValue = value;
         if (fissionReactor != null)
             fissionReactor.updateControlRodInsertion(controlRodInsertionValue);
@@ -1048,5 +1049,33 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
         tooltip.add(I18n.format("gregtech.machine.fission_reactor.tooltip.1"));
         tooltip.add(I18n.format("gregtech.machine.fission_reactor.tooltip.2"));
         tooltip.add(I18n.format("gregtech.machine.fission_reactor.tooltip.3"));
+    }
+
+    public double getMaxPower() {
+        return maxPower;
+    }
+
+    public double getPower() {
+        return power;
+    }
+
+    public double getMaxPressure() {
+        return maxPressure;
+    }
+
+    public double getPressure() {
+        return pressure;
+    }
+
+    public double getMaxTemperature() {
+        return maxTemperature;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public double getControlRodInsertion() {
+        return controlRodInsertionValue;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -3,7 +3,6 @@ package gregtech.common.metatileentities.multi;
 import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.ICoolantHandler;
 import gregtech.api.capability.IFuelRodHandler;
-import gregtech.api.capability.ILockableHandler;
 import gregtech.api.capability.IMaintenanceHatch;
 import gregtech.api.cover.ICustomEnergyCover;
 import gregtech.api.gui.GuiTextures;
@@ -774,19 +773,19 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
     }
 
     protected void lockAll() {
-        for (ILockableHandler handler : this.getAbilities(MultiblockAbility.IMPORT_COOLANT)) {
+        for (ICoolantHandler handler : this.getAbilities(MultiblockAbility.IMPORT_COOLANT)) {
             handler.setLock(true);
         }
-        for (ILockableHandler handler : this.getAbilities(MultiblockAbility.IMPORT_FUEL_ROD)) {
+        for (IFuelRodHandler handler : this.getAbilities(MultiblockAbility.IMPORT_FUEL_ROD)) {
             handler.setLock(true);
         }
     }
 
     protected void unlockAll() {
-        for (ILockableHandler handler : this.getAbilities(MultiblockAbility.IMPORT_COOLANT)) {
+        for (ICoolantHandler handler : this.getAbilities(MultiblockAbility.IMPORT_COOLANT)) {
             handler.setLock(false);
         }
-        for (ILockableHandler handler : this.getAbilities(MultiblockAbility.IMPORT_FUEL_ROD)) {
+        for (IFuelRodHandler handler : this.getAbilities(MultiblockAbility.IMPORT_FUEL_ROD)) {
             handler.setLock(false);
         }
         if (this.fissionReactor != null) {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -79,7 +79,6 @@ import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import org.apache.commons.lang3.ArrayUtils;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -5,6 +5,7 @@ import gregtech.api.capability.ICoolantHandler;
 import gregtech.api.capability.IFuelRodHandler;
 import gregtech.api.capability.ILockableHandler;
 import gregtech.api.capability.IMaintenanceHatch;
+import gregtech.api.cover.ICustomEnergyCover;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
@@ -87,7 +88,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
-                                          implements IDataInfoProvider, IProgressBarMultiblock {
+                                          implements IDataInfoProvider, IProgressBarMultiblock, ICustomEnergyCover {
 
     private FissionReactor fissionReactor;
     private int diameter;
@@ -894,6 +895,18 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
             writeCustomData(GregtechDataCodes.SYNC_LOCKING_STATE, (buf) -> buf.writeEnumValue(lockingState));
         }
         this.lockingState = lockingState;
+    }
+
+    @Override
+    public long getCoverCapacity() {
+        // power is in MW
+        return (int) (this.maxPower * 1e6);
+    }
+
+    @Override
+    public long getCoverStored() {
+        // power is in MW
+        return (int) (this.power * 1e6);
     }
 
     private enum LockingState {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -7,6 +7,7 @@ import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IControllable;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.EnergyContainerList;
+import gregtech.api.cover.ICustomEnergyCover;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.*;
@@ -54,7 +55,7 @@ import java.util.function.Supplier;
 import static gregtech.api.util.RelativeDirection.*;
 
 public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
-                                           implements IControllable, IProgressBarMultiblock {
+                                           implements IControllable, IProgressBarMultiblock, ICustomEnergyCover {
 
     // Structure Constants
     public static final int MAX_BATTERY_LAYERS = 18;
@@ -555,6 +556,16 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
             return "0";
         }
         return TextFormattingUtil.formatNumbers(energyBank.getCapacity());
+    }
+
+    @Override
+    public long getCoverCapacity() {
+        return getCapacityLong();
+    }
+
+    @Override
+    public long getCoverStored() {
+        return getStoredLong();
     }
 
     public long getAverageInLastSec() {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityControlRodPort.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityControlRodPort.java
@@ -91,7 +91,7 @@ public class MetaTileEntityControlRodPort extends MetaTileEntityMultiblockNotifi
     public void addInformation(ItemStack stack, @Nullable World world, @NotNull List<String> tooltip,
                                boolean advanced) {
         super.addInformation(stack, world, tooltip, advanced);
-        tooltip.add(I18n.format(this.getMetaName() + "tooltip.1"));
+        tooltip.add(I18n.format(this.getMetaName() + ".tooltip.1"));
     }
 
     @Override

--- a/src/main/java/gregtech/integration/opencomputers/OpenComputersModule.java
+++ b/src/main/java/gregtech/integration/opencomputers/OpenComputersModule.java
@@ -7,6 +7,7 @@ import gregtech.api.util.Mods;
 import gregtech.integration.IntegrationSubmodule;
 import gregtech.integration.opencomputers.drivers.*;
 import gregtech.integration.opencomputers.drivers.specific.DriverConverter;
+import gregtech.integration.opencomputers.drivers.specific.DriverFissionReactor;
 import gregtech.integration.opencomputers.drivers.specific.DriverFusionReactor;
 import gregtech.integration.opencomputers.drivers.specific.DriverPowerSubstation;
 import gregtech.integration.opencomputers.drivers.specific.DriverWorldAccelerator;
@@ -44,6 +45,7 @@ public class OpenComputersModule extends IntegrationSubmodule {
         registerDriver(new DriverWorldAccelerator());
         registerDriver(new DriverConverter());
         registerDriver(new DriverPowerSubstation());
+        registerDriver(new DriverFissionReactor());
     }
 
     public static void registerDriver(DriverBlock driver) {

--- a/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
+++ b/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
@@ -20,7 +20,7 @@ public class DriverFissionReactor extends DriverSidedTileEntity {
 
     @Override
     public Class<?> getTileEntityClass() {
-        return MetaTileEntityFusionReactor.class;
+        return MetaTileEntityFissionReactor.class;
     }
 
     @Override

--- a/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
+++ b/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
@@ -46,7 +46,7 @@ public class DriverFissionReactor extends DriverSidedTileEntity {
                                                         EnvironmentMetaTileEntity<MetaTileEntityFissionReactor> {
 
         public EnvironmentFissionReactor(IGregTechTileEntity holder, MetaTileEntityFissionReactor tileEntity) {
-            super(holder, tileEntity, "gt_fusionReactor");
+            super(holder, tileEntity, "gt_fissionReactor");
         }
 
         @Callback(doc = "function():number --  Returns the max power of the reactor, in MW.")

--- a/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
+++ b/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
@@ -43,7 +43,7 @@ public class DriverFissionReactor extends DriverSidedTileEntity {
     }
 
     public final static class EnvironmentFissionReactor extends
-                                                       EnvironmentMetaTileEntity<MetaTileEntityFissionReactor> {
+                                                        EnvironmentMetaTileEntity<MetaTileEntityFissionReactor> {
 
         public EnvironmentFissionReactor(IGregTechTileEntity holder, MetaTileEntityFissionReactor tileEntity) {
             super(holder, tileEntity, "gt_fusionReactor");

--- a/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
+++ b/src/main/java/gregtech/integration/opencomputers/drivers/specific/DriverFissionReactor.java
@@ -1,0 +1,104 @@
+package gregtech.integration.opencomputers.drivers.specific;
+
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.common.metatileentities.multi.MetaTileEntityFissionReactor;
+import gregtech.common.metatileentities.multi.electric.MetaTileEntityFusionReactor;
+import gregtech.integration.opencomputers.drivers.EnvironmentMetaTileEntity;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+
+public class DriverFissionReactor extends DriverSidedTileEntity {
+
+    @Override
+    public Class<?> getTileEntityClass() {
+        return MetaTileEntityFusionReactor.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityFissionReactor;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentFissionReactor((IGregTechTileEntity) tileEntity,
+                    (MetaTileEntityFissionReactor) ((IGregTechTileEntity) tileEntity).getMetaTileEntity());
+        }
+        return null;
+    }
+
+    public final static class EnvironmentFissionReactor extends
+                                                       EnvironmentMetaTileEntity<MetaTileEntityFissionReactor> {
+
+        public EnvironmentFissionReactor(IGregTechTileEntity holder, MetaTileEntityFissionReactor tileEntity) {
+            super(holder, tileEntity, "gt_fusionReactor");
+        }
+
+        @Callback(doc = "function():number --  Returns the max power of the reactor, in MW.")
+        public Object[] getMaxPower(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getMaxPower() };
+        }
+
+        @Callback(doc = "function():number --  Returns the power of the reactor, in MW.")
+        public Object[] getPower(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getPower() };
+        }
+
+        @Callback(doc = "function():number --  Returns the max temperature of the reactor.")
+        public Object[] getMaxTemperature(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getMaxTemperature() };
+        }
+
+        @Callback(doc = "function():number --  Returns the temperature of the reactor.")
+        public Object[] getTemperature(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getTemperature() };
+        }
+
+        @Callback(doc = "function():number --  Returns the max pressure of the reactor, in pascals.")
+        public Object[] getMaxPressure(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getMaxPressure() };
+        }
+
+        @Callback(doc = "function():number --  Returns the pressure of the reactor, in pascals.")
+        public Object[] getPressure(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getPressure() };
+        }
+
+        @Callback(doc = "function():number --  Returns how much control rods are inserted, in [0, 1]")
+        public Object[] getControlRodInsertion(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.getControlRodInsertion() };
+        }
+
+        @Callback(doc = "function(insertion:boolean) --  Sets how much control rods are inserted, in [0, 1]")
+        public Object[] setControlRodInsertion(final Context context, final Arguments args) {
+            tileEntity.setControlRodInsertionValue((float) args.checkDouble(0));
+            return new Object[] {};
+        }
+
+        @Callback(doc = "function():boolean --  Returns whether smiley is regulating control rods.")
+        public Object[] getSmiley(final Context context, final Arguments args) {
+            return new Object[] { tileEntity.areControlRodsRegulated() };
+        }
+
+        @Callback(doc = "function(smiley:boolean) --  Pass in true to revive smiley, pass in false to kill smiley.")
+        public Object[] setSmiley(final Context context, final Arguments args) {
+            tileEntity.toggleControlRodRegulation(args.checkBoolean(0));
+            return new Object[] {};
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds some features to the nuclear pr, and tweaks the reactor simulation a bit

## Implementation Details
Cleans up the fission code, removing some redundant stuff

There is now OC integration, someone should probably test that since I've never used OC and just looked at the other drivers

There is now a common interface to specify which MTEs have custom behavior with the energy covers, which is implemented by the PSS and fission reactor

The temperature of the reactor is now updated differently, which gaurantees that a reactor will not melt down if the coolant removes more heat than the reactor makes. This does **not** prevent the oscillating behavior, which is caused by the coolant removing too much heat once temp goes above 500K(where the coolant actually flows). 

For the temperature change: 
- is it ok if the reactor stays at 293K during the operation(while power goes up)
- currently, at max power, kEff wildly changes resulting in sporadic behavior, is this intended?
- how about just making the reactor's minimum temperature ``temperature * Math.min(1, kEff)``, so if kEff is above 1, temperature never decreases

## Outcome
Nuclear PR is 1 / infinity closer to merge

## Potential Compatibility Issues
none, hopefully
