### PR TITLE
Place ore prospector waypoints at vein height

### DIFF
--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -296,7 +296,7 @@ public class WidgetProspectingMap extends Widget {
                 }
                 oreInfo.forEach((name, count) -> {
                     int height = oreHeight.getOrDefault(name, 0);
-                    tooltips.add(name + " --- §e" + count + "§r§7, y" + height + "§r");
+                    tooltips.add(name + " --- §e" + count + "§r, §cy" + height + "§r");
                     hoveredNames.add(name);
                 });
             } else if (this.mode == ProspectorMode.FLUID) {

--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -262,7 +262,7 @@ public class WidgetProspectingMap extends Widget {
             if (this.mode == ProspectorMode.ORE) { // draw ore
                 tooltips.add(I18n.format("terminal.prospector.ore"));
                 HashMap<String, Integer> oreInfo = new HashMap<>();
-                HashMap<String, Float> oreHeight = new HashMap<>();
+                HashMap<String, Integer> oreHeight = new HashMap<>();
                 for (int i = 0; i < 16; i++) {
                     for (int j = 0; j < 16; j++) {
                         if (texture.map[cX * 16 + i][cZ * 16 + j] != null) {
@@ -271,7 +271,7 @@ public class WidgetProspectingMap extends Widget {
                                 if (ProspectingTexture.SELECTED_ALL.equals(texture.getSelected()) ||
                                         texture.getSelected().equals(dict)) {
                                     oreInfo.put(name, oreInfo.getOrDefault(name, 0) + 1);
-                                    oreHeight.put(name, oreHeight.getOrDefault(name, 0.0f) + height.intValue());
+                                    oreHeight.put(name, oreHeight.getOrDefault(name, 0) + height.intValue());
                                     if (oreInfo.get(name) > maxAmount[0]) {
                                         maxAmount[0] = oreInfo.get(name);
                                         MaterialStack m = OreDictUnifier.getMaterial(OreDictUnifier.get(dict));
@@ -287,16 +287,16 @@ public class WidgetProspectingMap extends Widget {
                 oreHeight.forEach((name, height) -> {
                     hoveredOreHeight += height;
                     int count = oreInfo.getOrDefault(name, 0);
-                    float avgHeight = count != 0 ? height / count : 0.0f;
+                    int avgHeight = count != 0 ? height / count : 0;
                     oreHeight.put(name, avgHeight);
                 });
                 int totalCount = oreInfo.values().stream().reduce(0, Integer::sum);
                 if (totalCount != 0) {
-                    hoveredOreHeight = Math.round(hoveredOreHeight / (float) totalCount);
+                    hoveredOreHeight /= totalCount;
                 }
                 oreInfo.forEach((name, count) -> {
-                    float height = oreHeight.getOrDefault(name, 0.0f);
-                    tooltips.add(name + ", y" + Math.round(height) + " --- " + count);
+                    int height = oreHeight.getOrDefault(name, 0);
+                    tooltips.add(name + ", y" + height + " --- " + count);
                     hoveredNames.add(name);
                 });
             } else if (this.mode == ProspectorMode.FLUID) {

--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -64,7 +64,7 @@ public class WidgetProspectingMap extends Widget {
     private long lastClicked;
 
     private final List<String> hoveredNames = new ArrayList<>();
-    private float hoveredOreHeight = 0.0f;
+    private int hoveredOreHeight = 0;
     private int color;
 
     public WidgetProspectingMap(int xPosition, int yPosition, int chunkRadius, WidgetOreList widgetOreList,
@@ -243,7 +243,7 @@ public class WidgetProspectingMap extends Widget {
         // draw tooltips
         if (this.isMouseOverElement(mouseX, mouseY) && texture != null) {
             this.hoveredNames.clear();
-            this.hoveredOreHeight = 0.0f;
+            this.hoveredOreHeight = 0;
             List<String> tooltips = new ArrayList<>();
             int cX = (mouseX - this.getPosition().x) / 16;
             int cZ = (mouseY - this.getPosition().y) / 16;
@@ -285,18 +285,18 @@ public class WidgetProspectingMap extends Widget {
                     }
                 }
                 oreHeight.forEach((name, height) -> {
+                    hoveredOreHeight += height;
                     int count = oreInfo.getOrDefault(name, 0);
-                    float avgHeight = height / (count != 0 ? count : 1);
+                    float avgHeight = count != 0 ? height / count : 0.0f;
                     oreHeight.put(name, avgHeight);
-                    hoveredOreHeight += avgHeight * count;
                 });
                 int totalCount = oreInfo.values().stream().reduce(0, Integer::sum);
                 if (totalCount != 0) {
-                    hoveredOreHeight /= totalCount;
+                    hoveredOreHeight = Math.round(hoveredOreHeight / (float) totalCount);
                 }
                 oreInfo.forEach((name, count) -> {
                     float height = oreHeight.getOrDefault(name, 0.0f);
-                    tooltips.add(name + " --- " + count + " at y: " + Math.round(height));
+                    tooltips.add(name + ", y" + Math.round(height) + " --- " + count);
                     hoveredNames.add(name);
                 });
             } else if (this.mode == ProspectorMode.FLUID) {
@@ -342,7 +342,7 @@ public class WidgetProspectingMap extends Widget {
 
         int xPos = ((Minecraft.getMinecraft().player.chunkCoordX + xDiff) << 4) + 8;
         int zPos = ((Minecraft.getMinecraft().player.chunkCoordZ + zDiff) << 4) + 8;
-        int yPos = hoveredOreHeight != 0.0f ? Math.round(hoveredOreHeight) :
+        int yPos = hoveredOreHeight != 0 ? hoveredOreHeight :
                 Minecraft.getMinecraft().world.getHeight(xPos, zPos);
 
         BlockPos b = new BlockPos(xPos, yPos, zPos);

--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -296,7 +296,7 @@ public class WidgetProspectingMap extends Widget {
                 }
                 oreInfo.forEach((name, count) -> {
                     int height = oreHeight.getOrDefault(name, 0);
-                    tooltips.add(name + ", y" + height + " --- " + count);
+                    tooltips.add(name + " --- §e" + count + "§r§7, y" + height + "§r");
                     hoveredNames.add(name);
                 });
             } else if (this.mode == ProspectorMode.FLUID) {


### PR DESCRIPTION
## What
Change ore prospector behavior to place waypoints at the average height of the hovered ores instead of at the surface. Also adds the height to the tooltip, might be too cluttered?

## Implementation Details
The height of each ore in the prospecting packet is averaged and stored in a map entry per oredict, then  the currently hovered ores are averaged again and stored in a member which later gets used when adding the waypoint. I mostly copied the way oreInfo and hoveredNames was done. Height is already given in the keys of the packet, so there should be no performance impact. 

## Outcome
When the player adds a waypoint, it gets placed directly at the height of the vein. Less tedious than having to look it up in jei or blindly mining up or down.

## Additional Information
![waypoints](https://github.com/user-attachments/assets/a4d2be5e-9fe1-471a-9315-c0bc52728c64)
![tooltips](https://github.com/user-attachments/assets/0bdfd45d-c4be-4f52-ad7a-73b6d43f0590)


## Potential Compatibility Issues
Not much, all changes are isolated to WidgetProspectingMap. If no ores are found it defaults to the surface, so fluid prospector behavior is unchanged.
