### PR TITLE
Fix Issues with Transporting Some Items to Some Inventories

### DIFF
--- a/src/main/java/gregtech/api/util/GTTransferUtils.java
+++ b/src/main/java/gregtech/api/util/GTTransferUtils.java
@@ -175,9 +175,6 @@ public class GTTransferUtils {
         if (handler == null || stack.isEmpty()) {
             return stack;
         }
-        if (!stack.isStackable()) {
-            return insertToEmpty(handler, stack, simulate);
-        }
 
         IntList emptySlots = new IntArrayList();
         int slots = handler.getSlots();


### PR DESCRIPTION
## What
This PR fixes issues with transporting items with a stack size of 1, via pipe or conveyor, into special inventories, such as Super/Quantum Chests or Storage Drawers.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/420

## Implementation Details
This PR simply removes the check in `GTTransferUtils.insertItem` for whether the item is not stackable, as these special inventories only have one slot, but can insert more than the typical item stack size in said slot.

## Outcome
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/420

## Additional Information
Implemented in Labs here: https://github.com/Nomi-CEu/Nomi-Labs/commit/29fe26592c32c10d8cbfe66ce8d53ad5ab439d2c

## Potential Compatibility Issues
None
