### PR TITLE
Improve Logging (again) for Unread Packet Data

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1083,10 +1083,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             if (trait == null) {
                 GTLog.logger.warn("Could not find MTETrait for id: {} at position {}.", traitNetworkId, getPos());
             } else {
+                ISyncedTileEntity.addCode(internalId, trait);
                 trait.receiveCustomData(internalId, buf);
-
-                // this should be fine, as nothing else is read after this
-                ISyncedTileEntity.checkCustomData(internalId, buf, trait);
             }
         } else if (dataId == COVER_ATTACHED_MTE) {
             CoverSaveHandler.readCoverPlacement(buf, this);
@@ -1102,10 +1100,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
             Cover cover = getCoverAtSide(coverSide);
             int internalId = buf.readVarInt();
             if (cover != null) {
+                ISyncedTileEntity.addCode(internalId, cover);
                 cover.readCustomData(internalId, buf);
-
-                // this should be fine, as nothing else is read after this
-                ISyncedTileEntity.checkCustomData(internalId, buf, cover);
             }
         } else if (dataId == UPDATE_SOUND_MUFFLED) {
             this.muffled = buf.readBoolean();

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -1,7 +1,6 @@
 package gregtech.api.metatileentity;
 
 import gregtech.api.block.BlockStateTileEntity;
-import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.interfaces.ISyncedTileEntity;
 import gregtech.api.network.PacketDataList;
 
@@ -80,12 +79,9 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity implemen
             for (String discriminatorKey : entryTag.getKeySet()) {
                 ByteBuf backedBuffer = Unpooled.copiedBuffer(entryTag.getByteArray(discriminatorKey));
                 int dataId = Integer.parseInt(discriminatorKey);
+                ISyncedTileEntity.addCode(dataId, this);
                 receiveCustomData(dataId, new PacketBuffer(backedBuffer));
-
-                MetaTileEntity mte = null;
-                if (this instanceof IGregTechTileEntity gtte)
-                    mte = gtte.getMetaTileEntity();
-                ISyncedTileEntity.checkCustomData(dataId, backedBuffer, mte == null ? this : mte);
+                ISyncedTileEntity.checkData(backedBuffer);
             }
         }
     }
@@ -105,11 +101,8 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity implemen
         super.readFromNBT(tag); // deserializes Forge data and capabilities
         byte[] updateData = tag.getByteArray("d");
         ByteBuf backedBuffer = Unpooled.copiedBuffer(updateData);
+        ISyncedTileEntity.track(this);
         receiveInitialSyncData(new PacketBuffer(backedBuffer));
-
-        MetaTileEntity mte = null;
-        if (this instanceof IGregTechTileEntity gtte)
-            mte = gtte.getMetaTileEntity();
-        ISyncedTileEntity.checkInitialData(backedBuffer, mte == null ? this : mte);
+        ISyncedTileEntity.checkData(backedBuffer);
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/interfaces/ISyncedTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/interfaces/ISyncedTileEntity.java
@@ -10,6 +10,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 
 import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
@@ -20,6 +22,8 @@ import java.util.function.Consumer;
 public interface ISyncedTileEntity {
 
     Consumer<PacketBuffer> NO_OP = buf -> {};
+    IntList datacodes = new IntArrayList();
+    ThreadLocal<Object> tracked = ThreadLocal.withInitial(() -> null);
 
     /**
      * Used to sync data from Server -> Client.
@@ -119,26 +123,25 @@ public interface ISyncedTileEntity {
      */
     void receiveCustomData(int discriminator, @NotNull PacketBuffer buf);
 
-    static void checkCustomData(int discriminator, @NotNull ByteBuf buf, Object obj) {
-        if (buf.readableBytes() == 0) return;
+    static void checkData(@NotNull ByteBuf buf) {
+        if (buf.readableBytes() != 0) {
+            if (datacodes.isEmpty()) {
+                GTLog.logger.error("Class {} failed to finish reading initialSyncData with {} bytes remaining",
+                        stringify(tracked.get()), buf.readableBytes());
+            } else {
+                GTLog.logger.error(
+                        "Class {} failed to finish reading receiveCustomData at code path [{}] with {} bytes remaining",
+                        stringify(tracked.get()), getCodePath(), buf.readableBytes());
+            }
+        }
 
-        GTLog.logger.error(
-                "Class {} failed to finish reading receiveCustomData with discriminator {} and {} bytes remaining",
-                stringify(obj), GregtechDataCodes.getNameFor(discriminator), buf.readableBytes());
-
-        buf.clear(); // clear to prevent further logging
-    }
-
-    static void checkInitialData(@NotNull ByteBuf buf, Object obj) {
-        if (buf.readableBytes() == 0) return;
-
-        GTLog.logger.error("Class {} failed to finish reading initialSyncData with {} bytes remaining",
-                stringify(obj), buf.readableBytes());
-
-        buf.clear(); // clear to prevent further logging
+        reset();
     }
 
     static String stringify(Object obj) {
+        if (obj instanceof IGregTechTileEntity gtte && gtte.getMetaTileEntity() != null)
+            obj = gtte.getMetaTileEntity();
+
         StringBuilder builder = new StringBuilder(obj.getClass().getSimpleName());
 
         BlockPos pos = null;
@@ -157,5 +160,28 @@ public interface ISyncedTileEntity {
                 .append(pos.getZ()).append("Z}");
 
         return builder.toString();
+    }
+
+    static void addCode(int code, Object trackedObject) {
+        datacodes.add(code);
+        track(trackedObject);
+    }
+
+    static void track(Object trackedObject) {
+        tracked.set(trackedObject);
+    }
+
+    static String getCodePath() {
+        var builder = new StringBuilder();
+        for (int i = 0; i < datacodes.size(); i++) {
+            builder.append(GregtechDataCodes.getNameFor(datacodes.get(i)));
+            if (i < datacodes.size() - 1) builder.append(" > ");
+        }
+        return builder.toString();
+    }
+
+    static void reset() {
+        datacodes.clear();
+        tracked.remove();
     }
 }


### PR DESCRIPTION
## What
tracks active data codes and relevant objects, then logs them after reading data

## Implementation Details
an int list and object fields were added to ISyncedTileEntity, along with methods to manipulate them
they might be better in a class perhaps?
actually made sure steam boilers don't invade the world
prints active data codes as a path like: `... [SYNC_MTE_TRAITS:3 > WORKABLE_ACTIVE:83] ...`

## Outcome
data is logged even better than before
steam boilers do not take over (for now)
