### PR TITLE
Prevent Grid from rendering when holding a cover when block takes no …

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -737,7 +737,7 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     }
 
     @Override
-    public final boolean acceptsCovers() {
+    public boolean acceptsCovers() {
         return covers.size() < EnumFacing.VALUES.length;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -530,6 +530,11 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IFastRend
     }
 
     @Override
+    public boolean acceptsCovers() {
+        return false;
+    }
+
+    @Override
     public boolean canRenderMachineGrid(@NotNull ItemStack mainHandStack, @NotNull ItemStack offHandStack) {
         return false;
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -5,8 +5,16 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.gui.Widget.ClickData;
 import gregtech.api.gui.resources.TextureArea;
-import gregtech.api.gui.widgets.*;
+import gregtech.api.gui.widgets.AbstractWidgetGroup;
+import gregtech.api.gui.widgets.ClickButtonWidget;
+import gregtech.api.gui.widgets.CraftingStationInputWidgetGroup;
+import gregtech.api.gui.widgets.ImageWidget;
+import gregtech.api.gui.widgets.LabelWidget;
+import gregtech.api.gui.widgets.SimpleTextWidget;
+import gregtech.api.gui.widgets.SlotWidget;
+import gregtech.api.gui.widgets.TabGroup;
 import gregtech.api.gui.widgets.TabGroup.TabLocation;
+import gregtech.api.gui.widgets.WidgetGroup;
 import gregtech.api.gui.widgets.tab.ItemTabInfo;
 import gregtech.api.items.itemhandlers.GTItemStackHandler;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -251,6 +259,11 @@ public class MetaTileEntityWorkbench extends MetaTileEntity implements ICrafting
 
     @Override
     public boolean canPlaceCoverOnSide(@NotNull EnumFacing side) {
+        return false;
+    }
+
+    @Override
+    public boolean acceptsCovers() {
         return false;
     }
 


### PR DESCRIPTION
…covers

## What
Prevents the Machine Grid from rendering when holding a cover item, but the MTE does not allow covers to be placed on any face. We cannot check the `canPlaceCoverOnSide` method in the rendering check, because we want the player to be able to use the machine grid, if the MTE can accept a cover on any side. Therefore, we do this override for cases where covers were denied being placed on any side.



## Outcome
Prevent Machine grid from showing when holding a cover and looking at MTEs that could not accept any cover.
