### PR TITLE
Fix saving/loading of the machine owner UUID to NBT

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -1326,8 +1326,11 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
 
         data.setBoolean(TAG_KEY_MUFFLED, muffled);
 
-        if (owner != null)
-            data.setUniqueId("Owner", owner);
+        if (owner != null) {
+            NBTTagCompound ownerTag = new NBTTagCompound();
+            ownerTag.setUniqueId("UUID", owner);
+            data.setTag("Owner", ownerTag);
+        }
 
         return data;
     }
@@ -1355,8 +1358,9 @@ public abstract class MetaTileEntity implements ISyncedTileEntity, CoverHolder, 
         CoverSaveHandler.readCoverNBT(data, this, covers::put);
         this.muffled = data.getBoolean(TAG_KEY_MUFFLED);
 
-        if (data.hasKey("Owner"))
-            this.owner = data.getUniqueId("Owner");
+        if (data.hasKey("Owner", 10)) {
+            this.owner = data.getCompoundTag("Owner").getUniqueId("UUID");
+        }
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes the saving and loading of the stored player UUID to track a machine's owner.
The problem was that when setting the UUID it used `setUniqueId("key", uuid)` which sets "(key)Most" and "(key)Least" to store the two longs that make up the UUID, but when checking if the NBT tag had a stored UUID, it only checked if it had a tag with the key "key", which it never would.

## Implementation Details
Saves the owner to a compound tag "Owner" and check/get that instead.

## Outcome
Machines don't lose their owner on world reloads.

## Potential Compatibility Issues
N/A
