### PR TITLE
Fix off by one in for Hatch Registration

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -785,7 +785,7 @@ public class MetaTileEntities {
         // MISC MTE's START: IDs 1150-2000
 
         // Import/Export Buses/Hatches, IDs 1150-1209
-        endPos = GregTechAPI.isHighTier() ? ITEM_IMPORT_BUS.length : GTValues.UHV;
+        endPos = GregTechAPI.isHighTier() ? ITEM_IMPORT_BUS.length : GTValues.UHV + 1;
         for (int i = 0; i < endPos; i++) {
             String voltageName = GTValues.VN[i].toLowerCase();
             ITEM_IMPORT_BUS[i] = new MetaTileEntityItemBus(gregtechId("item_bus.import." + voltageName), i, false);


### PR DESCRIPTION
## What
fixes an off by one issue when registering hatches in MetaTileEntities introduced by #2497 
which then causes a NPE when registering recipes for them

## Implementation Details
`+ 1`

## Outcome
we can dev again
