### PR TITLE
Improve Logging for Unread Packet Data

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -1,8 +1,5 @@
 package gregtech.api.capability;
 
-import gregtech.common.covers.ender.CoverAbstractEnderLink;
-import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityFluidHatch;
-
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.apache.commons.lang3.ArrayUtils;
@@ -12,6 +9,8 @@ import java.lang.reflect.Modifier;
 
 public class GregtechDataCodes {
 
+    public static final int UPDATE_PRIVATE = assignId();
+    public static final int LOCK_FILL = assignId();
     private static int nextId = 0;
 
     public static int assignId() {
@@ -196,9 +195,6 @@ public class GregtechDataCodes {
 
     static {
         registerFields(GregtechDataCodes.class);
-        // todo these really should be moved to this class
-        registerFields(CoverAbstractEnderLink.class, CoverAbstractEnderLink.UPDATE_PRIVATE);
-        registerFields(MetaTileEntityFluidHatch.class, MetaTileEntityFluidHatch.LOCK_FILL);
     }
 
     public static String getNameFor(int id) {

--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -1,5 +1,10 @@
 package gregtech.api.capability;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+
+import java.lang.reflect.Field;
+
 public class GregtechDataCodes {
 
     private static int nextId = 0;
@@ -180,4 +185,20 @@ public class GregtechDataCodes {
     // ME Parts
     public static final int UPDATE_AUTO_PULL = assignId();
     public static final int UPDATE_ONLINE_STATUS = assignId();
+
+    // Everything below MUST be last in the class!
+    public static final Int2ObjectMap<String> NAMES = new Int2ObjectArrayMap<>();
+
+    static {
+        try {
+            for (Field field : GregtechDataCodes.class.getFields()) {
+                if (field.getType() != Integer.TYPE) continue;
+                NAMES.put(field.getInt(null), field.getName());
+            }
+        } catch (IllegalAccessException ignored) {}
+    }
+
+    public static String getNameFor(int id) {
+        return NAMES.getOrDefault(id, "Unknown DataCode: " + id);
+    }
 }

--- a/src/main/java/gregtech/api/cover/CoverSaveHandler.java
+++ b/src/main/java/gregtech/api/cover/CoverSaveHandler.java
@@ -1,5 +1,6 @@
 package gregtech.api.cover;
 
+import gregtech.api.metatileentity.interfaces.ISyncedTileEntity;
 import gregtech.api.util.GTLog;
 
 import net.minecraft.nbt.NBTTagCompound;
@@ -66,6 +67,7 @@ public final class CoverSaveHandler {
             } else {
                 Cover cover = definition.createCover(coverHolder, facing);
                 cover.readInitialSyncData(buf);
+                ISyncedTileEntity.checkInitialData(buf, cover);
                 coverHolder.addCover(facing, cover);
             }
         }
@@ -107,6 +109,7 @@ public final class CoverSaveHandler {
             coverHolder.addCover(placementSide, cover);
 
             cover.readInitialSyncData(buf);
+            ISyncedTileEntity.checkInitialData(buf, cover);
         }
         coverHolder.scheduleRenderUpdate();
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1043,7 +1043,10 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             MTETrait trait = mteTraitByNetworkId.get(traitNetworkId);
             if (trait == null) {
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
-            } else trait.receiveInitialData(buf);
+            } else {
+                trait.receiveInitialSyncData(buf);
+                ISyncedTileEntity.checkInitialData(buf, trait);
+            }
         }
         CoverSaveHandler.receiveInitialSyncData(buf, this);
         this.muffled = buf.readBoolean();
@@ -1076,10 +1079,14 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             scheduleRenderUpdate();
         } else if (dataId == SYNC_MTE_TRAITS) {
             int traitNetworkId = buf.readVarInt();
+            int internalId = buf.readVarInt();
             MTETrait trait = mteTraitByNetworkId.get(traitNetworkId);
             if (trait == null) {
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
-            } else trait.receiveCustomData(buf.readVarInt(), buf);
+            } else {
+                trait.receiveCustomData(internalId, buf);
+                ISyncedTileEntity.checkCustomData(internalId, buf, trait);
+            }
         } else if (dataId == COVER_ATTACHED_MTE) {
             CoverSaveHandler.readCoverPlacement(buf, this);
         } else if (dataId == COVER_REMOVED_MTE) {
@@ -1095,10 +1102,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             int internalId = buf.readVarInt();
             if (cover != null) {
                 cover.readCustomData(internalId, buf);
+                ISyncedTileEntity.checkCustomData(internalId, buf, cover);
             }
-            if (buf.readableBytes() != 0)
-                ISyncedTileEntity.handleUnreadPacket(internalId, buf, this);
-            buf.clear(); // clear data so holder doesn't log error
         } else if (dataId == UPDATE_SOUND_MUFFLED) {
             this.muffled = buf.readBoolean();
             if (muffled) {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1096,6 +1096,9 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             if (cover != null) {
                 cover.readCustomData(internalId, buf);
             }
+            if (buf.readableBytes() != 0)
+                ISyncedTileEntity.handleUnreadPacket(internalId, buf, this);
+            buf.clear(); // clear data so holder doesn't log error
         } else if (dataId == UPDATE_SOUND_MUFFLED) {
             this.muffled = buf.readBoolean();
             if (muffled) {

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -80,19 +80,10 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity implemen
             NBTTagCompound entryTag = (NBTTagCompound) entryBase;
             for (String discriminatorKey : entryTag.getKeySet()) {
                 ByteBuf backedBuffer = Unpooled.copiedBuffer(entryTag.getByteArray(discriminatorKey));
-                receiveCustomData(Integer.parseInt(discriminatorKey), new PacketBuffer(backedBuffer));
+                int dataId = Integer.parseInt(discriminatorKey);
+                receiveCustomData(dataId, new PacketBuffer(backedBuffer));
                 if (backedBuffer.readableBytes() != 0) {
-                    String className = null;
-                    if (this instanceof IGregTechTileEntity gtte) {
-                        MetaTileEntity mte = gtte.getMetaTileEntity();
-                        if (mte != null) className = mte.getClass().getName();
-                    }
-                    if (className == null) {
-                        className = this.getClass().getName();
-                    }
-                    GTLog.logger.error(
-                            "Class {} failed to finish reading receiveCustomData with discriminator {} and {} bytes remaining",
-                            className, discriminatorKey, backedBuffer.readableBytes());
+                    ISyncedTileEntity.handleUnreadPacket(dataId, backedBuffer, this);
                 }
             }
         }

--- a/src/main/java/gregtech/common/covers/ender/CoverAbstractEnderLink.java
+++ b/src/main/java/gregtech/common/covers/ender/CoverAbstractEnderLink.java
@@ -60,7 +60,6 @@ public abstract class CoverAbstractEnderLink<T extends VirtualEntry> extends Cov
                                             implements CoverWithUI, ITickable, IControllable {
 
     protected static final Pattern COLOR_INPUT_PATTERN = Pattern.compile("[0-9a-fA-F]*");
-    public static final int UPDATE_PRIVATE = GregtechDataCodes.assignId();
 
     protected T activeEntry = null;
     protected String color = VirtualEntry.DEFAULT_COLOR;
@@ -100,7 +99,7 @@ public abstract class CoverAbstractEnderLink<T extends VirtualEntry> extends Cov
     @Override
     public void readCustomData(int discriminator, @NotNull PacketBuffer buf) {
         super.readCustomData(discriminator, buf);
-        if (discriminator == UPDATE_PRIVATE) {
+        if (discriminator == GregtechDataCodes.UPDATE_PRIVATE) {
             setPrivate(buf.readBoolean());
             updateLink();
         }
@@ -246,7 +245,7 @@ public abstract class CoverAbstractEnderLink<T extends VirtualEntry> extends Cov
     private void setPrivate(boolean isPrivate) {
         this.isPrivate = isPrivate;
         updateLink();
-        writeCustomData(UPDATE_PRIVATE, buffer -> buffer.writeBoolean(this.isPrivate));
+        writeCustomData(GregtechDataCodes.UPDATE_PRIVATE, buffer -> buffer.writeBoolean(this.isPrivate));
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -54,7 +54,6 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
                                       implements IMultiblockAbilityPart<IFluidTank>, IControllable {
 
     public static final int INITIAL_INVENTORY_SIZE = 8000;
-    public static final int LOCK_FILL = GregtechDataCodes.assignId();
 
     // only holding this for convenience
     protected final HatchFluidTank fluidTank;
@@ -168,7 +167,7 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
         super.receiveCustomData(dataId, buf);
         if (dataId == GregtechDataCodes.WORKING_ENABLED) {
             this.workingEnabled = buf.readBoolean();
-        } else if (dataId == LOCK_FILL) {
+        } else if (dataId == GregtechDataCodes.LOCK_FILL) {
             this.lockedFluid = NetworkUtils.readFluidStack(buf);
         }
     }
@@ -352,7 +351,8 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
             if (doFill && locked && lockedFluid == null) {
                 lockedFluid = resource.copy();
                 lockedFluid.amount = 1;
-                writeCustomData(LOCK_FILL, buffer -> NetworkUtils.writeFluidStack(buffer, lockedFluid));
+                writeCustomData(GregtechDataCodes.LOCK_FILL,
+                        buffer -> NetworkUtils.writeFluidStack(buffer, lockedFluid));
             }
             return accepted;
         }


### PR DESCRIPTION
## What
Improves the logging for unread packet data

## Implementation Details
Add a method to iterate through a classes fields to find valid data codes, then put the name of that field into a Int2String map.
the method also allows for addons to register their id classes as well
if the id is not registered, `"Unknown_DataCode:#"` is returned instead, with `#` being the id.
Adds a static method to ISyncedTileEntity to handle unread packet logging
log unread packet data at the MTE level for covers

## Outcome
Logging now tells us exactly which ID was called instead of just its assigned int
