### PR TITLE
Port the GT5u ME hatch wirecutter behavior

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -584,6 +584,9 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
         if (toolClasses.contains(ToolClasses.HARD_HAMMER)) {
             return onHardHammerClick(playerIn, hand, gridSideHit, hitResult);
         }
+        if (toolClasses.contains(ToolClasses.WIRE_CUTTER)) {
+            return onWireCutterClick(playerIn, hand, gridSideHit, hitResult);
+        }
         return false;
     }
 
@@ -662,6 +665,16 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
                     "gregtech.machine.muffle.on" : "gregtech.machine.muffle.off"), true);
         }
         return true;
+    }
+
+    /**
+     * Called when player clicks a wire cutter on specific side of this meta tile entity
+     *
+     * @return true if something happened, so the tool will get damaged and animation will be played
+     */
+    public boolean onWireCutterClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing,
+                                     CuboidRayTraceResult hitResult) {
+        return false;
     }
 
     public void onLeftClick(EntityPlayer player, EnumFacing facing, CuboidRayTraceResult hitResult) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -232,8 +232,9 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound data) {
+        super.writeToNBT(data);
         data.setBoolean("AllowExtraConnections", this.allowExtraConnections);
-        return super.writeToNBT(data);
+        return data;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityAEHostablePart.java
@@ -4,11 +4,14 @@ import gregtech.api.capability.IControllable;
 import gregtech.common.ConfigHolder;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockNotifiablePart;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentTranslation;
 
 import appeng.api.AEApi;
 import appeng.api.networking.GridFlags;
@@ -24,6 +27,7 @@ import appeng.me.helpers.AENetworkProxy;
 import appeng.me.helpers.BaseActionSource;
 import appeng.me.helpers.IGridProxyable;
 import appeng.me.helpers.MachineSource;
+import codechicken.lib.raytracer.CuboidRayTraceResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,12 +44,14 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
     private AENetworkProxy aeProxy;
     private int meUpdateTick;
     protected boolean isOnline;
+    private boolean allowExtraConnections;
 
     public MetaTileEntityAEHostablePart(ResourceLocation metaTileEntityId, int tier, boolean isExportHatch,
                                         Class<? extends IStorageChannel<T>> storageChannel) {
         super(metaTileEntityId, tier, isExportHatch);
         this.meUpdateTick = 0;
         this.storageChannel = storageChannel;
+        this.allowExtraConnections = false;
     }
 
     @Override
@@ -76,6 +82,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
         }
         buf.writeInt(this.meUpdateTick);
         buf.writeBoolean(this.isOnline);
+        buf.writeBoolean(this.allowExtraConnections);
     }
 
     @Override
@@ -95,6 +102,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
         }
         this.meUpdateTick = buf.readInt();
         this.isOnline = buf.readBoolean();
+        this.allowExtraConnections = buf.readBoolean();
     }
 
     @Override
@@ -112,7 +120,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
     @NotNull
     @Override
     public AECableType getCableConnectionType(@NotNull AEPartLocation part) {
-        if (part.getFacing() != this.frontFacing) {
+        if (part.getFacing() != this.frontFacing && !this.allowExtraConnections) {
             return AECableType.NONE;
         }
         return AECableType.SMART;
@@ -133,9 +141,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
     @Override
     public void setFrontFacing(EnumFacing frontFacing) {
         super.setFrontFacing(frontFacing);
-        if (this.aeProxy != null) {
-            this.aeProxy.setValidSides(EnumSet.of(this.getFrontFacing()));
-        }
+        updateConnectableSides();
     }
 
     @Override
@@ -174,7 +180,7 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
             AENetworkProxy proxy = new AENetworkProxy(holder, "mte_proxy", this.getStackForm(), true);
             proxy.setFlags(GridFlags.REQUIRE_CHANNEL);
             proxy.setIdlePowerUsage(ConfigHolder.compat.ae2.meHatchEnergyUsage);
-            proxy.setValidSides(EnumSet.of(this.getFrontFacing()));
+            proxy.setValidSides(getConnectableSides());
             return proxy;
         }
         return null;
@@ -197,5 +203,42 @@ public abstract class MetaTileEntityAEHostablePart<T extends IAEStack<T>> extend
         } catch (GridAccessException ignored) {
             return null;
         }
+    }
+
+    public EnumSet<EnumFacing> getConnectableSides() {
+        return this.allowExtraConnections ? EnumSet.allOf(EnumFacing.class) : EnumSet.of(getFrontFacing());
+    }
+
+    public void updateConnectableSides() {
+        if (this.aeProxy != null) {
+            this.aeProxy.setValidSides(getConnectableSides());
+        }
+    }
+
+    @Override
+    public boolean onWireCutterClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing,
+                                     CuboidRayTraceResult hitResult) {
+        this.allowExtraConnections = !this.allowExtraConnections;
+        updateConnectableSides();
+
+        if (!getWorld().isRemote) {
+            playerIn.sendStatusMessage(new TextComponentTranslation(this.allowExtraConnections ?
+                    "gregtech.machine.me.extra_connections.enabled" : "gregtech.machine.me.extra_connections.disabled"),
+                    true);
+        }
+
+        return true;
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound data) {
+        data.setBoolean("AllowExtraConnections", this.allowExtraConnections);
+        return super.writeToNBT(data);
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound data) {
+        super.readFromNBT(data);
+        this.allowExtraConnections = data.getBoolean("AllowExtraConnections");
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputBus.java
@@ -320,6 +320,7 @@ public class MetaTileEntityMEInputBus extends MetaTileEntityAEHostablePart<IAEIt
         tooltip.add(I18n.format("gregtech.machine.me.item_import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me_import_item_hatch.configs.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
+        tooltip.add(I18n.format("gregtech.machine.me.extra_connections.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEInputHatch.java
@@ -260,6 +260,7 @@ public class MetaTileEntityMEInputHatch extends MetaTileEntityAEHostablePart<IAE
         tooltip.add(I18n.format("gregtech.machine.me.fluid_import.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me_import_fluid_hatch.configs.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
+        tooltip.add(I18n.format("gregtech.machine.me.extra_connections.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputBus.java
@@ -186,6 +186,7 @@ public class MetaTileEntityMEOutputBus extends MetaTileEntityAEHostablePart<IAEI
         tooltip.add(I18n.format("gregtech.machine.item_bus.export.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.item_export.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.item_export.tooltip.2"));
+        tooltip.add(I18n.format("gregtech.machine.me.extra_connections.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEOutputHatch.java
@@ -188,6 +188,7 @@ public class MetaTileEntityMEOutputHatch extends MetaTileEntityAEHostablePart<IA
         tooltip.add(I18n.format("gregtech.machine.fluid_hatch.export.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.fluid_export.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.fluid_export.tooltip.2"));
+        tooltip.add(I18n.format("gregtech.machine.me.extra_connections.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -360,6 +360,7 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
         tooltip.add(I18n.format("gregtech.machine.me_import_item_hatch.configs.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.stocking_item.tooltip.2"));
+        tooltip.add(I18n.format("gregtech.machine.me.extra_connections.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -265,6 +265,7 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
         tooltip.add(I18n.format("gregtech.machine.me_import_fluid_hatch.configs.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.copy_paste.tooltip"));
         tooltip.add(I18n.format("gregtech.machine.me.stocking_fluid.tooltip.2"));
+        tooltip.add(I18n.format("gregtech.machine.me.extra_connections.tooltip"));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5333,6 +5333,8 @@ gregtech.machine.me.import_copy_settings=Saved settings to Data Stick
 gregtech.machine.me.import_paste_settings=Applied settings from Data Stick
 gregtech.machine.me.item_import.data_stick.name=§oME Input Bus Configuration Data
 gregtech.machine.me.fluid_import.data_stick.name=§oME Input Hatch Configuration Data
+gregtech.machine.me.extra_connections.enabled=Allow connections from all sides
+gregtech.machine.me.extra_connections.disabled=Allow connection only on front face
 
 # Universal tooltips
 gregtech.universal.tooltip.voltage_in=§aVoltage IN: §f%,d EU/t (%s§f)

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5335,6 +5335,7 @@ gregtech.machine.me.item_import.data_stick.name=§oME Input Bus Configuration Da
 gregtech.machine.me.fluid_import.data_stick.name=§oME Input Hatch Configuration Data
 gregtech.machine.me.extra_connections.enabled=Allow connections from all sides
 gregtech.machine.me.extra_connections.disabled=Allow connection only on front face
+gregtech.machine.me.extra_connections.tooltip=Right-click with wire cutters to allow connecting to AE2 on all sides
 
 # Universal tooltips
 gregtech.universal.tooltip.voltage_in=§aVoltage IN: §f%,d EU/t (%s§f)


### PR DESCRIPTION
## What
Ports the ME part's wirecutter behavior from GT5u, where it would allow you to have AE2 connections from any side instead of only the front face.

## Outcome
You can chain ME parts together to maybe have cleaner wiring.

## Additional Information
Should this be copied by data sticks? I'm leaning towards no but it's easy to implement.

They also only pass through 8 channels, and I'm not sure how to change that (should they pass 32 like a dense cable?).