### PR TITLE
Fix Filter Popup Panels deleting cached panel

### DIFF
--- a/src/main/java/gregtech/api/mui/GTGuis.java
+++ b/src/main/java/gregtech/api/mui/GTGuis.java
@@ -72,47 +72,37 @@ public class GTGuis {
         return createPanel(valueItem.unlocalizedName);
     }
 
-    public static ModularPanel createPopupPanel(String name, int width, int height) {
-        return new PopupPanel(name, width, height);
+    public static PopupPanel createPopupPanel(String name, int width, int height) {
+        return defaultPopupPanel(name)
+                .size(width, height);
     }
 
-    public static ModularPanel createPopupPanel(String name, int width, int height, boolean deleteCachedPanel) {
-        return new PopupPanel(name, width, height, false, false, deleteCachedPanel);
+    public static PopupPanel createPopupPanel(String name, int width, int height, boolean deleteCachedPanel) {
+        return createPopupPanel(name, width, height)
+                .deleteCachedPanel(deleteCachedPanel);
     }
 
-    public static ModularPanel defaultPopupPanel(String name) {
+    public static PopupPanel defaultPopupPanel(String name) {
         return new PopupPanel(name);
     }
 
-    public static ModularPanel defaultPopupPanel(String name, boolean disableBelow,
-                                                 boolean closeOnOutsideClick, boolean deleteCachedPanel) {
-        return new PopupPanel(name, DEFAULT_WIDTH, DEFAULT_HIEGHT, disableBelow, closeOnOutsideClick,
-                deleteCachedPanel);
+    public static PopupPanel defaultPopupPanel(String name, boolean disableBelow,
+                                               boolean closeOnOutsideClick, boolean deleteCachedPanel) {
+        return defaultPopupPanel(name)
+                .disablePanelsBelow(disableBelow)
+                .closeOnOutOfBoundsClick(closeOnOutsideClick)
+                .deleteCachedPanel(deleteCachedPanel);
     }
 
-    private static class PopupPanel extends ModularPanel {
+    public static class PopupPanel extends ModularPanel {
 
-        private final boolean disableBelow;
-        private final boolean closeOnOutsideClick;
-        private final boolean deleteCachedPanel;
+        private boolean disableBelow;
+        private boolean closeOnOutsideClick;
+        private boolean deleteCachedPanel;
 
-        public PopupPanel(@NotNull String name) {
-            this(name, DEFAULT_WIDTH, DEFAULT_HIEGHT);
-        }
-
-        public PopupPanel(@NotNull String name, int width, int height) {
-            this(name, width, height, false, false);
-        }
-
-        public PopupPanel(@NotNull String name, int width, int height, boolean disableBelow,
-                          boolean closeOnOutsideClick) {
-            this(name, width, height, disableBelow, closeOnOutsideClick, false);
-        }
-
-        public PopupPanel(@NotNull String name, int width, int height, boolean disableBelow,
-                          boolean closeOnOutsideClick, boolean deleteCachedPanel) {
+        private PopupPanel(@NotNull String name) {
             super(name);
-            size(width, height).align(Alignment.Center);
+            align(Alignment.Center);
             background(GTGuiTextures.BACKGROUND_POPUP);
             child(ButtonWidget.panelCloseButton().top(5).right(5)
                     .onMousePressed(mouseButton -> {
@@ -122,9 +112,6 @@ public class GTGuis {
                         }
                         return false;
                     }));
-            this.disableBelow = disableBelow;
-            this.closeOnOutsideClick = closeOnOutsideClick;
-            this.deleteCachedPanel = deleteCachedPanel;
         }
 
         @Override
@@ -133,6 +120,33 @@ public class GTGuis {
             if (deleteCachedPanel && isSynced() && getSyncHandler() instanceof IPanelHandler handler) {
                 handler.deleteCachedPanel();
             }
+        }
+
+        public PopupPanel disablePanelsBelow(boolean disableBelow) {
+            this.disableBelow = disableBelow;
+            return this;
+        }
+
+        public PopupPanel closeOnOutOfBoundsClick(boolean closeOnOutsideClick) {
+            this.closeOnOutsideClick = closeOnOutsideClick;
+            return this;
+        }
+
+        public PopupPanel deleteCachedPanel(boolean deleteCachedPanel) {
+            this.deleteCachedPanel = deleteCachedPanel;
+            return this;
+        }
+
+        @Override
+        public PopupPanel size(int w, int h) {
+            super.size(w, h);
+            return this;
+        }
+
+        @Override
+        public PopupPanel size(int val) {
+            super.size(val);
+            return this;
         }
 
         @Override

--- a/src/main/java/gregtech/api/mui/GTGuis.java
+++ b/src/main/java/gregtech/api/mui/GTGuis.java
@@ -83,7 +83,8 @@ public class GTGuis {
     }
 
     public static PopupPanel defaultPopupPanel(String name) {
-        return new PopupPanel(name);
+        return new PopupPanel(name)
+                .size(DEFAULT_WIDTH, DEFAULT_HIEGHT);
     }
 
     public static PopupPanel defaultPopupPanel(String name, boolean disableBelow,

--- a/src/main/java/gregtech/api/mui/GTGuis.java
+++ b/src/main/java/gregtech/api/mui/GTGuis.java
@@ -86,13 +86,15 @@ public class GTGuis {
 
     public static ModularPanel defaultPopupPanel(String name, boolean disableBelow,
                                                  boolean closeOnOutsideClick, boolean deleteCachedPanel) {
-        return new PopupPanel(name, DEFAULT_WIDTH, DEFAULT_HIEGHT, disableBelow, closeOnOutsideClick, deleteCachedPanel);
+        return new PopupPanel(name, DEFAULT_WIDTH, DEFAULT_HIEGHT, disableBelow, closeOnOutsideClick,
+                deleteCachedPanel);
     }
 
     private static class PopupPanel extends ModularPanel {
 
         private final boolean disableBelow;
         private final boolean closeOnOutsideClick;
+        private final boolean deleteCachedPanel;
 
         public PopupPanel(@NotNull String name) {
             this(name, DEFAULT_WIDTH, DEFAULT_HIEGHT);
@@ -116,15 +118,21 @@ public class GTGuis {
                     .onMousePressed(mouseButton -> {
                         if (mouseButton == 0 || mouseButton == 1) {
                             this.closeIfOpen(true);
-                            if (deleteCachedPanel && isSynced() && getSyncHandler() instanceof IPanelHandler handler) {
-                                handler.deleteCachedPanel();
-                            }
                             return true;
                         }
                         return false;
                     }));
             this.disableBelow = disableBelow;
             this.closeOnOutsideClick = closeOnOutsideClick;
+            this.deleteCachedPanel = deleteCachedPanel;
+        }
+
+        @Override
+        public void onClose() {
+            super.onClose();
+            if (deleteCachedPanel && isSynced() && getSyncHandler() instanceof IPanelHandler handler) {
+                handler.deleteCachedPanel();
+            }
         }
 
         @Override

--- a/src/main/java/gregtech/api/mui/GTGuis.java
+++ b/src/main/java/gregtech/api/mui/GTGuis.java
@@ -73,21 +73,20 @@ public class GTGuis {
     }
 
     public static ModularPanel createPopupPanel(String name, int width, int height) {
-        return createPopupPanel(name, width, height, false, false);
+        return new PopupPanel(name, width, height);
     }
 
-    public static ModularPanel createPopupPanel(String name, int width, int height, boolean disableBelow,
-                                                boolean closeOnOutsideClick) {
-        return new PopupPanel(name, width, height, disableBelow, closeOnOutsideClick);
+    public static ModularPanel createPopupPanel(String name, int width, int height, boolean deleteCachedPanel) {
+        return new PopupPanel(name, width, height, false, false, deleteCachedPanel);
     }
 
     public static ModularPanel defaultPopupPanel(String name) {
-        return defaultPopupPanel(name, false, false);
+        return new PopupPanel(name);
     }
 
     public static ModularPanel defaultPopupPanel(String name, boolean disableBelow,
-                                                 boolean closeOnOutsideClick) {
-        return new PopupPanel(name, DEFAULT_WIDTH, DEFAULT_HIEGHT, disableBelow, closeOnOutsideClick);
+                                                 boolean closeOnOutsideClick, boolean deleteCachedPanel) {
+        return new PopupPanel(name, DEFAULT_WIDTH, DEFAULT_HIEGHT, disableBelow, closeOnOutsideClick, deleteCachedPanel);
     }
 
     private static class PopupPanel extends ModularPanel {
@@ -95,8 +94,21 @@ public class GTGuis {
         private final boolean disableBelow;
         private final boolean closeOnOutsideClick;
 
+        public PopupPanel(@NotNull String name) {
+            this(name, DEFAULT_WIDTH, DEFAULT_HIEGHT);
+        }
+
+        public PopupPanel(@NotNull String name, int width, int height) {
+            this(name, width, height, false, false);
+        }
+
         public PopupPanel(@NotNull String name, int width, int height, boolean disableBelow,
                           boolean closeOnOutsideClick) {
+            this(name, width, height, disableBelow, closeOnOutsideClick, false);
+        }
+
+        public PopupPanel(@NotNull String name, int width, int height, boolean disableBelow,
+                          boolean closeOnOutsideClick, boolean deleteCachedPanel) {
             super(name);
             size(width, height).align(Alignment.Center);
             background(GTGuiTextures.BACKGROUND_POPUP);
@@ -104,7 +116,7 @@ public class GTGuis {
                     .onMousePressed(mouseButton -> {
                         if (mouseButton == 0 || mouseButton == 1) {
                             this.closeIfOpen(true);
-                            if (isSynced() && getSyncHandler() instanceof IPanelHandler handler) {
+                            if (deleteCachedPanel && isSynced() && getSyncHandler() instanceof IPanelHandler handler) {
                                 handler.deleteCachedPanel();
                             }
                             return true;

--- a/src/main/java/gregtech/common/covers/ender/CoverAbstractEnderLink.java
+++ b/src/main/java/gregtech/common/covers/ender/CoverAbstractEnderLink.java
@@ -288,7 +288,7 @@ public abstract class CoverAbstractEnderLink<T extends VirtualEntry> extends Cov
             for (String name : VirtualEnderRegistry.getEntryNames(getOwner(), type)) {
                 rows.add(createRow(name, syncManager, type));
             }
-            return GTGuis.createPopupPanel("entry_selector", 168, 112)
+            return GTGuis.createPopupPanel("entry_selector", 168, 112, true)
                     .child(IKey.lang("cover.generic.ender.known_channels")
                             .color(UI_TITLE_COLOR)
                             .asWidget()
@@ -310,7 +310,7 @@ public abstract class CoverAbstractEnderLink<T extends VirtualEntry> extends Cov
     protected PanelSyncHandler.IPanelBuilder entryDescription(String key, T entry) {
         return (syncManager, syncHandler) -> {
             var sync = new StringSyncValue(entry::getDescription, entry::setDescription);
-            return GTGuis.createPopupPanel(key, 168, 36 + 6)
+            return GTGuis.createPopupPanel(key, 168, 36 + 6, true)
                     .child(IKey.lang("cover.generic.ender.set_description.title", entry.getColorStr())
                             .color(UI_TITLE_COLOR)
                             .asWidget()

--- a/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/OreDictionaryItemFilter.java
@@ -75,7 +75,7 @@ public class OreDictionaryItemFilter extends BaseFilter {
 
     @Override
     public @NotNull ModularPanel createPopupPanel(PanelSyncManager syncManager) {
-        return GTGuis.createPopupPanel("ore_dict_filter", 188, 76)
+        return GTGuis.createPopupPanel("ore_dict_filter", 188, 76, false)
                 .padding(7)
                 .child(CoverWithUI.createTitleRow(getContainerStack()))
                 .child(createWidgets(syncManager).top(22));

--- a/src/main/java/gregtech/common/covers/filter/SimpleFluidFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SimpleFluidFilter.java
@@ -39,7 +39,7 @@ public class SimpleFluidFilter extends BaseFilter {
 
     @Override
     public @NotNull ModularPanel createPopupPanel(PanelSyncManager syncManager) {
-        return GTGuis.createPopupPanel("simple_fluid_filter", 98, 81)
+        return GTGuis.createPopupPanel("simple_fluid_filter", 98, 81, false)
                 .padding(4)
                 .child(CoverWithUI.createTitleRow(getContainerStack()))
                 .child(createWidgets(syncManager).top(22));

--- a/src/main/java/gregtech/common/covers/filter/SimpleItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SimpleItemFilter.java
@@ -94,7 +94,7 @@ public class SimpleItemFilter extends BaseFilter {
 
     @Override
     public @NotNull ModularPanel createPopupPanel(PanelSyncManager syncManager) {
-        return GTGuis.createPopupPanel("simple_item_filter", 98, 81)
+        return GTGuis.createPopupPanel("simple_item_filter", 98, 81, false)
                 .child(CoverWithUI.createTitleRow(getContainerStack()))
                 .child(createWidgets(syncManager).top(22).left(4));
     }

--- a/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
+++ b/src/main/java/gregtech/common/covers/filter/SmartItemFilter.java
@@ -98,7 +98,7 @@ public class SmartItemFilter extends BaseFilter {
 
     @Override
     public @NotNull ModularPanel createPopupPanel(PanelSyncManager syncManager) {
-        return GTGuis.createPopupPanel("smart_item_filter", 98 + 27, 81)
+        return GTGuis.createPopupPanel("smart_item_filter", 98 + 27, 81, false)
                 .child(CoverWithUI.createTitleRow(getContainerStack()))
                 .child(createWidgets(syncManager).top(22).left(4));
     }


### PR DESCRIPTION
## What
fixes #2716 
prevents filter popups from deleting their cached panel
also improves popup panel a bit

## Implementation Details
cached panel is deleted when the panel is closed instead of only in the button
the class is now public and replaced constructor parameters with builder methods
constructor is private
popup panel methods now return the popup panel class

## Outcome
filter popups can now be closed
