### PR TITLE
Fix Duplication Glitch with ME Storage Hatches/Buses

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -257,6 +257,8 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     protected boolean prepareRecipeDistinct(Recipe recipe) {
+        ((RecipeMapMultiblockController) metaTileEntity).refreshAllBeforeConsumption();
+
         recipe = Recipe.trimRecipeOutputs(recipe, getRecipeMap(), metaTileEntity.getItemOutputLimit(),
                 metaTileEntity.getFluidOutputLimit());
 
@@ -278,6 +280,12 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         }
 
         return false;
+    }
+
+    @Override
+    public boolean prepareRecipe(Recipe recipe) {
+        ((RecipeMapMultiblockController) metaTileEntity).refreshAllBeforeConsumption();
+        return super.prepareRecipe(recipe);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/interfaces/IRefreshBeforeConsumption.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/IRefreshBeforeConsumption.java
@@ -1,0 +1,13 @@
+package gregtech.api.metatileentity.interfaces;
+
+/**
+ * This Interface represents a MultiblockPart that should be refreshed before final recipe validation and input
+ * consumption.
+ */
+public interface IRefreshBeforeConsumption {
+
+    /**
+     * Called Server Side Only.
+     */
+    void refreshBeforeConsumption();
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/generator/LargeTurbineWorkableHandler.java
@@ -149,6 +149,7 @@ public class LargeTurbineWorkableHandler extends MultiblockFuelRecipeLogic {
             parallel = getParallel(recipe, holderEfficiency, turbineMaxVoltage);
 
             // Null check fluid here, since it can return null on first join into world or first form
+            ((RecipeMapMultiblockController) metaTileEntity).refreshAllBeforeConsumption();
             FluidStack inputFluid = getInputFluidStack();
             if (inputFluid == null || getInputFluidStack().amount < recipeFluidStack.amount * parallel) {
                 return false;

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -6,6 +6,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ImageCycleButtonWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.interfaces.IRefreshBeforeConsumption;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
@@ -37,7 +38,7 @@ import java.util.function.Predicate;
 
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_AUTO_PULL;
 
-public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
+public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus implements IRefreshBeforeConsumption {
 
     private static final int CONFIG_SIZE = 16;
     private boolean autoPull;
@@ -389,6 +390,14 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
         // set auto pull first to avoid issues with clearing the config after reading from the data stick
         this.setAutoPull(false);
         super.readConfigFromTag(tag);
+    }
+
+    @Override
+    public void refreshBeforeConsumption() {
+        if (isWorkingEnabled() && updateMEStatus()) {
+            if (autoPull) refreshList();
+            syncME();
+        }
     }
 
     private static class ExportOnlyAEStockingItemList extends ExportOnlyAEItemList {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -6,6 +6,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ImageCycleButtonWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.interfaces.IRefreshBeforeConsumption;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
 import gregtech.common.metatileentities.multi.multiblockpart.appeng.slot.ExportOnlyAEFluidList;
@@ -37,7 +38,7 @@ import java.util.function.Predicate;
 
 import static gregtech.api.capability.GregtechDataCodes.UPDATE_AUTO_PULL;
 
-public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
+public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch implements IRefreshBeforeConsumption {
 
     private static final int CONFIG_SIZE = 16;
     private boolean autoPull;
@@ -292,6 +293,14 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
         // set auto pull first to avoid issues with clearing the config after reading from the data stick
         this.setAutoPull(false);
         super.readConfigFromTag(tag);
+    }
+
+    @Override
+    public void refreshBeforeConsumption() {
+        if (isWorkingEnabled() && autoPull) {
+            refreshList();
+            syncME();
+        }
     }
 
     private static class ExportOnlyAEStockingFluidSlot extends ExportOnlyAEFluidSlot {


### PR DESCRIPTION
## What
This PR fixes a specific ME Stocking Bus/Hatch duplication glitch, which whilst not as common as the one fixed by #2608, can still be accidentally created.

Issue is as described in #2530. Specifically, it was reproduced as such:

1. Setup a small AE2 System, with item cells, crafting terminal and power
2. Setup 2 MultiSmelters and 2 PAs. Setup the PAs to run macerator.
3. Add stocking buses to all multis. No sharing. Setup PA buses to take in iron ingots, multismelters to take in iron dust.
4. Add ME output buses to all multis.
6. Add in Iron Ingots or Iron Dust. Wait a few moments, and watch the iron amount increase. Unset the stocking hatch to see all iron dust/ingot return, and note that the amount has increased.

## Implementation Details
There are several parts of this PR that could be improved:
- The Stocking Buses/Hatches are added to a 'list' of 'reload/refresh before consume' MTEs. Is there a better way to do this? We can't mess with the abilities.
- The specific timing for refreshing the stocking buses/hatches
   - This PR refreshes the buses/hatches at the beginning of `prepareRecipe`, meaning it is not called for every recipe search, just when a recipe is found, and is called before OC and Parallel handling, allowing for the recipe logic to exit with invalid recipes, based on inputs.
   - Experiment was conducted with refreshing in `setupAndConsumeRecipeInputs` instead, but invalid inputs there do not stop the recipe from running.

## Outcome
Fixes #2530

## Additional Information
Setup: (GCYM was not used to reduce variables, and due to incompatibility with GT Master State)
![2024-10-23_22 39 35](https://github.com/user-attachments/assets/1ed83c2e-35d7-408c-9487-def755725f26)

## Potential Compatibility Issues
Perhaps may not work with addons that override the `prepareRecipe` function.
