### PR TITLE
Make research EU/t long to be consistent with recipes using long

### DIFF
--- a/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
@@ -155,7 +155,7 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
         private final ItemStack dataStack;
         private final boolean ignoreNBT;
         private final int duration;
-        private final int EUt;
+        private final long EUt;
         private final int CWUt;
 
         /**
@@ -167,10 +167,10 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
          * @param CWUt          how much computation per tick this recipe needs if in Research Station
          *                      <p>
          *                      By default, will ignore NBT on researchStack input. If NBT matching is desired, see
-         *                      {@link #ResearchRecipeEntry(String, ItemStack, ItemStack, boolean, int, int, int)}
+         *                      {@link #ResearchRecipeEntry(String, ItemStack, ItemStack, boolean, int, long, int)}
          */
         public ResearchRecipeEntry(@NotNull String researchId, @NotNull ItemStack researchStack,
-                                   @NotNull ItemStack dataStack, int duration, int EUt, int CWUt) {
+                                   @NotNull ItemStack dataStack, int duration, long EUt, int CWUt) {
             this.researchId = researchId;
             this.researchStack = researchStack;
             this.dataStack = dataStack;
@@ -189,7 +189,7 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
          * @param CWUt          how much computation per tick this recipe needs if in Research Station
          */
         public ResearchRecipeEntry(@NotNull String researchId, @NotNull ItemStack researchStack,
-                                   @NotNull ItemStack dataStack, boolean ignoreNBT, int duration, int EUt, int CWUt) {
+                                   @NotNull ItemStack dataStack, boolean ignoreNBT, int duration, long EUt, int CWUt) {
             this.researchId = researchId;
             this.researchStack = researchStack;
             this.dataStack = dataStack;
@@ -222,7 +222,7 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
             return duration;
         }
 
-        public int getEUt() {
+        public long getEUt() {
             return EUt;
         }
 

--- a/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
@@ -17,7 +17,7 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
     protected ItemStack dataStack;
     protected boolean ignoreNBT;
     protected String researchId;
-    protected int eut;
+    protected long eut;
 
     public T researchStack(@NotNull ItemStack researchStack) {
         if (!researchStack.isEmpty()) {
@@ -47,7 +47,7 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
         return (T) this;
     }
 
-    public T EUt(int eut) {
+    public T EUt(long eut) {
         this.eut = eut;
         return (T) this;
     }

--- a/src/main/java/gregtech/api/util/AssemblyLineManager.java
+++ b/src/main/java/gregtech/api/util/AssemblyLineManager.java
@@ -129,13 +129,13 @@ public final class AssemblyLineManager {
     @Deprecated
     @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
     public static void createDefaultResearchRecipe(@NotNull String researchId, @NotNull ItemStack researchItem,
-                                                   @NotNull ItemStack dataItem, int duration, int EUt, int CWUt) {
+                                                   @NotNull ItemStack dataItem, int duration, long EUt, int CWUt) {
         createDefaultResearchRecipe(researchId, researchItem, dataItem, true, duration, EUt, CWUt);
     }
 
     public static void createDefaultResearchRecipe(@NotNull String researchId, @NotNull ItemStack researchItem,
                                                    @NotNull ItemStack dataItem, boolean ignoreNBT, int duration,
-                                                   int EUt, int CWUt) {
+                                                   long EUt, int CWUt) {
         if (!ConfigHolder.machines.enableResearch) return;
 
         NBTTagCompound compound = GTUtility.getOrCreateNbtCompound(dataItem);


### PR DESCRIPTION
## What
Changes EU/t from int to long for research.

## Implementation Details
int to long

## Outcome
use numbers bigger than int max, consistent with general recipes

## Potential Compatibility Issues
might have missed something
