### PR TITLE
Make grs setFormula method behave in the same way as ceu ones

### DIFF
--- a/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
+++ b/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
@@ -77,20 +77,22 @@ public class MaterialExpansion {
         return 0;
     }
 
-    public static void setHarvestLevel(Material m, int harvestLevel) {
-        if (checkFrozen("set harvest level")) return;
+    public static Material setHarvestLevel(Material m, int harvestLevel) {
+        if (checkFrozen("set harvest level")) return m;
         DustProperty prop = m.getProperty(PropertyKey.DUST);
         if (prop != null) {
             prop.setHarvestLevel(harvestLevel);
         } else logError(m, "set the harvest level", "Dust");
+        return m;
     }
 
-    public static void setBurnTime(Material m, int burnTime) {
-        if (checkFrozen("set burn time")) return;
+    public static Material setBurnTime(Material m, int burnTime) {
+        if (checkFrozen("set burn time")) return m;
         DustProperty prop = m.getProperty(PropertyKey.DUST);
         if (prop != null) {
             prop.setBurnTime(burnTime);
         } else logError(m, "set the burn time", "Dust");
+        return m;
     }
 
     ///////////////////////////////////
@@ -136,46 +138,47 @@ public class MaterialExpansion {
         return 0;
     }
 
-    public static void addToolEnchantment(Material m, Enchantment enchantment, int level) {
-        addScaledToolEnchantment(m, enchantment, level, 0);
+    public static Material addToolEnchantment(Material m, Enchantment enchantment, int level) {
+        return addScaledToolEnchantment(m, enchantment, level, 0);
     }
 
-    public static void addScaledToolEnchantment(Material m, Enchantment enchantment, int level, double levelGrowth) {
-        if (checkFrozen("add tool enchantment")) return;
+    public static Material addScaledToolEnchantment(Material m, Enchantment enchantment, int level, double levelGrowth) {
+        if (checkFrozen("add tool enchantment")) return m;
         MaterialToolProperty prop = m.getProperty(PropertyKey.TOOL);
         if (prop != null) {
             prop.addEnchantmentForTools(enchantment, level, levelGrowth);
         } else logError(m, "change tool enchantments", "Tool");
+        return m;
     }
 
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
+    public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
                                     boolean shouldIngoreCraftingTools) {
-        setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, 0, 0, shouldIngoreCraftingTools);
+        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, 0, 0, shouldIngoreCraftingTools);
     }
 
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
+    public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
                                     int enchantability, boolean shouldIngoreCraftingTools) {
-        setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0, shouldIngoreCraftingTools);
+        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0, shouldIngoreCraftingTools);
     }
 
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability) {
-        setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, 0, 0, false);
+    public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability) {
+        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, 0, 0, false);
     }
 
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
+    public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
                                     int enchantability) {
-        setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0, false);
+        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0, false);
     }
 
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
+    public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
                                     int enchantability, int toolHarvestLevel) {
-        setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, toolHarvestLevel, false);
+        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, toolHarvestLevel, false);
     }
 
-    public static void setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
+    public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
                                     int enchantability, int toolHarvestLevel,
                                     boolean shouldIngoreCraftingTools) {
-        if (checkFrozen("set tool stats")) return;
+        if (checkFrozen("set tool stats")) return m;
         MaterialToolProperty prop = m.getProperty(PropertyKey.TOOL);
         if (prop != null) {
             prop.setToolSpeed(toolSpeed);
@@ -185,19 +188,21 @@ public class MaterialExpansion {
             prop.setToolEnchantability(enchantability == 0 ? 10 : enchantability);
             prop.setShouldIgnoreCraftingTools(shouldIngoreCraftingTools);
         } else logError(m, "change tool stats", "Tool");
+        return m;
     }
 
     ////////////////////////////////////
     // Extra Tool Property //
     ////////////////////////////////////
 
-    public static void setOverrideToolStats(Material m, String toolId, ExtraToolProperty.Builder overrideBuilder) {
-        if (checkFrozen("set overriding tool stats")) return;
+    public static Material setOverrideToolStats(Material m, String toolId, ExtraToolProperty.Builder overrideBuilder) {
+        if (checkFrozen("set overriding tool stats")) return m;
         m.getProperties().ensureSet(PropertyKey.EXTRATOOL);
         ExtraToolProperty prop = m.getProperty(PropertyKey.EXTRATOOL);
         if (prop != null) {
             prop.setOverrideProperty(toolId, overrideBuilder.build());
         } else logError(m, "change tool stats", "Tool");
+        return m;
     }
 
     // Wire/Item Pipe/Fluid Pipe stuff?
@@ -206,15 +211,16 @@ public class MaterialExpansion {
     // Blast Property //
     ////////////////////////////////////
 
-    public static void setBlastTemp(Material m, int blastTemp) {
-        if (checkFrozen("set blast temperature")) return;
+    public static Material setBlastTemp(Material m, int blastTemp) {
+        if (checkFrozen("set blast temperature")) return m;
         if (blastTemp <= 0) {
             GroovyLog.get().error("Blast Temperature must be greater than zero! Material: " + m.getUnlocalizedName());
-            return;
+            return m;
         }
         BlastProperty prop = m.getProperty(PropertyKey.BLAST);
         if (prop != null) prop.setBlastTemperature(blastTemp);
         else m.setProperty(PropertyKey.BLAST, new BlastProperty(blastTemp));
+        return m;
     }
 
     public static int blastTemp(Material m) {

--- a/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
+++ b/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
@@ -142,7 +142,8 @@ public class MaterialExpansion {
         return addScaledToolEnchantment(m, enchantment, level, 0);
     }
 
-    public static Material addScaledToolEnchantment(Material m, Enchantment enchantment, int level, double levelGrowth) {
+    public static Material addScaledToolEnchantment(Material m, Enchantment enchantment, int level,
+                                                    double levelGrowth) {
         if (checkFrozen("add tool enchantment")) return m;
         MaterialToolProperty prop = m.getProperty(PropertyKey.TOOL);
         if (prop != null) {
@@ -152,13 +153,14 @@ public class MaterialExpansion {
     }
 
     public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
-                                    boolean shouldIngoreCraftingTools) {
+                                        boolean shouldIngoreCraftingTools) {
         return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, 0, 0, shouldIngoreCraftingTools);
     }
 
     public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
-                                    int enchantability, boolean shouldIngoreCraftingTools) {
-        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0, shouldIngoreCraftingTools);
+                                        int enchantability, boolean shouldIngoreCraftingTools) {
+        return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0,
+                shouldIngoreCraftingTools);
     }
 
     public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability) {
@@ -166,18 +168,18 @@ public class MaterialExpansion {
     }
 
     public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
-                                    int enchantability) {
+                                        int enchantability) {
         return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, 0, false);
     }
 
     public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
-                                    int enchantability, int toolHarvestLevel) {
+                                        int enchantability, int toolHarvestLevel) {
         return setToolStats(m, toolSpeed, toolAttackDamage, toolDurability, enchantability, toolHarvestLevel, false);
     }
 
     public static Material setToolStats(Material m, float toolSpeed, float toolAttackDamage, int toolDurability,
-                                    int enchantability, int toolHarvestLevel,
-                                    boolean shouldIngoreCraftingTools) {
+                                        int enchantability, int toolHarvestLevel,
+                                        boolean shouldIngoreCraftingTools) {
         if (checkFrozen("set tool stats")) return m;
         MaterialToolProperty prop = m.getProperty(PropertyKey.TOOL);
         if (prop != null) {

--- a/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
+++ b/src/main/java/gregtech/integration/groovy/MaterialExpansion.java
@@ -26,13 +26,13 @@ public class MaterialExpansion {
     // Material Methods //
     ////////////////////////////////////
 
-    public static void setFormula(Material m, String formula) {
-        setFormula(m, formula, false);
+    public static Material setFormula(Material m, String formula) {
+        return setFormula(m, formula, false);
     }
 
-    public static void setFormula(Material m, String formula, boolean withFormatting) {
-        if (checkFrozen("set material chemical formula")) return;
-        m.setFormula(formula, withFormatting);
+    public static Material setFormula(Material m, String formula, boolean withFormatting) {
+        if (checkFrozen("set material chemical formula")) return m;
+        return m.setFormula(formula, withFormatting);
     }
 
     public static boolean hasFlag(Material m, String flagName) {


### PR DESCRIPTION
## What
Make the `setFormula` method expansion from grs behave in the same way as ceu's. (i.e. returns the material instance instead of void return.

## Implementation Details
Simply changes method returns to the material instead of nothing.

## Outcome
In be4 this kind of code works in java but not in a grs script (since it considers groovy mixin'd methods first):
```groovy
LEU235UraniumDioxide = new Material.Builder(8661, SuSyUtility.susyId('leu_235_uranium_dioxide'))
                .dust()
                .iconSet(SAND)
                .components(LEU235, Oxygen * 2)
                .color(0x1d2618)
                .build()
                .setFormula("UO2", true) // This retuens the material in Java, but null in grs
```
instead one needs to use:
```groovy
LEU235UraniumDioxide = new Material.Builder(8661, SuSyUtility.susyId('leu_235_uranium_dioxide'))
                .dust()
                .iconSet(SAND)
                .components(LEU235, Oxygen * 2)
                .color(0x1d2618)
                .build()

LEU235UraniumDioxide.setFormula("UO2", true)
```
This PR makes the former form of code possible via grs.

## Potential Compatibility Issues
None that I could think of?