### PR TITLE
Improved locking Fluids in Output Hatches

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -348,8 +348,9 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
                 return;
             }
             if (!importItems.getStackInSlot(0).isEmpty()) {
-                IFluidHandlerItem fluidHandler = importItems.getStackInSlot(0).copy().getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
-                if (fluidHandler == null){
+                IFluidHandlerItem fluidHandler = importItems.getStackInSlot(0).copy()
+                        .getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+                if (fluidHandler == null) {
                     return;
                 }
                 FluidStack heldFluid = fluidHandler.drain(Integer.MAX_VALUE, false);


### PR DESCRIPTION
## What
I've added a second way of locking fluids in output hatches, because the old one is kind of a hassle sometimes imo. Since a recipe has to be run in order to fill the output in the first place, there's no way to lock fluids before the first run of the multiblock. If the fluids then end up in the wrong hatch, you're still screwed.

## Outcome
You can now place a fluid container in the input slot of the hatch and press the lock button. If the container contains a fluid, the locked fluid will be set to that one. With that option, you can filter your outputs inb4 running recipes.

## Additional Information
I've left the original way untouched and put that as priority. Meaning, it will take predence over the method I've implemented.
Screenshots attached.
![Screenshot (748)](https://github.com/user-attachments/assets/e347cbed-588f-4ae1-9e48-961e6e392a9e)
![Screenshot (749)](https://github.com/user-attachments/assets/1889f87d-338e-422e-b200-f356ba45f9ab)

