### PR TITLE
Add convenience methods to Material and OrePrefix for making ItemStacks

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -287,7 +287,7 @@ public class Material implements Comparable<Material> {
      * @param prefix the ore prefix to use
      * @return an item stack of the ore prefix using this material
      */
-    public ItemStack getItemForm(OrePrefix prefix) {
+    public ItemStack getItemForm(@NotNull OrePrefix prefix) {
         return OreDictUnifier.get(prefix, this);
     }
 
@@ -298,7 +298,7 @@ public class Material implements Comparable<Material> {
      * @param count  the amount the ItemStack will have
      * @return an item stack of the ore prefix using this material
      */
-    public ItemStack getItemForm(OrePrefix prefix, int count) {
+    public ItemStack getItemForm(@NotNull OrePrefix prefix, int count) {
         return OreDictUnifier.get(prefix, this, count);
     }
 

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -8,6 +8,7 @@ import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.fluids.store.FluidStorageKeys;
 import gregtech.api.unification.Element;
 import gregtech.api.unification.Elements;
+import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.info.MaterialFlag;
 import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.unification.material.info.MaterialIconSet;
@@ -29,6 +30,7 @@ import gregtech.api.unification.material.properties.RotorProperty;
 import gregtech.api.unification.material.properties.WireProperties;
 import gregtech.api.unification.material.properties.WoodProperty;
 import gregtech.api.unification.material.registry.MaterialRegistry;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.FluidTooltipUtil;
 import gregtech.api.util.GTUtility;
@@ -36,6 +38,7 @@ import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.SmallDigits;
 
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -276,6 +279,27 @@ public class Material implements Comparable<Material> {
      */
     public FluidStack getFluid(@NotNull FluidStorageKey key, int amount) {
         return new FluidStack(getFluid(key), amount);
+    }
+
+    /**
+     * Gets the item form of this material in the form of an {@link OrePrefix}
+     * 
+     * @param prefix the ore prefix to use
+     * @return an item stack of the ore prefix using this material
+     */
+    public ItemStack getItemForm(OrePrefix prefix) {
+        return OreDictUnifier.get(prefix, this);
+    }
+
+    /**
+     * Gets the item form of this material in the form of an {@link OrePrefix}
+     * 
+     * @param prefix the ore prefix to use
+     * @param count  the amount the ItemStack will have
+     * @return an item stack of the ore prefix using this material
+     */
+    public ItemStack getItemForm(OrePrefix prefix, int count) {
+        return OreDictUnifier.get(prefix, this, count);
     }
 
     public int getBlockHarvestLevel() {

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -287,7 +287,7 @@ public class Material implements Comparable<Material> {
      * @param prefix the ore prefix to use
      * @return an item stack of the ore prefix using this material
      */
-    public ItemStack getItemForm(@NotNull OrePrefix prefix) {
+    public @NotNull ItemStack getItemForm(@NotNull OrePrefix prefix) {
         return OreDictUnifier.get(prefix, this);
     }
 
@@ -298,7 +298,7 @@ public class Material implements Comparable<Material> {
      * @param count  the amount the ItemStack will have
      * @return an item stack of the ore prefix using this material
      */
-    public ItemStack getItemForm(@NotNull OrePrefix prefix, int count) {
+    public @NotNull ItemStack getItemForm(@NotNull OrePrefix prefix, int count) {
         return OreDictUnifier.get(prefix, this, count);
     }
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -1,5 +1,6 @@
 package gregtech.api.unification.ore;
 
+import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterials;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
@@ -12,6 +13,7 @@ import gregtech.api.util.function.TriConsumer;
 import gregtech.common.ConfigHolder;
 
 import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
 
 import com.google.common.base.Preconditions;
 import crafttweaker.annotations.ZenRegister;
@@ -701,6 +703,27 @@ public class OrePrefix {
 
     public boolean isMarkerPrefix() {
         return isMarkerPrefix;
+    }
+
+    /**
+     * Gets the item form of this ore prefix using a {@link Material}
+     * 
+     * @param material the Material to use
+     * @return an ItemStack of the Material using this ore prefix
+     */
+    public ItemStack getItemForm(Material material) {
+        return OreDictUnifier.get(this, material);
+    }
+
+    /**
+     * Gets the item form of this ore prefix using a {@link Material}
+     * 
+     * @param material the Material to use
+     * @param count    the amount the ItemStack will have
+     * @return an ItemStack of the Material using this ore prefix
+     */
+    public ItemStack getItemForm(Material material, int count) {
+        return OreDictUnifier.get(this, material, count);
     }
 
     @Override

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -711,7 +711,7 @@ public class OrePrefix {
      * @param material the Material to use
      * @return an ItemStack of the Material using this ore prefix
      */
-    public ItemStack getItemForm(@NotNull Material material) {
+    public @NotNull ItemStack getItemForm(@NotNull Material material) {
         return OreDictUnifier.get(this, material);
     }
 
@@ -722,7 +722,7 @@ public class OrePrefix {
      * @param count    the amount the ItemStack will have
      * @return an ItemStack of the Material using this ore prefix
      */
-    public ItemStack getItemForm(@NotNull Material material, int count) {
+    public @NotNull ItemStack getItemForm(@NotNull Material material, int count) {
         return OreDictUnifier.get(this, material, count);
     }
 

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -711,7 +711,7 @@ public class OrePrefix {
      * @param material the Material to use
      * @return an ItemStack of the Material using this ore prefix
      */
-    public ItemStack getItemForm(Material material) {
+    public ItemStack getItemForm(@NotNull Material material) {
         return OreDictUnifier.get(this, material);
     }
 
@@ -722,7 +722,7 @@ public class OrePrefix {
      * @param count    the amount the ItemStack will have
      * @return an ItemStack of the Material using this ore prefix
      */
-    public ItemStack getItemForm(Material material, int count) {
+    public ItemStack getItemForm(@NotNull Material material, int count) {
         return OreDictUnifier.get(this, material, count);
     }
 


### PR DESCRIPTION
## What
Adds 2 methods to Material and OrePrefix for generating an ItemStack using that material + an ore prefix, or that ore prefix + a material.

## Outcome
Easier coding ig

## Potential Compatibility Issues
N/A