### PR TITLE
Changed the most stable Isotope of Plutonium

### DIFF
--- a/src/main/java/gregtech/api/unification/Elements.java
+++ b/src/main/java/gregtech/api/unification/Elements.java
@@ -125,7 +125,7 @@ public class Elements {
     public static final Element U238 = add(92, 146, 1.4090285e+17, null, "Uranium-238", "U-238", true);
     public static final Element U235 = add(92, 143, 2.2195037e+16, null, "Uranium-235", "U-235", true);
     public static final Element Np = add(93, 144, "Neptunium", "Np");
-    public static final Element Pu = add(94, 152, 760332960000.0, null, "Plutonium", "Pu", false);
+    public static final Element Pu = add(94, 150, 2522880000000000L, null, "Plutonium", "Pu", false);
     public static final Element Pu239 = add(94, 145, 760332960000.0, null, "Plutonium-239", "Pu-239", true);
     public static final Element Pu241 = add(94, 147, 450649440.0, null, "Plutonium-241", "Pu-241", true);
     public static final Element Am = add(95, 150, "Americium", "Am");


### PR DESCRIPTION
## What
I have noticed that the element "Pu" uses number 246 as its most stable isotope (judging by the "false" for the "isIsotope" parameter). However Pu246 has a halflife time of only 11 days, compared to 10^7 years of Pu244. That makes me think that a mistake happened when initially assigning isotopes.
