### PR TITLE
Extra tooltips for machines

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBatteryBuffer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBatteryBuffer.java
@@ -175,6 +175,7 @@ public class MetaTileEntityBatteryBuffer extends TieredMetaTileEntity implements
     public void addToolUsages(ItemStack stack, @Nullable World world, List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.tool_action.screwdriver.access_covers"));
         tooltip.add(I18n.format("gregtech.tool_action.wrench.set_facing"));
+        tooltip.add(I18n.format("gregtech.tool_action.soft_mallet.reset"));
         super.addToolUsages(stack, world, tooltip, advanced);
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMachineHatch.java
@@ -97,6 +97,7 @@ public class MetaTileEntityMachineHatch extends MetaTileEntityMultiblockNotifiab
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("gregtech.machine.machine_hatch.processing_array"));
+        tooltip.add(I18n.format("gregtech.universal.disabled"));
     }
 
     @Override


### PR DESCRIPTION
## What
Adds tooltips to blocks/machines that I think are missing. Draft PR for now in case I find more in the future.

## Implementation Details
_Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed._

## Outcome
More tooltips

Currently has:
- Soft mallet tooltip on battery buffers to tell players you can toggle them on and off.
- Multiblock sharing disabled on machine access hatches.
