### PR TITLE
Add Missing Side Only Annotations

### DIFF
--- a/src/main/java/gregtech/api/recipes/recipeproperties/CleanroomProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/CleanroomProperty.java
@@ -4,6 +4,8 @@ import gregtech.api.metatileentity.multiblock.CleanroomType;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -25,6 +27,7 @@ public class CleanroomProperty extends RecipeProperty<CleanroomType> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(@NotNull Minecraft minecraft, int x, int y, int color, Object value) {
         CleanroomType type = castValue(value);
         if (type == null) return;

--- a/src/main/java/gregtech/api/recipes/recipeproperties/ComputationProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/ComputationProperty.java
@@ -2,6 +2,8 @@ package gregtech.api.recipes.recipeproperties;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ComputationProperty extends RecipeProperty<Integer> {
 
@@ -21,6 +23,7 @@ public class ComputationProperty extends RecipeProperty<Integer> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.computation_per_tick", castValue(value)), x, y,
                 color);

--- a/src/main/java/gregtech/api/recipes/recipeproperties/DefaultProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/DefaultProperty.java
@@ -2,6 +2,8 @@ package gregtech.api.recipes.recipeproperties;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class DefaultProperty<T> extends RecipeProperty<T> {
 
@@ -9,6 +11,7 @@ public class DefaultProperty<T> extends RecipeProperty<T> {
         super(key, type);
     }
 
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe." + getKey(),
                 castValue(value)), x, y, color);

--- a/src/main/java/gregtech/api/recipes/recipeproperties/DimensionProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/DimensionProperty.java
@@ -4,6 +4,8 @@ import gregtech.api.worldgen.config.WorldGenRegistry;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -26,6 +28,7 @@ public class DimensionProperty extends RecipeProperty<DimensionProperty.Dimensio
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         DimensionPropertyList list = castValue(value);
 

--- a/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/FusionEUToStartProperty.java
@@ -4,6 +4,8 @@ import gregtech.api.util.TextFormattingUtil;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,6 +34,7 @@ public class FusionEUToStartProperty extends RecipeProperty<Long> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.eu_to_start",
                 TextFormattingUtil.formatLongToCompactString(castValue(value))) + getFusionTierName(castValue(value)),

--- a/src/main/java/gregtech/api/recipes/recipeproperties/ImplosionExplosiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/ImplosionExplosiveProperty.java
@@ -3,6 +3,8 @@ package gregtech.api.recipes.recipeproperties;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ImplosionExplosiveProperty extends RecipeProperty<ItemStack> {
 
@@ -23,6 +25,7 @@ public class ImplosionExplosiveProperty extends RecipeProperty<ItemStack> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.explosive",
                 ((ItemStack) value).getDisplayName()), x, y, color);

--- a/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/PrimitiveProperty.java
@@ -1,6 +1,8 @@
 package gregtech.api.recipes.recipeproperties;
 
 import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 /**
  * Simple Marker Property to tell JEI to not display Total EU and EU/t.
@@ -22,6 +24,7 @@ public class PrimitiveProperty extends RecipeProperty<Boolean> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {}
 
     @Override

--- a/src/main/java/gregtech/api/recipes/recipeproperties/ResearchProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/ResearchProperty.java
@@ -2,6 +2,8 @@ package gregtech.api.recipes.recipeproperties;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -24,6 +26,7 @@ public final class ResearchProperty extends RecipeProperty<ResearchPropertyData>
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(@NotNull Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.research"), x, y, color);
     }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/ScanProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/ScanProperty.java
@@ -2,6 +2,8 @@ package gregtech.api.recipes.recipeproperties;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -24,6 +26,7 @@ public class ScanProperty extends RecipeProperty<Boolean> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.scan_for_research"), x, y, color);
     }

--- a/src/main/java/gregtech/api/recipes/recipeproperties/TemperatureProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/TemperatureProperty.java
@@ -4,6 +4,8 @@ import gregtech.api.unification.material.Material;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
@@ -31,6 +33,7 @@ public class TemperatureProperty extends RecipeProperty<Integer> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.temperature",
                 value, getMinTierForTemperature(castValue(value))), x, y, color);

--- a/src/main/java/gregtech/api/recipes/recipeproperties/TotalComputationProperty.java
+++ b/src/main/java/gregtech/api/recipes/recipeproperties/TotalComputationProperty.java
@@ -2,6 +2,8 @@ package gregtech.api.recipes.recipeproperties;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TotalComputationProperty extends RecipeProperty<Integer> {
 
@@ -21,6 +23,7 @@ public class TotalComputationProperty extends RecipeProperty<Integer> {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public void drawInfo(Minecraft minecraft, int x, int y, int color, Object value) {
         minecraft.fontRenderer.drawString(I18n.format("gregtech.recipe.total_computation", castValue(value)), x, y,
                 color);

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -42,6 +42,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.raytracer.IndexedCuboid6;
@@ -330,6 +332,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(CLIPBOARD_RENDERER.getParticleTexture(), 0xFFFFFF);
     }

--- a/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
+++ b/src/main/java/gregtech/common/metatileentities/converter/MetaTileEntityConverter.java
@@ -26,6 +26,8 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.raytracer.CuboidRayTraceResult;
 import codechicken.lib.render.CCRenderState;
@@ -155,6 +157,7 @@ public class MetaTileEntityConverter extends TieredMetaTileEntity {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[getTier()].getParticleSprite(), getPaintingColorForRendering());
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/centralmonitor/MetaTileEntityMonitorScreen.java
@@ -849,6 +849,7 @@ public class MetaTileEntityMonitorScreen extends MetaTileEntityMultiblockPart {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(null, -1);
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMultiblockPart.java
@@ -15,6 +15,8 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
@@ -40,6 +42,7 @@ public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(getBaseTexture().getParticleSprite(), getPaintingColorForRendering());
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityBuffer.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityBuffer.java
@@ -21,6 +21,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemStackHandler;
 
 import codechicken.lib.render.CCRenderState;
@@ -64,6 +66,7 @@ public class MetaTileEntityBuffer extends MetaTileEntity implements ITieredMetaT
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[tier].getParticleSprite(), this.getPaintingColorForRendering());
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -29,6 +29,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
@@ -78,6 +80,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements ILas
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[this.setTier].getParticleSprite(), this.getPaintingColorForRendering());
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -40,6 +40,8 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -118,6 +120,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[tier].getParticleSprite(), getPaintingColorForRendering());
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -52,6 +52,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import codechicken.lib.raytracer.CuboidRayTraceResult;
@@ -296,6 +298,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[tier].getParticleSprite(), getPaintingColorForRendering());
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -34,6 +34,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemStackHandler;
 
 import codechicken.lib.render.CCRenderState;
@@ -120,6 +122,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.CRAFTING_TABLE.getParticleSprite(), getDefaultPaintingColor());
     }

--- a/src/main/java/gregtech/common/pipelike/fluidpipe/longdistance/MetaTileEntityLDFluidEndpoint.java
+++ b/src/main/java/gregtech/common/pipelike/fluidpipe/longdistance/MetaTileEntityLDFluidEndpoint.java
@@ -20,6 +20,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.ColourMultiplier;
@@ -96,6 +98,7 @@ public class MetaTileEntityLDFluidEndpoint extends MetaTileEntityLongDistanceEnd
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[GTValues.LV].getParticleSprite(), 0xFFFFFF);
     }

--- a/src/main/java/gregtech/common/pipelike/itempipe/longdistance/MetaTileEntityLDItemEndpoint.java
+++ b/src/main/java/gregtech/common/pipelike/itempipe/longdistance/MetaTileEntityLDItemEndpoint.java
@@ -17,6 +17,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
@@ -97,6 +99,7 @@ public class MetaTileEntityLDItemEndpoint extends MetaTileEntityLongDistanceEndp
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
         return Pair.of(Textures.VOLTAGE_CASINGS[GTValues.LV].getParticleSprite(), 0xFFFFFF);
     }


### PR DESCRIPTION
## What
This PR adds missing SideOnly annotations to an overrided function of RecipeProperty and an overrided function of MetaTileEntity. This fixes GroovyScript Server crashes when calling classes which have this method not annotated as SideOnly (Such as MetaTileEntityDiode, or TemperatureProperty)

## Implementation Details
None

## Outcome
Fixes GrS Servers and Missing Annotations

## Additional Information
None

## Potential Compatibility Issues
None
