### PR TITLE
Laser Passthrough Hatches

### DIFF
--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -118,7 +118,7 @@ public class MetaBlocks {
     public static final Map<String, BlockFluidPipe[]> FLUID_PIPES = new Object2ObjectOpenHashMap<>();
     public static final Map<String, BlockItemPipe[]> ITEM_PIPES = new Object2ObjectOpenHashMap<>();
     public static final BlockOpticalPipe[] OPTICAL_PIPES = new BlockOpticalPipe[OpticalPipeType.values().length];
-    public static final BlockLaserPipe[] LASER_PIPES = new BlockLaserPipe[OpticalPipeType.values().length];
+    public static final BlockLaserPipe[] LASER_PIPES = new BlockLaserPipe[LaserPipeType.values().length];
     public static BlockLongDistancePipe LD_ITEM_PIPE;
     public static BlockLongDistancePipe LD_FLUID_PIPE;
 

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -89,6 +89,7 @@ import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityObjec
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityOpticalDataHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityPassthroughHatchFluid;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityPassthroughHatchItem;
+import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityPassthroughHatchLaser;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityReservoirHatch;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityRotorHolder;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntitySubstationEnergyHatch;
@@ -252,6 +253,7 @@ public class MetaTileEntities {
     public static MetaTileEntityLaserHatch[] LASER_OUTPUT_HATCH_256 = new MetaTileEntityLaserHatch[10]; // IV+
     public static MetaTileEntityLaserHatch[] LASER_OUTPUT_HATCH_1024 = new MetaTileEntityLaserHatch[10]; // IV+
     public static MetaTileEntityLaserHatch[] LASER_OUTPUT_HATCH_4096 = new MetaTileEntityLaserHatch[10]; // IV+
+    public static MetaTileEntityPassthroughHatchLaser PASSTHROUGH_HATCH_LASER;
     public static MetaTileEntityComputationHatch COMPUTATION_HATCH_RECEIVER;
     public static MetaTileEntityComputationHatch COMPUTATION_HATCH_TRANSMITTER;
     public static MetaTileEntityObjectHolder OBJECT_HOLDER;
@@ -954,7 +956,7 @@ public class MetaTileEntities {
                 new MetaTileEntityHPCABridge(gregtechId("hpca.bridge_component")));
 
         RESERVOIR_HATCH = registerMetaTileEntity(1418, new MetaTileEntityReservoirHatch(gregtechId("reservoir_hatch")));
-        // Free ID 1419
+        PASSTHROUGH_HATCH_LASER = registerMetaTileEntity(1419, new MetaTileEntityPassthroughHatchLaser(gregtechId("passthrough_hatch_laser"), 5));
         endPos = GregTechAPI.isHighTier() ? LASER_INPUT_HATCH_256.length - 1 :
                 Math.min(LASER_INPUT_HATCH_256.length - 1, GTValues.UHV - GTValues.IV);
         for (int i = 0; i < endPos; i++) {

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -956,7 +956,8 @@ public class MetaTileEntities {
                 new MetaTileEntityHPCABridge(gregtechId("hpca.bridge_component")));
 
         RESERVOIR_HATCH = registerMetaTileEntity(1418, new MetaTileEntityReservoirHatch(gregtechId("reservoir_hatch")));
-        PASSTHROUGH_HATCH_LASER = registerMetaTileEntity(1419, new MetaTileEntityPassthroughHatchLaser(gregtechId("passthrough_hatch_laser"), 5));
+        PASSTHROUGH_HATCH_LASER = registerMetaTileEntity(1419,
+                new MetaTileEntityPassthroughHatchLaser(gregtechId("passthrough_hatch_laser"), 5));
         endPos = GregTechAPI.isHighTier() ? LASER_INPUT_HATCH_256.length - 1 :
                 Math.min(LASER_INPUT_HATCH_256.length - 1, GTValues.UHV - GTValues.IV);
         for (int i = 0; i < endPos; i++) {

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchLaser.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchLaser.java
@@ -1,0 +1,98 @@
+package gregtech.common.metatileentities.multi.multiblockpart;
+
+import codechicken.lib.render.CCRenderState;
+import codechicken.lib.render.pipeline.IVertexOperation;
+import codechicken.lib.vec.Matrix4;
+
+import gregtech.api.GTValues;
+import gregtech.api.capability.GregtechTileCapabilities;
+import gregtech.api.capability.IControllable;
+import gregtech.api.capability.IEnergyContainer;
+import gregtech.api.capability.ILaserContainer;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+
+import gregtech.client.renderer.texture.Textures;
+import gregtech.client.utils.PipelineUtil;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+
+import net.minecraft.world.World;
+
+import net.minecraftforge.common.capabilities.Capability;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class MetaTileEntityPassthroughHatchLaser extends MetaTileEntityMultiblockPart implements IPassthroughHatch,
+                                                                                                 IMultiblockAbilityPart<IPassthroughHatch> {
+
+    public MetaTileEntityPassthroughHatchLaser(ResourceLocation metaTileEntityId, int tier) {
+        super(metaTileEntityId, tier);
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, EnumFacing side) {
+        if (capability == GregtechTileCapabilities.CAPABILITY_LASER && side == getFrontFacing().getOpposite()) {
+            World world = getWorld();
+            if (world != null && !world.isRemote) {
+                TileEntity te = world.getTileEntity(getPos().offset(getFrontFacing()));
+                if (te != null) {
+                    return GregtechTileCapabilities.CAPABILITY_LASER.cast(te.getCapability(GregtechTileCapabilities.CAPABILITY_LASER, getFrontFacing().getOpposite()));
+                }
+            }
+        }
+        return super.getCapability(capability, side);
+    }
+
+    @Override
+    public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
+        return new MetaTileEntityPassthroughHatchLaser(metaTileEntityId, getTier());
+    }
+
+
+    @Override
+    public MultiblockAbility<IPassthroughHatch> getAbility() {
+        return MultiblockAbility.PASSTHROUGH_HATCH;
+    }
+
+    @Override
+    public void registerAbilities(@NotNull List<IPassthroughHatch> abilityList) {
+        abilityList.add(this);
+    }
+
+    @Override
+    public @NotNull Class<?> getPassthroughType() {
+        return ILaserContainer.class;
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, @Nullable World world, @NotNull List<String> tooltip,
+                               boolean advanced) {
+        tooltip.add(I18n.format("gregtech.machine.laser_hatch.tooltip2"));
+        tooltip.add(I18n.format("gregtech.universal.enabled"));
+    }
+
+    @Override
+    public void addToolUsages(ItemStack stack, @Nullable World world, List<String> tooltip, boolean advanced) {
+        tooltip.add(I18n.format("gregtech.tool_action.screwdriver.access_covers"));
+        tooltip.add(I18n.format("gregtech.tool_action.wrench.set_facing"));
+        super.addToolUsages(stack, world, tooltip, advanced);
+    }
+
+    @Override
+    public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
+        super.renderMetaTileEntity(renderState, translation, pipeline);
+        Textures.LASER_SOURCE.renderSided(getFrontFacing(), renderState, translation, pipeline);
+        Textures.LASER_TARGET.renderSided(getFrontFacing().getOpposite(), renderState, translation, pipeline);
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchLaser.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityPassthroughHatchLaser.java
@@ -1,40 +1,32 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
-import codechicken.lib.render.CCRenderState;
-import codechicken.lib.render.pipeline.IVertexOperation;
-import codechicken.lib.vec.Matrix4;
-
-import gregtech.api.GTValues;
 import gregtech.api.capability.GregtechTileCapabilities;
-import gregtech.api.capability.IControllable;
-import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.ILaserContainer;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.IPassthroughHatch;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-
 import gregtech.client.renderer.texture.Textures;
-import gregtech.client.utils.PipelineUtil;
 
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
-
 import net.minecraft.world.World;
-
 import net.minecraftforge.common.capabilities.Capability;
 
+import codechicken.lib.render.CCRenderState;
+import codechicken.lib.render.pipeline.IVertexOperation;
+import codechicken.lib.vec.Matrix4;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
 public class MetaTileEntityPassthroughHatchLaser extends MetaTileEntityMultiblockPart implements IPassthroughHatch,
-                                                                                                 IMultiblockAbilityPart<IPassthroughHatch> {
+                                                 IMultiblockAbilityPart<IPassthroughHatch> {
 
     public MetaTileEntityPassthroughHatchLaser(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
@@ -47,7 +39,8 @@ public class MetaTileEntityPassthroughHatchLaser extends MetaTileEntityMultibloc
             if (world != null && !world.isRemote) {
                 TileEntity te = world.getTileEntity(getPos().offset(getFrontFacing()));
                 if (te != null) {
-                    return GregtechTileCapabilities.CAPABILITY_LASER.cast(te.getCapability(GregtechTileCapabilities.CAPABILITY_LASER, getFrontFacing().getOpposite()));
+                    return GregtechTileCapabilities.CAPABILITY_LASER.cast(te
+                            .getCapability(GregtechTileCapabilities.CAPABILITY_LASER, getFrontFacing().getOpposite()));
                 }
             }
         }
@@ -58,7 +51,6 @@ public class MetaTileEntityPassthroughHatchLaser extends MetaTileEntityMultibloc
     public MetaTileEntity createMetaTileEntity(IGregTechTileEntity tileEntity) {
         return new MetaTileEntityPassthroughHatchLaser(metaTileEntityId, getTier());
     }
-
 
     @Override
     public MultiblockAbility<IPassthroughHatch> getAbility() {

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -10,6 +10,7 @@ import gregtech.api.recipes.ingredients.GTRecipeOreInput;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.Mods;
+import gregtech.common.pipelike.laser.LaserPipeType;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -20,8 +21,7 @@ import static gregtech.api.recipes.RecipeMaps.ASSEMBLY_LINE_RECIPES;
 import static gregtech.api.unification.material.MarkerMaterials.Tier;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
-import static gregtech.common.blocks.MetaBlocks.LD_FLUID_PIPE;
-import static gregtech.common.blocks.MetaBlocks.LD_ITEM_PIPE;
+import static gregtech.common.blocks.MetaBlocks.*;
 import static gregtech.common.items.MetaItems.*;
 import static gregtech.common.metatileentities.MetaTileEntities.*;
 
@@ -1161,6 +1161,15 @@ public class MetaTileEntityMachineRecipeLoader {
 
     // TODO clean this up with a CraftingComponent rework
     private static void registerLaserRecipes() {
+        // Laser Passthrough Hatch
+        ASSEMBLER_RECIPES.recipeBuilder()
+                .input(HULL[IV])
+                .input(LASER_PIPES[LaserPipeType.NORMAL.ordinal()])
+                .input(lens, Diamond)
+                .circuitMeta(4)
+                .output(PASSTHROUGH_HATCH_LASER)
+                .duration(300).EUt(VA[IV]).buildAndRegister();
+
         // 256A Laser Source Hatches
         ASSEMBLER_RECIPES.recipeBuilder()
                 .input(HULL[IV])

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5340,6 +5340,8 @@ gregtech.machine.passthrough_hatch_item.name=Item Passthrough Hatch
 gregtech.machine.passthrough_hatch_item.tooltip=Sends Items from one Side to the other
 gregtech.machine.passthrough_hatch_fluid.name=Fluid Passthrough Hatch
 gregtech.machine.passthrough_hatch_fluid.tooltip=Sends Fluids from one Side to the other
+gregtech.machine.passthrough_hatch_laser.name=Laser Passthrough Hatch
+gregtech.machine.passthrough_hatch_laser.tooltip=Sends Laser Power from one Side to the other
 
 gregtech.machine.reservoir_hatch.name=Reservoir Hatch
 gregtech.machine.reservoir_hatch.tooltip=Not a Sink


### PR DESCRIPTION
## What
Adds Passthrough hatches for lasers

## Implementation Details
The hatch mirrors the extends on the source side to the side target sides  

## Outcome
can now use lasers in cleanrooms

## Additional Information
also fixed a typo from the original laser PR with registering laser pipe blocks

## Potential Compatibility Issues
none