### PR TITLE
Add convenience methods to the recipe builder

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -608,7 +608,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             if (fluidStack != null && fluidStack.amount > 0) {
                 fluidIngredients.add(new GTRecipeFluidInput(fluidStack));
             } else if (fluidStack != null) {
-                GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", fluidStack.amount,
+                GTLog.logger.error("Fluid Input count cannot be less than 1. Actual: {}.", fluidStack.amount,
                         new Throwable());
             } else {
                 GTLog.logger.error("FluidStack cannot be null.");

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes;
 
 import gregtech.api.GTValues;
+import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.multiblock.CleanroomType;
@@ -260,6 +261,10 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return input(new GTRecipeItemInput(new ItemStack(block, count)));
     }
 
+    public R input(Block block, int count, int meta) {
+        return input(new GTRecipeItemInput(new ItemStack(block, count, meta)));
+    }
+
     public R input(Block block, int count, @SuppressWarnings("unused") boolean wild) {
         return input(new GTRecipeItemInput(new ItemStack(block, count, GTValues.W)));
     }
@@ -516,6 +521,10 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return outputs(new ItemStack(item, count));
     }
 
+    public R output(Block item, int count, int meta) {
+        return outputs(new ItemStack(item, count, meta));
+    }
+
     public R output(MetaItem<?>.MetaValueItem item, int count) {
         return outputs(item.getStackForm(count));
     }
@@ -555,6 +564,14 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
+    public R fluidInput(@NotNull Fluid fluid) {
+        return fluidInputs(new GTRecipeFluidInput(fluid, 1));
+    }
+
+    public R fluidInput(@NotNull Fluid fluid, int amount) {
+        return fluidInputs(new GTRecipeFluidInput(fluid, amount));
+    }
+
     public R fluidInputs(Collection<GTRecipeInput> fluidIngredients) {
         this.fluidInputs.addAll(fluidIngredients);
         return (R) this;
@@ -569,11 +586,20 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         if (input != null && input.amount > 0) {
             this.fluidInputs.add(new GTRecipeFluidInput(input));
         } else if (input != null) {
-            GTLog.logger.error("Fluid Input count cannot be less than 0. Actual: {}.", input.amount, new Throwable());
+            GTLog.logger.error("Fluid Input count cannot be less than 1. Actual: {}.", input.amount,
+                    new IllegalArgumentException());
         } else {
             GTLog.logger.error("FluidStack cannot be null.");
         }
         return (R) this;
+    }
+
+    public R fluidInputs(@NotNull Material material, int amount) {
+        return fluidInputs(material.getFluid(amount));
+    }
+
+    public R fluidInputs(@NotNull Material material, @NotNull FluidStorageKey storageKey, int amount) {
+        return fluidInputs(material.getFluid(storageKey, amount));
     }
 
     public R fluidInputs(FluidStack... fluidStacks) {
@@ -597,11 +623,27 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         return (R) this;
     }
 
+    public R fluidOutputs(@NotNull Fluid fluid) {
+        return fluidOutputs(new FluidStack(fluid, 1));
+    }
+
+    public R fluidOutputs(@NotNull Fluid fluid, int amount) {
+        return fluidOutputs(new FluidStack(fluid, amount));
+    }
+
     public R fluidOutputs(FluidStack output) {
         if (output != null && output.amount > 0) {
             this.fluidOutputs.add(output);
         }
         return (R) this;
+    }
+
+    public R fluidOutputs(@NotNull Material material, int amount) {
+        return fluidOutputs(material.getFluid(amount));
+    }
+
+    public R fluidOutputs(@NotNull Material material, @NotNull FluidStorageKey storageKey, int amount) {
+        return fluidOutputs(material.getFluid(storageKey, amount));
     }
 
     public R fluidOutputs(FluidStack... outputs) {

--- a/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
@@ -131,81 +131,66 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
      * @return this
      */
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull ItemStack researchStack) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(researchStack));
+        return scannerResearch(b -> b.researchStack(researchStack));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaItem<?>.MetaValueItem metaItem) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(metaItem));
+        return scannerResearch(b -> b.researchStack(metaItem));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaItem<?>.MetaValueItem metaItem, int amount) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(metaItem, amount));
+        return scannerResearch(b -> b.researchStack(metaItem, amount));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaItem<?>.MetaValueItem metaItem, int amount,
                                                      boolean ignoreNBT) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(metaItem, amount, ignoreNBT));
+        return scannerResearch(b -> b.researchStack(metaItem, amount, ignoreNBT));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaTileEntity mte) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(mte));
+        return scannerResearch(b -> b.researchStack(mte));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaTileEntity mte, int amount) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(mte, amount));
+        return scannerResearch(b -> b.researchStack(mte, amount));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaTileEntity mte, int amount, boolean ignoreNBT) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(mte, amount, ignoreNBT));
+        return scannerResearch(b -> b.researchStack(mte, amount, ignoreNBT));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull OrePrefix prefix, @NotNull Material material) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(prefix, material));
+        return scannerResearch(b -> b.researchStack(prefix, material));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull OrePrefix prefix, @NotNull Material material,
                                                      int amount) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(prefix, material, amount));
+        return scannerResearch(b -> b.researchStack(prefix, material, amount));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull OrePrefix prefix, @NotNull Material material, int amount,
                                                      boolean ignoreNBT) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(prefix, material, amount, ignoreNBT));
+        return scannerResearch(b -> b.researchStack(prefix, material, amount, ignoreNBT));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(block));
+        return scannerResearch(b -> b.researchStack(block));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(block, amount));
+        return scannerResearch(b -> b.researchStack(block, amount));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount, int meta) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(block, amount, meta));
+        return scannerResearch(b -> b.researchStack(block, amount, meta));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount, boolean ignoreNBT) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(block, amount, ignoreNBT));
+        return scannerResearch(b -> b.researchStack(block, amount, ignoreNBT));
     }
 
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount, int meta, boolean ignoreNBT) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
-                .researchStack(block, amount, meta, ignoreNBT));
+        return scannerResearch(b -> b.researchStack(block, amount, meta, ignoreNBT));
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/AssemblyLineRecipeBuilder.java
@@ -1,16 +1,21 @@
 package gregtech.api.recipes.builders;
 
+import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IDataItem;
+import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.properties.impl.ResearchProperty;
 import gregtech.api.recipes.properties.impl.ResearchPropertyData;
+import gregtech.api.unification.material.Material;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.AssemblyLineManager;
 import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import gregtech.common.ConfigHolder;
 
+import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -126,7 +131,81 @@ public class AssemblyLineRecipeBuilder extends RecipeBuilder<AssemblyLineRecipeB
      * @return this
      */
     public AssemblyLineRecipeBuilder scannerResearch(@NotNull ItemStack researchStack) {
-        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder().researchStack(researchStack));
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(researchStack));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaItem<?>.MetaValueItem metaItem) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(metaItem));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaItem<?>.MetaValueItem metaItem, int amount) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(metaItem, amount));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaItem<?>.MetaValueItem metaItem, int amount,
+                                                     boolean ignoreNBT) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(metaItem, amount, ignoreNBT));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaTileEntity mte) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(mte));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaTileEntity mte, int amount) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(mte, amount));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull MetaTileEntity mte, int amount, boolean ignoreNBT) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(mte, amount, ignoreNBT));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull OrePrefix prefix, @NotNull Material material) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(prefix, material));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull OrePrefix prefix, @NotNull Material material,
+                                                     int amount) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(prefix, material, amount));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull OrePrefix prefix, @NotNull Material material, int amount,
+                                                     boolean ignoreNBT) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(prefix, material, amount, ignoreNBT));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(block));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(block, amount));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount, int meta) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(block, amount, meta));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount, boolean ignoreNBT) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(block, amount, ignoreNBT));
+    }
+
+    public AssemblyLineRecipeBuilder scannerResearch(@NotNull Block block, int amount, int meta, boolean ignoreNBT) {
+        return scannerResearch(b -> new ResearchRecipeBuilder.ScannerRecipeBuilder()
+                .researchStack(block, amount, meta, ignoreNBT));
     }
 
     /**

--- a/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ResearchRecipeBuilder.java
@@ -4,9 +4,14 @@ import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.metaitem.stats.IDataItem;
 import gregtech.api.items.metaitem.stats.IItemBehaviour;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.material.Material;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.AssemblyLineManager;
 import gregtech.api.util.GTStringUtils;
 
+import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -24,6 +29,7 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
             this.researchStack = researchStack;
             this.ignoreNBT = true;
         }
+        // noinspection unchecked
         return (T) this;
     }
 
@@ -32,23 +38,83 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
             this.researchStack = researchStack;
             this.ignoreNBT = ignoreNBT;
         }
+        // noinspection unchecked
         return (T) this;
+    }
+
+    public T researchStack(@NotNull MetaItem<?>.MetaValueItem metaItem) {
+        return researchStack(metaItem.getStackForm());
+    }
+
+    public T researchStack(@NotNull MetaItem<?>.MetaValueItem metaItem, int amount) {
+        return researchStack(metaItem.getStackForm(amount));
+    }
+
+    public T researchStack(@NotNull MetaItem<?>.MetaValueItem metaItem, int amount, boolean ignoreNBT) {
+        return researchStack(metaItem.getStackForm(amount), ignoreNBT);
+    }
+
+    public T researchStack(@NotNull MetaTileEntity mte) {
+        return researchStack(mte.getStackForm());
+    }
+
+    public T researchStack(@NotNull MetaTileEntity mte, int amount) {
+        return researchStack(mte.getStackForm(amount));
+    }
+
+    public T researchStack(@NotNull MetaTileEntity mte, int amount, boolean ignoreNBT) {
+        return researchStack(mte.getStackForm(amount), ignoreNBT);
+    }
+
+    public T researchStack(@NotNull OrePrefix prefix, @NotNull Material material) {
+        return researchStack(OreDictUnifier.get(prefix, material));
+    }
+
+    public T researchStack(@NotNull OrePrefix prefix, @NotNull Material material, int amount) {
+        return researchStack(OreDictUnifier.get(prefix, material, amount));
+    }
+
+    public T researchStack(@NotNull OrePrefix prefix, @NotNull Material material, int amount, boolean ignoreNBT) {
+        return researchStack(OreDictUnifier.get(prefix, material, amount), ignoreNBT);
+    }
+
+    public T researchStack(@NotNull Block block) {
+        return researchStack(new ItemStack(block));
+    }
+
+    public T researchStack(@NotNull Block block, int amount) {
+        return researchStack(new ItemStack(block, amount));
+    }
+
+    public T researchStack(@NotNull Block block, int amount, int meta) {
+        return researchStack(new ItemStack(block, amount, meta));
+    }
+
+    public T researchStack(@NotNull Block block, int amount, boolean ignoreNBT) {
+        return researchStack(new ItemStack(block, amount), ignoreNBT);
+    }
+
+    public T researchStack(@NotNull Block block, int amount, int meta, boolean ignoreNBT) {
+        return researchStack(new ItemStack(block, amount, meta), ignoreNBT);
     }
 
     public T dataStack(@NotNull ItemStack dataStack) {
         if (!dataStack.isEmpty()) {
             this.dataStack = dataStack;
         }
+        // noinspection unchecked
         return (T) this;
     }
 
     public T researchId(String researchId) {
         this.researchId = researchId;
+        // noinspection unchecked
         return (T) this;
     }
 
     public T EUt(long eut) {
         this.eut = eut;
+        // noinspection unchecked
         return (T) this;
     }
 

--- a/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
@@ -28,7 +28,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(NiobiumTitanium.getFluid(L * 8))
                 .outputs(FUSION_REACTOR[0].getStackForm())
                 .scannerResearch(b -> b
-                        .researchStack(OreDictUnifier.get(wireGtSingle, IndiumTinBariumTitaniumCuprate))
+                        .researchStack(wireGtSingle, IndiumTinBariumTitaniumCuprate)
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(800).EUt(VA[LuV]).buildAndRegister();
@@ -46,7 +46,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(VanadiumGallium.getFluid(L * 8))
                 .outputs(FUSION_REACTOR[1].getStackForm())
                 .stationResearch(b -> b
-                        .researchStack(FUSION_REACTOR[0].getStackForm())
+                        .researchStack(FUSION_REACTOR[0])
                         .CWUt(16)
                         .EUt(VA[ZPM]))
                 .duration(1000).EUt(61440).buildAndRegister();
@@ -64,7 +64,7 @@ public class AssemblyLineLoader {
                 .fluidInputs(YttriumBariumCuprate.getFluid(L * 8))
                 .outputs(FUSION_REACTOR[2].getStackForm())
                 .stationResearch(b -> b
-                        .researchStack(FUSION_REACTOR[1].getStackForm())
+                        .researchStack(FUSION_REACTOR[1])
                         .CWUt(96)
                         .EUt(VA[UV]))
                 .duration(1000).EUt(VA[ZPM]).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/AssemblyLineLoader.java
@@ -1,6 +1,5 @@
 package gregtech.loaders.recipe;
 
-import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterials.Tier;
 
 import static gregtech.api.GTValues.*;

--- a/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/BatteryRecipes.java
@@ -360,7 +360,7 @@ public class BatteryRecipes {
                 .input(bolt, Naquadah, 16)
                 .fluidInputs(SolderingAlloy.getFluid(L * 5))
                 .output(ENERGY_LAPOTRONIC_ORB_CLUSTER)
-                .scannerResearch(ENERGY_LAPOTRONIC_ORB.getStackForm())
+                .scannerResearch(ENERGY_LAPOTRONIC_ORB)
                 .buildAndRegister();
 
         // Energy Module
@@ -381,7 +381,7 @@ public class BatteryRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 10))
                 .output(ENERGY_MODULE)
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_LAPOTRONIC_ORB_CLUSTER.getStackForm())
+                        .researchStack(ENERGY_LAPOTRONIC_ORB_CLUSTER)
                         .CWUt(16))
                 .buildAndRegister();
 
@@ -404,7 +404,7 @@ public class BatteryRecipes {
                 .fluidInputs(Polybenzimidazole.getFluid(L * 4))
                 .output(ENERGY_CLUSTER)
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_MODULE.getStackForm())
+                        .researchStack(ENERGY_MODULE)
                         .CWUt(96)
                         .EUt(VA[ZPM]))
                 .buildAndRegister();
@@ -429,7 +429,7 @@ public class BatteryRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 18))
                 .output(ULTIMATE_BATTERY)
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_CLUSTER.getStackForm())
+                        .researchStack(ENERGY_CLUSTER)
                         .CWUt(144)
                         .EUt(VA[UHV]))
                 .buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -1457,7 +1457,7 @@ public class CircuitRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 10))
                 .output(CRYSTAL_MAINFRAME_UV)
                 .stationResearch(b -> b
-                        .researchStack(CRYSTAL_COMPUTER_ZPM.getStackForm())
+                        .researchStack(CRYSTAL_COMPUTER_ZPM)
                         .CWUt(16))
                 .buildAndRegister();
 
@@ -1524,7 +1524,7 @@ public class CircuitRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(1152))
                 .output(WETWARE_SUPER_COMPUTER_UV)
                 .stationResearch(b -> b
-                        .researchStack(WETWARE_PROCESSOR_ASSEMBLY_ZPM.getStackForm())
+                        .researchStack(WETWARE_PROCESSOR_ASSEMBLY_ZPM)
                         .CWUt(16))
                 .buildAndRegister();
 
@@ -1545,7 +1545,7 @@ public class CircuitRecipes {
                 .fluidInputs(Polybenzimidazole.getFluid(L * 8))
                 .output(WETWARE_MAINFRAME_UHV)
                 .stationResearch(b -> b
-                        .researchStack(WETWARE_SUPER_COMPUTER_UV.getStackForm())
+                        .researchStack(WETWARE_SUPER_COMPUTER_UV)
                         .CWUt(96)
                         .EUt(VA[UV]))
                 .EUt(300000).duration(2000).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -100,7 +100,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ELECTRIC_MOTOR_LuV)
-                .scannerResearch(ELECTRIC_MOTOR_IV.getStackForm())
+                .scannerResearch(ELECTRIC_MOTOR_IV)
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -115,7 +115,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ELECTRIC_MOTOR_ZPM)
                 .scannerResearch(b -> b
-                        .researchStack(ELECTRIC_MOTOR_LuV.getStackForm())
+                        .researchStack(ELECTRIC_MOTOR_LuV)
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -133,7 +133,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ELECTRIC_MOTOR_UV)
                 .stationResearch(b -> b
-                        .researchStack(ELECTRIC_MOTOR_ZPM.getStackForm())
+                        .researchStack(ELECTRIC_MOTOR_ZPM)
                         .CWUt(32)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -302,7 +302,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(250))
                 .fluidInputs(StyreneButadieneRubber.getFluid(L * 8))
                 .output(CONVEYOR_MODULE_LuV)
-                .scannerResearch(CONVEYOR_MODULE_IV.getStackForm())
+                .scannerResearch(CONVEYOR_MODULE_IV)
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -317,7 +317,7 @@ public class ComponentRecipes {
                 .fluidInputs(StyreneButadieneRubber.getFluid(L * 16))
                 .output(CONVEYOR_MODULE_ZPM)
                 .scannerResearch(b -> b
-                        .researchStack(CONVEYOR_MODULE_LuV.getStackForm())
+                        .researchStack(CONVEYOR_MODULE_LuV)
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -335,7 +335,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(CONVEYOR_MODULE_UV)
                 .stationResearch(b -> b
-                        .researchStack(CONVEYOR_MODULE_ZPM.getStackForm())
+                        .researchStack(CONVEYOR_MODULE_ZPM)
                         .CWUt(32)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -351,7 +351,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ELECTRIC_PUMP_LuV)
-                .scannerResearch(ELECTRIC_PUMP_IV.getStackForm())
+                .scannerResearch(ELECTRIC_PUMP_IV)
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -366,7 +366,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ELECTRIC_PUMP_ZPM)
                 .scannerResearch(b -> b
-                        .researchStack(ELECTRIC_PUMP_LuV.getStackForm())
+                        .researchStack(ELECTRIC_PUMP_LuV)
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -384,7 +384,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ELECTRIC_PUMP_UV)
                 .stationResearch(b -> b
-                        .researchStack(ELECTRIC_PUMP_ZPM.getStackForm())
+                        .researchStack(ELECTRIC_PUMP_ZPM)
                         .CWUt(32)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -587,7 +587,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ELECTRIC_PISTON_LUV)
-                .scannerResearch(ELECTRIC_PISTON_IV.getStackForm())
+                .scannerResearch(ELECTRIC_PISTON_IV)
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -603,7 +603,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ELECTRIC_PISTON_ZPM)
                 .scannerResearch(b -> b
-                        .researchStack(ELECTRIC_PISTON_LUV.getStackForm())
+                        .researchStack(ELECTRIC_PISTON_LUV)
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -622,7 +622,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ELECTRIC_PISTON_UV)
                 .stationResearch(b -> b
-                        .researchStack(ELECTRIC_PISTON_ZPM.getStackForm())
+                        .researchStack(ELECTRIC_PISTON_ZPM)
                         .CWUt(32)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -708,7 +708,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .fluidInputs(Lubricant.getFluid(250))
                 .output(ROBOT_ARM_LuV)
-                .scannerResearch(ROBOT_ARM_IV.getStackForm())
+                .scannerResearch(ROBOT_ARM_IV)
                 .duration(600).EUt(6000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
@@ -725,7 +725,7 @@ public class ComponentRecipes {
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(ROBOT_ARM_ZPM)
                 .scannerResearch(b -> b
-                        .researchStack(ROBOT_ARM_LuV.getStackForm())
+                        .researchStack(ROBOT_ARM_LuV)
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(600).EUt(24000).buildAndRegister();
@@ -745,7 +745,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(ROBOT_ARM_UV)
                 .stationResearch(b -> b
-                        .researchStack(ROBOT_ARM_ZPM.getStackForm())
+                        .researchStack(ROBOT_ARM_ZPM)
                         .CWUt(32)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -824,7 +824,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .output(FIELD_GENERATOR_LuV)
                 .scannerResearch(b -> b
-                        .researchStack(FIELD_GENERATOR_IV.getStackForm())
+                        .researchStack(FIELD_GENERATOR_IV)
                         .duration(2400))
                 .duration(600).EUt(6000).buildAndRegister();
 
@@ -840,7 +840,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .output(FIELD_GENERATOR_ZPM)
                 .stationResearch(b -> b
-                        .researchStack(FIELD_GENERATOR_LuV.getStackForm())
+                        .researchStack(FIELD_GENERATOR_LuV)
                         .CWUt(4))
                 .duration(600).EUt(24000).buildAndRegister();
 
@@ -857,7 +857,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(FIELD_GENERATOR_UV)
                 .stationResearch(b -> b
-                        .researchStack(FIELD_GENERATOR_ZPM.getStackForm())
+                        .researchStack(FIELD_GENERATOR_ZPM)
                         .CWUt(48)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -932,7 +932,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .output(SENSOR_LuV)
                 .scannerResearch(b -> b
-                        .researchStack(SENSOR_IV.getStackForm())
+                        .researchStack(SENSOR_IV)
                         .duration(2400))
                 .duration(600).EUt(6000).buildAndRegister();
 
@@ -948,7 +948,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .output(SENSOR_ZPM)
                 .stationResearch(b -> b
-                        .researchStack(SENSOR_LuV.getStackForm())
+                        .researchStack(SENSOR_LuV)
                         .CWUt(4))
                 .duration(600).EUt(24000).buildAndRegister();
 
@@ -965,7 +965,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(SENSOR_UV)
                 .stationResearch(b -> b
-                        .researchStack(SENSOR_ZPM.getStackForm())
+                        .researchStack(SENSOR_ZPM)
                         .CWUt(48)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();
@@ -1045,7 +1045,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 2))
                 .output(EMITTER_LuV)
                 .scannerResearch(b -> b
-                        .researchStack(EMITTER_IV.getStackForm())
+                        .researchStack(EMITTER_IV)
                         .duration(2400))
                 .duration(600).EUt(6000).buildAndRegister();
 
@@ -1061,7 +1061,7 @@ public class ComponentRecipes {
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .output(EMITTER_ZPM)
                 .stationResearch(b -> b
-                        .researchStack(EMITTER_LuV.getStackForm())
+                        .researchStack(EMITTER_LuV)
                         .CWUt(8))
                 .duration(600).EUt(24000).buildAndRegister();
 
@@ -1078,7 +1078,7 @@ public class ComponentRecipes {
                 .fluidInputs(Naquadria.getFluid(L * 4))
                 .output(EMITTER_UV)
                 .stationResearch(b -> b
-                        .researchStack(EMITTER_ZPM.getStackForm())
+                        .researchStack(EMITTER_ZPM)
                         .CWUt(48)
                         .EUt(VA[ZPM]))
                 .duration(600).EUt(100000).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/ComputerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComputerRecipes.java
@@ -8,8 +8,6 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockComputerCasing;
 import gregtech.common.blocks.BlockGlassCasing;
 
-import net.minecraft.item.ItemStack;
-
 import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLY_LINE_RECIPES;

--- a/src/main/java/gregtech/loaders/recipe/ComputerRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComputerRecipes.java
@@ -38,7 +38,9 @@ public class ComputerRecipes {
                 .output(ADVANCED_DATA_ACCESS_HATCH)
                 .fluidInputs(SolderingAlloy.getFluid(L * 4))
                 .fluidInputs(Polybenzimidazole.getFluid(L * 4))
-                .stationResearch(b -> b.researchStack(DATA_BANK.getStackForm()).CWUt(4))
+                .stationResearch(b -> b
+                        .researchStack(DATA_BANK)
+                        .CWUt(4))
                 .duration(400).EUt(6000).buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder()
@@ -103,7 +105,7 @@ public class ComputerRecipes {
                 .fluidInputs(Lubricant.getFluid(500))
                 .output(DATA_BANK)
                 .scannerResearch(b -> b
-                        .researchStack(DATA_ACCESS_HATCH.getStackForm())
+                        .researchStack(DATA_ACCESS_HATCH)
                         .duration(2400)
                         .EUt(VA[EV]))
                 .duration(1200).EUt(6000).buildAndRegister();
@@ -121,7 +123,7 @@ public class ComputerRecipes {
                 .fluidInputs(VanadiumGallium.getFluid(L * 8))
                 .output(RESEARCH_STATION)
                 .scannerResearch(b -> b
-                        .researchStack(SCANNER[LuV].getStackForm())
+                        .researchStack(SCANNER[LuV])
                         .duration(2400)
                         .EUt(VA[IV]))
                 .duration(1200).EUt(100000).buildAndRegister();
@@ -138,7 +140,7 @@ public class ComputerRecipes {
                 .fluidInputs(Polybenzimidazole.getFluid(L * 2))
                 .output(OBJECT_HOLDER)
                 .scannerResearch(b -> b
-                        .researchStack(ITEM_IMPORT_BUS[ZPM].getStackForm())
+                        .researchStack(ITEM_IMPORT_BUS[ZPM])
                         .duration(2400)
                         .EUt(VA[IV]))
                 .duration(1200).EUt(100000).buildAndRegister();
@@ -156,7 +158,7 @@ public class ComputerRecipes {
                 .fluidInputs(Polybenzimidazole.getFluid(L * 4))
                 .output(NETWORK_SWITCH)
                 .stationResearch(b -> b
-                        .researchStack(new ItemStack(OPTICAL_PIPES[0]))
+                        .researchStack(OPTICAL_PIPES[0])
                         .CWUt(32)
                         .EUt(VA[ZPM]))
                 .duration(1200).EUt(100000).buildAndRegister();
@@ -174,7 +176,7 @@ public class ComputerRecipes {
                 .fluidInputs(PCBCoolant.getFluid(4000))
                 .output(HIGH_PERFORMANCE_COMPUTING_ARRAY)
                 .scannerResearch(b -> b
-                        .researchStack(COVER_SCREEN.getStackForm())
+                        .researchStack(COVER_SCREEN)
                         .duration(2400)
                         .EUt(VA[IV]))
                 .duration(1200).EUt(100000).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MetaTileEntityMachineRecipeLoader.java
@@ -340,7 +340,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(720))
                 .output(ENERGY_OUTPUT_HATCH[LuV])
                 .scannerResearch(b -> b
-                        .researchStack(ENERGY_OUTPUT_HATCH[IV].getStackForm())
+                        .researchStack(ENERGY_OUTPUT_HATCH[IV])
                         .EUt(VA[EV]))
                 .duration(400).EUt(VA[LuV]).buildAndRegister();
 
@@ -354,7 +354,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(1440))
                 .output(ENERGY_OUTPUT_HATCH[ZPM])
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_OUTPUT_HATCH[LuV].getStackForm())
+                        .researchStack(ENERGY_OUTPUT_HATCH[LuV])
                         .CWUt(8))
                 .duration(600).EUt(VA[ZPM]).buildAndRegister();
 
@@ -368,7 +368,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(2880))
                 .output(ENERGY_OUTPUT_HATCH[UV])
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_OUTPUT_HATCH[ZPM].getStackForm())
+                        .researchStack(ENERGY_OUTPUT_HATCH[ZPM])
                         .CWUt(64)
                         .EUt(VA[ZPM]))
                 .duration(800).EUt(VA[UV]).buildAndRegister();
@@ -383,7 +383,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(5760))
                 .output(ENERGY_OUTPUT_HATCH[UHV])
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_OUTPUT_HATCH[UV].getStackForm())
+                        .researchStack(ENERGY_OUTPUT_HATCH[UV])
                         .CWUt(128)
                         .EUt(VA[UV]))
                 .duration(1000).EUt(VA[UHV]).buildAndRegister();
@@ -468,7 +468,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(720))
                 .output(ENERGY_INPUT_HATCH[LuV])
                 .scannerResearch(b -> b
-                        .researchStack(ENERGY_INPUT_HATCH[IV].getStackForm())
+                        .researchStack(ENERGY_INPUT_HATCH[IV])
                         .EUt(VA[EV]))
                 .duration(400).EUt(VA[LuV]).buildAndRegister();
 
@@ -482,7 +482,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(1440))
                 .output(ENERGY_INPUT_HATCH[ZPM])
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_INPUT_HATCH[LuV].getStackForm())
+                        .researchStack(ENERGY_INPUT_HATCH[LuV])
                         .CWUt(8))
                 .duration(600).EUt(VA[ZPM]).buildAndRegister();
 
@@ -496,7 +496,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(2880))
                 .output(ENERGY_INPUT_HATCH[UV])
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_INPUT_HATCH[ZPM].getStackForm())
+                        .researchStack(ENERGY_INPUT_HATCH[ZPM])
                         .CWUt(64)
                         .EUt(VA[ZPM]))
                 .duration(800).EUt(VA[UV]).buildAndRegister();
@@ -511,7 +511,7 @@ public class MetaTileEntityMachineRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(5760))
                 .output(ENERGY_INPUT_HATCH[UHV])
                 .stationResearch(b -> b
-                        .researchStack(ENERGY_INPUT_HATCH[UV].getStackForm())
+                        .researchStack(ENERGY_INPUT_HATCH[UV])
                         .CWUt(128)
                         .EUt(VA[UV]))
                 .duration(1000).EUt(VA[UHV]).buildAndRegister();

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -254,7 +254,7 @@ public class MiscRecipeLoader {
                 .inputs(ELECTRIC_MOTOR_LuV.getStackForm(2))
                 .input(screw, HSSS, 8)
                 .outputs(QUANTUM_CHESTPLATE_ADVANCED.getStackForm())
-                .scannerResearch(GRAVITATION_ENGINE.getStackForm())
+                .scannerResearch(GRAVITATION_ENGINE)
                 .buildAndRegister();
 
         ASSEMBLER_RECIPES.recipeBuilder().duration(80).EUt(VA[HV])


### PR DESCRIPTION
## What
- Adds a few methods to the main recipes builder to make making recipes easier. Example: `.fluidInputs(material, amount)`, instead of `.fluidInputs(material.getFluid(amount)`.
- Adds a bunch of methods to the assembly line and scanner/station research recipe builder to make setting up recipe easier. Example: `.researchStack(metaItem, amount)` instead of `.researchStack(metaItem.getStackForm(amount))`

## Potential Compatibility Issues
In the `AssemblyLineRecipeBuilder`, the `.scannerResearch(itemStack)` method used to make a new `ScannerRecipeBuilder` in the lambda when that lambda is already applied with a new builder. I don't see why that was there, but I could be missing the original context.