### PR TITLE
Change bloom layer to use mixin instead of enumHelper

### DIFF
--- a/src/main/java/gregtech/client/utils/BloomEffectUtil.java
+++ b/src/main/java/gregtech/client/utils/BloomEffectUtil.java
@@ -338,7 +338,7 @@ public class BloomEffectUtil {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static void init() {
-        bloom = EnumHelper.addEnum(BlockRenderLayer.class, "BLOOM", new Class[] { String.class }, "Bloom");
+        bloom = BlockRenderLayer.valueOf("BLOOM");
         BLOOM = bloom;
         if (Mods.Nothirium.isModLoaded()) {
             try {

--- a/src/main/java/gregtech/mixins/minecraft/BlockRenderLayerMixin.java
+++ b/src/main/java/gregtech/mixins/minecraft/BlockRenderLayerMixin.java
@@ -1,0 +1,31 @@
+package gregtech.mixins.minecraft;
+
+import net.minecraft.util.BlockRenderLayer;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(BlockRenderLayer.class)
+public class BlockRenderLayerMixin {
+
+    @Final
+    @Shadow
+    @Mutable
+    private static BlockRenderLayer[] $VALUES;
+
+    @SuppressWarnings("all")
+    @Invoker("<init>")
+    private static BlockRenderLayer create(String name, int ordinal, String directoryName) {
+        throw new IllegalStateException("Unreachable");
+    }
+
+    static {
+        BlockRenderLayer bloom = create("BLOOM", $VALUES.length, "Bloom");
+
+        $VALUES = ArrayUtils.add($VALUES, bloom);
+    }
+}

--- a/src/main/resources/mixins.gregtech.minecraft.json
+++ b/src/main/resources/mixins.gregtech.minecraft.json
@@ -9,6 +9,7 @@
   },
   "mixins": [
     "BlockConcretePowderMixin",
+    "BlockRenderLayerMixin",
     "DamageSourceMixin",
     "EnchantmentCanApplyMixin",
     "MinecraftMixin"


### PR DESCRIPTION
## What
As the title says.

## Implementation Details
Add a mixin targeting `BlockRenderLayer.class`, adding the bloom layer during initialization.

## Outcome
This fixes issues with EnumMaps, like https://github.com/embeddedt/VintageFix/issues/112 .

## Additional Information
I've also tried to get Nothirium patch using mixin, but I'm still waiting for auther's reply since it's gonna use some codes from Nothirium but it's ARR licenced.
For Vintagium I failed to get mixin work and idk why 😢 .

## Potential Compatibility Issues
None that I can think of?
