### PR TITLE
Remove old comment about material IDs for addons

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -79,26 +79,6 @@ public class Materials {
          */
         MaterialFlagAddition.register();
 
-        /*
-         * FOR ADDON DEVELOPERS:
-         *
-         * GTCEu will not take more than 3000 IDs. Anything past ID 2999
-         * is considered FAIR GAME, take whatever you like.
-         *
-         * If you would like to reserve IDs, feel free to reach out to the
-         * development team and claim a range of IDs! We will mark any
-         * claimed ranges below this comment. Max value is 32767.
-         *
-         * - Gregicality: 3000-19999
-         * - Gregification: 20000-20999
-         * - HtmlTech: 21000-21499
-         * - GregTech Food Option: 21500-22499
-         * - FREE RANGE 22500-23599
-         * - MechTech: 23600-23999
-         * - FREE RANGE 24000-31999
-         * - Reserved for CraftTweaker: 32000-32767
-         */
-
         CHEMICAL_DYES = new Material[] {
                 Materials.DyeWhite, Materials.DyeOrange,
                 Materials.DyeMagenta, Materials.DyeLightBlue,


### PR DESCRIPTION
Removes the comment about what material IDs have been allocated to addons since https://github.com/GregTechCEu/GregTech/pull/1805 allows addon specific material registries.
Part two of #2767 because I fogor :skull: 