### PR TITLE
fix recipes having null cleanrooms

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -129,10 +129,9 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     }
 
     public R cleanroom(@Nullable CleanroomType cleanroom) {
-        if (!ConfigHolder.machines.enableCleanroom) {
-            return (R) this;
+        if (ConfigHolder.machines.enableCleanroom && cleanroom != null) {
+            this.applyProperty(CleanroomProperty.getInstance(), cleanroom);
         }
-        this.applyProperty(CleanroomProperty.getInstance(), cleanroom);
         return (R) this;
     }
 


### PR DESCRIPTION
## What
Fixes a bug introduced in #2607, where a null cleanroom property would be stored in recipes.

This happened when the chemical reactor copied its recipes to the LCR, calling `.cleanroom(builder.getCleanroom())` which passed a null cleanroom, and then applied and stored the null value in the LCR's recipe.

## Outcome
Fixes crash when caused by null cleanroom recipe property entries.
