### PR TITLE
Fix Fusion Reactor not finding recipes

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -5,8 +5,6 @@ import gregtech.api.capability.GregtechDataCodes;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.capability.impl.EnergyContainerList;
-import gregtech.api.capability.impl.FluidTankList;
-import gregtech.api.capability.impl.ItemHandlerList;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
@@ -274,10 +272,7 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController
 
     @Override
     protected void initializeAbilities() {
-        this.inputInventory = new ItemHandlerList(getAbilities(MultiblockAbility.IMPORT_ITEMS));
-        this.inputFluidInventory = new FluidTankList(true, getAbilities(MultiblockAbility.IMPORT_FLUIDS));
-        this.outputInventory = new ItemHandlerList(getAbilities(MultiblockAbility.EXPORT_ITEMS));
-        this.outputFluidInventory = new FluidTankList(true, getAbilities(MultiblockAbility.EXPORT_FLUIDS));
+        super.initializeAbilities();
         List<IEnergyContainer> energyInputs = getAbilities(MultiblockAbility.INPUT_ENERGY);
         this.inputEnergyContainers = new EnergyContainerList(energyInputs);
         long euCapacity = calculateEnergyStorageFactor(energyInputs.size());


### PR DESCRIPTION
## What
Fixes a small issue introduced by #2420 where the fusion reactor couldn't find recipes properly. the fusion reactor overrides `initializeAbilities()` without calling super, making `extendedFluidInputs` be empty. since the fusion reactor is not distinct, its recipe logic used `extendedFluidInputs`.

## Implementation Details
fusion reactor calls super in `initializaeAbilities()`

## Outcome
fusion reactor can find recipes correctly
