### PR TITLE
Add Recipe Outputs in GUI of Multiblocks with RecipeMap

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockDisplayText.java
@@ -2,12 +2,17 @@ package gregtech.api.metatileentity.multiblock;
 
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.TextComponentUtil;
 import gregtech.api.util.TextFormattingUtil;
 import gregtech.common.ConfigHolder;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.*;
+import net.minecraftforge.fluids.FluidStack;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -477,6 +482,43 @@ public class MultiblockDisplayText {
         public Builder addCustom(Consumer<List<ITextComponent>> customConsumer) {
             customConsumer.accept(textList);
             return this;
+        }
+
+        /** While the Multiblock is active, add lines which display the outputs of the currently run recipe. */
+        public Builder addRecipeOutputsLine(@Nullable Recipe recipe) {
+            if (!isStructureFormed || !isActive) {
+                return this;
+            }
+            if (recipe == null) {
+                return this;
+            }
+            if (!recipe.getAllItemOutputs().isEmpty()) {
+                textList.add(TextComponentUtil.translationWithColor(TextFormatting.GRAY,
+                        "gregtech.multiblock.recipe_outputs", itemOutputsToString(recipe.getAllItemOutputs())));
+            }
+            if (!recipe.getAllFluidOutputs().isEmpty()) {
+                textList.add(TextComponentUtil.translationWithColor(TextFormatting.GRAY,
+                        "gregtech.multiblock.recipe_outputs", fluidOutputsToString(recipe.getAllFluidOutputs())));
+            }
+            return this;
+        }
+
+        private String fluidOutputsToString(List<FluidStack> stacks) {
+            StringBuilder output = new StringBuilder();
+            for (FluidStack stack : stacks) {
+                output.append(stack.amount).append("L of ").append(stack.getLocalizedName()).append(", ");
+            }
+            String str = output.toString();
+            return str.substring(0, str.length() - 2);
+        }
+
+        private String itemOutputsToString(List<ItemStack> stacks) {
+            StringBuilder output = new StringBuilder();
+            for (ItemStack stack : stacks) {
+                output.append(stack.getCount()).append("x ").append(stack.getDisplayName()).append(", ");
+            }
+            String str = output.toString();
+            return str.substring(0, str.length() - 2);
         }
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -151,7 +151,8 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 .addEnergyTierLine(GTUtility.getTierByVoltage(recipeMapWorkable.getMaxVoltage()))
                 .addParallelsLine(recipeMapWorkable.getParallelLimit())
                 .addWorkingStatusLine()
-                .addProgressLine(recipeMapWorkable.getProgressPercent());
+                .addProgressLine(recipeMapWorkable.getProgressPercent())
+                .addRecipeOutputsLine(recipeMapWorkable.getPreviousRecipe());
     }
 
     @Override

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5817,6 +5817,8 @@ gregtech.multiblock.hpca.info_coolant_name=PCB Coolant
 gregtech.multiblock.hpca.info_bridging_enabled=Bridging Enabled
 gregtech.multiblock.hpca.info_bridging_disabled=Bridging Disabled
 
+gregtech.multiblock.recipe_outputs=Crafting: %s
+
 gregtech.command.usage=Usage: /gregtech <worldgen/hand/recipecheck/datafix>
 gregtech.command.worldgen.usage=Usage: /gregtech worldgen <reload>
 gregtech.command.worldgen.reload.usage=Usage: /gregtech worldgen reload


### PR DESCRIPTION
## What
This is a port of a feature from GTNH, where multiblock GUIs show what items/fluids they are currently crafting.

## Implementation Details
Maybe the helper methods to convert the recipe outputs to a string are better placed inside another class than `MultiblockDisplayText`. For now, I have only changed the behaviour for `RecipeMapMultiblockController`s. If the PR is accepted, I will change the behaviour for all multiblocks which override the default `addDisplayText` method as well.

## Additional Information
A screenshot from the LCR is attached.
![Screenshot (737)](https://github.com/user-attachments/assets/1b35614b-bbf7-440c-afcf-5556dba04eed)

