### PR TITLE
Remove arbitrary restriction on casings per craft

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -270,8 +270,10 @@ public class ConfigHolder {
         @Config.Comment({ "Whether to make the recipe for the EBF Controller harder.", "Default: false" })
         public boolean harderEBFControllerRecipe = false;
 
-        @Config.Comment({ "How many Multiblock Casings to make per craft. Either 1, 2, or 3.", "Default: 2" })
-        @Config.RangeInt(min = 1, max = 3)
+        @Config.Comment({
+                "How many Multiblock Casings to make per craft. Must be greater than 0 and fit in a stack.",
+                "Default: 2" })
+        @Config.RangeInt(min = 1, max = 64)
         public int casingsPerCraft = 2;
 
         @Config.Comment({

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -272,6 +272,7 @@ public class ConfigHolder {
 
         @Config.Comment({
                 "How many Multiblock Casings to make per craft. Must be greater than 0 and fit in a stack.",
+                "'Normal' values would be 1, 2, or 3.",
                 "Default: 2" })
         @Config.RangeInt(min = 1, max = 64)
         public int casingsPerCraft = 2;


### PR DESCRIPTION
## What
Removes arbitrary hard cap of 3 on the casings per craft config value, allowing it to be set anywhere in the range 1 to 64.

## Outcome
Less arbitrary restrictions in configs because they're bad. (Meaningful restrictions do not fit in this category)
