### PR TITLE
Add OCing past MAX and fix multi Laser and Substation Hatch support

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -74,6 +74,14 @@ public class GTValues {
     public static final int[] VHA = { 7, 16, 60, 240, 960, 3840, 15360, 61440, 245760, 983040, 3932160, 15728640,
             62914560, 251658240, 1006632960 };
 
+    /**
+     * The Voltage Tiers extended all the way to max Long value for overclocking
+     */
+    public static final long[] VOC = { 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432,
+            134217728, 536870912, Integer.MAX_VALUE, 8589934592L, 34359738368L, 137438953472L, 549755813888L, 2199023255552L,
+            8796093022208L, 35184372088832L, 140737488355328L, 562949953421312L, 2251799813685248L, 9007199254740992L,
+            36028797018963968L, 144115188075855872L, 576460752303423488L, 2305843009213693952L, Long.MAX_VALUE};
+
     public static final int ULV = 0;
     public static final int LV = 1;
     public static final int MV = 2;
@@ -90,22 +98,28 @@ public class GTValues {
     public static final int UXV = 12;
     public static final int OpV = 13;
     public static final int MAX = 14;
+    public static final int MAX_TRUE = 30;
 
     /**
      * The short names for the voltages, used for registration primarily
      */
     public static final String[] VN = new String[] { "ULV", "LV", "MV", "HV", "EV", "IV", "LuV", "ZPM", "UV", "UHV",
-            "UEV", "UIV", "UXV", "OpV", "MAX" };
+            "UEV", "UIV", "UXV", "OpV", "MAX", "MAX+" };
 
     /**
      * The short names for the voltages, formatted for text
      */
+    public static final String MAX_PLUS = RED.toString() + BOLD + "M" + YELLOW + BOLD + "A" + GREEN + BOLD + "X" + AQUA + BOLD + "+" + LIGHT_PURPLE + BOLD;
     public static final String[] VNF = new String[] {
             DARK_GRAY + "ULV", GRAY + "LV", AQUA + "MV",
             GOLD + "HV", DARK_PURPLE + "EV", DARK_BLUE + "IV",
             LIGHT_PURPLE + "LuV", RED + "ZPM", DARK_AQUA + "UV",
             DARK_RED + "UHV", GREEN + "UEV", DARK_GREEN + "UIV",
-            YELLOW + "UXV", BLUE + "OpV", RED.toString() + BOLD + "MAX" };
+            YELLOW + "UXV", BLUE + "OpV", RED.toString() + BOLD + "MAX",
+            MAX_PLUS + "1", MAX_PLUS + "2", MAX_PLUS + "3", MAX_PLUS + "4",
+            MAX_PLUS + "5", MAX_PLUS + "6", MAX_PLUS + "7", MAX_PLUS + "8",
+            MAX_PLUS + "9", MAX_PLUS + "10", MAX_PLUS + "11", MAX_PLUS + "12",
+            MAX_PLUS + "13", MAX_PLUS + "14", MAX_PLUS + "15", MAX_PLUS + "16",};
 
     /**
      * Color values for the voltages

--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -78,9 +78,10 @@ public class GTValues {
      * The Voltage Tiers extended all the way to max Long value for overclocking
      */
     public static final long[] VOC = { 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432,
-            134217728, 536870912, Integer.MAX_VALUE, 8589934592L, 34359738368L, 137438953472L, 549755813888L, 2199023255552L,
+            134217728, 536870912, Integer.MAX_VALUE, 8589934592L, 34359738368L, 137438953472L, 549755813888L,
+            2199023255552L,
             8796093022208L, 35184372088832L, 140737488355328L, 562949953421312L, 2251799813685248L, 9007199254740992L,
-            36028797018963968L, 144115188075855872L, 576460752303423488L, 2305843009213693952L, Long.MAX_VALUE};
+            36028797018963968L, 144115188075855872L, 576460752303423488L, 2305843009213693952L, Long.MAX_VALUE };
 
     public static final int ULV = 0;
     public static final int LV = 1;
@@ -109,7 +110,8 @@ public class GTValues {
     /**
      * The short names for the voltages, formatted for text
      */
-    public static final String MAX_PLUS = RED.toString() + BOLD + "M" + YELLOW + BOLD + "A" + GREEN + BOLD + "X" + AQUA + BOLD + "+" + LIGHT_PURPLE + BOLD;
+    public static final String MAX_PLUS = RED.toString() + BOLD + "M" + YELLOW + BOLD + "A" + GREEN + BOLD + "X" +
+            AQUA + BOLD + "+" + LIGHT_PURPLE + BOLD;
     public static final String[] VNF = new String[] {
             DARK_GRAY + "ULV", GRAY + "LV", AQUA + "MV",
             GOLD + "HV", DARK_PURPLE + "EV", DARK_BLUE + "IV",
@@ -119,7 +121,7 @@ public class GTValues {
             MAX_PLUS + "1", MAX_PLUS + "2", MAX_PLUS + "3", MAX_PLUS + "4",
             MAX_PLUS + "5", MAX_PLUS + "6", MAX_PLUS + "7", MAX_PLUS + "8",
             MAX_PLUS + "9", MAX_PLUS + "10", MAX_PLUS + "11", MAX_PLUS + "12",
-            MAX_PLUS + "13", MAX_PLUS + "14", MAX_PLUS + "15", MAX_PLUS + "16",};
+            MAX_PLUS + "13", MAX_PLUS + "14", MAX_PLUS + "15", MAX_PLUS + "16", };
 
     /**
      * Color values for the voltages

--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -854,7 +854,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     protected int getNumberOfOCs(long recipeEUt) {
         if (!isAllowOverclocking()) return 0;
 
-        int recipeTier = GTUtility.getTierByVoltage(recipeEUt);
+        int recipeTier = GTUtility.getOCTierByVoltage(recipeEUt);
         int maximumTier = getOverclockForTier(getMaximumOverclockVoltage());
         if (maximumTier <= GTValues.LV) return 0;
 
@@ -911,7 +911,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
      * @return the highest voltage tier the machine should use to overclock with
      */
     protected int getOverclockForTier(long voltage) {
-        return GTUtility.getTierByVoltage(voltage);
+        return GTUtility.getOCTierByVoltage(voltage);
     }
 
     /**

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -331,7 +331,6 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                 // amperage is 1 when the energy is not exactly on a tier
 
                 // the voltage for recipe search is always on tier, so take the closest lower tier
-                //return GTValues.V[GTUtility.getFloorTierByVoltage(voltage)]; test
                 return GTValues.VOC[GTUtility.getFloorTierByVoltage(voltage)];
             } else {
                 // amperage != 1 means the voltage is exactly on a tier

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -331,7 +331,8 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                 // amperage is 1 when the energy is not exactly on a tier
 
                 // the voltage for recipe search is always on tier, so take the closest lower tier
-                return GTValues.V[GTUtility.getFloorTierByVoltage(voltage)];
+                //return GTValues.V[GTUtility.getFloorTierByVoltage(voltage)]; test
+                return GTValues.VOC[GTUtility.getFloorTierByVoltage(voltage)];
             } else {
                 // amperage != 1 means the voltage is exactly on a tier
                 // ignore amperage, since only the voltage is relevant for recipe search

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -420,7 +420,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
                 // The voltage for recipe search is always on tier, so take the closest lower tier.
                 // List check is done because single hatches will always be a "clean voltage," no need
                 // for any additional checks.
-                return GTValues.V[GTUtility.getFloorTierByVoltage(voltage)];
+                return GTValues.VOC[GTUtility.getFloorTierByVoltage(voltage)];
             }
             return voltage;
         } else {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/FuelMultiblockController.java
@@ -34,7 +34,10 @@ public abstract class FuelMultiblockController extends RecipeMapMultiblockContro
     @Override
     protected void initializeAbilities() {
         super.initializeAbilities();
-        this.energyContainer = new EnergyContainerList(getAbilities(MultiblockAbility.OUTPUT_ENERGY));
+        List<IEnergyContainer> outputEnergy = new ArrayList<>(getAbilities(MultiblockAbility.OUTPUT_ENERGY));
+        outputEnergy.addAll(getAbilities(MultiblockAbility.SUBSTATION_OUTPUT_ENERGY));
+        outputEnergy.addAll(getAbilities(MultiblockAbility.OUTPUT_LASER));
+        this.energyContainer = new EnergyContainerList(outputEnergy);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
@@ -138,7 +138,7 @@ public class MultiblockDisplayText {
                 String energyFormatted = TextFormattingUtil.formatNumbers(energyUsage);
                 // wrap in text component to keep it from being formatted
                 ITextComponent voltageName = new TextComponentString(
-                        GTValues.VNF[GTUtility.getTierByVoltage(energyUsage)]);
+                        GTValues.VNF[GTUtility.getOCTierByVoltage(energyUsage)]);
 
                 textList.add(TextComponentUtil.translationWithColor(
                         TextFormatting.GRAY,

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -124,7 +124,10 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
         this.outputInventory = new ItemHandlerList(getAbilities(MultiblockAbility.EXPORT_ITEMS));
         this.outputFluidInventory = new FluidTankList(allowSameFluidFillForOutputs(),
                 getAbilities(MultiblockAbility.EXPORT_FLUIDS));
-        this.energyContainer = new EnergyContainerList(getAbilities(MultiblockAbility.INPUT_ENERGY));
+
+        List<IEnergyContainer> inputEnergy = new ArrayList<>(getAbilities(MultiblockAbility.INPUT_ENERGY));
+        inputEnergy.addAll(getAbilities(MultiblockAbility.INPUT_LASER));
+        this.energyContainer = new EnergyContainerList(inputEnergy);
     }
 
     private void resetTileAbilities() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -126,6 +126,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 getAbilities(MultiblockAbility.EXPORT_FLUIDS));
 
         List<IEnergyContainer> inputEnergy = new ArrayList<>(getAbilities(MultiblockAbility.INPUT_ENERGY));
+        inputEnergy.addAll(getAbilities(MultiblockAbility.SUBSTATION_INPUT_ENERGY));
         inputEnergy.addAll(getAbilities(MultiblockAbility.INPUT_LASER));
         this.energyContainer = new EnergyContainerList(inputEnergy);
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -76,6 +76,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static gregtech.api.GTValues.V;
+import static gregtech.api.GTValues.VOC;
 
 public class GTUtility {
 
@@ -260,13 +261,23 @@ public class GTUtility {
     }
 
     /**
+     * @return Lowest tier of the voltage that can handle {@code voltage}, extended up to max long value; that is,
+     *         a voltage with value greater than equal than {@code voltage}. If there's no
+     *         tier that can handle it, {@code MAX_TRUE} is returned.
+     */
+    public static byte getOCTierByVoltage(long voltage) {
+        return (byte) Math.min(GTValues.MAX_TRUE, nearestLesser(VOC, voltage) + 1);
+    }
+
+    /**
      * Ex: This method turns both 1024 and 512 into HV.
      *
      * @return the highest voltage tier with value below or equal to {@code voltage}, or
      *         {@code ULV} if there's no tier below
      */
     public static byte getFloorTierByVoltage(long voltage) {
-        return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(V, voltage));
+        //return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(V, voltage)); test
+        return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(VOC, voltage));
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -276,7 +276,6 @@ public class GTUtility {
      *         {@code ULV} if there's no tier below
      */
     public static byte getFloorTierByVoltage(long voltage) {
-        // return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(V, voltage)); test
         return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(VOC, voltage));
     }
 

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -276,7 +276,7 @@ public class GTUtility {
      *         {@code ULV} if there's no tier below
      */
     public static byte getFloorTierByVoltage(long voltage) {
-        //return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(V, voltage)); test
+        // return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(V, voltage)); test
         return (byte) Math.max(GTValues.ULV, nearestLesserOrEqual(VOC, voltage));
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -635,7 +635,8 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
     @Override
     public int getEnergyTier() {
         if (energyContainer == null) return GTValues.LV;
-        return Math.max(GTValues.LV, GTUtility.getFloorTierByVoltage(energyContainer.getInputVoltage()));
+        return Math.min(GTValues.MAX,
+                Math.max(GTValues.LV, GTUtility.getFloorTierByVoltage(energyContainer.getInputVoltage())));
     }
 
     @Override

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -83,7 +83,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                 }
                 if (endText == null) {
                     endText = ": " + TextFormattingUtil.formatNumbers(eut) + TextFormatting.RESET + " EU/t (" +
-                            GTValues.VNF[GTUtility.getTierByVoltage(eut)] + TextFormatting.RESET + ")";
+                            GTValues.VNF[GTUtility.getOCTierByVoltage(eut)] + TextFormatting.RESET + ")";
                 }
 
                 if (eut == 0) return tooltip;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -63,7 +63,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 // IGregTechTileEntity...)
                 text = TextFormatting.RED + TextFormattingUtil.formatNumbers(eut) + TextStyleClass.INFO +
                         " EU/t" + TextFormatting.GREEN +
-                        " (" + GTValues.VNF[GTUtility.getTierByVoltage(eut)] + TextFormatting.GREEN + ")";
+                        " (" + GTValues.VNF[GTUtility.getOCTierByVoltage(eut)] + TextFormatting.GREEN + ")";
             }
 
             if (eut == 0) return; // do not display 0 eut

--- a/src/test/java/gregtech/api/util/TierByVoltageTest.java
+++ b/src/test/java/gregtech/api/util/TierByVoltageTest.java
@@ -127,7 +127,7 @@ public class TierByVoltageTest {
         expectTier(0L, ULV, ULV);
         expectTier(2L, ULV, ULV);
         expectTier(Integer.MAX_VALUE + 1L, MAX, MAX);
-        expectTier(Long.MAX_VALUE, MAX, MAX);
+        expectTier(Long.MAX_VALUE, MAX, MAX_TRUE);
         expectTier(-1L, ULV, ULV);
     }
 


### PR DESCRIPTION
## What
In base CEu, there was never a need for machines to be able to overclock beyond MAX voltage, nor was there a need for multiblocks with SUBSTATION_INPUT_ENERGY or INPUT_LASER to actually be able to perform recipes using the power in those hatches. However, addons wishing to extend the game and add new content often want both of those things.

## Outcome
Base CEu is not impacted at all. In any addon that adds any way to give a machine >MAX voltage, those machines will now be able to overclock further. In any addon that adds multiblocks that have SUBSTATION_INPUT_ENERGY or INPUT_LASER, those machines will now be able to use the power in those hatches to perform recipes.

## Additional Information
![image](https://github.com/user-attachments/assets/395904f8-444b-4a45-82f8-b4aa5aef579c)
For tier names and colors above max, I used "MAX+X" with these 5 colors. This is impossible to see in base CEu (for this screenshot, I had temporarily allowed the EBF to accept Laser Target Hatches.)

The reason these two changes are bundled together is because I found out that multiblock INPUT_LASER support was broken while I was trying to test OCing past MAX.
