### PR TITLE
Fix Issues with Switching Modes on MultiMapMultiblockController

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiMapMultiblockController.java
@@ -59,7 +59,6 @@ public abstract class MultiMapMultiblockController extends RecipeMapMultiblockCo
                     index = (recipeMapIndex + 1) % recipeMaps.length;
 
                 setRecipeMapIndex(index);
-                this.recipeMapWorkable.forceRecipeRecheck();
             } else {
                 playerIn.sendStatusMessage(
                         new TextComponentTranslation("gregtech.multiblock.multiple_recipemaps.switch_message"), true);
@@ -79,6 +78,7 @@ public abstract class MultiMapMultiblockController extends RecipeMapMultiblockCo
         this.recipeMapIndex = index;
         if (!getWorld().isRemote) {
             writeCustomData(GregtechDataCodes.RECIPE_MAP_INDEX, buf -> buf.writeByte(index));
+            recipeMapWorkable.forceRecipeRecheck();
             markDirty();
         }
     }


### PR DESCRIPTION
## What
This PR fixes an issue where changing the machine mode, of a MultiMapMulitblockController, in the GUI, does not force a recipe recheck.

## Implementation Details
None

## Outcome
Fixes issues with changing machine modes on the fly.

## Additional Information
Implemented in Labs here: https://github.com/Nomi-CEu/Nomi-Labs/commit/42a67350eb4d79878408f08a9c87680b1dc98c5c

## Potential Compatibility Issues
None
