### PR TITLE
Fix Issues from Unread Packet Data

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -9,8 +9,6 @@ import java.lang.reflect.Modifier;
 
 public class GregtechDataCodes {
 
-    public static final int UPDATE_PRIVATE = assignId();
-    public static final int LOCK_FILL = assignId();
     private static int nextId = 0;
 
     public static int assignId() {
@@ -97,6 +95,7 @@ public class GregtechDataCodes {
     public static final int MAINTENANCE_MULTIPLIER = assignId();
     public static final int UPDATE_UPWARDS_FACING = assignId();
     public static final int UPDATE_FLIP = assignId();
+    public static final int LOCK_FILL = assignId();
 
     // Item Bus Item Stack Auto Collapsing
     public static final int TOGGLE_COLLAPSE_ITEMS = assignId();
@@ -156,6 +155,9 @@ public class GregtechDataCodes {
 
     // Detector Covers
     public static final int UPDATE_INVERTED = assignId();
+
+    // Ender Covers
+    public static final int UPDATE_PRIVATE = assignId();
 
     // HPCA / Research Station
     public static final int DAMAGE_STATE = assignId();

--- a/src/main/java/gregtech/api/cover/CoverSaveHandler.java
+++ b/src/main/java/gregtech/api/cover/CoverSaveHandler.java
@@ -1,6 +1,5 @@
 package gregtech.api.cover;
 
-import gregtech.api.metatileentity.interfaces.ISyncedTileEntity;
 import gregtech.api.util.GTLog;
 
 import net.minecraft.nbt.NBTTagCompound;
@@ -67,7 +66,6 @@ public final class CoverSaveHandler {
             } else {
                 Cover cover = definition.createCover(coverHolder, facing);
                 cover.readInitialSyncData(buf);
-                ISyncedTileEntity.checkInitialData(buf, cover);
                 coverHolder.addCover(facing, cover);
             }
         }
@@ -109,7 +107,6 @@ public final class CoverSaveHandler {
             coverHolder.addCover(placementSide, cover);
 
             cover.readInitialSyncData(buf);
-            ISyncedTileEntity.checkInitialData(buf, cover);
         }
         coverHolder.scheduleRenderUpdate();
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1084,6 +1084,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
             } else {
                 trait.receiveCustomData(internalId, buf);
+
+                // this should be fine, as nothing else is read after this
                 ISyncedTileEntity.checkCustomData(internalId, buf, trait);
             }
         } else if (dataId == COVER_ATTACHED_MTE) {
@@ -1101,6 +1103,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             int internalId = buf.readVarInt();
             if (cover != null) {
                 cover.readCustomData(internalId, buf);
+
+                // this should be fine, as nothing else is read after this
                 ISyncedTileEntity.checkCustomData(internalId, buf, cover);
             }
         } else if (dataId == UPDATE_SOUND_MUFFLED) {

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1045,7 +1045,6 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
             } else {
                 trait.receiveInitialSyncData(buf);
-                ISyncedTileEntity.checkInitialData(buf, trait);
             }
         }
         CoverSaveHandler.receiveInitialSyncData(buf, this);


### PR DESCRIPTION
## What
Fixes issues with #2698

## Implementation Details
data checks were placed in the middle of data being read, which is very problematic as the buffer is reset when checking to prevent logging the same issue several times

## Outcome
data is actually read