### PR TITLE
Add an easier way for MTEs to be added to creative tabs

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1689,6 +1689,11 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
 
     public void removeFromCreativeTab(CreativeTabs creativeTab) {
         Preconditions.checkNotNull(creativeTab, "creativeTab");
+        if (creativeTab == CreativeTabs.SEARCH) {
+            GTLog.logger.error("Cannot remove MTEs from the creative search tab!",
+                    new IllegalArgumentException());
+            return;
+        }
         if (!creativeTabs.contains(creativeTab)) {
             GTLog.logger.error("{} is not in the creative tab {}.", this, creativeTab.tabLabel,
                     new IllegalArgumentException());

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1690,8 +1690,13 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     public void removeFromCreativeTab(CreativeTabs creativeTab) {
         Preconditions.checkNotNull(creativeTab, "creativeTab");
         if (creativeTab == CreativeTabs.SEARCH) {
-            GTLog.logger.error("Cannot remove MTEs from the creative search tab!",
+            GTLog.logger.error("Cannot remove MTEs from the creative search tab.",
                     new IllegalArgumentException());
+            return;
+        }
+        if (creativeTab == GTCreativeTabs.TAB_GREGTECH_MACHINES &&
+                metaTileEntityId.getNamespace().equals(GTValues.MODID)) {
+            GTLog.logger.error("Cannot remove GT MTEs from the GT machines tab.", new IllegalArgumentException());
             return;
         }
         if (!creativeTabs.contains(creativeTab)) {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -168,9 +168,12 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     @Nullable
     private UUID owner = null;
 
-    private final Set<CreativeTabs> additionalCreativeTabs = new ObjectArraySet<>();
-    private boolean showsInSearchTab = true;
-    private boolean showsInGTCreativeTab = true;
+    private final Set<CreativeTabs> creativeTabs = new ObjectArraySet<>();
+
+    {
+        creativeTabs.add(CreativeTabs.SEARCH);
+        creativeTabs.add(GTCreativeTabs.TAB_GREGTECH_MACHINES);
+    }
 
     protected MetaTileEntity(@NotNull ResourceLocation metaTileEntityId) {
         this.metaTileEntityId = metaTileEntityId;
@@ -368,9 +371,7 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
      *      MachineItemBlock#addCreativeTab(CreativeTabs)
      */
     public boolean isInCreativeTab(CreativeTabs creativeTab) {
-        return (showsInSearchTab && creativeTab == CreativeTabs.SEARCH) ||
-                (showsInGTCreativeTab && creativeTab == GTCreativeTabs.TAB_GREGTECH_MACHINES) ||
-                additionalCreativeTabs.contains(creativeTab);
+        return creativeTabs.contains(creativeTab);
     }
 
     public String getItemSubTypeId(ItemStack itemStack) {
@@ -1677,23 +1678,27 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
      */
     public void addAdditionalCreativeTabs(CreativeTabs creativeTab) {
         Preconditions.checkNotNull(creativeTab, "creativeTab");
-        if (creativeTab == GTCreativeTabs.TAB_GREGTECH_MACHINES || creativeTab == CreativeTabs.SEARCH) {
-            GTLog.logger.error("Adding {} as additional creative tab is redundant.", creativeTab.tabLabel,
+        if (creativeTabs.contains(creativeTab)) {
+            GTLog.logger.error("{} is already in the creative tab {}.", this, creativeTab.tabLabel,
                     new IllegalArgumentException());
+            return;
         }
 
-        additionalCreativeTabs.add(creativeTab);
+        creativeTabs.add(creativeTab);
     }
 
-    public Set<CreativeTabs> getAdditionalCreativeTabs() {
-        return Collections.unmodifiableSet(additionalCreativeTabs);
+    public void removeFromCreativeTab(CreativeTabs creativeTab) {
+        Preconditions.checkNotNull(creativeTab, "creativeTab");
+        if (!creativeTabs.contains(creativeTab)) {
+            GTLog.logger.error("{} is not in the creative tab {}.", this, creativeTab.tabLabel,
+                    new IllegalArgumentException());
+            return;
+        }
+
+        creativeTabs.remove(creativeTab);
     }
 
-    public void removeFromSearchTab() {
-        showsInSearchTab = false;
-    }
-
-    public void removeFromGTCreativeTab() {
-        showsInGTCreativeTab = false;
+    public Set<CreativeTabs> getCreativeTabs() {
+        return Collections.unmodifiableSet(creativeTabs);
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -368,9 +368,9 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
      *      MachineItemBlock#addCreativeTab(CreativeTabs)
      */
     public boolean isInCreativeTab(CreativeTabs creativeTab) {
-        if (showsInSearchTab && creativeTab == CreativeTabs.SEARCH) return true;
-        if (showsInGTCreativeTab && creativeTab == GTCreativeTabs.TAB_GREGTECH_MACHINES) return true;
-        return additionalCreativeTabs.contains(creativeTab);
+        return (showsInSearchTab && creativeTab == CreativeTabs.SEARCH) ||
+                (showsInGTCreativeTab && creativeTab == GTCreativeTabs.TAB_GREGTECH_MACHINES) ||
+                additionalCreativeTabs.contains(creativeTab);
     }
 
     public String getItemSubTypeId(ItemStack itemStack) {


### PR DESCRIPTION
## What
Add a method to add more creative tabs to an MTE.

## Implementation Details
Adds a set to be checked against in `isInCreativeTab` and methods to exclude the default GT machine and search tab.

## Outcome
I don't have to do https://github.com/Zorbatron/ZBGT/commit/2caf7df9e9e31da9fc9284b2dd8a91c936209170 anymore