### PR TITLE
Fix various grs hand command issue

### DIFF
--- a/src/main/java/gregtech/integration/groovy/GrSRecipeHelper.java
+++ b/src/main/java/gregtech/integration/groovy/GrSRecipeHelper.java
@@ -37,11 +37,6 @@ public class GrSRecipeHelper {
             for (GTRecipeInput fluidIngredient : recipe.getFluidInputs()) {
                 builder.append(GroovyScriptCodeConverter.asGroovyCode(fluidIngredient.getInputFluidStack(), false));
 
-                if (fluidIngredient.getAmount() > 1) {
-                    builder.append(" * ")
-                            .append(fluidIngredient.getAmount());
-                }
-
                 builder.append(", ");
             }
             builder.delete(builder.length() - 2, builder.length())

--- a/src/main/java/gregtech/integration/groovy/GroovyHandCommand.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyHandCommand.java
@@ -2,7 +2,6 @@ package gregtech.integration.groovy;
 
 import gregtech.api.items.toolitem.IGTTool;
 import gregtech.api.unification.OreDictUnifier;
-import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.ClipboardUtil;
@@ -42,10 +41,10 @@ public class GroovyHandCommand {
         // material info
         MaterialStack ms = OreDictUnifier.getMaterial(stackInHand);
         if (ms != null) {
-            Material material = ms.material;
-            String copyText = "material('" + RecipeCompatUtil.getRLPrefix(material) + material + "')";
+            String materialString = RecipeCompatUtil.getRLPrefix(ms.material) + ms.material;
+            String copyText = "material('" + materialString + "')";
             event.messages.add(TextCopyable.translation(copyText, "gregtech.command.hand.material").build()
-                    .appendSibling(new TextComponentString(" " + material)
+                    .appendSibling(new TextComponentString(" " + materialString)
                             .setStyle(new Style().setColor(TextFormatting.GREEN))));
         }
         // ore prefix info

--- a/src/main/java/gregtech/integration/groovy/GroovyHandCommand.java
+++ b/src/main/java/gregtech/integration/groovy/GroovyHandCommand.java
@@ -2,6 +2,7 @@ package gregtech.integration.groovy;
 
 import gregtech.api.items.toolitem.IGTTool;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.ClipboardUtil;
@@ -33,18 +34,18 @@ public class GroovyHandCommand {
         }
 
         // tool info
-        if (stackInHand.getItem() instanceof IGTTool) {
-            IGTTool tool = (IGTTool) stackInHand.getItem();
+        if (stackInHand.getItem() instanceof IGTTool tool) {
             event.messages.add(
                     new TextComponentTranslation("gregtech.command.hand.tool_stats", tool.getToolClasses(stackInHand)));
         }
 
         // material info
-        MaterialStack material = OreDictUnifier.getMaterial(stackInHand);
-        if (material != null) {
-            String copyText = "material('" + material.material + "')";
+        MaterialStack ms = OreDictUnifier.getMaterial(stackInHand);
+        if (ms != null) {
+            Material material = ms.material;
+            String copyText = "material('" + RecipeCompatUtil.getRLPrefix(material) + material + "')";
             event.messages.add(TextCopyable.translation(copyText, "gregtech.command.hand.material").build()
-                    .appendSibling(new TextComponentString(" " + material.material)
+                    .appendSibling(new TextComponentString(" " + material)
                             .setStyle(new Style().setColor(TextFormatting.GREEN))));
         }
         // ore prefix info


### PR DESCRIPTION
## What
Fixes:
 - Hand commands not adding namespaces for materials/metaitems/metaprefix items/pipes/frames/material blocks registered by addons
 
| Type  | Before  | After |
| ------------- | ------------- | ------------- |
| MetaPrefixItems  | ![image](https://github.com/user-attachments/assets/7c458ab2-03e2-4d6f-bca4-1edd24b9bc6b)  | ![image](https://github.com/user-attachments/assets/5d2bc3a0-d04d-4094-bcb1-8482cc7d0ec5)  |
| MetaItems  | ![image](https://github.com/user-attachments/assets/0ea81ce6-6160-40d0-bb63-6fac2b18d578)  | ![image](https://github.com/user-attachments/assets/b73cdd7f-29fa-466d-bb92-8c91c3c5de1b)  |
| Pipes  | ![image](https://github.com/user-attachments/assets/3a96b6d1-e170-4178-bbb3-cffac04da55c)  | ![image](https://github.com/user-attachments/assets/af520af2-2d42-4240-a4bb-1ac88019941c)  |
| Frames  | ![image](https://github.com/user-attachments/assets/8c5a14bc-d950-45a9-b0ce-2a082db95143)  | ![image](https://github.com/user-attachments/assets/9fdaada5-d7ac-43c4-bcd6-3a23e84b5324)  |
| MaterialBlocks  | ![image](https://github.com/user-attachments/assets/cd4ebce8-2b20-4087-97e6-55c204538a1d)  | ![image](https://github.com/user-attachments/assets/d0501069-a0b3-4817-b376-994c7fecad36)  |
| Recipe Removal Strings  | ![image](https://github.com/user-attachments/assets/72379231-f3ad-40fa-b566-e68dd336e49e)  | ![image](https://github.com/user-attachments/assets/cf7634b6-6cb7-4609-a9a4-2a082a30986b)  |


## Implementation Details
Adding check for nameSpaces for these items.

## Outcome
Commands mentioned above now works fine.

## Potential Compatibility Issues
None that I am aware of.