### PR TITLE
remove catch throwable where possible

### DIFF
--- a/src/main/java/gregtech/client/particle/GTParticleManager.java
+++ b/src/main/java/gregtech/client/particle/GTParticleManager.java
@@ -142,10 +142,10 @@ public class GTParticleManager {
 
     private static void renderGlParticlesInLayer(@NotNull Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> renderQueue,
                                                  @NotNull EffectRenderContext context) {
-        for (var e : renderQueue.entrySet()) {
+        for (var entry : renderQueue.entrySet()) {
             @Nullable
-            IRenderSetup handler = e.getKey();
-            ArrayDeque<GTParticle> particles = e.getValue();
+            IRenderSetup handler = entry.getKey();
+            ArrayDeque<GTParticle> particles = entry.getValue();
             if (particles.isEmpty()) continue;
 
             boolean initialized = false;
@@ -160,8 +160,8 @@ public class GTParticleManager {
                             }
                         }
                         particle.renderParticle(buffer, context);
-                    } catch (Throwable throwable) {
-                        GTLog.logger.error("particle render error: {}", particle.toString(), throwable);
+                    } catch (RuntimeException e) {
+                        GTLog.logger.error("particle render error: {}", particle.toString(), e);
                         particle.setExpired();
                     }
                 }

--- a/src/main/java/gregtech/common/covers/facade/FacadeHelper.java
+++ b/src/main/java/gregtech/common/covers/facade/FacadeHelper.java
@@ -52,15 +52,15 @@ public class FacadeHelper {
     }
 
     private static IBlockState lookupBlockForItemUnsafe(ItemStack itemStack) {
-        if (!(itemStack.getItem() instanceof ItemBlock)) {
+        if (!(itemStack.getItem() instanceof ItemBlock itemBlock)) {
             return null;
         }
-        Block block = ((ItemBlock) itemStack.getItem()).getBlock();
+        Block block = itemBlock.getBlock();
         int blockMetadata = itemStack.getItem().getMetadata(itemStack);
         try {
             // noinspection deprecation
             return block.getStateFromMeta(blockMetadata);
-        } catch (Throwable e) {
+        } catch (RuntimeException e) {
             return null;
         }
     }

--- a/src/main/java/gregtech/common/gui/widget/monitor/WidgetCoverList.java
+++ b/src/main/java/gregtech/common/gui/widget/monitor/WidgetCoverList.java
@@ -92,8 +92,8 @@ public class WidgetCoverList extends ScrollableListWidget {
         if (!result && mouseY >= this.getPosition().y && mouseY <= this.getPosition().y + this.getSize().height) {
             Widget widget = this.widgets.stream().filter(it -> it.isMouseOverElement(mouseX, mouseY)).findFirst()
                     .orElse(null);
-            if (widget instanceof WidgetGroup) {
-                List<Widget> children = ((WidgetGroup) widget).getContainedWidgets(true);
+            if (widget instanceof WidgetGroup wg) {
+                List<Widget> children = wg.getContainedWidgets(true);
                 if (children.get(0).isMouseOverElement(mouseX, mouseY)) {
                     try {
                         String posString = ObfuscationReflectionHelper.getPrivateValue(LabelWidget.class,
@@ -108,7 +108,7 @@ public class WidgetCoverList extends ScrollableListWidget {
                                 ((SlotWidget) children.get(0)).getHandle().getStack().getDisplayName() +
                                         ": " + posString));
                         return false;
-                    } catch (Throwable e) {
+                    } catch (NumberFormatException e) {
                         GTLog.logger.error("Could not reflect GregTech WidgetLabel text", e);
                     }
                 }

--- a/src/main/java/gregtech/common/items/EnchantmentTableTweaks.java
+++ b/src/main/java/gregtech/common/items/EnchantmentTableTweaks.java
@@ -53,7 +53,7 @@ public class EnchantmentTableTweaks {
                     resultSlot.slotNumber = previousLapisSlot.slotNumber;
                     container.inventorySlots.set(index, resultSlot);
                 }
-            } catch (Throwable exception) {
+            } catch (RuntimeException exception) {
                 GTLog.logger.warn("Failed to replace enchantment container slot", exception);
             }
         }

--- a/src/main/java/gregtech/common/worldgen/LootTableHelper.java
+++ b/src/main/java/gregtech/common/worldgen/LootTableHelper.java
@@ -55,9 +55,9 @@ public class LootTableHelper {
             gsonField.setAccessible(true);
             Gson gsonInstance = (Gson) gsonField.get(null);
             replaceGsonTypeHierarchySerializer(gsonInstance, LootEntry.class, LootTableEntrySerializerDelegate::new);
-        } catch (Throwable exception) {
-            GTLog.logger.fatal("Failed to initialize loot table helper", exception);
-            throw new RuntimeException(exception);
+        } catch (SecurityException | IllegalAccessException e) {
+            GTLog.logger.fatal("Failed to initialize loot table helper", e);
+            throw new IllegalStateException(e);
         }
         registerLootEntry("gregtech:meta_item", LootEntryMetaItem::deserialize);
         registerLootEntry("gregtech:ore_dict", LootEntryOreDict::deserialize);


### PR DESCRIPTION
## What
Removes places where we use `catch (Throwable)` instead of `catch (RuntimeException)`. Catching throwable can lead to many issues since it is a superclass of `Error`. Places using `MethodHandle#invoke` and its variants are required to catch throwable, so those are unchanged.
