### PR TITLE
Let recipe builders skip map build actions

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -893,6 +893,10 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) new RecipeBuilder<>(this);
     }
 
+    /**
+     * Only use if you absolutely don't want the recipe to be run through any build actions.
+     * Instead, you should blacklist specific actions with {@link #ignoreBuildAction(ResourceLocation)}
+     */
     public R ignoreAllBuildActions() {
         this.ignoreAllBuildActions = true;
         return (R) this;

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -911,6 +911,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             GTLog.logger.error("Recipe map {} does not contain build action {}!", recipeMap, buildActionName,
                     new Throwable());
             return (R) this;
+        } else if (ignoredBuildActions.containsKey(buildActionName)) {
+            return (R) this;
         }
 
         ignoredBuildActions.put(buildActionName, recipeMap.getBuildActions().get(buildActionName));

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -133,7 +133,9 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.category = recipeBuilder.category;
         this.recipePropertyStorage = recipeBuilder.recipePropertyStorage.copy();
         this.ignoreAllBuildActions = recipeBuilder.ignoreAllBuildActions;
-        this.ignoredBuildActions = new Object2ObjectOpenHashMap<>(recipeBuilder.ignoredBuildActions);
+        if (recipeBuilder.ignoredBuildActions != null) {
+            this.ignoredBuildActions = new Object2ObjectOpenHashMap<>(recipeBuilder.ignoredBuildActions);
+        }
     }
 
     public R cleanroom(@Nullable CleanroomType cleanroom) {

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -1076,6 +1076,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
                 .append("dimensions", getDimensionIDs().toString())
                 .append("dimensions_blocked", getBlockedDimensionIDs().toString())
                 .append("recipeStatus", recipeStatus)
+                .append("ignoresRecipeMapBuildActions", ignoreRecipeMapBuildActions)
                 .toString();
     }
 }

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -55,7 +55,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -132,6 +132,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         this.hidden = recipeBuilder.hidden;
         this.category = recipeBuilder.category;
         this.recipePropertyStorage = recipeBuilder.recipePropertyStorage.copy();
+        this.ignoreAllBuildActions = recipeBuilder.ignoreAllBuildActions;
+        this.ignoredBuildActions = new Object2ObjectOpenHashMap<>(recipeBuilder.ignoredBuildActions);
     }
 
     public R cleanroom(@Nullable CleanroomType cleanroom) {
@@ -909,9 +911,6 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             GTLog.logger.error("Recipe map {} does not contain build action {}!", recipeMap, buildActionName,
                     new Throwable());
             return (R) this;
-        } else if (ignoredBuildActions.containsKey(buildActionName)) {
-            GTLog.logger.error("Builder already ignores {}!", buildActionName, new Throwable());
-            return (R) this;
         }
 
         ignoredBuildActions.put(buildActionName, recipeMap.getBuildActions().get(buildActionName));
@@ -1091,7 +1090,8 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     /**
      * Get all ignored build actions for the recipe map.
-     * Will return an empty map if none are ignored.
+     * 
+     * @return A map of ignored build actions.
      */
     public @NotNull Map<ResourceLocation, RecipeBuildAction<R>> getIgnoredBuildActions() {
         if (ignoreAllBuildActions) {
@@ -1099,7 +1099,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         }
 
         if (ignoredBuildActions == null) {
-            return new HashMap<>();
+            return Collections.emptyMap();
         }
 
         return ignoredBuildActions;

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -85,6 +85,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
     protected EnumValidationResult recipeStatus = EnumValidationResult.VALID;
     protected RecipePropertyStorage recipePropertyStorage = RecipePropertyStorage.EMPTY;
     protected boolean recipePropertyStorageErrored = false;
+    protected boolean ignoreRecipeMapBuildActions = false;
 
     protected RecipeBuilder() {
         this.inputs = new ArrayList<>();
@@ -887,6 +888,11 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) new RecipeBuilder<>(this);
     }
 
+    public R ignoreRecipeMapBuildActions() {
+        this.ignoreRecipeMapBuildActions = true;
+        return (R) this;
+    }
+
     public ValidationResult<Recipe> build() {
         EnumValidationResult result = recipePropertyStorageErrored ? EnumValidationResult.INVALID : validate();
         return ValidationResult.newResult(result, new Recipe(inputs, outputs,
@@ -985,8 +991,10 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
      */
     @MustBeInvokedByOverriders
     public void buildAndRegister() {
-        for (RecipeBuildAction<R> action : recipeMap.getBuildActions()) {
-            action.accept((R) this);
+        if (!ignoreRecipeMapBuildActions) {
+            for (RecipeBuildAction<R> action : recipeMap.getBuildActions()) {
+                action.accept((R) this);
+            }
         }
         ValidationResult<Recipe> validationResult = build();
         recipeMap.addRecipe(validationResult);
@@ -1045,6 +1053,10 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
 
     public @Nullable CleanroomType getCleanroom() {
         return this.recipePropertyStorage.get(CleanroomProperty.getInstance(), null);
+    }
+
+    public boolean ignoresRecipeMapBuildActions() {
+        return ignoreRecipeMapBuildActions;
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -347,8 +347,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
      * @return the build actions for this RecipeMap's default RecipeBuilder
      */
     @ApiStatus.Internal
-    protected @UnmodifiableView @NotNull Collection<@NotNull RecipeBuildAction<R>> getBuildActions() {
-        return this.recipeBuildActions.values();
+    protected @UnmodifiableView @NotNull Map<ResourceLocation, RecipeBuildAction<R>> getBuildActions() {
+        return this.recipeBuildActions;
     }
 
     public RecipeMap<R> allowEmptyOutput() {


### PR DESCRIPTION
## What
Allow a recipe builder to ignore a recipe map's build actions.

## Outcome
You can make assembler recipes that use soldering alloy that don't have tin recipes generated, or make arc furnace recipes that don't use a fluid without oxygen being assigned automatically.

## Potential Compatibility Issues
Shouldn't be any.
