### PR TITLE
Assorted fission fixes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -332,7 +332,7 @@ public class UnknownCompositionMaterials {
                 .build();
 
         Corium = new Material.Builder(1560, gregtechId("corium"))
-                .liquid(new FluidBuilder().temperature(2500).block().density(8.0D))
+                .liquid(new FluidBuilder().temperature(2500).block().density(8.0D).viscosity(10000))
                 .color(0x7A6B50)
                 .flags(NO_UNIFICATION, STICKY, GLOWING)
                 .build();

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -811,7 +811,6 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
         int radius = this.diameter / 2;     // This is the floor of the radius, the actual radius is 0.5 blocks
         // larger
         BlockPos reactorOrigin = this.getPos().offset(this.frontFacing.getOpposite(), radius);
-        radius--;
         boolean foundFuel = false;
         for (int i = -radius; i <= radius; i++) {
             for (int j = -radius; j <= radius; j++) {

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityFissionReactor.java
@@ -337,6 +337,11 @@ public class MetaTileEntityFissionReactor extends MultiblockWithDisplayBase
     }
 
     @Override
+    public boolean allowsExtendedFacing() {
+        return false;
+    }
+
+    @Override
     public void updateFormedValid() {
         // Take in coolant, take in fuel, update reactor, output steam
 


### PR DESCRIPTION
## What
Fixes a [bug found by BoomerVillager  on discord](https://discord.com/channels/701354865217110096/1248393524332990625/1260462585778802729).
Also preemptively removes the possibility to rotate the controller, as the current component code would most definitely not tolerate that.

## Implementation Details
- one line fixes, nothing to worry about I hope

## Outcome
- fixes an issue where some blocks near the reactors edge were ignored during reactor component population
- makes the reactor non-rotatable 
- makes corium much more viscous

## Additional Information
I know there are probably people out there that want rotatable reactors, maybe someone with a lot of time on their hand can figure that out.
