### PR TITLE
Fix Catalysts in Dichlorobenzidine and Diaminobenzidine

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -369,23 +369,16 @@ public class PolymerRecipes {
         LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
                 .fluidInputs(Dichlorobenzidine.getFluid(1000))
                 .fluidInputs(Ammonia.getFluid(2000))
-                .notConsumable(dust, Zinc)
+                .notConsumable(dust, Copper)
                 .fluidOutputs(Diaminobenzidine.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(2000))
                 .buildAndRegister();
 
-        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(200)
-                .input(dustTiny, Copper)
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(200)
                 .fluidInputs(Nitrochlorobenzene.getFluid(2000))
                 .fluidInputs(Hydrogen.getFluid(2000))
+                .notConsumable(dust, Zinc)
                 .fluidOutputs(Dichlorobenzidine.getFluid(1000))
-                .buildAndRegister();
-
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(1800)
-                .input(dust, Copper)
-                .fluidInputs(Nitrochlorobenzene.getFluid(18000))
-                .fluidInputs(Hydrogen.getFluid(18000))
-                .fluidOutputs(Dichlorobenzidine.getFluid(9000))
                 .buildAndRegister();
 
         CHEMICAL_RECIPES.recipeBuilder().EUt(VA[HV]).duration(100)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/PolymerRecipes.java
@@ -366,12 +366,20 @@ public class PolymerRecipes {
                 .buildAndRegister();
 
         // 3,3-Diaminobenzidine
-        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
+        CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(100)
                 .fluidInputs(Dichlorobenzidine.getFluid(1000))
                 .fluidInputs(Ammonia.getFluid(2000))
-                .notConsumable(dust, Copper)
+                .input(dustTiny, Copper)
                 .fluidOutputs(Diaminobenzidine.getFluid(1000))
                 .fluidOutputs(HydrochloricAcid.getFluid(2000))
+                .buildAndRegister();
+
+        LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[IV]).duration(900)
+                .fluidInputs(Dichlorobenzidine.getFluid(9000))
+                .fluidInputs(Ammonia.getFluid(18000))
+                .input(dust, Copper)
+                .fluidOutputs(Diaminobenzidine.getFluid(9000))
+                .fluidOutputs(HydrochloricAcid.getFluid(18000))
                 .buildAndRegister();
 
         LARGE_CHEMICAL_RECIPES.recipeBuilder().EUt(VA[EV]).duration(200)


### PR DESCRIPTION
## What
This PR fixes the catalysts of 3,3-Dichlorobenzidine and 3,3-Diaminobenzidine being swapped, relative to the actual synthesis process.

See https://github.com/Nomi-CEu/Nomi-CEu/issues/935.

## Implementation Details
~~This PR removes the specialised LCR recipe for Dichlorobenzidine, and makes it require a whole dust of zinc, set to non-consumable. I assumed this would be preferable behaviour, given they are catalysts, but I can reverse this change if necessary.~~

Edit:
Since consuming copper is intended, the recipe for Diaminobenzidine has been moved to the chemical reactor, with tiny pile of copper, and a seperate recipe in the large chemical reactor has been created, with copper dust. The duration, inputs and outputs have been multiplied 9x, but not the EUt, just as before.

## Outcome
Fixes https://github.com/Nomi-CEu/Nomi-CEu/issues/935.
Chemists are slightly happier.
~~The usage of zinc/copper in Dichlorobenzidine is actually one of a catalyst.~~

## Additional Information
None

## Potential Compatibility Issues
Patterns and/or processing lines will break. Should be a simple swap in PBI setups.