### PR TITLE
General improvements to GT Module Code

### DIFF
--- a/src/main/java/gregtech/api/modules/IGregTechModule.java
+++ b/src/main/java/gregtech/api/modules/IGregTechModule.java
@@ -29,25 +29,25 @@ public interface IGregTechModule {
         return Collections.emptySet();
     }
 
-    default void construction(FMLConstructionEvent event) {}
+    default void construction(@NotNull FMLConstructionEvent event) {}
 
-    default void preInit(FMLPreInitializationEvent event) {}
+    default void preInit(@NotNull FMLPreInitializationEvent event) {}
 
-    default void init(FMLInitializationEvent event) {}
+    default void init(@NotNull FMLInitializationEvent event) {}
 
-    default void postInit(FMLPostInitializationEvent event) {}
+    default void postInit(@NotNull FMLPostInitializationEvent event) {}
 
-    default void loadComplete(FMLLoadCompleteEvent event) {}
+    default void loadComplete(@NotNull FMLLoadCompleteEvent event) {}
 
-    default void serverAboutToStart(FMLServerAboutToStartEvent event) {}
+    default void serverAboutToStart(@NotNull FMLServerAboutToStartEvent event) {}
 
-    default void serverStarting(FMLServerStartingEvent event) {}
+    default void serverStarting(@NotNull FMLServerStartingEvent event) {}
 
-    default void serverStarted(FMLServerStartedEvent event) {}
+    default void serverStarted(@NotNull FMLServerStartedEvent event) {}
 
-    default void serverStopping(FMLServerStoppingEvent event) {}
+    default void serverStopping(@NotNull FMLServerStoppingEvent event) {}
 
-    default void serverStopped(FMLServerStoppedEvent event) {}
+    default void serverStopped(@NotNull FMLServerStoppedEvent event) {}
 
     /**
      * Register packets using GregTech's packet handling API here.
@@ -87,7 +87,11 @@ public interface IGregTechModule {
         return Collections.emptyList();
     }
 
-    default boolean processIMC(FMLInterModComms.IMCMessage message) {
+    /**
+     * @param message the message to process
+     * @return if the message was processed, stopping all other modules from processing it
+     */
+    default boolean processIMC(@NotNull FMLInterModComms.IMCMessage message) {
         return false;
     }
 

--- a/src/main/java/gregtech/api/modules/IGregTechModule.java
+++ b/src/main/java/gregtech/api/modules/IGregTechModule.java
@@ -21,7 +21,7 @@ public interface IGregTechModule {
     /**
      * What other modules this module depends on.
      * <p>
-     * e.g. <code>new ResourceLocation("gregtech", "foo_module")</code> represents a dependency on the module
+     * e.g. {@code new ResourceLocation("gregtech", "foo_module")} represents a dependency on the module
      * "foo_module" in the container "gregtech"
      */
     @NotNull

--- a/src/main/java/gregtech/api/modules/IModuleManager.java
+++ b/src/main/java/gregtech/api/modules/IModuleManager.java
@@ -4,23 +4,28 @@ import gregtech.api.util.GTUtility;
 
 import net.minecraft.util.ResourceLocation;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public interface IModuleManager {
 
-    default boolean isModuleEnabled(String containerID, String moduleID) {
+    default boolean isModuleEnabled(@NotNull String containerID, @NotNull String moduleID) {
         return isModuleEnabled(new ResourceLocation(containerID, moduleID));
     }
 
-    default boolean isModuleEnabled(String moduleID) {
+    default boolean isModuleEnabled(@NotNull String moduleID) {
         return isModuleEnabled(GTUtility.gregtechId(moduleID));
     }
 
-    boolean isModuleEnabled(ResourceLocation id);
+    boolean isModuleEnabled(@NotNull ResourceLocation id);
 
-    void registerContainer(IModuleContainer container);
+    void registerContainer(@NotNull IModuleContainer container);
 
+    @Nullable
     IModuleContainer getLoadedContainer();
 
+    @NotNull
     ModuleStage getStage();
 
-    boolean hasPassedStage(ModuleStage stage);
+    boolean hasPassedStage(@NotNull ModuleStage stage);
 }

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -36,7 +36,7 @@ public final class ModuleManager implements IModuleManager {
 
     private Map<String, IModuleContainer> containers = new Object2ReferenceLinkedOpenHashMap<>();
     private final Map<ResourceLocation, IGregTechModule> sortedModules = new Object2ReferenceLinkedOpenHashMap<>();
-    private final Set<IGregTechModule> loadedModules = new ReferenceOpenHashSet<>();
+    private final Set<IGregTechModule> loadedModules = new ReferenceLinkedOpenHashSet<>();
 
     private @Nullable IModuleContainer currentContainer;
 

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -15,7 +15,6 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -117,6 +117,7 @@ public final class ModuleManager implements IModuleManager {
                 MinecraftForge.ORE_GEN_BUS.register(clazz);
             }
         }
+        currentContainer = null;
     }
 
     public void onConstruction(@NotNull FMLConstructionEvent event) {
@@ -127,6 +128,7 @@ public final class ModuleManager implements IModuleManager {
             module.construction(event);
             module.getLogger().debug("Construction complete");
         }
+        currentContainer = null;
     }
 
     public void onPreInit(@NotNull FMLPreInitializationEvent event) {
@@ -143,6 +145,7 @@ public final class ModuleManager implements IModuleManager {
             module.preInit(event);
             module.getLogger().debug("Pre-init complete");
         }
+        currentContainer = null;
     }
 
     public void onInit(@NotNull FMLInitializationEvent event) {
@@ -153,6 +156,7 @@ public final class ModuleManager implements IModuleManager {
             module.init(event);
             module.getLogger().debug("Init complete");
         }
+        currentContainer = null;
     }
 
     public void onPostInit(@NotNull FMLPostInitializationEvent event) {
@@ -163,6 +167,7 @@ public final class ModuleManager implements IModuleManager {
             module.postInit(event);
             module.getLogger().debug("Post-init complete");
         }
+        currentContainer = null;
     }
 
     public void onLoadComplete(@NotNull FMLLoadCompleteEvent event) {
@@ -173,6 +178,7 @@ public final class ModuleManager implements IModuleManager {
             module.loadComplete(event);
             module.getLogger().debug("Load-complete complete");
         }
+        currentContainer = null;
     }
 
     public void onServerAboutToStart(@NotNull FMLServerAboutToStartEvent event) {
@@ -183,6 +189,7 @@ public final class ModuleManager implements IModuleManager {
             module.serverAboutToStart(event);
             module.getLogger().debug("Server-about-to-start complete");
         }
+        currentContainer = null;
     }
 
     public void onServerStarting(@NotNull FMLServerStartingEvent event) {
@@ -193,6 +200,7 @@ public final class ModuleManager implements IModuleManager {
             module.serverStarting(event);
             module.getLogger().debug("Server-starting complete");
         }
+        currentContainer = null;
     }
 
     public void onServerStarted(@NotNull FMLServerStartedEvent event) {
@@ -203,6 +211,7 @@ public final class ModuleManager implements IModuleManager {
             module.serverStarted(event);
             module.getLogger().debug("Server-started complete");
         }
+        currentContainer = null;
     }
 
     public void onServerStopping(@NotNull FMLServerStoppingEvent event) {
@@ -210,6 +219,7 @@ public final class ModuleManager implements IModuleManager {
             currentContainer = containers.get(getContainerID(module));
             module.serverStopping(event);
         }
+        currentContainer = null;
     }
 
     public void onServerStopped(@NotNull FMLServerStoppedEvent event) {
@@ -217,6 +227,7 @@ public final class ModuleManager implements IModuleManager {
             currentContainer = containers.get(getContainerID(module));
             module.serverStopped(event);
         }
+        currentContainer = null;
     }
 
     /**

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -41,7 +41,7 @@ public final class ModuleManager implements IModuleManager {
     private @Nullable IModuleContainer currentContainer;
 
     private ModuleStage currentStage = ModuleStage.C_SETUP;
-    private final Logger logger = LogManager.getLogger("GregTech Module Loader");
+    private static final Logger logger = LogManager.getLogger("GregTech Module Loader");
     private Configuration config;
 
     private ModuleManager() {}
@@ -96,8 +96,8 @@ public final class ModuleManager implements IModuleManager {
      */
     public void setup(@NotNull ASMDataTable asmDataTable, @NotNull File configDirectory) {
         // find and register all containers registered with the @ModuleContainer annotation
-        // then sort them by container name
         discoverContainers(asmDataTable);
+        // then sort them by container name
         containers = containers.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toMap(
@@ -365,7 +365,7 @@ public final class ModuleManager implements IModuleManager {
      * @param table the ASM Data Table containing the module data
      * @return a map of Container ID to list of associated modules sorted by Module ID
      */
-    private @NotNull Map<String, List<IGregTechModule>> getModules(@NotNull ASMDataTable table) {
+    private static @NotNull Map<String, List<IGregTechModule>> getModules(@NotNull ASMDataTable table) {
         List<IGregTechModule> instances = getInstances(table);
         Map<String, List<IGregTechModule>> modules = new Object2ReferenceLinkedOpenHashMap<>();
         for (IGregTechModule module : instances) {
@@ -380,7 +380,7 @@ public final class ModuleManager implements IModuleManager {
      * @return all IGregTechModule instances in sorted order by Container and Module ID
      */
     @SuppressWarnings("unchecked")
-    private @NotNull List<IGregTechModule> getInstances(@NotNull ASMDataTable table) {
+    private static @NotNull List<IGregTechModule> getInstances(@NotNull ASMDataTable table) {
         Set<ASMDataTable.ASMData> dataSet = table.getAll(GregTechModule.class.getCanonicalName());
         List<IGregTechModule> instances = new ArrayList<>();
         for (ASMDataTable.ASMData data : dataSet) {
@@ -413,6 +413,11 @@ public final class ModuleManager implements IModuleManager {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Discovers ModuleContainers and registers them
+     *
+     * @param table the table containing the ModuleContainer data
+     */
     private void discoverContainers(@NotNull ASMDataTable table) {
         Set<ASMDataTable.ASMData> dataSet = table.getAll(ModuleContainer.class.getCanonicalName());
         for (ASMDataTable.ASMData data : dataSet) {

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -386,7 +386,6 @@ public final class ModuleManager implements IModuleManager {
         for (ASMDataTable.ASMData data : dataSet) {
             String moduleID = (String) data.getAnnotationInfo().get("moduleID");
             List<String> modDependencies = (List<String>) data.getAnnotationInfo().get("modDependencies");
-
             if (modDependencies == null || modDependencies.stream().allMatch(Loader::isModLoaded)) {
                 try {
                     Class<?> clazz = Class.forName(data.getClassName());
@@ -426,7 +425,7 @@ public final class ModuleManager implements IModuleManager {
                 if (IGregTechModule.class.isAssignableFrom(clazz)) {
                     registerContainer((IModuleContainer) clazz.getConstructor().newInstance());
                 } else {
-                    logger.error("Module Class {} is not an instanceof IModuleContainer", clazz.getName());
+                    logger.error("Module Container Class {} is not an instanceof IModuleContainer", clazz.getName());
                 }
             } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException |
                      InvocationTargetException e) {

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -435,7 +435,7 @@ public final class ModuleManager implements IModuleManager {
     }
 
     /**
-     * @param module the module to get the comment fo
+     * @param module the module to get the comment for
      * @return the comment for the module's configuration
      */
     private static String getComment(@NotNull IGregTechModule module) {


### PR DESCRIPTION
## What
Makes some general improvements to the GT Module code.
1. Adds annotations to method signatures and some fields to improve nullity clarity
2. Uses `clazz.getConstructor().newInstance()` instead of `clazz.newInstance()`, since it's deprecated in Java 9, and can throw hidden checked exceptions previously not accounted for.
3. Fixes a bug where the last active module container is treated as active between initialization events, and indefinitely after the last event. 
4. Improves some error messages for improper module API usage.
5. Makes some other general code improvements, such as using FastUtil collections.

## Outcome
Improves GT Module related code.
