### PR TITLE
Fix Crafting Station Connected Inventory Desync

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -135,7 +135,8 @@ public class MetaTileEntityWorkbench extends MetaTileEntity {
             craftingGrid.setStackInSlot(i, NetworkUtils.readItemStack(buf));
         }
         this.recipeMemory.receiveInitialSyncData(buf);
-        this.connectedInventory = new ItemHandlerList(Collections.singletonList(new GTItemStackHandler(this, buf.readVarInt())));
+        this.connectedInventory = new ItemHandlerList(
+                Collections.singletonList(new GTItemStackHandler(this, buf.readVarInt())));
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes an issue where `getAvailableHandlers()` was being called on the client side, overwriting the connected inventory with an invalid handler. This would also overwrite any attempts to sync the connected inventory through initial sync. The connected inventory should only be computed server-side, and only the reference returned on the client-side.

## Implementation Details
the connected inventory should now only be calculated on the server side
connected inventory searching is now split off into it's own method
connected inventory is synced on initial sync
add server check for when writing data

## Outcome
the error `"Here are x slots, but expected y"` from ModularUI should now be fixed
