### PR TITLE
Override getItem in BlockMachine.class

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -206,6 +206,15 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
         return ItemStack.EMPTY;
     }
 
+    @NotNull
+    @Override
+    public ItemStack getItem(@NotNull World world, @NotNull BlockPos pos, @NotNull IBlockState state) {
+        MetaTileEntity metaTileEntity = getMetaTileEntity(world, pos);
+        if (metaTileEntity == null)
+            return ItemStack.EMPTY;
+        return metaTileEntity.getStackForm();
+    }
+
     @Override
     public void addCollisionBoxToList(@NotNull IBlockState state, @NotNull World worldIn, @NotNull BlockPos pos,
                                       @NotNull AxisAlignedBB entityBox, @NotNull List<AxisAlignedBB> collidingBoxes,


### PR DESCRIPTION
## What
Overriding `getItem` method in BlockMachine so that some mods (e.g. xnet) can get gt machine blocks correctly.

## Implementation Details
return `metaTileEntity.getStackForm()` for `getItem`.

## Outcome
fixes issues like https://github.com/SymmetricDevs/Supersymmetry/issues/877

## Potential Compatibility Issues
None that I can think of.
