### PR TITLE
Fix creative tanks only outputting up to 1kL at a time

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -129,7 +129,7 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
             if (fluidHandler == null || fluidHandler.getTankProperties().length == 0)
                 return;
 
-            FluidStack stack = fluidTank.getFluid().copy();
+            FluidStack stack = fluidTank.getFluid();
             int canInsertAmount = fluidHandler.fill(stack, false);
             stack.amount = Math.min(mBPerCycle, canInsertAmount);
 
@@ -230,6 +230,18 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
         @Override
         public int fill(FluidStack resource, boolean doFill) {
             return 0;
+        }
+
+        @Override
+        public FluidStack getFluid() {
+            FluidStack fluid = super.getFluid();
+
+            if (fluid != null) {
+                fluid = fluid.copy();
+                fluid.amount = mBPerCycle;
+            }
+
+            return fluid;
         }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityCreativeTank.java
@@ -129,11 +129,7 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
             if (fluidHandler == null || fluidHandler.getTankProperties().length == 0)
                 return;
 
-            FluidStack stack = fluidTank.getFluid();
-            int canInsertAmount = fluidHandler.fill(stack, false);
-            stack.amount = Math.min(mBPerCycle, canInsertAmount);
-
-            fluidHandler.fill(stack, true);
+            fluidHandler.fill(fluidTank.drain(mBPerCycle, false), true);
         }
     }
 
@@ -230,18 +226,6 @@ public class MetaTileEntityCreativeTank extends MetaTileEntityQuantumTank {
         @Override
         public int fill(FluidStack resource, boolean doFill) {
             return 0;
-        }
-
-        @Override
-        public FluidStack getFluid() {
-            FluidStack fluid = super.getFluid();
-
-            if (fluid != null) {
-                fluid = fluid.copy();
-                fluid.amount = mBPerCycle;
-            }
-
-            return fluid;
         }
     }
 }


### PR DESCRIPTION
## What
Fixes an issue with #1963 which made it so creative tanks would only push 1kL of fluid at a time.

## Implementation Details
Is overriding `getFluid` in the creative tank handler a good idea or would it be better to re-add the `stack.amount = mBPerCycle;` that was removed in #1963?

## Outcome
Creative tanks work again.