### PR TITLE
Increase Efficiency of Solid Fuels in Large Boilers

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/BoilerRecipeLogic.java
@@ -120,13 +120,13 @@ public class BoilerRecipeLogic extends AbstractRecipeLogic implements ICategoryO
             for (int i = 0; i < importItems.getSlots(); i++) {
                 ItemStack stack = importItems.getStackInSlot(i);
                 int fuelBurnTime = (int) Math.ceil(TileEntityFurnace.getItemBurnTime(stack));
-                if (fuelBurnTime / 80 > 0) { // try to ensure this fuel can burn for at least 1 tick
+                if (fuelBurnTime / 8 > 0) { // try to ensure this fuel can burn for at least 1 tick
                     if (FluidUtil.getFluidHandler(stack) != null) continue;
-                    this.excessFuel += fuelBurnTime % 80;
-                    int excessProgress = this.excessFuel / 80;
-                    this.excessFuel %= 80;
+                    this.excessFuel += fuelBurnTime % 8;
+                    int excessProgress = this.excessFuel / 8;
+                    this.excessFuel %= 8;
                     setMaxProgress(excessProgress +
-                            adjustBurnTimeForThrottle(boiler.boilerType.runtimeBoost(fuelBurnTime / 80)));
+                            adjustBurnTimeForThrottle(boiler.boilerType.runtimeBoost(fuelBurnTime / 8)));
                     stack.shrink(1);
                     didStartRecipe = true;
                     break;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -213,7 +213,7 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
                                boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("gregtech.multiblock.large_boiler.rate_tooltip",
-                (int) (boilerType.steamPerTick() * 20 * boilerType.runtimeBoost(20) / 20.0)));
+                (int) (boilerType.steamPerTick() * 20 * boilerType.runtimeBoost(200) / 20.0)));
         tooltip.add(
                 I18n.format("gregtech.multiblock.large_boiler.heat_time_tooltip", boilerType.getTicksToBoiling() / 20));
         tooltip.add(I18n.format("gregtech.universal.tooltip.base_production_fluid", boilerType.steamPerTick()));


### PR DESCRIPTION
## What
This PR increases the duration of solid fuels in large boilers, increasing it by 10x, leading to a 10x increase in steam production for these fuels, and for the baseline of coal.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/677

## Implementation Details
Why 10x? Well...

### Singleblock Boiler Efficiency
Small, singleblock boilers run on the tick time of the fuel, without duration cuts. Large boilers cut the duration via dividing by 80 (currently), which has been changed to dividing by 8.

However, small boilers only decrease duration once every 12 ticks. Coupled with the higher efficiency of the high pressure boilers, at full heat, with one coal, a high pressure boiler produces:

`30 (steam per tick) * 1600 (coal burn time) * 12 (duration buffer) / 2 (double burn time for high-pressure) = 288 Buckets of Steam`

A normal solid fuel boiler, under same conditions, produces:

`12 (steam per tick) * 1600 (coal burn time) * 12 (duration buffer) ~= 230 Buckets of Steam`

This is before accounting for cooldown steam production. For a high pressure, this adds around:
`15 (average steam per tick over temperature decrease) * 900 (temperature - lower 100 degrees) * 40 (temp. decrease happens every 40 ticks) = 540 Buckets of Steam`

For a normal boiler, this decreases to around:
`6 (average steam per tick over temperature decrease) * 400 (temperature - lower 100 degrees) * 45 (temp. decrease happens every 45 ticks) = 108 Buckets of Steam`

This means that a high pressure boiler produces `828 Buckets of Steam`, and a normal boiler produces `338 Buckets of Steam`, on one coal alone.

In reality, when comparing this to the large boiler, we can mostly ignore cooldown rate, so we will use the comparison stats of 288 Buckets of Steam.

### Current Large Boiler Production Rate
This is said in the tooltip, but its also visible in the code. A bronze large boiler produces only `32 Buckets of Steam`, increasing to `128 Buckets of Steam` for a tungstensteel large boiler, per piece of coal, at full heat. Even the tungstensteel boiler has half the fuel efficiency of a high-pressure solid singleblock boiler, and the singleblocks are cheaper!

### Solution
After this PR, this increases to 320 buckets for bronze, up to 1.2K buckets for tungstensteel. This compares nicely with the 288 buckets produced by a high-pressure singleblock boiler, without changing setups via changing steam output rates.

## Outcome
Makes large boilers fuel-efficient.

Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/677

## Additional Information
I have also considered these other potential solutions:

### Decrease singleblock fuel consumption rate
I do not like this idea, as it will make earlygame fuel consumption much higher and harder.

### Increase steam output
This will also buff liquid fuel outputs, and may not balance well with existing turbines and setups.

## Potential Compatibility Issues
Will increase solid fuel burn times for addons that use `BoilerRecipeLogic`. I found no usages in GregTech apart from the MetaTileEntity itself.
