### PR TITLE
Fix Cover Transfers Between Non-Tickable and Tickable Pipes

### DIFF
--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -67,7 +67,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
         if (tileEntity instanceof SyncedTileEntityBase pipeBase) {
             addPacketsFrom(pipeBase);
         }
-        coverableImplementation.transferDataTo(tileEntity.getCoverableImplementation());
+        tileEntity.getCoverableImplementation().transferDataTo(coverableImplementation);
         setFrameMaterial(tileEntity.getFrameMaterial());
     }
 


### PR DESCRIPTION
## What
This PR fixes cover transfers between non-tickable and tickable pipes, actually transferring the covers. The old implementation would simply clear the old cover impl.

## Implementation Details
None

## Outcome
Fixes disappearing covers on item pipes.

Fixes https://github.com/GregTechCEu/GregTech/issues/2564
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/987

## Additional Information
None

## Potential Compatibility Issues
None
