### PR TITLE
Add `writeCustomData()` overload

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/interfaces/ISyncedTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/ISyncedTileEntity.java
@@ -11,6 +11,8 @@ import java.util.function.Consumer;
  */
 public interface ISyncedTileEntity {
 
+    Consumer<PacketBuffer> NO_OP = buf -> {};
+
     /**
      * Used to sync data from Server -> Client.
      * Called during initial loading of the chunk or when many blocks change at once.
@@ -67,6 +69,27 @@ public interface ISyncedTileEntity {
      * @see gregtech.api.capability.GregtechDataCodes
      */
     void writeCustomData(int discriminator, @NotNull Consumer<@NotNull PacketBuffer> dataWriter);
+
+    /**
+     * Used to send an empty anonymous Server -> Client packet.
+     * <p>
+     * Data is received in {@link #receiveCustomData(int, PacketBuffer)};
+     * <p>
+     * Typically used to signal to the client that a rendering update is needed
+     * when sending a server-side state update.
+     * <p>
+     * <em>Should be called manually</em>.
+     * <p>
+     * This method is called <strong>Server-Side</strong>.
+     * <p>
+     * Equivalent to {@link net.minecraft.tileentity.TileEntity#getUpdatePacket}
+     *
+     * @param discriminator the discriminator determining the packet sent.
+     * @see gregtech.api.capability.GregtechDataCodes
+     */
+    default void writeCustomData(int discriminator) {
+        writeCustomData(discriminator, NO_OP);
+    }
 
     /**
      * Used to receive an anonymous Server -> Client packet.

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -190,7 +190,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
             this.guiContainerCache = fakeModularUIContainer;
             if (getWorld().isRemote)
                 this.guiCache = new FakeModularGui(ui, fakeModularUIContainer);
-            this.writeCustomData(CREATE_FAKE_UI, buffer -> {});
+            this.writeCustomData(CREATE_FAKE_UI);
         } catch (Exception e) {
             GTLog.logger.error(e);
         }


### PR DESCRIPTION
## What
adds an overload for `writeCustomData()` that only accepts an id without configuring the buffer

## Implementation Details
ideal for when all you need is the id to run logic without needing the buffer

## Outcome
a simpler way of syncing to client
