### PR TITLE
fix duplicate assembly line research entries

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -437,7 +437,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * @see GTRecipeHandler#removeAllRecipes(RecipeMap)
      */
     @ApiStatus.Internal
-    void removeAllRecipes() {
+    protected void removeAllRecipes() {
         if (GroovyScriptModule.isCurrentlyRunning()) {
             this.lookup.getRecipes(false).forEach(this.getGroovyScriptRecipeMap()::addBackup);
         }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -62,6 +62,12 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
     }
 
     @Override
+    protected void removeAllRecipes() {
+        super.removeAllRecipes();
+        researchEntries.clear();
+    }
+
+    @Override
     public void addDataStickEntry(@NotNull String researchId, @NotNull Recipe recipe) {
         if (researchId.contains("xmetaitem.")) {
             // save compatibility with an issue in 2.8.6, causing research IDs to change

--- a/src/main/java/gregtech/common/items/behaviors/DataItemBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/DataItemBehavior.java
@@ -6,11 +6,12 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.machines.IResearchRecipeMap;
 import gregtech.api.util.AssemblyLineManager;
+import gregtech.api.util.ItemStackHashStrategy;
 
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -41,7 +42,7 @@ public class DataItemBehavior implements IItemBehaviour, IDataItem {
                 .getDataStickEntry(researchId);
         if (recipes != null && !recipes.isEmpty()) {
             lines.add(I18n.format("behavior.data_item.assemblyline.title"));
-            Collection<ItemStack> added = new ObjectOpenHashSet<>();
+            Collection<ItemStack> added = new ObjectOpenCustomHashSet<>(ItemStackHashStrategy.comparingAllButCount());
             for (Recipe recipe : recipes) {
                 ItemStack output = recipe.getOutputs().get(0);
                 if (added.add(output)) {


### PR DESCRIPTION
## What
Fixes two scenarios where duplicate research entries would show on a data stick tooltip.

1. Calling `RecipeMap::removeAllRecipes` did not clear research entries, causing duplicates to appear for recipes added afterwards which used pre-existing `researchID`s.
2. Two recipes outputting the same item, but with different `researchID`s would show the same item twice on the tooltip, because no `ItemStackHashStrategy` was used.

## Outcome
Fixes duplicate research entries.