### PR TITLE
fix tierByVoltage MAX tier off by one

### DIFF
--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -254,7 +254,7 @@ public class GTUtility {
      *         tier that can handle it, {@code MAX} is returned.
      */
     public static byte getTierByVoltage(long voltage) {
-        if (voltage >= Integer.MAX_VALUE) {
+        if (voltage >= GTValues.V[GTValues.MAX]) {
             return GTValues.MAX;
         }
         return getOCTierByVoltage(voltage);


### PR DESCRIPTION
## What
Fixes an off by one error introduced in #2617. `MAX` is now `1 << 31` instead of `(1 << 31) - 1`, which means `Integer.MAX_VALUE` no longer indicates `MAX` tier.