### PR TITLE
Fix Voiding and Incorrect Input Consumption in Parallel Recipes

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -818,7 +818,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             if (ri.isNonConsumable()) {
                 newRecipeInputs.add(ri);
             } else {
-                newRecipeInputs.add(ri.withAmount(ri.getAmount() * numberOfOperations));
+                newRecipeInputs.add(ri.copyWithAmount(ri.getAmount() * numberOfOperations));
             }
         });
 
@@ -826,7 +826,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             if (fi.isNonConsumable()) {
                 newFluidInputs.add(fi);
             } else {
-                newFluidInputs.add(fi.withAmount(fi.getAmount() * numberOfOperations));
+                newFluidInputs.add(fi.copyWithAmount(fi.getAmount() * numberOfOperations));
             }
         });
 

--- a/src/main/java/gregtech/api/util/OverlayedItemHandler.java
+++ b/src/main/java/gregtech/api/util/OverlayedItemHandler.java
@@ -58,7 +58,8 @@ public class OverlayedItemHandler {
             ItemStack slotKey = this.slots[i].getItemStack();
             if (slotKey.isEmpty() || ItemStackHashStrategy.comparingAllButCount().equals(slotKey, stack)) {
                 // if the slot is not full
-                int canInsertUpTo = this.slots[i].getSlotLimit() - this.slots[i].getCount();
+                int canInsertUpTo = Math.min(this.slots[i].getSlotLimit() - this.slots[i].getCount(),
+                        stack.getMaxStackSize());
                 if (canInsertUpTo > 0) {
                     int insertedAmount = Math.min(canInsertUpTo, amountToInsert);
                     this.slots[i].setItemStack(stack.copy()); // this copy may not be need, needs further tests

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -12,6 +12,7 @@ import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.RecipeMapBuilder;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.util.GTUtility;
@@ -24,6 +25,7 @@ import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityItemB
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityMultiblockPart;
 
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -38,8 +40,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 
 public class IParallelableRecipeLogicTest {
 
@@ -711,6 +712,45 @@ public class IParallelableRecipeLogicTest {
                 exportFluidBus.getExportFluids(), Integer.MAX_VALUE, parallelLimit);
 
         MatcherAssert.assertThat(outputRecipe, nullValue());
+    }
+
+    @Test
+    public void findParallelRecipe_SmallMaxStackSize() {
+        MetaTileEntityElectricBlastFurnace EBF = initEBF(521);
+
+        int parallelLimit = 4;
+
+        // Create a recipe Map to be used for testing
+        RecipeMap<BlastRecipeBuilder> map = new RecipeMapBuilder<>("electric_blast_furnace", new BlastRecipeBuilder())
+                .itemInputs(3).itemOutputs(2).fluidInputs(1).fluidOutputs(1).build();
+
+        // Create a simple recipe to be used for testing
+        // Use an output item with small max stack size
+        Recipe recipe = map.recipeBuilder()
+                .inputs(new ItemStack(Blocks.COBBLESTONE))
+                .outputs(new ItemStack(Items.ELYTRA))
+                .blastFurnaceTemp(1000)
+                .EUt(30).duration(100)
+                .build().getResult();
+
+        IParallelableRecipeLogic logic = new ParallelableTestLogic(EBF, map, ParallelLogicType.MULTIPLY);
+
+        // Populate the Input Bus
+        importItemBus.getImportItems().insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
+
+        // Saturate the export bus, except for one slot
+        exportItemBus.getExportItems().insertItem(0, new ItemStack(Blocks.BONE_BLOCK, 16), false);
+        exportItemBus.getExportItems().insertItem(1, new ItemStack(Blocks.BONE_BLOCK, 16), false);
+        exportItemBus.getExportItems().insertItem(2, new ItemStack(Blocks.BONE_BLOCK, 16), false);
+        // exportItemBus.getExportItems().insertItem(3, new ItemStack(Blocks.BONE_BLOCK, 16), false);
+
+        RecipeBuilder<?> parallelRecipe = logic.findMultipliedParallelRecipe(map, recipe,
+                importItemBus.getImportItems(), importFluidBus.getImportFluids(),
+                exportItemBus.getExportItems(), exportFluidBus.getExportFluids(), parallelLimit, Integer.MAX_VALUE,
+                EBF);
+
+        MatcherAssert.assertThat(parallelRecipe, notNullValue());
+        MatcherAssert.assertThat(parallelRecipe.getParallel(), is(1));
     }
 
     @Test

--- a/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/recipes/logic/IParallelableRecipeLogicTest.java
@@ -742,7 +742,6 @@ public class IParallelableRecipeLogicTest {
         exportItemBus.getExportItems().insertItem(0, new ItemStack(Blocks.BONE_BLOCK, 16), false);
         exportItemBus.getExportItems().insertItem(1, new ItemStack(Blocks.BONE_BLOCK, 16), false);
         exportItemBus.getExportItems().insertItem(2, new ItemStack(Blocks.BONE_BLOCK, 16), false);
-        // exportItemBus.getExportItems().insertItem(3, new ItemStack(Blocks.BONE_BLOCK, 16), false);
 
         RecipeBuilder<?> parallelRecipe = logic.findMultipliedParallelRecipe(map, recipe,
                 importItemBus.getImportItems(), importFluidBus.getImportFluids(),


### PR DESCRIPTION
## What
This PR fixes two issues relating to parallel recipes:
- Inputs being modified, leading to incorrect input consumption, when said inputs are not cached
- Voiding of parallel recipes when outputs have stack sizes less than 64, and the output bus is too full

The only recipe with non-cached inputs in vanilla GT is canning machine filling recipes.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/924

## Implementation Details
This PR simply copies the GTRecipeInput when applying parallel, instead of modifying it directly. This has no effect on cached inputs, which are copied when `withAmount` is called regardless. 

For the output voiding fix, this PR simply checks for the minimum of the slot's available space and the stack's `maxStackSize`, as empty slots return an available space of 64 regardless of intended stack.

## Outcome
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/924
Fixes edge case voiding with parallel recipes

## Additional Information
This PR was originally implemented in Labs here: https://github.com/Nomi-CEu/Nomi-Labs/commit/1c3528981c1334ba2a0edbb1ef570a25fc0723d2 & https://github.com/Nomi-CEu/Nomi-Labs/commit/eb4fab3def802c62d0bc29769e73c7127f61a5ae

## Potential Compatibility Issues
None
