### PR TITLE
Remove old comment about MTE IDs for addons 

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntities.java
@@ -1218,28 +1218,6 @@ public class MetaTileEntities {
 
         // 1820-1849 are taken for UHV+ 4A/16A/64A Energy/Dynamo Hatches
         // 1850-1869 are taken for UHV+ Input/Output Buses/Hatches
-
-        /*
-         * FOR ADDON DEVELOPERS:
-         *
-         * GTCEu will not take more than 2000 IDs. Anything past ID 1999
-         * is considered FAIR GAME, take whatever you like.
-         *
-         * If you would like to reserve IDs, feel free to reach out to the
-         * development team and claim a range of IDs! We will mark any
-         * claimed ranges below this comment. Max value is 32767.
-         *
-         * - Gregicality / Shadows of Greg: 2000-3999
-         * - Reserved for Integration Modules in GTCEu: 4000-4499
-         * - GregTech Food Option: 8500-8999
-         * - HtmlTech: 9000-9499
-         * - PCM's Ore Addon: 9500-9999
-         * - GCM: 10000-10099
-         * - MechTech: 10100-10499
-         * - MBT 10500 - 10999
-         * - CT(MBT) 32000 - ~
-         * - FREE RANGE 11000-32767
-         */
     }
 
     private static void registerSimpleMetaTileEntity(SimpleMachineMetaTileEntity[] machines,


### PR DESCRIPTION
Removes the comment about what MTE IDs have been allocated to addons since #2505 made MTE registration namespaced.