### PR TITLE
Fix Steam Boiler Temperature Not Increasing with Some Fuels

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -213,7 +213,7 @@ public abstract class SteamBoiler extends MetaTileEntity implements IDataInfoPro
     private void updateCurrentTemperature() {
         if (fuelMaxBurnTime > 0) {
             if (getOffsetTimer() % 12 == 0) {
-                if (fuelBurnTimeLeft % 2 == 0 && currentTemperature < getMaxTemperate())
+                if (currentTemperature < getMaxTemperate())
                     currentTemperature++;
                 fuelBurnTimeLeft -= isHighPressure ? 2 : 1;
                 if (fuelBurnTimeLeft <= 0) {


### PR DESCRIPTION
## What
Another fix of the steam boiler with fuels with odd burn rates (like the tiny coal dust). Fixes temperature not increasing.

## Implementation Details
None

## Outcome
Fixes some fuels not increasing the boiler's temperature... sometimes.

## Additional Information
None. Except why was that check added in the first place?

## Potential Compatibility Issues
None