### PR TITLE
Fix MTE Initial Sync sending the wrong data

### DIFF
--- a/src/main/java/gregtech/api/block/machines/BlockMachine.java
+++ b/src/main/java/gregtech/api/block/machines/BlockMachine.java
@@ -296,12 +296,13 @@ public class BlockMachine extends BlockCustomParticle implements ITileEntityProv
                     removed.add(key);
                 }
                 removed.forEach(mteTag::removeTag);
-            } else {
-                sampleMetaTileEntity.initFromItemStackData(stackTag);
             }
         }
         MetaTileEntity metaTileEntity = holder.setMetaTileEntity(sampleMetaTileEntity, mteTag);
         if (mteTag == null) {
+            if (stackTag != null && !stackTag.isEmpty())
+                metaTileEntity.initFromItemStackData(stackTag);
+
             if (metaTileEntity.isValidFrontFacing(EnumFacing.UP)) {
                 metaTileEntity.setFrontFacing(EnumFacing.getDirectionFromEntityLiving(pos, placer));
             } else {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -89,9 +89,12 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IGre
      * Also can use certain data to preinit the block before data is synced
      */
     @Override
-    public MetaTileEntity setMetaTileEntity(MetaTileEntity sampleMetaTileEntity) {
+    public MetaTileEntity setMetaTileEntity(@NotNull MetaTileEntity sampleMetaTileEntity,
+                                            @Nullable NBTTagCompound tagCompound) {
         Preconditions.checkNotNull(sampleMetaTileEntity, "metaTileEntity");
         setRawMetaTileEntity(sampleMetaTileEntity.createMetaTileEntity(this));
+        if (tagCompound != null && !tagCompound.isEmpty())
+            getMetaTileEntity().readFromNBT(tagCompound);
         if (hasWorld() && !getWorld().isRemote) {
             updateBlockOpacity();
             writeCustomData(INITIALIZE_MTE, buffer -> {

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IGregTechTileEntity.java
@@ -3,6 +3,11 @@ package gregtech.api.metatileentity.interfaces;
 import gregtech.api.gui.IUIHolder;
 import gregtech.api.metatileentity.MetaTileEntity;
 
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * A simple compound Interface for all my TileEntities.
  * <p/>
@@ -13,7 +18,11 @@ public interface IGregTechTileEntity extends IHasWorldObjectAndCoords, INeighbor
 
     MetaTileEntity getMetaTileEntity();
 
-    MetaTileEntity setMetaTileEntity(MetaTileEntity metaTileEntity);
+    default MetaTileEntity setMetaTileEntity(MetaTileEntity metaTileEntity) {
+        return setMetaTileEntity(metaTileEntity, null);
+    }
+
+    MetaTileEntity setMetaTileEntity(@NotNull MetaTileEntity metaTileEntity, @Nullable NBTTagCompound tagCompound);
 
     long getOffsetTimer(); // todo might not keep this one
 


### PR DESCRIPTION
## What
Fixes a small issue when placing a block with NBT from creative mode's "ctrl + pick block". Originally, MTE initial sync is called within `MetaTileEntityHolder#setMetaTileEntity()` before the MTE is set with `readFromNBT()`, which gives the client incorrect info.
`MetaTileEntityHolder#setMetaTileEntity()` is moved after the mte tag is handled, and the method was overloaded to accept the tag for the MTE to read before syncing.

## Implementation Details
overload of method `MetaTileEntityHolder#setMetaTileEntity()` along with a default to maintain backwards compat

## Outcome
using ctrl + pick block to copy MTEs now sync the correct data to client on initial sync
