### PR TITLE
Display the maximum input and output rates, and average I/O in ATs.

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityActiveTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityActiveTransformer.java
@@ -178,8 +178,8 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
                         // Max input line
                         ITextComponent maxInputFormatted = TextComponentUtil.stringWithColor(
                                 TextFormatting.WHITE,
-                                TextFormattingUtil.formatNumbers(powerInput.getInputVoltage() * powerInput.getInputAmperage()) + " EU/t"
-                        );
+                                TextFormattingUtil.formatNumbers(
+                                        powerInput.getInputVoltage() * powerInput.getInputAmperage()) + " EU/t");
                         tl.add(TextComponentUtil.translationWithColor(
                                 TextFormatting.GREEN,
                                 "gregtech.multiblock.active_transformer.max_in",
@@ -188,8 +188,8 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
                         // Max output line
                         ITextComponent maxOutputFormatted = TextComponentUtil.stringWithColor(
                                 TextFormatting.WHITE,
-                                TextFormattingUtil.formatNumbers(powerOutput.getOutputVoltage() * powerOutput.getOutputAmperage()) + " EU/t"
-                        );
+                                TextFormattingUtil.formatNumbers(
+                                        powerOutput.getOutputVoltage() * powerOutput.getOutputAmperage()) + " EU/t");
                         tl.add(TextComponentUtil.translationWithColor(
                                 TextFormatting.RED,
                                 "gregtech.multiblock.active_transformer.max_out",
@@ -198,8 +198,7 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
                         // Average I/O line
                         ITextComponent avgInputFormatted = TextComponentUtil.stringWithColor(
                                 TextFormatting.WHITE,
-                                TextFormattingUtil.formatNumbers(averageIOLastSec) + " EU/t"
-                        );
+                                TextFormattingUtil.formatNumbers(averageIOLastSec) + " EU/t");
                         tl.add(TextComponentUtil.translationWithColor(
                                 TextFormatting.AQUA,
                                 "gregtech.multiblock.active_transformer.average_io",
@@ -300,5 +299,9 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
         tooltip.add(I18n.format("gregtech.machine.active_transformer.tooltip2"));
         tooltip.add(I18n.format("gregtech.machine.active_transformer.tooltip3") + TooltipHelper.RAINBOW_SLOW +
                 I18n.format("gregtech.machine.active_transformer.tooltip3.5"));
+    }
+
+    public long getAverageIOLastSec() {
+        return this.averageIOLastSec;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityActiveTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityActiveTransformer.java
@@ -15,6 +15,8 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.pattern.PatternMatchContext;
 import gregtech.api.pattern.TraceabilityPredicate;
+import gregtech.api.util.TextComponentUtil;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.Textures;
 import gregtech.client.utils.TooltipHelper;
@@ -30,6 +32,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
@@ -50,6 +53,8 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
     private IEnergyContainer powerOutput;
     private IEnergyContainer powerInput;
     private boolean isActive = false;
+    private long averageIOLastSec;
+    private long netIOLastSec;
 
     public MetaTileEntityActiveTransformer(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId);
@@ -64,10 +69,18 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
 
     @Override
     protected void updateFormedValid() {
-        if (isWorkingEnabled()) {
-            long canDrain = powerInput.getEnergyStored();
-            long totalDrained = powerOutput.changeEnergy(canDrain);
-            powerInput.removeEnergy(totalDrained);
+        if (!getWorld().isRemote) {
+            if ((getOffsetTimer() % 20) == 0) {
+                averageIOLastSec = netIOLastSec / 20;
+                netIOLastSec = 0;
+            }
+
+            if (isWorkingEnabled()) {
+                long canDrain = powerInput.getEnergyStored();
+                long totalDrained = powerOutput.changeEnergy(canDrain);
+                powerInput.removeEnergy(totalDrained);
+                netIOLastSec += totalDrained;
+            }
         }
     }
 
@@ -159,7 +172,40 @@ public class MetaTileEntityActiveTransformer extends MultiblockWithDisplayBase i
                         "gregtech.multiblock.idling",
                         "gregtech.multiblock.idling",
                         "gregtech.machine.active_transformer.routing")
-                .addWorkingStatusLine();
+                .addWorkingStatusLine()
+                .addCustom(tl -> {
+                    if (isStructureFormed()) {
+                        // Max input line
+                        ITextComponent maxInputFormatted = TextComponentUtil.stringWithColor(
+                                TextFormatting.WHITE,
+                                TextFormattingUtil.formatNumbers(powerInput.getInputVoltage() * powerInput.getInputAmperage()) + " EU/t"
+                        );
+                        tl.add(TextComponentUtil.translationWithColor(
+                                TextFormatting.GREEN,
+                                "gregtech.multiblock.active_transformer.max_in",
+                                maxInputFormatted));
+
+                        // Max output line
+                        ITextComponent maxOutputFormatted = TextComponentUtil.stringWithColor(
+                                TextFormatting.WHITE,
+                                TextFormattingUtil.formatNumbers(powerOutput.getOutputVoltage() * powerOutput.getOutputAmperage()) + " EU/t"
+                        );
+                        tl.add(TextComponentUtil.translationWithColor(
+                                TextFormatting.RED,
+                                "gregtech.multiblock.active_transformer.max_out",
+                                maxOutputFormatted));
+
+                        // Average I/O line
+                        ITextComponent avgInputFormatted = TextComponentUtil.stringWithColor(
+                                TextFormatting.WHITE,
+                                TextFormattingUtil.formatNumbers(averageIOLastSec) + " EU/t"
+                        );
+                        tl.add(TextComponentUtil.translationWithColor(
+                                TextFormatting.AQUA,
+                                "gregtech.multiblock.active_transformer.average_io",
+                                avgInputFormatted));
+                    }
+                });
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
+++ b/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
@@ -40,6 +40,7 @@ public class HWYLAModule extends IntegrationSubmodule implements IWailaPlugin {
         // one day, if cover provider is ported to waila, register it right here
         BlockOreDataProvider.INSTANCE.register(registrar);
         LampDataProvider.INSTANCE.register(registrar);
+        ActiveTransformerDataProvider.INSTANCE.register(registrar);
     }
 
     /** Render an ItemStack. */

--- a/src/main/java/gregtech/integration/hwyla/provider/ActiveTransformerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ActiveTransformerDataProvider.java
@@ -61,7 +61,8 @@ public class ActiveTransformerDataProvider extends CapabilityDataProvider<IMulti
             NBTTagCompound tag = accessor.getNBTData()
                     .getCompoundTag("gregtech.IMultiblockController.ActiveTransformer");
 
-            tooltip.add(I18n.format("gregtech.waila.active_transformer.average_io", TextFormattingUtil.formatNumbers(tag.getLong("AverageIO"))));
+            tooltip.add(I18n.format("gregtech.waila.active_transformer.average_io",
+                    TextFormattingUtil.formatNumbers(tag.getLong("AverageIO"))));
         }
 
         return tooltip;

--- a/src/main/java/gregtech/integration/hwyla/provider/ActiveTransformerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ActiveTransformerDataProvider.java
@@ -3,6 +3,7 @@ package gregtech.integration.hwyla.provider;
 import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IMultiblockController;
+import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityActiveTransformer;
 
 import net.minecraft.client.resources.I18n;
@@ -60,7 +61,7 @@ public class ActiveTransformerDataProvider extends CapabilityDataProvider<IMulti
             NBTTagCompound tag = accessor.getNBTData()
                     .getCompoundTag("gregtech.IMultiblockController.ActiveTransformer");
 
-            tooltip.add(I18n.format("gregtech.waila.active_transformer.average_io", tag.getLong("AverageIO")));
+            tooltip.add(I18n.format("gregtech.waila.active_transformer.average_io", TextFormattingUtil.formatNumbers(tag.getLong("AverageIO"))));
         }
 
         return tooltip;

--- a/src/main/java/gregtech/integration/hwyla/provider/ActiveTransformerDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/ActiveTransformerDataProvider.java
@@ -1,0 +1,68 @@
+package gregtech.integration.hwyla.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechCapabilities;
+import gregtech.api.capability.IMultiblockController;
+import gregtech.common.metatileentities.multi.electric.MetaTileEntityActiveTransformer;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.capabilities.Capability;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaRegistrar;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class ActiveTransformerDataProvider extends CapabilityDataProvider<IMultiblockController> {
+
+    public static final ActiveTransformerDataProvider INSTANCE = new ActiveTransformerDataProvider();
+
+    @Override
+    public void register(@NotNull IWailaRegistrar registrar) {
+        registrar.registerBodyProvider(this, TileEntity.class);
+        registrar.registerNBTProvider(this, TileEntity.class);
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.multiblock.activetransformer");
+    }
+
+    @Override
+    protected @NotNull Capability<IMultiblockController> getCapability() {
+        return GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER;
+    }
+
+    @Override
+    protected NBTTagCompound getNBTData(IMultiblockController capability, NBTTagCompound tag) {
+        if (capability instanceof MetaTileEntityActiveTransformer activeTransformer) {
+            if (activeTransformer.isStructureFormed() && activeTransformer.isActive()) {
+                NBTTagCompound subTag = new NBTTagCompound();
+
+                subTag.setLong("AverageIO", activeTransformer.getAverageIOLastSec());
+
+                tag.setTag("gregtech.IMultiblockController.ActiveTransformer", subTag);
+            }
+        }
+        return tag;
+    }
+
+    @Override
+    @NotNull
+    public List<String> getWailaBody(ItemStack itemStack, List<String> tooltip, IWailaDataAccessor accessor,
+                                     IWailaConfigHandler config) {
+        if (!config.getConfig("gregtech.multiblock") || accessor.getTileEntity() == null) {
+            return tooltip;
+        }
+
+        if (accessor.getNBTData().hasKey("gregtech.IMultiblockController.ActiveTransformer")) {
+            NBTTagCompound tag = accessor.getNBTData()
+                    .getCompoundTag("gregtech.IMultiblockController.ActiveTransformer");
+
+            tooltip.add(I18n.format("gregtech.waila.active_transformer.average_io", tag.getLong("AverageIO")));
+        }
+
+        return tooltip;
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
+++ b/src/main/java/gregtech/integration/theoneprobe/TheOneProbeModule.java
@@ -43,6 +43,7 @@ public class TheOneProbeModule extends IntegrationSubmodule {
         oneProbe.registerProvider(new LampInfoProvider());
         oneProbe.registerProvider(new LDPipeProvider());
         oneProbe.registerProvider(new LaserContainerInfoProvider());
+        oneProbe.registerProvider(new ActiveTransformerInfoProvider());
 
         // Dev environment debug providers
         oneProbe.registerProvider(new DebugPipeNetInfoProvider());

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
@@ -28,7 +28,7 @@ public class ActiveTransformerInfoProvider extends CapabilityInfoProvider<IMulti
 
     @Override
     protected boolean allowDisplaying(@NotNull IMultiblockController capability) {
-        return capability instanceof MetaTileEntityActiveTransformer;
+        return capability instanceof MetaTileEntityActiveTransformer activeTransformer && activeTransformer.isActive();
     }
 
     @Override
@@ -39,17 +39,15 @@ public class ActiveTransformerInfoProvider extends CapabilityInfoProvider<IMulti
     @Override
     protected void addProbeInfo(IMultiblockController capability, IProbeInfo probeInfo, EntityPlayer player,
                                 TileEntity tileEntity, IProbeHitData data) {
-        if (capability.isStructureFormed() && capability instanceof MetaTileEntityActiveTransformer activeTransformer &&
-                activeTransformer.isActive()) {
-            long averageIO = activeTransformer.getAverageIOLastSec();
-            ITextComponent text = TextComponentUtil.translationWithColor(
-                    TextFormatting.AQUA,
-                    "gregtech.multiblock.active_transformer.average_io",
-                    TextComponentUtil.stringWithColor(TextFormatting.WHITE,
-                            player.isSneaking() || averageIO < 10_000 ?
-                                    TextFormattingUtil.formatNumbers(averageIO) + " EU/t" :
-                                    ElementProgress.format(averageIO, NumberFormat.COMPACT, "EU/t")));
-            probeInfo.text(text.getFormattedText());
-        }
+        long averageIO = ((MetaTileEntityActiveTransformer) capability).getAverageIOLastSec();
+        ITextComponent text = TextComponentUtil.translationWithColor(
+                TextFormatting.AQUA,
+                "gregtech.multiblock.active_transformer.average_io",
+                TextComponentUtil.stringWithColor(TextFormatting.WHITE,
+                        player.isSneaking() || averageIO < 10_000 ?
+                                TextFormattingUtil.formatNumbers(averageIO) + " EU/t" :
+                                ElementProgress.format(averageIO, NumberFormat.COMPACT, "EU/t")));
+
+        probeInfo.text(text.getFormattedText());
     }
 }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
@@ -15,6 +15,8 @@ import net.minecraftforge.common.capabilities.Capability;
 
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.NumberFormat;
+import mcjty.theoneprobe.apiimpl.elements.ElementProgress;
 import org.jetbrains.annotations.NotNull;
 
 public class ActiveTransformerInfoProvider extends CapabilityInfoProvider<IMultiblockController> {
@@ -37,12 +39,17 @@ public class ActiveTransformerInfoProvider extends CapabilityInfoProvider<IMulti
     @Override
     protected void addProbeInfo(IMultiblockController capability, IProbeInfo probeInfo, EntityPlayer player,
                                 TileEntity tileEntity, IProbeHitData data) {
-        if (capability.isStructureFormed() && capability instanceof MetaTileEntityActiveTransformer activeTransformer) {
+        if (capability.isStructureFormed() && capability instanceof MetaTileEntityActiveTransformer activeTransformer &&
+                activeTransformer.isActive()) {
+            long averageIO = activeTransformer.getAverageIOLastSec();
             ITextComponent text = TextComponentUtil.translationWithColor(
                     TextFormatting.AQUA,
                     "gregtech.multiblock.active_transformer.average_io",
                     TextComponentUtil.stringWithColor(TextFormatting.WHITE,
-                            TextFormattingUtil.formatNumbers(activeTransformer.getAverageIOLastSec()) + " EU/t"));
+                            player.isSneaking() || averageIO < 10_000 ?
+                                    TextFormattingUtil.formatNumbers(
+                                            activeTransformer.getAverageIOLastSec()) + " EU/t" :
+                                    ElementProgress.format(averageIO, NumberFormat.COMPACT, "EU/t")));
             probeInfo.text(text.getFormattedText());
         }
     }

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
@@ -1,0 +1,49 @@
+package gregtech.integration.theoneprobe.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechCapabilities;
+import gregtech.api.capability.IMultiblockController;
+import gregtech.api.util.TextComponentUtil;
+import gregtech.api.util.TextFormattingUtil;
+import gregtech.common.metatileentities.multi.electric.MetaTileEntityActiveTransformer;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.common.capabilities.Capability;
+
+import mcjty.theoneprobe.api.IProbeHitData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import org.jetbrains.annotations.NotNull;
+
+public class ActiveTransformerInfoProvider extends CapabilityInfoProvider<IMultiblockController> {
+
+    @Override
+    public String getID() {
+        return GTValues.MODID + ":active_transformer_info_provider";
+    }
+
+    @Override
+    protected boolean allowDisplaying(@NotNull IMultiblockController capability) {
+        return capability instanceof MetaTileEntityActiveTransformer;
+    }
+
+    @Override
+    protected @NotNull Capability<IMultiblockController> getCapability() {
+        return GregtechCapabilities.CAPABILITY_MULTIBLOCK_CONTROLLER;
+    }
+
+    @Override
+    protected void addProbeInfo(IMultiblockController capability, IProbeInfo probeInfo, EntityPlayer player,
+                                TileEntity tileEntity, IProbeHitData data) {
+        if (capability.isStructureFormed() && capability instanceof MetaTileEntityActiveTransformer activeTransformer) {
+            ITextComponent text = TextComponentUtil.translationWithColor(
+                    TextFormatting.AQUA,
+                    "gregtech.multiblock.active_transformer.average_io",
+                    TextComponentUtil.stringWithColor(TextFormatting.WHITE,
+                            TextFormattingUtil.formatNumbers(activeTransformer.getAverageIOLastSec()) + " EU/t"));
+            probeInfo.text(text.getFormattedText());
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/ActiveTransformerInfoProvider.java
@@ -47,8 +47,7 @@ public class ActiveTransformerInfoProvider extends CapabilityInfoProvider<IMulti
                     "gregtech.multiblock.active_transformer.average_io",
                     TextComponentUtil.stringWithColor(TextFormatting.WHITE,
                             player.isSneaking() || averageIO < 10_000 ?
-                                    TextFormattingUtil.formatNumbers(
-                                            activeTransformer.getAverageIOLastSec()) + " EU/t" :
+                                    TextFormattingUtil.formatNumbers(averageIO) + " EU/t" :
                                     ElementProgress.format(averageIO, NumberFormat.COMPACT, "EU/t")));
             probeInfo.text(text.getFormattedText());
         }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5748,7 +5748,7 @@ gregtech.multiblock.power_substation.under_one_hour_left=Less than 1 hour until 
 
 gregtech.multiblock.active_transformer.max_in=Max Input: %s
 gregtech.multiblock.active_transformer.max_out=Max Output: %s
-gregtech.multiblock.active_transformer.average_io=Avg. EU I/O: %s
+gregtech.multiblock.active_transformer.average_io=Average I/O: %s
 
 gregtech.multiblock.data_bank.providing=Providing data.
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -124,6 +124,7 @@ gregtech.waila.progress_idle=Idle
 gregtech.waila.progress_tick=Progress: %d t / %d t
 gregtech.waila.progress_sec=Progress: %d s / %d s
 gregtech.waila.progress_computation=Computation: %s / %s
+gregtech.waila.active_transformer.average_io=Average I/O: %,d EU/t
 
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5746,6 +5746,10 @@ gregtech.multiblock.power_substation.time_years=%s Years
 gregtech.multiblock.power_substation.time_forever=Forever
 gregtech.multiblock.power_substation.under_one_hour_left=Less than 1 hour until fully drained!
 
+gregtech.multiblock.active_transformer.max_in=Max Input: %s
+gregtech.multiblock.active_transformer.max_out=Max Output: %s
+gregtech.multiblock.active_transformer.average_io=Avg. EU I/O: %s
+
 gregtech.multiblock.data_bank.providing=Providing data.
 
 gregtech.multiblock.hpca.computation=Providing: %s

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -124,7 +124,7 @@ gregtech.waila.progress_idle=Idle
 gregtech.waila.progress_tick=Progress: %d t / %d t
 gregtech.waila.progress_sec=Progress: %d s / %d s
 gregtech.waila.progress_computation=Computation: %s / %s
-gregtech.waila.active_transformer.average_io=Average I/O: %,d EU/t
+gregtech.waila.active_transformer.average_io=Average I/O: %d EU/t
 
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4880,6 +4880,9 @@ gregtech.machine.active_transformer.tooltip3=Can transmit power at incredible di
 gregtech.machine.active_transformer.tooltip3.5= Lasers§7.
 gregtech.multiblock.active_transformer.description=The Active Transformer is a multiblock structure that can accept any number or tier of Energy Hatches, and transform them into any number or tier of Dynamo Hatches. They can be chained with Laser Source and Target Hatches, allowing long distance power transportation without any losses. Lasers must be in a straight line, otherwise they will not send energy.
 gregtech.machine.active_transformer.routing=Routing.
+gregtech.multiblock.active_transformer.max_in=Max Input: %s
+gregtech.multiblock.active_transformer.max_out=Max Output: %s
+gregtech.multiblock.active_transformer.average_io=Average I/O: %s
 
 gregtech.machine.research_station.name=Research Station
 gregtech.machine.research_station.tooltip.1=More than just a Multiblock Scanner
@@ -5745,10 +5748,6 @@ gregtech.multiblock.power_substation.time_days=%s Days
 gregtech.multiblock.power_substation.time_years=%s Years
 gregtech.multiblock.power_substation.time_forever=Forever
 gregtech.multiblock.power_substation.under_one_hour_left=Less than 1 hour until fully drained!
-
-gregtech.multiblock.active_transformer.max_in=Max Input: %s
-gregtech.multiblock.active_transformer.max_out=Max Output: %s
-gregtech.multiblock.active_transformer.average_io=Average I/O: %s
 
 gregtech.multiblock.data_bank.providing=Providing data.
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -124,7 +124,7 @@ gregtech.waila.progress_idle=Idle
 gregtech.waila.progress_tick=Progress: %d t / %d t
 gregtech.waila.progress_sec=Progress: %d s / %d s
 gregtech.waila.progress_computation=Computation: %s / %s
-gregtech.waila.active_transformer.average_io=Average I/O: %d EU/t
+gregtech.waila.active_transformer.average_io=Average I/O: %s EU/t
 
 gregtech.multiblock.title=Multiblock Pattern
 gregtech.multiblock.primitive_blast_furnace.bronze.description=The Primitive Blast Furnace (PBF) is a multiblock structure used for cooking steel in the early game. Although not very fast, it will provide you with steel for your first setups.


### PR DESCRIPTION
## What
The Active Transformer GUI now shows the maximum combined input and output EU/t of its hatches.
It also shows the average transferred EU/t in the GUI and in TOP.

## Implementation Details
The update loop now checks if it's server side, which it didn't before. From my brief testing it doesn't change anything, but I'm not sure why it didn't before.

## Outcome
The player gets more information on their ATs.

## Additional Information
Main GUI
![image](https://github.com/user-attachments/assets/612240fa-a2d6-46c0-966e-1c2ddcc871e2)
TOP integration
![image](https://github.com/user-attachments/assets/2300843c-069b-4bf0-bfc1-bf4f0b7e7f5b)
Truncating with SI prefixes in TOP
![image](https://github.com/user-attachments/assets/bf9000aa-f249-4621-b1e7-3b8e1188fcb7)


## Potential Compatibility Issues
None that I know of.