### PR TITLE
Add a config option for the magnet's attraction delay

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -35,7 +35,6 @@ public class ConfigHolder {
     // TODO move to ToolsModule config
     @Config.Comment("Config options for Tools and Armor")
     @Config.Name("Tool and Armor Options")
-    @Config.RequiresMcRestart
     public static ToolOptions tools = new ToolOptions();
 
     @Config.Comment("Config options for World Generation features")
@@ -641,34 +640,42 @@ public class ConfigHolder {
 
     public static class ToolOptions {
 
+        @Config.RequiresMcRestart
         @Config.Name("NanoSaber Options")
         public NanoSaber nanoSaber = new NanoSaber();
 
+        @Config.RequiresMcRestart
         @Config.Comment("NightVision Goggles Voltage Tier. Default: 1 (LV)")
         @Config.RangeInt(min = 0, max = 14)
         public int voltageTierNightVision = 1;
 
+        @Config.RequiresMcRestart
         @Config.Comment("NanoSuit Voltage Tier. Default: 3 (HV)")
         @Config.RangeInt(min = 0, max = 14)
         public int voltageTierNanoSuit = 3;
 
+        @Config.RequiresMcRestart
         @Config.Comment({ "Advanced NanoSuit Chestplate Voltage Tier.", "Default: 3 (HV)" })
         @Config.RangeInt(min = 0, max = 14)
         public int voltageTierAdvNanoSuit = 3;
 
+        @Config.RequiresMcRestart
         @Config.Comment({ "QuarkTech Suit Voltage Tier.", "Default: 5 (IV)" })
         @Config.RangeInt(min = 0, max = 14)
         @Config.SlidingOption
         public int voltageTierQuarkTech = 5;
 
+        @Config.RequiresMcRestart
         @Config.Comment({ "Advanced QuarkTech Suit Chestplate Voltage Tier.", "Default: 5 (LuV)" })
         @Config.RangeInt(min = 0, max = 14)
         public int voltageTierAdvQuarkTech = 6;
 
+        @Config.RequiresMcRestart
         @Config.Comment({ "Electric Impeller Jetpack Voltage Tier.", "Default: 2 (MV)" })
         @Config.RangeInt(min = 0, max = 14)
         public int voltageTierImpeller = 2;
 
+        @Config.RequiresMcRestart
         @Config.Comment({ "Advanced Electric Jetpack Voltage Tier.", "Default: 3 (HV)" })
         @Config.RangeInt(min = 0, max = 14)
         public int voltageTierAdvImpeller = 3;
@@ -680,6 +687,11 @@ public class ConfigHolder {
 
         @Config.Comment("Armor HUD Location")
         public ArmorHud armorHud = new ArmorHud();
+
+        @Config.Comment({ "How often items should be moved by a magnet", "Default: 10 ticks" })
+        @Config.RangeInt(min = 1, max = 100)
+        @Config.SlidingOption
+        public int magnetDelay = 10;
     }
 
     public static class ArmorHud {

--- a/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/ItemMagnetBehavior.java
@@ -6,6 +6,7 @@ import gregtech.api.capability.IElectricItem;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
 import gregtech.api.util.Mods;
+import gregtech.common.ConfigHolder;
 import gregtech.integration.baubles.BaublesModule;
 
 import net.minecraft.client.resources.I18n;
@@ -81,7 +82,7 @@ public class ItemMagnetBehavior implements IItemBehaviour {
     public void onUpdate(ItemStack stack, Entity entity) {
         // Adapted logic from Draconic Evolution
         // https://github.com/Draconic-Inc/Draconic-Evolution/blob/1.12.2/src/main/java/com/brandon3055/draconicevolution/items/tools/Magnet.java
-        if (!entity.isSneaking() && entity.ticksExisted % 10 == 0 && isActive(stack) &&
+        if (!entity.isSneaking() && entity.ticksExisted % ConfigHolder.tools.magnetDelay == 0 && isActive(stack) &&
                 entity instanceof EntityPlayer player) {
             World world = entity.getEntityWorld();
             if (!drainEnergy(true, stack, energyDraw)) {


### PR DESCRIPTION
## What
Adds a config option so that the 10 tick delay between magnet pickups isn't hard coded. Additionally makes the electric damage chance give the warning about needing a game restart.

## Implementation Details
I removed `@Config.RequiresMcRestart` from applying to all ToolOptions and reapplied them under each option individually. I did a little testing to check if the configs actually needed a restart (most did) so the overall behavior shouldn't change.

## Outcome
Faster magnets :smiley: 

## Potential Compatibility Issues
None that I know of