### PR TITLE
Added repairing recipe workaround for specially registered tools

### DIFF
--- a/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
+++ b/src/main/java/gregtech/asm/hooks/RecipeRepairItemHooks.java
@@ -96,7 +96,7 @@ public class RecipeRepairItemHooks {
 
                     // two GT tools, so use own logic to produce the correct output
                     IGTTool tool = (IGTTool) first.getItem();
-                    ItemStack output = tool.get(tool.getToolMaterial(first));
+                    ItemStack output = tool.get(tool.getToolMaterial(first), first);
 
                     NBTTagCompound outputTag = ToolHelper.getToolTag(output);
                     outputTag.setInteger(ToolHelper.DURABILITY_KEY, i1);

--- a/src/main/java/gregtech/mixins/minecraft/RecipeRepairItemMixin.java
+++ b/src/main/java/gregtech/mixins/minecraft/RecipeRepairItemMixin.java
@@ -76,7 +76,7 @@ public class RecipeRepairItemMixin {
             if (itemstack2.getItemDamage() == 0 && itemstack3.getItemDamage() == 0) {
                 return ItemStack.EMPTY;
             } else {
-                ItemStack output = first.get(first.getToolMaterial(itemstack2));
+                ItemStack output = first.get(first.getToolMaterial(itemstack2), itemstack2);
                 NBTTagCompound outputTag = ToolHelper.getToolTag(output);
                 outputTag.setInteger(ToolHelper.DURABILITY_KEY, itemDamage);
                 return output;


### PR DESCRIPTION
This fix will eliminate the `NullPointerException` caused from repairing tools without `toolProperty` properly set for the material. Therefore, the current soft-mallet/plumber duplication will be fixed since they are separately registered currently.

## What
Fixes #2692.

## Implementation Details
The new `IGTTool.get` can take additional item to infer the required properties if `toolProperty` is not set.

## Outcome
Fixes #2692.

## Potential Compatibility Issues
If some mod can change the max durability NBT then this might break (as max durability is inferred from the items).