### PR TITLE
Fix Legacy Filter NBT Reading

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -683,10 +683,11 @@ public class CoverConveyor extends CoverBase implements CoverWithUI, ITickable, 
         this.isWorkingAllowed = tagCompound.getBoolean("WorkingAllowed");
         this.manualImportExportMode = ManualImportExportMode.VALUES[tagCompound.getInteger("ManualImportExportMode")];
         var filterTag = tagCompound.getCompoundTag("Filter");
-        if (!filterTag.hasKey("IsBlacklist"))
-            this.itemFilterContainer.deserializeNBT(filterTag);
-        else
+        if (filterTag.hasKey("IsBlacklist")) {
             this.itemFilterContainer.handleLegacyNBT(filterTag);
+        } else {
+            this.itemFilterContainer.deserializeNBT(filterTag);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverConveyor.java
+++ b/src/main/java/gregtech/common/covers/CoverConveyor.java
@@ -682,8 +682,11 @@ public class CoverConveyor extends CoverBase implements CoverWithUI, ITickable, 
         this.distributionMode = DistributionMode.VALUES[tagCompound.getInteger("DistributionMode")];
         this.isWorkingAllowed = tagCompound.getBoolean("WorkingAllowed");
         this.manualImportExportMode = ManualImportExportMode.VALUES[tagCompound.getInteger("ManualImportExportMode")];
-        this.itemFilterContainer.deserializeNBT(tagCompound.getCompoundTag("Filter"));
-        this.itemFilterContainer.handleLegacyNBT(tagCompound.getCompoundTag("Filter"));
+        var filterTag = tagCompound.getCompoundTag("Filter");
+        if (!filterTag.hasKey("IsBlacklist"))
+            this.itemFilterContainer.deserializeNBT(filterTag);
+        else
+            this.itemFilterContainer.handleLegacyNBT(filterTag);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -191,15 +191,13 @@ public class CoverFluidFilter extends CoverBase implements CoverWithUI {
     public void readFromNBT(@NotNull NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
         this.filterMode = FluidFilterMode.values()[tagCompound.getInteger("FilterMode")];
-        var filterTag = tagCompound.getCompoundTag("Filter");
-        if (filterTag.hasKey("IsBlacklist")) {
+        if (tagCompound.hasKey("IsBlacklist")) {
             this.fluidFilterContainer.setFilterStack(getDefinition().getDropItemStack());
             this.fluidFilterContainer.handleLegacyNBT(tagCompound);
             this.fluidFilterContainer.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
         } else {
-            this.fluidFilterContainer.deserializeNBT(filterTag);
+            this.fluidFilterContainer.deserializeNBT(tagCompound.getCompoundTag("Filter"));
         }
-
     }
 
     private class FluidHandlerFiltered extends FluidHandlerDelegate {

--- a/src/main/java/gregtech/common/covers/CoverFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidFilter.java
@@ -192,13 +192,14 @@ public class CoverFluidFilter extends CoverBase implements CoverWithUI {
         super.readFromNBT(tagCompound);
         this.filterMode = FluidFilterMode.values()[tagCompound.getInteger("FilterMode")];
         var filterTag = tagCompound.getCompoundTag("Filter");
-        if (!filterTag.hasKey("FilterInventory")) {
+        if (filterTag.hasKey("IsBlacklist")) {
             this.fluidFilterContainer.setFilterStack(getDefinition().getDropItemStack());
+            this.fluidFilterContainer.handleLegacyNBT(tagCompound);
+            this.fluidFilterContainer.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
         } else {
             this.fluidFilterContainer.deserializeNBT(filterTag);
         }
 
-        this.fluidFilterContainer.handleLegacyNBT(tagCompound);
     }
 
     private class FluidHandlerFiltered extends FluidHandlerDelegate {

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -182,10 +182,14 @@ public class CoverItemFilter extends CoverBase implements CoverWithUI {
         var filterTag = tagCompound.getCompoundTag("Filter");
         if (!filterTag.hasKey("FilterInventory")) {
             this.itemFilterContainer.setFilterStack(getDefinition().getDropItemStack());
+        }
+
+        if (tagCompound.hasKey("IsBlacklist")) {
+            this.itemFilterContainer.handleLegacyNBT(filterTag);
+            this.itemFilterContainer.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
         } else {
             this.itemFilterContainer.deserializeNBT(filterTag);
         }
-        this.itemFilterContainer.handleLegacyNBT(tagCompound);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -179,13 +179,12 @@ public class CoverItemFilter extends CoverBase implements CoverWithUI {
     public void readFromNBT(@NotNull NBTTagCompound tagCompound) {
         super.readFromNBT(tagCompound);
         this.filterMode = ItemFilterMode.VALUES[tagCompound.getInteger("FilterMode")];
-        var filterTag = tagCompound.getCompoundTag("Filter");
         if (tagCompound.hasKey("IsBlacklist")) {
             this.itemFilterContainer.setFilterStack(getDefinition().getDropItemStack());
-            this.itemFilterContainer.handleLegacyNBT(filterTag);
+            this.itemFilterContainer.handleLegacyNBT(tagCompound);
             this.itemFilterContainer.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
         } else {
-            this.itemFilterContainer.deserializeNBT(filterTag);
+            this.itemFilterContainer.deserializeNBT(tagCompound.getCompoundTag("Filter"));
         }
     }
 

--- a/src/main/java/gregtech/common/covers/CoverItemFilter.java
+++ b/src/main/java/gregtech/common/covers/CoverItemFilter.java
@@ -180,11 +180,8 @@ public class CoverItemFilter extends CoverBase implements CoverWithUI {
         super.readFromNBT(tagCompound);
         this.filterMode = ItemFilterMode.VALUES[tagCompound.getInteger("FilterMode")];
         var filterTag = tagCompound.getCompoundTag("Filter");
-        if (!filterTag.hasKey("FilterInventory")) {
-            this.itemFilterContainer.setFilterStack(getDefinition().getDropItemStack());
-        }
-
         if (tagCompound.hasKey("IsBlacklist")) {
+            this.itemFilterContainer.setFilterStack(getDefinition().getDropItemStack());
             this.itemFilterContainer.handleLegacyNBT(filterTag);
             this.itemFilterContainer.setBlacklistFilter(tagCompound.getBoolean("IsBlacklist"));
         } else {

--- a/src/main/java/gregtech/common/covers/CoverPump.java
+++ b/src/main/java/gregtech/common/covers/CoverPump.java
@@ -405,8 +405,11 @@ public class CoverPump extends CoverBase implements CoverWithUI, ITickable, ICon
         this.isWorkingAllowed = tagCompound.getBoolean("WorkingAllowed");
         this.manualImportExportMode = ManualImportExportMode.VALUES[tagCompound.getInteger("ManualImportExportMode")];
         this.bucketMode = BucketMode.VALUES[tagCompound.getInteger("BucketMode")];
-        this.fluidFilterContainer.deserializeNBT(tagCompound.getCompoundTag("Filter"));
-        this.fluidFilterContainer.handleLegacyNBT(tagCompound);
+        var filterTag = tagCompound.getCompoundTag("Filter");
+        if (filterTag.hasKey("IsBlacklist"))
+            this.fluidFilterContainer.handleLegacyNBT(filterTag);
+        else
+            this.fluidFilterContainer.deserializeNBT(filterTag);
     }
 
     @Override

--- a/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
@@ -201,11 +201,13 @@ public abstract class BaseFilterContainer extends ItemStackHandler {
     }
 
     public void handleLegacyNBT(NBTTagCompound nbt) {
-        super.deserializeNBT(nbt.getCompoundTag("FilterInventory"));
-        setFilterStack(getFilterStack());
-        if (hasFilter()) {
-            getFilter().getFilterReader().handleLegacyNBT(nbt);
+        if (getFilterStack().isEmpty()) {
+            super.deserializeNBT(nbt.getCompoundTag("FilterInventory"));
+            setFilter(BaseFilter.getFilterFromStack(getFilterStack()));
         }
+
+        if (hasFilter())
+            getFilter().getFilterReader().handleLegacyNBT(nbt);
     }
 
     /** Uses Cleanroom MUI */

--- a/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
@@ -201,6 +201,8 @@ public abstract class BaseFilterContainer extends ItemStackHandler {
     }
 
     public void handleLegacyNBT(NBTTagCompound nbt) {
+        super.deserializeNBT(nbt.getCompoundTag("FilterInventory"));
+        setFilterStack(getFilterStack());
         if (hasFilter()) {
             getFilter().getFilterReader().handleLegacyNBT(nbt);
         }

--- a/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
@@ -201,7 +201,9 @@ public abstract class BaseFilterContainer extends ItemStackHandler {
     }
 
     public void handleLegacyNBT(NBTTagCompound nbt) {
-        if (getFilterStack().isEmpty()) {
+        // for filters as covers, the stack is set manually, and "FilterInventory" doesn't exist to be deserialized
+        // also, ItemStackHandler's deserialization doesn't use setStackInSlot, so I have to do that manually here
+        if (nbt.hasKey("FilterInventory")) {
             super.deserializeNBT(nbt.getCompoundTag("FilterInventory"));
             setFilter(BaseFilter.getFilterFromStack(getFilterStack()));
         }

--- a/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
@@ -187,7 +187,6 @@ public abstract class BaseFilterContainer extends ItemStackHandler {
     public NBTTagCompound serializeNBT() {
         NBTTagCompound tagCompound = new NBTTagCompound();
         tagCompound.setTag("FilterInventory", super.serializeNBT());
-        // tagCompound.setInteger("MaxStackSize", getMaxTransferSize());
         tagCompound.setInteger("TransferStackSize", getTransferSize());
         return tagCompound;
     }

--- a/src/main/java/gregtech/common/covers/filter/readers/SimpleItemFilterReader.java
+++ b/src/main/java/gregtech/common/covers/filter/readers/SimpleItemFilterReader.java
@@ -81,6 +81,7 @@ public class SimpleItemFilterReader extends BaseFilterReader implements IItemHan
             }
             NBTTagList list = getInventoryNbt();
             list.set(slot, stack.isEmpty() ? new NBTTagCompound() : stack.serializeNBT());
+            markDirty();
         }
     }
 


### PR DESCRIPTION
## What
Fixes #2569, along with properly handling the reading of legacy NBT. for filter as covers in particular, "FilterMode" is used for the filter cover mode, which conflicts with the smart item filter mode's NBT. oh and i also forgor to mark the cover as dirty on setting a stack in the simple item filter.

## Implementation Details
i used to rely on "FilterInventory" for checking if the incoming nbt was legacy, and sometimes calling both `deserializeNBT()` and `handleLegacyNBT()` at the same time. "IsBlacklist" is a better check because legacy NBT has it written outside of "Filter", whereas it is inside "Filter" currently.

## Outcome
legacy NBT is actually read correctly, and smart filter settings are saved.

## Additional Information
*i hate nbt*
