### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/main/java/gregtech/api/items/OreDictNames.java
+++ b/src/main/java/gregtech/api/items/OreDictNames.java
@@ -10,6 +10,7 @@ public enum OreDictNames {
     cobblestone, // For just cobblestone.
     stoneCobble, // For any kind of cobblestone (e.g. mossy cobblestone).
     stoneBricks, // For any kind of stone bricks
+    sand, // For either type of sand
 
     craftingAnvil,
     craftingFurnace,

--- a/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/UniversalDistillationRecipeBuilder.java
@@ -64,12 +64,20 @@ public class UniversalDistillationRecipeBuilder extends RecipeBuilder<UniversalD
                         .duration(Math.max(1, recipeDuration / ratio));
 
             else if (!shouldDivide) {
-                builder.fluidInputs(this.fluidInputs.get(0))
+                RecipeBuilder<?> distilleryBuilder = builder.fluidInputs(this.fluidInputs.get(0))
                         .fluidOutputs(this.fluidOutputs.get(i))
                         .outputs(this.outputs)
                         .duration(recipeDuration)
-                        .cleanroom(getCleanroom())
-                        .buildAndRegister();
+                        .cleanroom(getCleanroom());
+
+                if (!this.chancedOutputs.isEmpty()) {
+                    distilleryBuilder.chancedOutput(this.chancedOutputs.get(0).getIngredient(),
+                            this.chancedOutputs.get(0).getChance() / this.fluidOutputs.size(),
+                            this.chancedOutputs.get(0).getChanceBoost());
+                }
+
+                distilleryBuilder.buildAndRegister();
+
                 continue;
             }
 
@@ -82,6 +90,13 @@ public class UniversalDistillationRecipeBuilder extends RecipeBuilder<UniversalD
 
                     builder.outputs(stack);
                 }
+            } else if (!this.chancedOutputs.isEmpty()) {
+                int dividedChance = this.chancedOutputs.get(0).getChance() / this.fluidOutputs.size();
+                if (dividedChance > 0) {
+                    builder.chancedOutput(this.chancedOutputs.get(0).getIngredient().copy(), dividedChance,
+                            this.chancedOutputs.get(0).getChanceBoost());
+                }
+
             }
             builder.buildAndRegister();
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingBus.java
@@ -44,7 +44,7 @@ public class MetaTileEntityMEStockingBus extends MetaTileEntityMEInputBus {
     private Predicate<ItemStack> autoPullTest;
 
     public MetaTileEntityMEStockingBus(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, GTValues.LuV);
+        super(metaTileEntityId, GTValues.IV);
         this.autoPullTest = $ -> false;
     }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/appeng/MetaTileEntityMEStockingHatch.java
@@ -44,7 +44,7 @@ public class MetaTileEntityMEStockingHatch extends MetaTileEntityMEInputHatch {
     private Predicate<FluidStack> autoPullTest;
 
     public MetaTileEntityMEStockingHatch(ResourceLocation metaTileEntityId) {
-        super(metaTileEntityId, GTValues.LuV);
+        super(metaTileEntityId, GTValues.IV);
         this.autoPullTest = $ -> false;
     }
 

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.items.OreDictNames;
 import gregtech.api.items.armor.ArmorMetaItem;
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.recipes.ModHandler;
@@ -417,7 +418,7 @@ public class MiscRecipeLoader {
         MIXER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.DIRT))
                 .input(dust, Wood, 2)
-                .inputs(new ItemStack(Blocks.SAND, 4))
+                .input(OreDictNames.sand.name(), 4)
                 .fluidInputs(Water.getFluid(1000))
                 .output(FERTILIZER, 4)
                 .duration(100).EUt(VA[LV]).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.items.OreDictNames;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.ingredients.GTRecipeOreInput;
@@ -121,10 +122,10 @@ public class VanillaStandardRecipes {
                 "dustFlint");
 
         ModHandler.addShapedRecipe("quartz_sand", OreDictUnifier.get(OrePrefix.dust, Materials.QuartzSand), "S", "m",
-                'S', new ItemStack(Blocks.SAND));
+                'S', OreDictNames.sand);
 
         RecipeMaps.MACERATOR_RECIPES.recipeBuilder()
-                .inputs(new ItemStack(Blocks.SAND))
+                .input(OreDictNames.sand.name())
                 .output(OrePrefix.dust, Materials.QuartzSand)
                 .duration(30).buildAndRegister();
 
@@ -145,7 +146,7 @@ public class VanillaStandardRecipes {
                 .buildAndRegister();
 
         RecipeMaps.ARC_FURNACE_RECIPES.recipeBuilder().duration(20).EUt(VA[LV])
-                .inputs(new ItemStack(Blocks.SAND, 1))
+                .input(OreDictNames.sand.name())
                 .outputs(new ItemStack(Blocks.GLASS, 2))
                 .buildAndRegister();
 


### PR DESCRIPTION
## What
Some miscellaneous fixes, from the playthrough general issue tracker. Better late than never

Allows more use of Red Sand with sand recipes. Closes #2667 
Fixes the Texture of the Stocking Hatch/Bus to match the tier. Closes #2677
Fixes Distillery recipes not copying chanced outputs from the Distillation Tower.

## Implementation Details
For the Distillery Outputs, I basically just took the chanced output from the distillation tower, and divided the chance by the number of fluid outputs (ie the number of distillery recipes that would be created), and then added an output to each created distillery recipe, with a reduced chance.

## Outcome
Fixes some minor issues brought up in the playthrough tracker.