### PR TITLE
add OreRecipeHandler#processOre oreTypeMultiplier parameter

### DIFF
--- a/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/recipe/handlers/OreRecipeHandler.java
@@ -31,8 +31,10 @@ public class OreRecipeHandler {
 
     public static void register() {
         OrePrefix.ore.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreEndstone.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
-        OrePrefix.oreNetherrack.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
+        OrePrefix.oreEndstone.addProcessingHandler(PropertyKey.ORE,
+                ((prefix, material, property) -> processOre(prefix, material, property, 2)));
+        OrePrefix.oreNetherrack.addProcessingHandler(PropertyKey.ORE,
+                ((prefix, material, property) -> processOre(prefix, material, property, 2)));
         if (ConfigHolder.worldgen.allUniqueStoneTypes) {
             OrePrefix.oreGranite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
             OrePrefix.oreDiorite.addProcessingHandler(PropertyKey.ORE, OreRecipeHandler::processOre);
@@ -65,6 +67,10 @@ public class OreRecipeHandler {
     }
 
     public static void processOre(OrePrefix orePrefix, Material material, OreProperty property) {
+        processOre(OrePrefix.ore, material, property, 1);
+    }
+
+    public static void processOre(OrePrefix orePrefix, Material material, OreProperty property, int oreTypeMultiplier) {
         Material byproductMaterial = property.getOreByProduct(0, material);
         ItemStack byproductStack = OreDictUnifier.get(OrePrefix.gem, byproductMaterial);
         if (byproductStack.isEmpty()) byproductStack = OreDictUnifier.get(OrePrefix.dust, byproductMaterial);
@@ -80,7 +86,6 @@ public class OreRecipeHandler {
         } else {
             ingotStack = OreDictUnifier.get(OrePrefix.dust, smeltingMaterial);
         }
-        int oreTypeMultiplier = orePrefix == OrePrefix.oreNetherrack || orePrefix == OrePrefix.oreEndstone ? 2 : 1;
         ingotStack.setCount(ingotStack.getCount() * property.getOreMultiplier() * oreTypeMultiplier);
         crushedStack.setCount(crushedStack.getCount() * property.getOreMultiplier());
 


### PR DESCRIPTION
## What
Allows easier handling of other ores that multiply their yield, instead of hard-coding Netherrack and End Stone.
