### PR TITLE
Show required energy in Quantum controller when out of power

### DIFF
--- a/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
+++ b/src/main/java/gregtech/integration/hwyla/HWYLAModule.java
@@ -4,7 +4,23 @@ import gregtech.api.GTValues;
 import gregtech.api.modules.GregTechModule;
 import gregtech.api.util.Mods;
 import gregtech.integration.IntegrationSubmodule;
-import gregtech.integration.hwyla.provider.*;
+import gregtech.integration.hwyla.provider.ActiveTransformerDataProvider;
+import gregtech.integration.hwyla.provider.BatteryBufferDataProvider;
+import gregtech.integration.hwyla.provider.BlockOreDataProvider;
+import gregtech.integration.hwyla.provider.ControllableDataProvider;
+import gregtech.integration.hwyla.provider.ConverterDataProvider;
+import gregtech.integration.hwyla.provider.DiodeDataProvider;
+import gregtech.integration.hwyla.provider.ElectricContainerDataProvider;
+import gregtech.integration.hwyla.provider.LampDataProvider;
+import gregtech.integration.hwyla.provider.MaintenanceDataProvider;
+import gregtech.integration.hwyla.provider.MultiRecipeMapDataProvider;
+import gregtech.integration.hwyla.provider.MultiblockDataProvider;
+import gregtech.integration.hwyla.provider.PrimitivePumpDataProvider;
+import gregtech.integration.hwyla.provider.QuantumStorageProvider;
+import gregtech.integration.hwyla.provider.RecipeLogicDataProvider;
+import gregtech.integration.hwyla.provider.SteamBoilerDataProvider;
+import gregtech.integration.hwyla.provider.TransformerDataProvider;
+import gregtech.integration.hwyla.provider.WorkableDataProvider;
 import gregtech.modules.GregTechModules;
 
 import net.minecraft.item.ItemStack;
@@ -42,6 +58,7 @@ public class HWYLAModule extends IntegrationSubmodule implements IWailaPlugin {
         LampDataProvider.INSTANCE.register(registrar);
         ActiveTransformerDataProvider.INSTANCE.register(registrar);
         BatteryBufferDataProvider.INSTANCE.register(registrar);
+        QuantumStorageProvider.INSTANCE.register(registrar);
     }
 
     /** Render an ItemStack. */

--- a/src/main/java/gregtech/integration/hwyla/provider/QuantumStorageProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/QuantumStorageProvider.java
@@ -38,7 +38,7 @@ public class QuantumStorageProvider implements IWailaDataProvider {
     public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world,
                                      BlockPos pos) {
         if (te instanceof IGregTechTileEntity gtte) {
-            if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?> storage &&
+            if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?>storage &&
                     (storage.getType() == IQuantumStorage.Type.ITEM ||
                             storage.getType() == IQuantumStorage.Type.FLUID)) {
                 var controller = storage.getQuantumController();
@@ -81,27 +81,27 @@ public class QuantumStorageProvider implements IWailaDataProvider {
             } else {
                 tooltip.add(I18n.format("gregtech.top.energy_consumption") + eutText);
             }
-        } else if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?> storage &&
+        } else if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?>storage &&
                 (storage.getType() == IQuantumStorage.Type.ITEM ||
                         storage.getType() == IQuantumStorage.Type.FLUID)) {
-            if (accessor.getNBTData().hasKey("gregtech.IQuantumStorageController")) {
-                NBTTagCompound tag = accessor.getNBTData()
-                        .getCompoundTag("gregtech.IQuantumStorageController");
-                int connection = tag.getInteger("Connection");
-                String status;
+                            if (accessor.getNBTData().hasKey("gregtech.IQuantumStorageController")) {
+                                NBTTagCompound tag = accessor.getNBTData()
+                                        .getCompoundTag("gregtech.IQuantumStorageController");
+                                int connection = tag.getInteger("Connection");
+                                String status;
 
-                switch (connection) {
-                    case 1 -> status = I18n.format("gregtech.top.quantum_status.powered");
-                    case 2 -> status = I18n.format("gregtech.top.quantum_status.connected");
-                    default -> status = I18n.format("gregtech.top.quantum_status.disconnected");
-                }
+                                switch (connection) {
+                                    case 1 -> status = I18n.format("gregtech.top.quantum_status.powered");
+                                    case 2 -> status = I18n.format("gregtech.top.quantum_status.connected");
+                                    default -> status = I18n.format("gregtech.top.quantum_status.disconnected");
+                                }
 
-                status = I18n.format("gregtech.top.quantum_status.label") +
-                        status;
+                                status = I18n.format("gregtech.top.quantum_status.label") +
+                                        status;
 
-                tooltip.add(status);
-            }
-        }
+                                tooltip.add(status);
+                            }
+                        }
 
         return tooltip;
     }

--- a/src/main/java/gregtech/integration/hwyla/provider/QuantumStorageProvider.java
+++ b/src/main/java/gregtech/integration/hwyla/provider/QuantumStorageProvider.java
@@ -1,0 +1,113 @@
+package gregtech.integration.hwyla.provider;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.IQuantumController;
+import gregtech.api.capability.IQuantumStorage;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.util.GTUtility;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.IWailaRegistrar;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class QuantumStorageProvider implements IWailaDataProvider {
+
+    public static final QuantumStorageProvider INSTANCE = new QuantumStorageProvider();
+
+    public void register(@NotNull IWailaRegistrar registrar) {
+        registrar.registerBodyProvider(this, IGregTechTileEntity.class);
+        registrar.registerNBTProvider(this, IGregTechTileEntity.class);
+        registrar.addConfig(GTValues.MOD_NAME, "gregtech.quantum_storage");
+    }
+
+    @NotNull
+    @Override
+    public NBTTagCompound getNBTData(EntityPlayerMP player, TileEntity te, NBTTagCompound tag, World world,
+                                     BlockPos pos) {
+        if (te instanceof IGregTechTileEntity gtte) {
+            if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?> storage &&
+                    (storage.getType() == IQuantumStorage.Type.ITEM ||
+                            storage.getType() == IQuantumStorage.Type.FLUID)) {
+                var controller = storage.getQuantumController();
+                int status = 0;
+
+                if (controller != null) {
+                    if (controller.isPowered()) {
+                        status = 1;
+                    } else {
+                        status = 2;
+                    }
+                }
+
+                NBTTagCompound subTag = new NBTTagCompound();
+                subTag.setInteger("Connection", status);
+                tag.setTag("gregtech.IQuantumStorageController", subTag);
+            }
+        }
+
+        return tag;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getWailaBody(ItemStack itemStack, List<String> tooltip, IWailaDataAccessor accessor,
+                                     IWailaConfigHandler config) {
+        if (!config.getConfig("gregtech.quantum_storage") ||
+                !(accessor.getTileEntity() instanceof IGregTechTileEntity gtte)) {
+            return tooltip;
+        }
+
+        if (gtte.getMetaTileEntity() instanceof IQuantumController controller) {
+            String eutText = configureEnergyUsage(controller.getEnergyUsage() / 10);
+            if (controller.getCount(IQuantumStorage.Type.ENERGY) == 0) {
+                tooltip.add(I18n.format("gregtech.top.quantum_controller.no_hatches"));
+                tooltip.add(I18n.format("gregtech.top.energy_required") + eutText);
+            } else if (!controller.isPowered()) {
+                tooltip.add(I18n.format("gregtech.top.quantum_controller.no_power"));
+                tooltip.add(I18n.format("gregtech.top.energy_required") + eutText);
+            } else {
+                tooltip.add(I18n.format("gregtech.top.energy_consumption") + eutText);
+            }
+        } else if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?> storage &&
+                (storage.getType() == IQuantumStorage.Type.ITEM ||
+                        storage.getType() == IQuantumStorage.Type.FLUID)) {
+            if (accessor.getNBTData().hasKey("gregtech.IQuantumStorageController")) {
+                NBTTagCompound tag = accessor.getNBTData()
+                        .getCompoundTag("gregtech.IQuantumStorageController");
+                int connection = tag.getInteger("Connection");
+                String status;
+
+                switch (connection) {
+                    case 1 -> status = I18n.format("gregtech.top.quantum_status.powered");
+                    case 2 -> status = I18n.format("gregtech.top.quantum_status.connected");
+                    default -> status = I18n.format("gregtech.top.quantum_status.disconnected");
+                }
+
+                status = I18n.format("gregtech.top.quantum_status.label") +
+                        status;
+
+                tooltip.add(status);
+            }
+        }
+
+        return tooltip;
+    }
+
+    public String configureEnergyUsage(long EUs) {
+        return TextFormatting.RED.toString() + EUs + " EU/t" + TextFormatting.GREEN +
+                " (" + GTValues.VNF[GTUtility.getTierByVoltage(EUs)] + TextFormatting.GREEN + ")";
+    }
+}

--- a/src/main/java/gregtech/integration/theoneprobe/provider/QuantumStorageProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/QuantumStorageProvider.java
@@ -34,6 +34,7 @@ public class QuantumStorageProvider implements IProbeInfoProvider {
                 String eutText = configureEnergyUsage(controller.getEnergyUsage() / 10);
                 if (controller.getCount(IQuantumStorage.Type.ENERGY) == 0) {
                     probeInfo.text("{*gregtech.top.quantum_controller.no_hatches*}");
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_required*} " + eutText);
                 } else if (!controller.isPowered()) {
                     probeInfo.text("{*gregtech.top.quantum_controller.no_power*}");
                     probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_required*} " + eutText);

--- a/src/main/java/gregtech/integration/theoneprobe/provider/QuantumStorageProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/QuantumStorageProvider.java
@@ -31,13 +31,14 @@ public class QuantumStorageProvider implements IProbeInfoProvider {
         if (blockState.getBlock().hasTileEntity(blockState) &&
                 world.getTileEntity(data.getPos()) instanceof IGregTechTileEntity gtte) {
             if (gtte.getMetaTileEntity() instanceof IQuantumController controller) {
+                String eutText = configureEnergyUsage(controller.getEnergyUsage() / 10);
                 if (controller.getCount(IQuantumStorage.Type.ENERGY) == 0) {
                     probeInfo.text("{*gregtech.top.quantum_controller.no_hatches*}");
                 } else if (!controller.isPowered()) {
                     probeInfo.text("{*gregtech.top.quantum_controller.no_power*}");
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_required*} " + eutText);
                 } else {
-                    long usage = controller.getEnergyUsage();
-                    configureEnergyUsage(usage / 10, probeInfo);
+                    probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + eutText);
                 }
             } else if (gtte.getMetaTileEntity() instanceof IQuantumStorage<?>storage &&
                     (storage.getType() == IQuantumStorage.Type.ITEM ||
@@ -59,10 +60,8 @@ public class QuantumStorageProvider implements IProbeInfoProvider {
                 "{*" + status + "*}";
     }
 
-    public void configureEnergyUsage(long EUs, IProbeInfo probeInfo) {
-        if (EUs == 0) return;
-        String text = TextFormatting.RED.toString() + EUs + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
+    public String configureEnergyUsage(long EUs) {
+        return TextFormatting.RED.toString() + EUs + TextStyleClass.INFO + " EU/t" + TextFormatting.GREEN +
                 " (" + GTValues.VNF[GTUtility.getTierByVoltage(EUs)] + TextFormatting.GREEN + ")";
-        probeInfo.text(TextStyleClass.INFO + "{*gregtech.top.energy_consumption*} " + text);
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -68,6 +68,7 @@ gregtech.top.working_disabled=Working Disabled
 
 gregtech.top.energy_consumption=Using
 gregtech.top.energy_production=Producing
+gregtech.top.energy_required=Requires
 
 gregtech.top.transform_up=Step Up
 gregtech.top.transform_down=Step Down


### PR DESCRIPTION
## What
Changes the TOP Quantum Controller info to show the required amount of power when the controller is unpowered. So that the player can know which kind of energy hatches they have to use at a minimum

## Outcome

Changes the TOP Quantum Controller info to show the required amount of power when the controller is unpowered. So that the player can know which kind of energy hatches they have to use at a minimum