### PR TITLE
JEI Fuel Recipe Change Suggestions

### DIFF
--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 /**
  * Class that represent machine recipe.
@@ -777,6 +778,17 @@ public class Recipe {
     public int getUnhiddenPropertyCount() {
         return (int) recipePropertyStorage.getRecipeProperties().stream()
                 .filter((property) -> !property.getKey().isHidden()).count();
+    }
+
+    /**
+     * Calculates the number of lines added to the JEI page by properties.
+     * Written to replace the getUnhiddenPropertyCount() method for more versatility.
+     *
+     * @return the number of lines
+     */
+    public int getAdditionalLinesCount() {
+        return recipePropertyStorage.getRecipeProperties().stream()
+                .flatMapToInt((property) -> IntStream.of(property.getKey().getInfoLineCount(property.getValue()))).sum();
     }
 
     public IRecipePropertyStorage getRecipePropertyStorage() {

--- a/src/main/java/gregtech/api/recipes/builders/FuelRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/FuelRecipeBuilder.java
@@ -3,6 +3,11 @@ package gregtech.api.recipes.builders;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.recipeproperties.FuelProperty;
+
+import gregtech.api.util.ValidationResult;
+
+import org.jetbrains.annotations.NotNull;
 
 public class FuelRecipeBuilder extends RecipeBuilder<FuelRecipeBuilder> {
 
@@ -19,5 +24,20 @@ public class FuelRecipeBuilder extends RecipeBuilder<FuelRecipeBuilder> {
     @Override
     public FuelRecipeBuilder copy() {
         return new FuelRecipeBuilder(this);
+    }
+
+    @Override
+    public boolean applyProperty(@NotNull String key, Object value) {
+        if (key.equals(FuelProperty.KEY)) {
+            this.applyProperty(FuelProperty.getInstance(), value);
+            return true;
+        }
+        return super.applyProperty(key, value);
+    }
+
+    @Override
+    public ValidationResult<Recipe> build() {
+        applyProperty(FuelProperty.getInstance(), recipeMap.getUnlocalizedName());
+        return super.build();
     }
 }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/FuelProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/FuelProperty.java
@@ -1,5 +1,7 @@
 package gregtech.api.recipes.recipeproperties;
 
+import gregtech.common.ConfigHolder;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 
@@ -18,7 +20,16 @@ public class FuelProperty extends RecipeProperty<String> {
     @Override
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         for(int i = 1; i <= getTranslationLineCount(castValue(value)); i++) {
-            minecraft.fontRenderer.drawString(I18n.format(getTranslationKey(castValue(value), i) ), x, y+10*(i-getTranslationLineCount(castValue(value))), color);
+            minecraft.fontRenderer.drawString(I18n.format(getTranslationKey(castValue(value), i), getExtraInfo(castValue(value)) ), x, y+10*(i-getTranslationLineCount(castValue(value))), color);
+        }
+    }
+
+    public String getExtraInfo(String unlocalizedName) {
+        switch (unlocalizedName) {
+            case "steam_turbine":
+                return "" + 1.0 / ConfigHolder.machines.multiblockSteamToEU;
+            default:
+                return "";
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/FuelProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/FuelProperty.java
@@ -1,0 +1,42 @@
+package gregtech.api.recipes.recipeproperties;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+
+public class FuelProperty extends RecipeProperty<String> {
+    public static final String KEY = "fuel";
+    private static FuelProperty INSTANCE;
+    private FuelProperty() {super( KEY, String.class ); }
+
+    public static FuelProperty getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new FuelProperty();
+        }
+        return INSTANCE;
+    }
+
+    @Override
+    public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
+        for(int i = 1; i <= getTranslationLineCount(castValue(value)); i++) {
+            minecraft.fontRenderer.drawString(I18n.format(getTranslationKey(castValue(value), i) ), x, y+10*(i-getTranslationLineCount(castValue(value))), color);
+        }
+    }
+
+    private static String getTranslationKey(String unlocalizedName, int lineNum) {
+        return "gregtech.jei." + unlocalizedName + ".info." + lineNum;
+    }
+
+    private static int getTranslationLineCount(String unlocalizedName) {
+        int i = 0;
+        while( !I18n.format(getTranslationKey(unlocalizedName, i+1)).equals(getTranslationKey(unlocalizedName, i+1)) ) { i++; }
+        return i;
+    }
+
+    @Override
+    public int getInfoHeight(Object value) {
+        return 10 * getTranslationLineCount(castValue(value));
+    }
+
+    @Override
+    public int getInfoLineCount(Object value) { return getTranslationLineCount(castValue(value)); }
+}

--- a/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/RecipeProperty.java
@@ -45,6 +45,13 @@ public abstract class RecipeProperty<T> {
     }
 
     /**
+     * Get how many lines a property adds to it's JEI page.
+     *
+     * @return 0 lines if hidden, 1 if not
+     */
+    public int getInfoLineCount(Object value) { return isHidden() ? 0 : 1; }
+
+    /**
      * Controls if the property should display any information in JEI
      *
      * @return true to hide information from JEI

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -245,7 +245,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         if (drawEUt) defaultLines++;
         if (drawDuration) defaultLines++;
 
-        int yPosition = recipeHeight - ((recipe.getUnhiddenPropertyCount() + defaultLines) * 10 - 3);
+        int yPosition = recipeHeight - ((recipe.getAdditionalLinesCount() + defaultLines) * 10 - 3);
 
         // Default entries
         if (drawTotalEU) {

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -17,6 +17,7 @@ import gregtech.api.recipes.ingredients.GTRecipeInput;
 import gregtech.api.recipes.machines.IResearchRecipeMap;
 import gregtech.api.recipes.machines.IScannerRecipeMap;
 import gregtech.api.recipes.recipeproperties.ComputationProperty;
+import gregtech.api.recipes.recipeproperties.FuelProperty;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.recipes.recipeproperties.ScanProperty;
 import gregtech.api.recipes.recipeproperties.TotalComputationProperty;
@@ -262,7 +263,7 @@ public class GTRecipeWrapper extends AdvancedRecipeWrapper {
         }
         if (drawEUt) {
             minecraft.fontRenderer.drawString(
-                    I18n.format(recipe.getEUt() >= 0 ? "gregtech.recipe.eu" : "gregtech.recipe.eu_inverted",
+                    I18n.format(recipe.hasProperty(FuelProperty.getInstance()) ? "gregtech.recipe.eu_inverted" : "gregtech.recipe.eu",
                             Math.abs(recipe.getEUt()), GTValues.VN[GTUtility.getTierByVoltage(recipe.getEUt())]),
                     0, yPosition += LINE_HEIGHT, 0x111111);
         }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5506,6 +5506,13 @@ gregtech.jei.materials.average_mass=Average mass: %,d
 gregtech.jei.materials.average_protons=Average protons: %,d
 gregtech.jei.materials.average_neutrons=Average neutrons: %,d
 
+# Add info to the bottom of the JEI page for fuel recipes
+#   Formula: "gregtech.jei." + unlocalized name of recipe map + ".info." + line number
+#   You can add as many lines as you want, but the size of the entire page does not increase automatically
+gregtech.jei.combustion_generator.info.1=Fuel use and energy production
+gregtech.jei.combustion_generator.info.2=rates are multiplied §64x§0 per tier.
+
+
 gregtech.veins.ore.bauxite=Bauxite Vein
 gregtech.veins.ore.magnetite=Magnetite Vein
 gregtech.veins.ore.naquadah=Naquadah Vein

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5512,6 +5512,9 @@ gregtech.jei.materials.average_neutrons=Average neutrons: %,d
 gregtech.jei.combustion_generator.info.1=Fuel use and energy production
 gregtech.jei.combustion_generator.info.2=rates are multiplied §64x§0 per tier.
 
+gregtech.jei.gas_turbine.info.1=Fuel use and energy production
+gregtech.jei.gas_turbine.info.2=rates are multiplied §64x§0 per tier.
+gregtech.jei.steam_turbine.info.1=Steam use per tick is §6%dx§0 the EU/t
 
 gregtech.veins.ore.bauxite=Bauxite Vein
 gregtech.veins.ore.magnetite=Magnetite Vein


### PR DESCRIPTION
### STILL IN PROGRESS
## Overview
I noticed some problems with JEI pages, mostly regarding generators and the large steam boiler. This PR aims to fix the issues and/or provide some additional information to the player to reduce confusion.

## Changes
- For generator fuels in JEI, the "Usage:" text is properly replaced with "Generation:" (This was previously defined by the sign of the EU/t, but no recipes have a negative EU/t, and fuel recipes would break if they were set to be negative.)
- For some recipes in which changes through voltage tiers are not reflected in JEI (eg. the rate at which fuels are consumed in combustion generators) helper text was added to the bottom of the JEI page. Feel free to change this at will; I tried to pull information from constants or configs wherever possible, but some of the data is experimental.
- Fuel recipes have the ability to add info to their JEI pages with a dynamic line count through only the lang file, just in case translations have different lengths or a pack/addon dev wishes to add their own information.
**In Progress:**
Changed Large Boilers to have their own JEI page with information unique to boilers (eg. water and steam, half/doubled durations for combustion and dense fuels respectively) and removing the Large Boiler machines from the Combustion and Semi-Fuel tabs, all while maintaining compatibility with existing packs and addons.

## Implementation Details
There are some edits to the following files that (while utmost care was taken to ensure continued compatibility for packs) may cause unseen issues or use methods in ways that are unintended.
- **RecipeProperty.java** : Added public property getInfoLineCount() that can be overridden to tell the recipe wrapper how many lines a recipe property would add to their JEI page. Without overriding, the function accounts automatically for properties that add only one or zero lines, so no changes need to be made to existing recipe properties.
- **Recipe.java** : Added public method getAdditionalLinesCount() to serve the same purpose as getHiddenPropertyCount while accounting for recipes with properties that add multiple lines to their JEI page.
- **GTRecipeWrapper.java** : The "Usage:" to "Generation:" text in recipe pages was based off the sign of the EU/t. This has been replaced with the FuelProperty recipe property. Additionally, the usage of getHiddenPropertyCount() has been switched to getAdditionalLinesCount().
- **FuelRecipeBuilder** : Added the FuelProperty recipe property to fuel recipes for generators; this builder was already used for all necessary recipes, so no other files should really required editing.
**In Progress:**
Adding a new recipe map for Large Boiler fuels that simply copies from the Combustion Fuels and Semi-Fluid Fuels at registration, and setting the duration to the respective half/doubled values and ensuring that BoilerRecipeLogic.java still handles the recipe properly.

## Screenshots
![image](https://github.com/user-attachments/assets/ae223ba0-a147-4f0a-b249-c180b2222ab3)
![image](https://github.com/user-attachments/assets/49b0118f-7a5a-4325-9c5c-285989ad4ad5)
![image](https://github.com/user-attachments/assets/4dea4bdf-4718-4b94-87b4-21122bf880d7)
(In Progress: )
![image](https://github.com/user-attachments/assets/c0f837df-4f13-4eb1-b88f-084952de1143)

## Potential Compatibility Issues
_Honestly, I completely understand if this PR gets rejected simply because it goes to deep into the files, but I'm hoping the changes are worth it. I wont be offended if nothing gets accepted, don't worry!_
I'm not certain that getAdditionalLinesCount() works entirely with multiple properties, especially when mixing hidden and unhidden properties. This will likely be resolved by the time I finish the branch.
I tried making it so addon devs wouldn't have to edit too much in the way of java files, but if one would like to add dynamic variables to a fuel recipe it would be a little hacky probably.