### PR TITLE
improve power substation power bank code

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -604,9 +604,12 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         private static final String NBT_SIZE = "Size";
         private static final String NBT_STORED = "Stored";
         private static final String NBT_MAX = "Max";
-        private final long[] stored = new long[2], max = new long[2];
+        // the following two fields represent ((a[0] << 63) | a[1])
+        private final long[] stored = new long[2];
+        private final long[] max = new long[2];
         private BigInteger capacity;
-        private long drain, drainMod;
+        private long drain;
+        private long drainMod;
 
         public PowerStationEnergyBank(List<IBatteryData> batteries) {
             for (IBatteryData i : batteries) {
@@ -617,6 +620,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         }
 
         public PowerStationEnergyBank(NBTTagCompound storageTag) {
+            // legacy nbt handling
             if (storageTag.hasKey(NBT_SIZE, Constants.NBT.TAG_INT)) {
                 int size = storageTag.getInteger(NBT_SIZE);
                 for (int i = 0; i < size; i++) {
@@ -693,7 +697,9 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
             if (stored[1] + amount < 0) {
                 stored[0]++;
                 stored[1] += Long.MIN_VALUE;
-                if (max[0] == stored[0] && max[1] < stored[1] + amount) amount = max[1] - stored[1];
+                if (max[0] == stored[0] && max[1] < stored[1] + amount) {
+                    amount = max[1] - stored[1];
+                }
             }
             stored[1] += amount;
             return amount;
@@ -732,7 +738,8 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         }
 
         private static void add(long[] num, long val) {
-            if ((num[1] += val) < 0) {
+            num[1] += val;
+            if (num[1] < 0) {
                 num[0]++;
                 num[1] -= Long.MIN_VALUE;
             }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -600,6 +600,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
     }
 
     public static class PowerStationEnergyBank {
+
         private static final String NBT_SIZE = "Size";
         private static final String NBT_STORED = "Stored";
         private static final String NBT_MAX = "Max";

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -600,12 +600,9 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
     }
 
     public static class PowerStationEnergyBank {
-
         private static final String NBT_SIZE = "Size";
         private static final String NBT_STORED = "Stored";
         private static final String NBT_MAX = "Max";
-        public static final String NBT_DRAIN = "Drain";
-        public static final String NBT_DRAIN_MOD = "Drain_Mod";
         private final long[] stored = new long[2], max = new long[2];
         private BigInteger capacity;
         private long drain, drainMod;
@@ -631,10 +628,6 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
             } else {
                 stored[0] = storageTag.getLong(NBT_STORED + "0");
                 stored[1] = storageTag.getLong(NBT_STORED + "1");
-                max[0] = storageTag.getLong(NBT_MAX + "0");
-                max[1] = storageTag.getLong(NBT_MAX + "1");
-                drain = storageTag.getLong(NBT_DRAIN);
-                drainMod = storageTag.getLong(NBT_DRAIN_MOD);
             }
             capacity = summarize(max);
         }
@@ -642,10 +635,6 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         public NBTTagCompound writeToNBT(NBTTagCompound compound) {
             compound.setLong(NBT_STORED + "0", stored[0]);
             compound.setLong(NBT_STORED + "1", stored[1]);
-            compound.setLong(NBT_MAX + "0", max[0]);
-            compound.setLong(NBT_MAX + "1", max[1]);
-            compound.setLong(NBT_DRAIN, drain);
-            compound.setLong(NBT_DRAIN_MOD, drainMod);
             return compound;
         }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -605,6 +605,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         private static final String NBT_STORED = "Stored";
         private static final String NBT_MAX = "Max";
         public static final String NBT_DRAIN = "Drain";
+        public static final String NBT_DRAIN_MOD = "Drain_Mod";
         private final long[] stored = new long[2], max = new long[2];
         private BigInteger capacity;
         private long drain, drainMod;
@@ -633,6 +634,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
                 max[0] = storageTag.getLong(NBT_MAX + "0");
                 max[1] = storageTag.getLong(NBT_MAX + "1");
                 drain = storageTag.getLong(NBT_DRAIN);
+                drainMod = storageTag.getLong(NBT_DRAIN_MOD);
             }
             capacity = summarize(max);
         }
@@ -643,6 +645,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
             compound.setLong(NBT_MAX + "0", max[0]);
             compound.setLong(NBT_MAX + "1", max[1]);
             compound.setLong(NBT_DRAIN, drain);
+            compound.setLong(NBT_DRAIN_MOD, drainMod);
             return compound;
         }
 

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPowerSubstation.java
@@ -629,6 +629,8 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
             } else {
                 stored[0] = storageTag.getLong(NBT_STORED + "0");
                 stored[1] = storageTag.getLong(NBT_STORED + "1");
+                drain = storageTag.getLong("drain");
+                drainMod = storageTag.getLong("drainMod");
             }
             capacity = summarize(max);
         }
@@ -636,6 +638,8 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         public NBTTagCompound writeToNBT(NBTTagCompound compound) {
             compound.setLong(NBT_STORED + "0", stored[0]);
             compound.setLong(NBT_STORED + "1", stored[1]);
+            compound.setLong("drain", drain);
+            compound.setLong("drainMod", drainMod);
             return compound;
         }
 
@@ -706,7 +710,7 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
             }
             if (stored[1] < amount) {
                 stored[0]--;
-                stored[1] = stored[1] - amount + Long.MAX_VALUE + 1;
+                stored[1] -= amount + Long.MIN_VALUE;
             } else stored[1] -= amount;
             return amount;
         }
@@ -728,11 +732,10 @@ public class MetaTileEntityPowerSubstation extends MultiblockWithDisplayBase
         }
 
         private static void add(long[] num, long val) {
-            if (val + num[1] < 0) {
+            if ((num[1] += val) < 0) {
                 num[0]++;
-                num[1] += Long.MIN_VALUE;
+                num[1] -= Long.MIN_VALUE;
             }
-            num[1] += val;
         }
 
         @VisibleForTesting

--- a/src/test/java/gregtech/common/metatileentities/multiblock/PowerSubstationTest.java
+++ b/src/test/java/gregtech/common/metatileentities/multiblock/PowerSubstationTest.java
@@ -2,6 +2,7 @@ package gregtech.common.metatileentities.multiblock;
 
 import gregtech.Bootstrap;
 import gregtech.api.metatileentity.multiblock.IBatteryData;
+import gregtech.api.util.random.XoShiRo256PlusPlusRandom;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityPowerSubstation.PowerStationEnergyBank;
 
 import org.hamcrest.Matcher;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Consumer;
 
 import static gregtech.common.metatileentities.multi.electric.MetaTileEntityPowerSubstation.MAX_BATTERY_LAYERS;
@@ -257,7 +257,7 @@ public class PowerSubstationTest {
 
     @Test
     public void Test_Optimized_Big_Integer_Summarize() {
-        Consumer<Random> testRunner = r -> {
+        Consumer<XoShiRo256PlusPlusRandom> testRunner = r -> {
             BigInteger summation = BigInteger.ZERO;
             long[] storageValues = new long[9 * MAX_BATTERY_LAYERS];
             for (int i = 0; i < storageValues.length; i++) {
@@ -271,7 +271,7 @@ public class PowerSubstationTest {
         };
 
         for (int i = 0; i < 100; i++) {
-            testRunner.accept(new Random());
+            testRunner.accept(new XoShiRo256PlusPlusRandom());
         }
     }
 
@@ -282,15 +282,13 @@ public class PowerSubstationTest {
         MatcherAssert.assertThat(storage.getPassiveDrainPerTick(),
                 is(2 * PASSIVE_DRAIN_MAX_PER_STORAGE));
 
-        Consumer<Random> testRunner = r -> {
+        Consumer<XoShiRo256PlusPlusRandom> testRunner = r -> {
             int numTruncated = 0;
             BigInteger nonTruncated = BigInteger.ZERO;
 
             long[] storageValues = new long[9 * MAX_BATTERY_LAYERS];
             for (int i = 0; i < storageValues.length; i++) {
-                // hack around not having bounded long
-                // PASSIVE_DRAIN_MAX_PER_STORAGE * PASSIVE_DRAIN_DIVISOR * 2 is pretty close to 1 << 45
-                long randomLong = (long) Math.abs(r.nextInt()) << 14 | Math.abs(r.nextInt(1 << 14));
+                long randomLong = r.nextLong(PASSIVE_DRAIN_MAX_PER_STORAGE * PASSIVE_DRAIN_DIVISOR * 2);
                 storageValues[i] = randomLong;
                 if (randomLong / PASSIVE_DRAIN_DIVISOR >= PASSIVE_DRAIN_MAX_PER_STORAGE) {
                     numTruncated++;
@@ -307,13 +305,13 @@ public class PowerSubstationTest {
         };
 
         for (int i = 0; i < 100; i++) {
-            testRunner.accept(new Random());
+            testRunner.accept(new XoShiRo256PlusPlusRandom());
         }
     }
 
     @Test
     public void Test_Fill_Drain_Randomized() {
-        Consumer<Random> testRunner = r -> {
+        Consumer<XoShiRo256PlusPlusRandom> testRunner = r -> {
             BigInteger capacity = BigInteger.ZERO;
             long[] storageValues = new long[9 * MAX_BATTERY_LAYERS];
             for (int i = 0; i < storageValues.length; i++) {
@@ -329,7 +327,9 @@ public class PowerSubstationTest {
 
             BigInteger current = BigInteger.valueOf(Long.MAX_VALUE)
                     .multiply(BigInteger.valueOf(9 * MAX_BATTERY_LAYERS / 4));
-            for (int i = 0; i < 9 * MAX_BATTERY_LAYERS / 4; i++) storage.fill(Long.MAX_VALUE);
+            for (int i = 0; i < 9 * MAX_BATTERY_LAYERS / 4; i++) {
+                storage.fill(Long.MAX_VALUE);
+            }
 
             MatcherAssert.assertThat(storage.getStored(), is(current));
 
@@ -375,7 +375,7 @@ public class PowerSubstationTest {
         };
 
         for (int i = 0; i < 100; i++) {
-            testRunner.accept(new Random());
+            testRunner.accept(new XoShiRo256PlusPlusRandom());
         }
     }
 


### PR DESCRIPTION
## What
remembered seeing this kila tier code when doing my multiblock pattern rework, now it should be better

## Implementation Details
instead using a long array with the battery values it uses 2 longs, one is in base (1 << 63), this theorectically means it can only hold up to (1 << 126) - 1, but be real
also improves random tests for the power substation

## Outcome
biginteger but mutable

## Additional Information
nothing

## Potential Compatibility Issues
none, probably if the legacy nbt code works