### PR TITLE
Fix PA & Cleanroom Sync Issues

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -353,7 +353,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
             this.currentMachineStack = machine;
         }
 
-        public void updateCleanroom() {
+        private void updateCleanroom() {
             // Set the cleanroom of the MTEs to the PA's cleanroom reference
             if (mte instanceof ICleanroomReceiver receiver) {
                 if (ConfigHolder.machines.cleanMultiblocks) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -238,6 +238,14 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
         return mte == null ? 0 : mte.getItemOutputLimit();
     }
 
+    @Override
+    public void setCleanroom(ICleanroomProvider provider) {
+        super.setCleanroom(provider);
+
+        // Sync Cleanroom Change to Internal Workable MTE
+        ((ProcessingArrayWorkable) this.recipeMapWorkable).updateCleanroom();
+    }
+
     @SuppressWarnings("InnerClassMayBeStatic")
     protected class ProcessingArrayWorkable extends MultiblockRecipeLogic {
 
@@ -334,15 +342,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                 mte = holder.setMetaTileEntity(mte);
                 holder.setWorld(this.metaTileEntity.getWorld());
 
-                // Set the cleanroom of the MTEs to the PA's cleanroom reference
-                if (mte instanceof ICleanroomReceiver receiver) {
-                    if (ConfigHolder.machines.cleanMultiblocks) {
-                        receiver.setCleanroom(DUMMY_CLEANROOM);
-                    } else {
-                        ICleanroomProvider provider = controller.getCleanroom();
-                        if (provider != null) receiver.setCleanroom(provider);
-                    }
-                }
+                updateCleanroom();
             }
 
             // Find the voltage tier of the machine.
@@ -351,6 +351,18 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
             this.machineVoltage = GTValues.V[this.machineTier];
 
             this.currentMachineStack = machine;
+        }
+
+        public void updateCleanroom() {
+            // Set the cleanroom of the MTEs to the PA's cleanroom reference
+            if (mte instanceof ICleanroomReceiver receiver) {
+                if (ConfigHolder.machines.cleanMultiblocks) {
+                    receiver.setCleanroom(DUMMY_CLEANROOM);
+                } else {
+                    ICleanroomProvider provider = ((RecipeMapMultiblockController) metaTileEntity).getCleanroom();
+                    if (provider != null) receiver.setCleanroom(provider);
+                }
+            }
         }
 
         @Override


### PR DESCRIPTION
## What
This PR fixes an issue with PAs, where the cleanroom state of the internal MTE would be out of sync with the cleanroom state of the PA controller, causing recipes failing to run.

This issue was initially reported in https://github.com/Nomi-CEu/Nomi-CEu/issues/844, but the issue was reproduced with latest GT dev (without other mods, apart from HEI, TOP, CodeChickenLib, ModularUI and MixinBooter).

This PR fixes two issues relating to PAs and Cleanrooms. The first can be reproduced as follows:
1. Make a Plascrete Floor
2. Build an Normal/Advanced PA **(Must Place Controller)**
3. *Save and Quit the World* (Step may not be needed)
4. Finish off the cleanroom, & place the cleanroom controller **(IMPORTANT: Must Be Placed after Step 5)**
5. Wait until cleanroom is clean, validate that PA runs.
6. Quit world, rejoin, PA is no longer running.
7. Remove and Re-Insert Machines in Machine Access Interface for the PA to start running again

This issue seems to happen if the cleanroom controller is loaded AFTER the PA's first recipe search, causing a lack of sync between the cleanroom state of the PA multiblock and the internal meta tile entity, which handles the logic.

As the reproduction steps are quite lengthy, here is a world where the issue can be reproduced (just don't break the PA controller). 

[GregTech PA Test.zip](https://github.com/user-attachments/files/16486538/GregTech.PA.Test.zip)

The other issue, which is caused by the same sync issue, can be simply reproduced by having a running PA in a cleanroom, and then breaking and replacing the controller. The PA will not run until you remove and re-insert Machines in Machine Access Interface.

This PR can also be thought of as simply applying the mixin fix in https://github.com/Nomi-CEu/Nomi-Labs/commit/3b5953524bb2317ff6f5e705d70f17aecc61119d.

## Implementation Details
None.

## Outcome
Fixes issues with PAs and Cleanrooms.

## Additional Information
None

## Potential Compatibility Issues
None
