### PR TITLE
Fix the cleanroom multiblock overriding the cleanroom provider set by cleaning hatches.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/WorkableTieredMetaTileEntity.java
@@ -47,6 +47,7 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity
 
     public final boolean handlesRecipeOutputs;
 
+    @Nullable
     private ICleanroomProvider cleanroom;
 
     public WorkableTieredMetaTileEntity(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap,
@@ -210,7 +211,12 @@ public abstract class WorkableTieredMetaTileEntity extends TieredMetaTileEntity
     }
 
     @Override
-    public void setCleanroom(ICleanroomProvider provider) {
+    public void setCleanroom(@NotNull ICleanroomProvider provider) {
         this.cleanroom = provider;
+    }
+
+    @Override
+    public void unsetCleanroom() {
+        this.cleanroom = null;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
@@ -64,4 +64,11 @@ public final class DummyCleanroom implements ICleanroomProvider {
 
     @Override
     public void adjustCleanAmount(int amount) {}
+
+    // Have a higher priority than the cleanroom multiblock (which doesn't override getPriority so it'll return 0)
+    // doesn't replace the set cleanroom in multiblocks.
+    @Override
+    public int getPriority() {
+        return 1;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/DummyCleanroom.java
@@ -69,6 +69,6 @@ public final class DummyCleanroom implements ICleanroomProvider {
     // doesn't replace the set cleanroom in multiblocks.
     @Override
     public int getPriority() {
-        return 1;
+        return Integer.MAX_VALUE;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomProvider.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomProvider.java
@@ -49,4 +49,13 @@ public interface ICleanroomProvider {
      * @return the tier {@link gregtech.api.GTValues#V} of energy the cleanroom uses at minimum
      */
     int getEnergyTier();
+
+    /**
+     * Get the priority of this cleanroom provider to determine which should be used.
+     * 
+     * @return the priority this cleanroom provider should have over other cleanrooms.
+     */
+    default int getPriority() {
+        return 0;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomReceiver.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/ICleanroomReceiver.java
@@ -1,5 +1,6 @@
 package gregtech.api.metatileentity.multiblock;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -19,5 +20,11 @@ public interface ICleanroomReceiver {
      *
      * @param provider the cleanroom to assign to this machine
      */
-    void setCleanroom(ICleanroomProvider provider);
+    void setCleanroom(@NotNull ICleanroomProvider provider);
+
+    /**
+     * Set the receiver's reference to null. Use instead of passing {@code null} to
+     * {@link ICleanroomReceiver#setCleanroom(ICleanroomProvider)}
+     */
+    void unsetCleanroom();
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -51,6 +51,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
 
     private boolean isDistinct = false;
 
+    @Nullable
     private ICleanroomProvider cleanroom;
 
     public RecipeMapMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap) {
@@ -320,9 +321,14 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     @Override
-    public void setCleanroom(ICleanroomProvider provider) {
+    public void setCleanroom(@NotNull ICleanroomProvider provider) {
         if (cleanroom == null || provider.getPriority() > cleanroom.getPriority()) {
             this.cleanroom = provider;
         }
+    }
+
+    @Override
+    public void unsetCleanroom() {
+        this.cleanroom = null;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -321,6 +321,8 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
 
     @Override
     public void setCleanroom(ICleanroomProvider provider) {
-        this.cleanroom = provider;
+        if (cleanroom == null || provider.getPriority() > cleanroom.getPriority()) {
+            this.cleanroom = provider;
+        }
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityCleanroom.java
@@ -150,7 +150,11 @@ public class MetaTileEntityCleanroom extends MultiblockWithDisplayBase
         resetTileAbilities();
         this.cleanroomLogic.invalidate();
         this.cleanAmount = MIN_CLEAN_AMOUNT;
-        cleanroomReceivers.forEach(receiver -> receiver.setCleanroom(null));
+        cleanroomReceivers.forEach(receiver -> {
+            if (receiver.getCleanroom() == this) {
+                receiver.unsetCleanroom();
+            }
+        });
         cleanroomReceivers.clear();
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityProcessingArray.java
@@ -239,10 +239,17 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
     }
 
     @Override
-    public void setCleanroom(ICleanroomProvider provider) {
+    public void setCleanroom(@NotNull ICleanroomProvider provider) {
         super.setCleanroom(provider);
 
         // Sync Cleanroom Change to Internal Workable MTE
+        ((ProcessingArrayWorkable) this.recipeMapWorkable).updateCleanroom();
+    }
+
+    @Override
+    public void unsetCleanroom() {
+        super.unsetCleanroom();
+
         ((ProcessingArrayWorkable) this.recipeMapWorkable).updateCleanroom();
     }
 
@@ -269,8 +276,8 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
             super.invalidate();
 
             // invalidate mte's cleanroom reference
-            if (mte != null && mte instanceof ICleanroomReceiver) {
-                ((ICleanroomReceiver) mte).setCleanroom(null);
+            if (mte != null && mte instanceof ICleanroomReceiver cleanroomMTE) {
+                cleanroomMTE.unsetCleanroom();
             }
 
             // Reset locally cached variables upon invalidation
@@ -284,7 +291,7 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
 
         /**
          * Checks if a provided Recipe Map is valid to be used in the processing array
-         * Will filter out anything in the config blacklist, and also any non-singleblock machines
+         * Will filter out anything in the config blacklist, and also any non-single block machines
          *
          * @param recipeMap The recipeMap to check
          * @return {@code true} if the provided recipeMap is valid for use
@@ -360,7 +367,11 @@ public class MetaTileEntityProcessingArray extends RecipeMapMultiblockController
                     receiver.setCleanroom(DUMMY_CLEANROOM);
                 } else {
                     ICleanroomProvider provider = ((RecipeMapMultiblockController) metaTileEntity).getCleanroom();
-                    if (provider != null) receiver.setCleanroom(provider);
+                    if (provider == null) {
+                        receiver.unsetCleanroom();
+                    } else {
+                        receiver.setCleanroom(provider);
+                    }
                 }
             }
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -35,6 +35,7 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
 
     static {
         CLEANED_TYPES.add(CleanroomType.CLEANROOM);
+        CLEANED_TYPES.add(CleanroomType.STERILE_CLEANROOM);
     }
 
     // must come after the static block

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -52,9 +52,9 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
     @Override
     public void addToMultiBlock(MultiblockControllerBase controllerBase) {
         super.addToMultiBlock(controllerBase);
-        if (controllerBase instanceof ICleanroomReceiver &&
-                ((ICleanroomReceiver) controllerBase).getCleanroom() == null) {
-            ((ICleanroomReceiver) controllerBase).setCleanroom(DUMMY_CLEANROOM);
+        if (controllerBase instanceof ICleanroomReceiver cleanroomReceiver &&
+                cleanroomReceiver.getCleanroom() == null) {
+            cleanroomReceiver.setCleanroom(DUMMY_CLEANROOM);
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -35,7 +35,6 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
 
     static {
         CLEANED_TYPES.add(CleanroomType.CLEANROOM);
-        CLEANED_TYPES.add(CleanroomType.STERILE_CLEANROOM);
     }
 
     // must come after the static block

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityCleaningMaintenanceHatch.java
@@ -52,8 +52,7 @@ public class MetaTileEntityCleaningMaintenanceHatch extends MetaTileEntityAutoMa
     @Override
     public void addToMultiBlock(MultiblockControllerBase controllerBase) {
         super.addToMultiBlock(controllerBase);
-        if (controllerBase instanceof ICleanroomReceiver cleanroomReceiver &&
-                cleanroomReceiver.getCleanroom() == null) {
+        if (controllerBase instanceof ICleanroomReceiver cleanroomReceiver) {
             cleanroomReceiver.setCleanroom(DUMMY_CLEANROOM);
         }
     }


### PR DESCRIPTION
## What
In my addon, I have a maintenance hatch that is like the cleaning maintenance hatch but it does sterile cleaning. The cleanroom set by the hatch gets overriden by a cleanroom multiblock if the multi is built inside one.

## Implementation Details
An `ICleanroomProvider` can specify a priority which and in `RecipeMapMultiblockController`s, the internal cleanroom provider will only be set if the new one has a higher priority than the existing one. This priority defaults to `0`. Cleaning hatches override than and return max int, so it won't be replaced by a cleanroom multiblocks provider (which doesn't override `getPriority`.

## Additional Information
https://github.com/Zorbatron/ZBGT/issues/133