### PR TITLE
Add block recipes for materials that has only dust and block

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/MaterialRecipeHandler.java
@@ -160,6 +160,11 @@ public class MaterialRecipeHandler {
                         .inputs(dustStack)
                         .outputs(OreDictUnifier.get(OrePrefix.plate, mat))
                         .buildAndRegister();
+            } else if (!OreDictUnifier.get(block, mat).isEmpty()) {
+                COMPRESSOR_RECIPES.recipeBuilder()
+                        .input(dust, mat, (int) (block.getMaterialAmount(mat) / M))
+                        .output(block, mat)
+                        .duration(300).EUt(2).buildAndRegister();
             }
 
             // Some Ores with Direct Smelting Results have neither ingot nor gem properties


### PR DESCRIPTION
## What
Add block recipes for materials that has only dust and block

## Additional Information
Block recipes will be added to Arsenic, Electrotine, and TricalciumPhosphate when Forestry is loaded.

