### PR TITLE
Properly fix potential NPE in MetaTileEntity

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -846,8 +846,8 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
     }
 
     public void update() {
-        if (!getWorld().isRemote && !allowTickAcceleration()) {
-            int currentTick = FMLCommonHandler.instance().getMinecraftServerInstance().getTickCounter();
+        if (!allowTickAcceleration() && getWorld().getMinecraftServer() != null) {
+            int currentTick = getWorld().getMinecraftServer().getTickCounter();
             if (currentTick == lastTick) {
                 return;
             }

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -73,7 +73,6 @@ import net.minecraftforge.fluids.FluidActionResult;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;


### PR DESCRIPTION
## What
`!getWorld().isRemote` returns true for tracked dummy worlds on client, causing a NPE for getting a MinecraftServer
this causes the JEI module to fail during load specifically for integrated servers.

## Implementation Details
replace check with a direct null check

## Outcome
MTEs no longer NPE

## Additional Information
how did nobody else experience this
