### PR TITLE
Add a method to the material builder to set the color using separate r, g, and b values instead of them being moshed together.

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableList;
 import crafttweaker.annotations.ZenRegister;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 import stanhebben.zenscript.annotations.OperatorType;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
@@ -866,6 +867,20 @@ public class Material implements Comparable<Material> {
         public Builder color(int color) {
             this.materialInfo.color = color;
             return this;
+        }
+
+        /**
+         * Set the color of this Material.
+         * Defaults to 0xFFFFFF unless {@link Builder#colorAverage()} was called, where it will be a weighted average of
+         * the components of the Material.
+         *
+         * @param r the red component of the color
+         * @param g the green component of the color
+         * @param b the blue component of the color
+         */
+        public Builder color(@Range(from = 0, to = 255) int r, @Range(from = 0, to = 255) int g,
+                             @Range(from = 0, to = 255) int b) {
+            return color(GTUtility.combineRGB(r, g, b));
         }
 
         public Builder colorAverage() {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -61,6 +61,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -75,7 +76,7 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public class GTUtility {
+public final class GTUtility {
 
     public static <T> String[] mapToString(T[] array, Function<T, String> mapper) {
         String[] result = new String[array.length];
@@ -958,5 +959,10 @@ public class GTUtility {
 
         // Sanity check to make sure we don't accidentally create full-amp recipes.
         return Math.min(voltage, GTValues.VA[workingTier]);
+    }
+
+    public static int combineRGB(@Range(from = 0, to = 255) int r, @Range(from = 0, to = 255) int g,
+                                 @Range(from = 0, to = 255) int b) {
+        return (r << 16) | (g << 8) | b;
     }
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -76,7 +76,7 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public final class GTUtility {
+public class GTUtility {
 
     public static <T> String[] mapToString(T[] array, Function<T, String> mapper) {
         String[] result = new String[array.length];


### PR DESCRIPTION
## What
Adds an overload to `color(int)` in the Material builder for easier coloring.

## Outcome
Less pain when dealing with colors.