### PR TITLE
Proper Reloading of OreDict Ing Cache on Servers

### DIFF
--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -64,6 +64,7 @@ import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.LoaderState;
 import net.minecraftforge.fml.common.Mod;
@@ -420,9 +421,13 @@ public class CommonProxy {
         // If JEI and GS is not loaded, refresh ore dict ingredients
         // Not needed if JEI is loaded, as done in the JEI plugin (and this runs after that)
         // Not needed if GS is loaded, as done after script loads (and this runs after that)
-        if (!GregTechAPI.moduleManager.isModuleEnabled(GregTechModules.MODULE_JEI) &&
-                !GroovyScriptModule.isCurrentlyRunning())
-            GTRecipeOreInput.refreshStackCache();
+        if (!GroovyScriptModule.isCurrentlyRunning()) {
+            // EXCEPTION: IF GrS is not loaded, and JEI is loaded, and we are in a dedicated server env, refresh
+            // This is due to JEI Plugin Register not taking place on server, and GrS not acting as the backup.
+            if (!GregTechAPI.moduleManager.isModuleEnabled(GregTechModules.MODULE_JEI) ||
+                    FMLCommonHandler.instance().getSide().isServer())
+                GTRecipeOreInput.refreshStackCache();
+        }
     }
 
     public boolean isFancyGraphics() {

--- a/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyScriptModule.java
@@ -33,6 +33,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -93,8 +94,9 @@ public class GroovyScriptModule extends IntegrationSubmodule implements GroovyPl
     @SubscribeEvent
     @Optional.Method(modid = Mods.Names.GROOVY_SCRIPT)
     public static void afterScriptLoad(ScriptRunEvent.Post event) {
-        // Not Needed if JEI Module is enabled
-        if (!GregTechAPI.moduleManager.isModuleEnabled(GregTechModules.MODULE_JEI))
+        // Not Needed if JEI Module is enabled, unless we are on server (JEI Plugin Register doesn't take place)
+        if (!GregTechAPI.moduleManager.isModuleEnabled(GregTechModules.MODULE_JEI) ||
+                FMLCommonHandler.instance().getSide().isServer())
             GTRecipeOreInput.refreshStackCache();
     }
 


### PR DESCRIPTION
## What
This PR fixes the cache reloading of Ore Dict Ingredients, first introduced in https://github.com/GregTechCEu/GregTech/pull/2456, on Dedicated Servers with JEI installed.

Due to the reloading being delegated to the JEI Plugin in such a case, which does not take place on dedicated servers, the original PR did not reload the cache, causing issues with recipes not running whilst appearing in JEI.

See https://github.com/Nomi-CEu/Nomi-CEu/pull/1309 for the corresponding Nomi-CEu PR, and https://github.com/Nomi-CEu/Nomi-Labs/commit/a56bf2a0379f40529897b05df7ed8dd1fdfdc024 for the corresponding Nomi Labs commit.

## Implementation Details
None

## Outcome
Fixes issues with recipes not running on dedicated servers, under certain modifications from CT & GS, or premature comparison of recipes containing Ore Dict Ingredients by addons.

## Additional Information
None

## Potential Compatibility Issues
None