### PR TITLE
Add Overload to `where()` in FactoryBlockPattern

### DIFF
--- a/src/main/java/gregtech/api/pattern/FactoryBlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/FactoryBlockPattern.java
@@ -1,6 +1,5 @@
 package gregtech.api.pattern;
 
-import gregtech.api.util.GTLog;
 import gregtech.api.util.RelativeDirection;
 
 import com.google.common.base.Joiner;
@@ -132,7 +131,8 @@ public class FactoryBlockPattern {
         if (symbol.length() == 1) {
             return where(symbol.charAt(0), blockMatcher);
         }
-        throw new IllegalArgumentException(String.format("Symbol \"%s\" is invalid! It must be exactly one character!", symbol));
+        throw new IllegalArgumentException(
+                String.format("Symbol \"%s\" is invalid! It must be exactly one character!", symbol));
     }
 
     public BlockPattern build() {

--- a/src/main/java/gregtech/api/pattern/FactoryBlockPattern.java
+++ b/src/main/java/gregtech/api/pattern/FactoryBlockPattern.java
@@ -1,5 +1,6 @@
 package gregtech.api.pattern;
 
+import gregtech.api.util.GTLog;
 import gregtech.api.util.RelativeDirection;
 
 import com.google.common.base.Joiner;
@@ -125,6 +126,13 @@ public class FactoryBlockPattern {
     public FactoryBlockPattern where(char symbol, TraceabilityPredicate blockMatcher) {
         this.symbolMap.put(symbol, new TraceabilityPredicate(blockMatcher).sort());
         return this;
+    }
+
+    public FactoryBlockPattern where(String symbol, TraceabilityPredicate blockMatcher) {
+        if (symbol.length() == 1) {
+            return where(symbol.charAt(0), blockMatcher);
+        }
+        throw new IllegalArgumentException(String.format("Symbol \"%s\" is invalid! It must be exactly one character!", symbol));
     }
 
     public BlockPattern build() {


### PR DESCRIPTION
## What
adds a method to pass in a string whose length gets checked to pass it in as a `char`. primarily useful for GroovyScript, where it's not possible to create `char` literals.

## Implementation Details
idk if throwing an exception is the right call instead of just logging it.

## Outcome
death to `as char` in GrS