### PR TITLE
Fix Ghost Circuit Scrolling Twice

### DIFF
--- a/src/main/java/gregtech/api/mui/widget/GhostCircuitSlotWidget.java
+++ b/src/main/java/gregtech/api/mui/widget/GhostCircuitSlotWidget.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.GhostCircuitItemStackHandler;
 import gregtech.api.mui.GTGuiTextures;
 import gregtech.api.mui.GTGuis;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
+import gregtech.api.util.GTLog;
 import gregtech.client.utils.TooltipHelper;
 
 import net.minecraft.network.PacketBuffer;
@@ -55,7 +56,7 @@ public class GhostCircuitSlotWidget extends ItemSlot {
         if (isSelectorPanelOpen()) return true;
         MouseData mouseData = MouseData.create(scrollDirection.modifier);
         getSyncHandler().syncToServer(3, mouseData::writeToPacket);
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/api/mui/widget/GhostCircuitSlotWidget.java
+++ b/src/main/java/gregtech/api/mui/widget/GhostCircuitSlotWidget.java
@@ -4,7 +4,6 @@ import gregtech.api.capability.impl.GhostCircuitItemStackHandler;
 import gregtech.api.mui.GTGuiTextures;
 import gregtech.api.mui.GTGuis;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
-import gregtech.api.util.GTLog;
 import gregtech.client.utils.TooltipHelper;
 
 import net.minecraft.network.PacketBuffer;


### PR DESCRIPTION
## What
fixes scrolling twice for the ghost circuit

## Implementation Details
return true on scroll to tell mui2 that the input event should be cancelled, otherwise the input event is run twice

## Outcome
ghost circuit slot scrolls correctly