### PR TITLE
Fix Stocking Buses running recipes while offline

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -45,6 +45,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
     private int meUpdateTick;
     protected boolean isOnline;
     private boolean allowExtraConnections;
+    protected boolean meStatusChanged = false;
 
     public MetaTileEntityAEHostablePart(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch,
                                         Class<? extends IStorageChannel<T>> storageChannel) {
@@ -158,6 +159,9 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
             if (this.isOnline != isOnline) {
                 writeCustomData(UPDATE_ONLINE_STATUS, buf -> buf.writeBoolean(isOnline));
                 this.isOnline = isOnline;
+                this.meStatusChanged = true;
+            } else {
+                this.meStatusChanged = false;
             }
         }
         return this.isOnline;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -68,6 +68,11 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
             refreshList();
             syncME();
         }
+
+        // Immediately Sync if the status changed, to prevent running recipes while offline
+        if (this.meStatusChanged && !this.isOnline) {
+            syncME();
+        }
     }
 
     // Update the visual display for the fake items. This also is important for the item handler's

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -69,9 +69,15 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
             syncME();
         }
 
-        // Immediately Sync if the status changed, to prevent running recipes while offline
+        // Immediately clear cached items if the status changed, to prevent running recipes while offline
         if (this.meStatusChanged && !this.isOnline) {
-            syncME();
+            if (autoPull) {
+                clearInventory(0);
+            } else {
+                for (int i = 0; i < CONFIG_SIZE; i++) {
+                    getAEItemHandler().getInventory()[i].setStack(null);
+                }
+            }
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -64,18 +64,20 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && isWorkingEnabled() && autoPull && getOffsetTimer() % 100 == 0) {
-            refreshList();
-            syncME();
-        }
+        if (!getWorld().isRemote) {
+            if (isWorkingEnabled() && autoPull && getOffsetTimer() % 100 == 0) {
+                refreshList();
+                syncME();
+            }
 
-        // Immediately clear cached items if the status changed, to prevent running recipes while offline
-        if (this.meStatusChanged && !this.isOnline) {
-            if (autoPull) {
-                clearInventory(0);
-            } else {
-                for (int i = 0; i < CONFIG_SIZE; i++) {
-                    getAEItemHandler().getInventory()[i].setStack(null);
+            // Immediately clear cached items if the status changed, to prevent running recipes while offline
+            if (this.meStatusChanged && !this.isOnline) {
+                if (autoPull) {
+                    clearInventory(0);
+                } else {
+                    for (int i = 0; i < CONFIG_SIZE; i++) {
+                        getAEItemHandler().getInventory()[i].setStack(null);
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -69,9 +69,16 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
             syncME();
         }
 
-        // Immediately Sync if the status changed, to prevent running recipes while offline
+        // Immediately clear cached fluids if the status changed, to prevent running recipes while offline
         if (this.meStatusChanged && !this.isOnline) {
-            syncME();
+            if (autoPull) {
+                this.getAEFluidHandler().clearConfig();
+            } else {
+                for (int i = 0; i < CONFIG_SIZE; i++) {
+                    getAEFluidHandler().getInventory()[i].setStack(null);
+                }
+
+            }
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -64,20 +64,21 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
     @Override
     public void update() {
         super.update();
-        if (!getWorld().isRemote && isWorkingEnabled() && autoPull && getOffsetTimer() % 100 == 0) {
-            refreshList();
-            syncME();
-        }
+        if (!getWorld().isRemote) {
+            if (isWorkingEnabled() && autoPull && getOffsetTimer() % 100 == 0) {
+                refreshList();
+                syncME();
+            }
 
-        // Immediately clear cached fluids if the status changed, to prevent running recipes while offline
-        if (this.meStatusChanged && !this.isOnline) {
-            if (autoPull) {
-                this.getAEFluidHandler().clearConfig();
-            } else {
-                for (int i = 0; i < CONFIG_SIZE; i++) {
-                    getAEFluidHandler().getInventory()[i].setStack(null);
+            // Immediately clear cached fluids if the status changed, to prevent running recipes while offline
+            if (this.meStatusChanged && !this.isOnline) {
+                if (autoPull) {
+                    this.getAEFluidHandler().clearConfig();
+                } else {
+                    for (int i = 0; i < CONFIG_SIZE; i++) {
+                        getAEFluidHandler().getInventory()[i].setStack(null);
+                    }
                 }
-
             }
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -68,6 +68,11 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
             refreshList();
             syncME();
         }
+
+        // Immediately Sync if the status changed, to prevent running recipes while offline
+        if (this.meStatusChanged && !this.isOnline) {
+            syncME();
+        }
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes Stocking buses/hatches running recipes while they are offline.

Closes #2559

## Implementation Details
Immediately resync the inventory if the online status of the network changes

## Outcome
Fixes Stocking buses being able to provide inputs to multiblocks while they are offline.
