### PR TITLE
Update PropertyContainer.java

### DIFF
--- a/src/main/java/gregtech/integration/groovy/PropertyContainer.java
+++ b/src/main/java/gregtech/integration/groovy/PropertyContainer.java
@@ -42,6 +42,6 @@ public class PropertyContainer extends GroovyPropertyContainer {
     }
 
     public void lateMaterialEvent(Closure<?> eventListener) {
-        materialEvent(EventPriority.NORMAL, eventListener);
+        lateMaterialEvent(EventPriority.NORMAL, eventListener);
     }
 }


### PR DESCRIPTION
some minor bugfix, lateMaterialEvent in groovy actually calls materialEvent, which cause unable to iterate through the material system