### PR TITLE
Fix and Improve Steam Boiler

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -216,7 +216,7 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
                 if (fuelBurnTimeLeft % 2 == 0 && currentTemperature < getMaxTemperate())
                     currentTemperature++;
                 fuelBurnTimeLeft -= isHighPressure ? 2 : 1;
-                if (fuelBurnTimeLeft == 0) {
+                if (fuelBurnTimeLeft <= 0) {
                     this.fuelMaxBurnTime = 0;
                     this.timeBeforeCoolingDown = getCooldownInterval();
                     // boiler has no fuel now, so queue burning state update
@@ -304,6 +304,10 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
 
     public double getTemperaturePercent() {
         return currentTemperature / (getMaxTemperate() * 1.0);
+    }
+
+    public int getCurrentTemperature() {
+        return currentTemperature;
     }
 
     public double getFuelLeftPercent() {

--- a/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/SteamBoilerInfoProvider.java
@@ -30,10 +30,9 @@ public class SteamBoilerInfoProvider implements IProbeInfoProvider {
             if (te instanceof IGregTechTileEntity igtte) {
                 MetaTileEntity mte = igtte.getMetaTileEntity();
                 if (mte instanceof SteamBoiler boiler) {
-                    if (boiler.isBurning()) {
-                        // Boiler is active
-                        int steamOutput = boiler.getTotalSteamOutput();
-
+                    int steamOutput = boiler.getTotalSteamOutput();
+                    // If we are producing steam, or we have fuel
+                    if (steamOutput > 0 || boiler.isBurning()) {
                         // Creating steam
                         if (steamOutput > 0 && boiler.hasWater()) {
                             probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_production*} " +
@@ -42,10 +41,18 @@ public class SteamBoilerInfoProvider implements IProbeInfoProvider {
                                     Materials.Steam.getUnlocalizedName() + "*}");
                         }
 
-                        // Initial heat-up
-                        if (steamOutput <= 0) {
+                        // Cooling Down
+                        if (!boiler.isBurning()) {
                             probeInfo.text(TextStyleClass.INFO.toString() + TextFormatting.RED +
-                                    "{*gregtech.top.steam_heating_up*}");
+                                    "{*gregtech.top.steam_cooling_down*}");
+                        }
+
+                        // Initial heat-up
+                        if (steamOutput <= 0 && boiler.getCurrentTemperature() > 0) {
+                            // Current Temperature = the % until the boiler reaches 100
+                            probeInfo.text(TextStyleClass.INFO.toString() + TextFormatting.RED +
+                                    "{*gregtech.top.steam_heating_up*} " +
+                                    TextFormattingUtil.formatNumbers(boiler.getCurrentTemperature()) + "%");
                         }
 
                         // No water

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -62,7 +62,8 @@ gregtech.top.transform_up=Step Up
 gregtech.top.transform_down=Step Down
 gregtech.top.transform_input=Input:
 gregtech.top.transform_output=Output:
-gregtech.top.steam_heating_up=Heating up
+gregtech.top.steam_heating_up=Heating Up:
+gregtech.top.steam_cooling_down=Cooling Down
 gregtech.top.steam_no_water=No Water
 
 gregtech.top.convert_eu=Converting §eEU§r -> §cFE§r


### PR DESCRIPTION
## What
This PR includes an assortment of fixes and improvements to steam boilers.

Fixes:
- Fixes boiler not resetting `fuelMaxBurnTime` to 0 if `fuelBurnTimeLeft` is less than 0 (sometimes happens with high pressure boilers)

Improvements:
- TOP: Displays steam production, and cooling down, when the boiler is cooling down
- TOP: Displays % until boiler starts producing steam, in the heat up phase

## Implementation Details
Heat up phase: Should it display % until boiler reaches 100C, or until max temperature?
Production: Should boiler display its current temperature?

## Outcome
Fixes boilers appearing as active, when fuel runs out
Fixes #2632
Improves TOP Display

## Additional Information
None

## Potential Compatibility Issues
None
