### PR TITLE
fix most gases using the wrong translation key

### DIFF
--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -51,7 +51,7 @@ public final class FluidStorageKeys {
      * @return the registry name
      */
     public static @NotNull String prefixedRegistryName(@NotNull String prefix, @NotNull FluidStorageKey key,
-                                                        @NotNull Material material) {
+                                                       @NotNull Material material) {
         FluidProperty property = material.getProperty(PropertyKey.FLUID);
         if (property != null && property.getPrimaryKey() != key) {
             return prefix + material.getName();

--- a/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
+++ b/src/main/java/gregtech/api/fluids/store/FluidStorageKeys.java
@@ -27,7 +27,7 @@ public final class FluidStorageKeys {
                 }
 
                 FluidProperty property = m.getProperty(PropertyKey.FLUID);
-                if (m.isElement() || (property != null && property.getPrimaryKey() != FluidStorageKeys.LIQUID)) {
+                if (m.isElement() || property == null || property.getPrimaryKey() != FluidStorageKeys.GAS) {
                     return "gregtech.fluid.gas_generic";
                 }
                 return "gregtech.fluid.generic";
@@ -43,12 +43,14 @@ public final class FluidStorageKeys {
     private FluidStorageKeys() {}
 
     /**
+     * Used to create registry names for fluids that only have a prefix when not stored by the primary key.
+     *
      * @param prefix   the prefix string for the registry name
      * @param key      the key which does not require the prefix
      * @param material the material to create a registry name for
      * @return the registry name
      */
-    private static @NotNull String prefixedRegistryName(@NotNull String prefix, @NotNull FluidStorageKey key,
+    public static @NotNull String prefixedRegistryName(@NotNull String prefix, @NotNull FluidStorageKey key,
                                                         @NotNull Material material) {
         FluidProperty property = material.getProperty(PropertyKey.FLUID);
         if (property != null && property.getPrimaryKey() != key) {

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -391,8 +391,7 @@ public class ElementMaterials {
 
         Krypton = new Material.Builder(52, gregtechId("krypton"))
                 .gas(new FluidBuilder()
-                        .customStill()
-                        .translation("gregtech.fluid.generic"))
+                        .customStill())
                 .color(0x80FF80)
                 .element(Elements.Kr)
                 .build();


### PR DESCRIPTION
## What
Fixes most gases using the wrong translation key. This caused most fluids to show as "[name] Gas" instead of just "[name]." Some worse examples of this are: "Wood Gas Gas" and "Steam Gas."

## Outcome
Fixes incorrect gas translation keys being used.
