### PR TITLE
move MAX+ tiers into VOCN and VOCNF arrays

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -105,14 +105,33 @@ public class GTValues {
      * The short names for the voltages, used for registration primarily
      */
     public static final String[] VN = new String[] { "ULV", "LV", "MV", "HV", "EV", "IV", "LuV", "ZPM", "UV", "UHV",
-            "UEV", "UIV", "UXV", "OpV", "MAX", "MAX+" };
+            "UEV", "UIV", "UXV", "OpV", "MAX" };
+
+    /**
+     * The short names for the voltages, up to max Long, used for registration primarily
+     */
+    public static final String[] VOCN = new String[] { "ULV", "LV", "MV", "HV", "EV", "IV", "LuV", "ZPM", "UV", "UHV",
+            "UEV", "UIV", "UXV", "OpV", "MAX", "MAX+1", "MAX+2", "MAX+3", "MAX+4", "MAX+5", "MAX+6", "MAX+7", "MAX+8",
+            "MAX+9", "MAX+10", "MAX+11", "MAX+12", "MAX+13", "MAX+14", "MAX+15", "MAX+16",
+    };
+
+    private static final String MAX_PLUS = RED.toString() + BOLD + "M" + YELLOW + BOLD + "A" + GREEN + BOLD + "X" +
+            AQUA + BOLD + "+" + LIGHT_PURPLE + BOLD;
 
     /**
      * The short names for the voltages, formatted for text
      */
-    public static final String MAX_PLUS = RED.toString() + BOLD + "M" + YELLOW + BOLD + "A" + GREEN + BOLD + "X" +
-            AQUA + BOLD + "+" + LIGHT_PURPLE + BOLD;
     public static final String[] VNF = new String[] {
+            DARK_GRAY + "ULV", GRAY + "LV", AQUA + "MV",
+            GOLD + "HV", DARK_PURPLE + "EV", DARK_BLUE + "IV",
+            LIGHT_PURPLE + "LuV", RED + "ZPM", DARK_AQUA + "UV",
+            DARK_RED + "UHV", GREEN + "UEV", DARK_GREEN + "UIV",
+            YELLOW + "UXV", BLUE + "OpV", RED.toString() + BOLD + "MAX" };
+
+    /**
+     * The short names for the voltages, up to max Long, formatted for text
+     */
+    public static final String[] VOCNF = new String[] {
             DARK_GRAY + "ULV", GRAY + "LV", AQUA + "MV",
             GOLD + "HV", DARK_PURPLE + "EV", DARK_BLUE + "IV",
             LIGHT_PURPLE + "LuV", RED + "ZPM", DARK_AQUA + "UV",

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
@@ -93,7 +93,7 @@ public class MultiblockDisplayText {
                 String energyFormatted = TextFormattingUtil.formatNumbers(maxVoltage);
                 // wrap in text component to keep it from being formatted
                 ITextComponent voltageName = new TextComponentString(
-                        GTValues.VNF[GTUtility.getFloorTierByVoltage(maxVoltage)]);
+                        GTValues.VOCNF[GTUtility.getFloorTierByVoltage(maxVoltage)]);
 
                 ITextComponent bodyText = TextComponentUtil.translationWithColor(
                         TextFormatting.GRAY,
@@ -138,7 +138,7 @@ public class MultiblockDisplayText {
                 String energyFormatted = TextFormattingUtil.formatNumbers(energyUsage);
                 // wrap in text component to keep it from being formatted
                 ITextComponent voltageName = new TextComponentString(
-                        GTValues.VNF[GTUtility.getOCTierByVoltage(energyUsage)]);
+                        GTValues.VOCNF[GTUtility.getOCTierByVoltage(energyUsage)]);
 
                 textList.add(TextComponentUtil.translationWithColor(
                         TextFormatting.GRAY,
@@ -159,7 +159,7 @@ public class MultiblockDisplayText {
                 String energyFormatted = TextFormattingUtil.formatNumbers(maxVoltage);
                 // wrap in text component to keep it from being formatted
                 ITextComponent voltageName = new TextComponentString(
-                        GTValues.VNF[GTUtility.getFloorTierByVoltage(maxVoltage)]);
+                        GTValues.VOCNF[GTUtility.getFloorTierByVoltage(maxVoltage)]);
 
                 textList.add(TextComponentUtil.translationWithColor(
                         TextFormatting.GRAY,
@@ -182,7 +182,7 @@ public class MultiblockDisplayText {
                 String energyFormatted = TextFormattingUtil.formatNumbers(maxVoltage);
                 // wrap in text component to keep it from being formatted
                 ITextComponent voltageName = new TextComponentString(
-                        GTValues.VNF[GTUtility.getFloorTierByVoltage(maxVoltage)]);
+                        GTValues.VOCNF[GTUtility.getFloorTierByVoltage(maxVoltage)]);
 
                 textList.add(TextComponentUtil.translationWithColor(
                         TextFormatting.GRAY,

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeEnergy.java
@@ -146,7 +146,7 @@ public class MetaTileEntityCreativeEnergy extends MetaTileEntity implements ILas
             } else {
                 voltage = V[MAX];
                 amps = Integer.MAX_VALUE;
-                setTier = 14;
+                setTier = MAX;
             }
         }, "gregtech.creative.energy.sink", "gregtech.creative.energy.source"));
 

--- a/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/RecipeLogicDataProvider.java
@@ -83,7 +83,7 @@ public class RecipeLogicDataProvider extends CapabilityDataProvider<AbstractReci
                 }
                 if (endText == null) {
                     endText = ": " + TextFormattingUtil.formatNumbers(eut) + TextFormatting.RESET + " EU/t (" +
-                            GTValues.VNF[GTUtility.getOCTierByVoltage(eut)] + TextFormatting.RESET + ")";
+                            GTValues.VOCNF[GTUtility.getOCTierByVoltage(eut)] + TextFormatting.RESET + ")";
                 }
 
                 if (eut == 0) return tooltip;

--- a/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/RecipeLogicInfoProvider.java
@@ -63,7 +63,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<AbstractReci
                 // IGregTechTileEntity...)
                 text = TextFormatting.RED + TextFormattingUtil.formatNumbers(eut) + TextStyleClass.INFO +
                         " EU/t" + TextFormatting.GREEN +
-                        " (" + GTValues.VNF[GTUtility.getOCTierByVoltage(eut)] + TextFormatting.GREEN + ")";
+                        " (" + GTValues.VOCNF[GTUtility.getOCTierByVoltage(eut)] + TextFormatting.GREEN + ")";
             }
 
             if (eut == 0) return; // do not display 0 eut


### PR DESCRIPTION
## What
Moves the MAX+ tiers into two new arrays; `VOCN` and `VOCNF`. This preserves compat with some existing implementations relying on `VNF` being the same length as `V`, namely the creative energy generator (which would previously crash because of this).
