### PR TITLE
More Tweaker Information in JEI Recipe Display

### DIFF
--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -39,6 +39,10 @@ death.attack.screwdriver_lv=%s had their screws removed by %s
 
 enchantment.disjunction=Disjunction
 
+gregtech.jei.remove_recipe.tooltip=Copies a %s Snippet to Remove this Recipe
+gregtech.jei.ct_recipe.tooltip=CraftTweaker Recipe
+gregtech.jei.gs_recipe.tooltip=GroovyScript Recipe
+
 gregtech.machine.steam_grinder.name=Steam Grinder
 gregtech.multiblock.steam_grinder.description=A Multiblock Macerator at the Steam Age. Requires at least 14 Bronze Casings to form. Cannot use normal Input/Output busses, nor Fluid Hatches other than the Steam Hatch.
 gregtech.multiblock.steam.low_steam=Not enough Steam to run!


### PR DESCRIPTION
## What
This PR improves the JEI Recipe Display's support for Tweakers:
- Allows Localisation of the 'X' Button's Tooltip
- Adds an 'I' Logo in the place of the 'X' Button when a recipe is created by a tweaker

## Implementation Details
None

## Outcome
Makes it clearer to pack developers what recipes their pack creates.

## Additional Information
None

## Potential Compatibility Issues
None
