### PR TITLE
Rearrange GT JEI categories

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -106,6 +106,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private int maxFluidInputs;
     private int maxFluidOutputs;
 
+    private final GTRecipeCategory primaryRecipeCategory;
+
     /**
      * @deprecated {@link RecipeMapUI#isJEIVisible()}
      */
@@ -129,80 +131,6 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     private @Nullable RecipeMap<?> smallRecipeMap;
 
     /**
-     * Create and register new instance of RecipeMap with specified properties. All
-     * maximum I/O size for item and fluids will be able to be modified.
-     *
-     * @param unlocalizedName      the unlocalized name for the RecipeMap
-     * @param maxInputs            the maximum item inputs
-     * @param maxOutputs           the maximum item outputs
-     * @param maxFluidInputs       the maximum fluid inputs
-     * @param maxFluidOutputs      the maximum fluid outputs
-     * @param defaultRecipeBuilder the default RecipeBuilder for the RecipeMap
-     * @param isHidden             if the RecipeMap should have a category in JEI
-     *
-     * @deprecated {@link RecipeMap#RecipeMap(String, R, RecipeMapUIFunction, int, int, int, int)}
-     */
-    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
-    @Deprecated
-    public RecipeMap(@NotNull String unlocalizedName,
-                     int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs,
-                     @NotNull R defaultRecipeBuilder,
-                     boolean isHidden) {
-        this(unlocalizedName,
-                maxInputs, true, maxOutputs, true,
-                maxFluidInputs, true, maxFluidOutputs, true,
-                defaultRecipeBuilder, isHidden);
-    }
-
-    /**
-     * Create and register new instance of RecipeMap with specified properties.
-     *
-     * @param unlocalizedName      the unlocalized name for the RecipeMap
-     * @param maxInputs            the maximum item inputs
-     * @param modifyItemInputs     if modification of the maximum item input is permitted
-     * @param maxOutputs           the maximum item outputs
-     * @param modifyItemOutputs    if modification of the maximum item output is permitted
-     * @param maxFluidInputs       the maximum fluid inputs
-     * @param modifyFluidInputs    if modification of the maximum fluid input is permitted
-     * @param maxFluidOutputs      the maximum fluid outputs
-     * @param modifyFluidOutputs   if modification of the maximum fluid output is permitted
-     * @param defaultRecipeBuilder the default RecipeBuilder for the RecipeMap
-     * @param isHidden             if the RecipeMap should have a category in JEI
-     *
-     * @deprecated {@link RecipeMap#RecipeMap(String, R, RecipeMapUIFunction, int, int, int, int)}
-     */
-    @ApiStatus.ScheduledForRemoval(inVersion = "2.9")
-    @Deprecated
-    public RecipeMap(@NotNull String unlocalizedName,
-                     int maxInputs, boolean modifyItemInputs,
-                     int maxOutputs, boolean modifyItemOutputs,
-                     int maxFluidInputs, boolean modifyFluidInputs,
-                     int maxFluidOutputs, boolean modifyFluidOutputs,
-                     @NotNull R defaultRecipeBuilder,
-                     boolean isHidden) {
-        this.unlocalizedName = unlocalizedName;
-
-        this.maxInputs = maxInputs;
-        this.maxFluidInputs = maxFluidInputs;
-        this.maxOutputs = maxOutputs;
-        this.maxFluidOutputs = maxFluidOutputs;
-
-        defaultRecipeBuilder.setRecipeMap(this);
-        defaultRecipeBuilder
-                .category(GTRecipeCategory.create(GTValues.MODID, unlocalizedName, getTranslationKey(), this));
-        this.recipeBuilderSample = defaultRecipeBuilder;
-
-        this.recipeMapUI = new RecipeMapUI<>(this, modifyItemInputs, modifyItemOutputs, modifyFluidInputs,
-                modifyFluidOutputs, false);
-        this.recipeMapUI.setJEIVisible(!isHidden);
-
-        RECIPE_MAP_REGISTRY.put(unlocalizedName, this);
-
-        this.grsVirtualizedRecipeMap = GregTechAPI.moduleManager.isModuleEnabled(GregTechModules.MODULE_GRS) ?
-                new VirtualizedRecipeMap(this) : null;
-    }
-
-    /**
      * Create and register new instance of RecipeMap with specified properties.
      *
      * @param unlocalizedName      the unlocalized name for the RecipeMap
@@ -223,10 +151,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         this.maxFluidInputs = maxFluidInputs;
         this.maxOutputs = maxOutputs;
         this.maxFluidOutputs = maxFluidOutputs;
+        this.primaryRecipeCategory = GTRecipeCategory.create(GTValues.MODID, unlocalizedName, getTranslationKey(),
+                this);
 
         defaultRecipeBuilder.setRecipeMap(this);
-        defaultRecipeBuilder
-                .category(GTRecipeCategory.create(GTValues.MODID, unlocalizedName, getTranslationKey(), this));
+        defaultRecipeBuilder.category(primaryRecipeCategory);
         this.recipeBuilderSample = defaultRecipeBuilder;
         RECIPE_MAP_REGISTRY.put(unlocalizedName, this);
 
@@ -1512,6 +1441,10 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                     "' does not match this RecipeMap '" + this.unlocalizedName + "'");
         }
         this.recipeMapUI = recipeMapUI;
+    }
+
+    public @NotNull GTRecipeCategory getPrimaryRecipeCategory() {
+        return primaryRecipeCategory;
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMapBuilder.java
@@ -49,6 +49,8 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
 
     private @Nullable Map<ResourceLocation, RecipeBuildAction<B>> buildActions;
 
+    private boolean sortToBack;
+
     /**
      * @param unlocalizedName      the name of the recipemap
      * @param defaultRecipeBuilder the default recipe builder of the recipemap
@@ -283,6 +285,18 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
     }
 
     /**
+     * Have the primary {@link gregtech.api.recipes.category.GTRecipeCategory} for the RecipeMap be sorted to the end
+     * of the JEI recipe category list.
+     *
+     * @param sortToBack if it should be sorted to the back
+     * @return this
+     */
+    public @NotNull RecipeMapBuilder<B> jeiSortToBack(boolean sortToBack) {
+        this.sortToBack = sortToBack;
+        return this;
+    }
+
+    /**
      * <strong>Do not call this twice. RecipeMapBuilders are not re-usable.</strong>
      *
      * @return a new RecipeMap
@@ -297,6 +311,7 @@ public class RecipeMapBuilder<B extends RecipeBuilder<B>> {
         if (buildActions != null) {
             recipeMap.onRecipeBuild(buildActions);
         }
+        recipeMap.getPrimaryRecipeCategory().jeiSortToBack(sortToBack);
         return recipeMap;
     }
 }

--- a/src/main/java/gregtech/api/recipes/category/GTRecipeCategory.java
+++ b/src/main/java/gregtech/api/recipes/category/GTRecipeCategory.java
@@ -5,7 +5,10 @@ import gregtech.api.recipes.RecipeMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 public final class GTRecipeCategory {
@@ -18,6 +21,7 @@ public final class GTRecipeCategory {
     private final String translationKey;
     private final RecipeMap<?> recipeMap;
     private Object icon;
+    private boolean sortToBack;
 
     /**
      * Create a GTRecipeCategory
@@ -44,11 +48,18 @@ public final class GTRecipeCategory {
         return categories.get(categoryName);
     }
 
+    /**
+     * @return all of the GTRecipeCategory instances
+     */
+    public static @NotNull @UnmodifiableView Collection<GTRecipeCategory> getCategories() {
+        return Collections.unmodifiableCollection(categories.values());
+    }
+
     private GTRecipeCategory(@NotNull String modid, @NotNull String name, @NotNull String translationKey,
                              @NotNull RecipeMap<?> recipeMap) {
         this.modid = modid;
         this.name = name;
-        this.uniqueID = modid + ':' + this.name;
+        this.uniqueID = modid + '.' + this.name;
         this.translationKey = translationKey;
         this.recipeMap = recipeMap;
     }
@@ -85,7 +96,7 @@ public final class GTRecipeCategory {
      * @param icon the icon to use as a JEI category
      * @return this
      */
-    public GTRecipeCategory jeiIcon(@Nullable Object icon) {
+    public @NotNull GTRecipeCategory jeiIcon(@Nullable Object icon) {
         this.icon = icon;
         return this;
     }
@@ -93,6 +104,19 @@ public final class GTRecipeCategory {
     @Nullable
     public Object getJEIIcon() {
         return this.icon;
+    }
+
+    /**
+     * @param sortToBack if the category should be at the end of the JEI category list
+     * @return this
+     */
+    public @NotNull GTRecipeCategory jeiSortToBack(boolean sortToBack) {
+        this.sortToBack = sortToBack;
+        return this;
+    }
+
+    public boolean shouldSortToBackJEI() {
+        return sortToBack;
     }
 
     @Override

--- a/src/main/java/gregtech/api/recipes/category/RecipeCategories.java
+++ b/src/main/java/gregtech/api/recipes/category/RecipeCategories.java
@@ -10,19 +10,22 @@ public final class RecipeCategories {
             "arc_furnace_recycling",
             "gregtech.recipe.category.arc_furnace_recycling",
             RecipeMaps.ARC_FURNACE_RECIPES)
-            .jeiIcon(GuiTextures.ARC_FURNACE_RECYLCING_CATEGORY);
+            .jeiIcon(GuiTextures.ARC_FURNACE_RECYLCING_CATEGORY)
+            .jeiSortToBack(true);
 
     public static final GTRecipeCategory MACERATOR_RECYCLING = GTRecipeCategory.create(GTValues.MODID,
             "macerator_recycling",
             "gregtech.recipe.category.macerator_recycling",
             RecipeMaps.MACERATOR_RECIPES)
-            .jeiIcon(GuiTextures.MACERATOR_RECYLCING_CATEGORY);
+            .jeiIcon(GuiTextures.MACERATOR_RECYLCING_CATEGORY)
+            .jeiSortToBack(true);
 
     public static final GTRecipeCategory EXTRACTOR_RECYCLING = GTRecipeCategory.create(GTValues.MODID,
             "extractor_recycling",
             "gregtech.recipe.category.extractor_recycling",
             RecipeMaps.EXTRACTOR_RECIPES)
-            .jeiIcon(GuiTextures.EXTRACTOR_RECYLCING_CATEGORY);
+            .jeiIcon(GuiTextures.EXTRACTOR_RECYLCING_CATEGORY)
+            .jeiSortToBack(true);
 
     private RecipeCategories() {}
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapResearchStation.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapResearchStation.java
@@ -16,5 +16,6 @@ public class RecipeMapResearchStation<R extends RecipeBuilder<R>> extends Recipe
                                     @NotNull RecipeMapUIFunction recipeMapUI) {
         super(unlocalizedName, defaultRecipeBuilder, recipeMapUI, 2, 1, 0, 0);
         setSound(GTValues.FOOLS.get() ? GTSoundEvents.SCIENCE : GTSoundEvents.COMPUTATION);
+        getPrimaryRecipeCategory().jeiSortToBack(true);
     }
 }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapScanner.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapScanner.java
@@ -25,6 +25,7 @@ public class RecipeMapScanner extends RecipeMap<SimpleRecipeBuilder> implements 
                             @NotNull RecipeMapUIFunction recipeMapUI) {
         super(unlocalizedName, defaultRecipeBuilder, recipeMapUI, 2, 1, 1, 0);
         setSound(GTSoundEvents.ELECTROLYZER);
+        getPrimaryRecipeCategory().jeiSortToBack(true);
     }
 
     @Override

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -465,6 +465,9 @@ public class ConfigHolder {
                 "Default: true" })
         public boolean enableFancyChestRender = true;
 
+        @Config.Comment({ "Whether to prefer the Material Tree over other categories in JEI", "Default: false" })
+        public boolean preferMaterialTreeInJEI = false;
+
         public static class GuiConfig {
 
             @Config.Comment({ "The scrolling speed of widgets", "Default: 13" })

--- a/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
+++ b/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
@@ -27,6 +27,7 @@ import gregtech.api.util.Mods;
 import gregtech.api.worldgen.config.BedrockFluidDepositDefinition;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.config.WorldGenRegistry;
+import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.items.MetaItems;
 import gregtech.common.items.ToolItems;
@@ -70,16 +71,20 @@ import mezz.jei.api.ISubtypeRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.ingredients.IIngredientRegistry;
 import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.config.Constants;
 import mezz.jei.input.IShowsRecipeFocuses;
 import mezz.jei.input.InputHandler;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -156,7 +161,7 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
         ModularUIGuiHandler modularUIGuiHandler = new ModularUIGuiHandler(jeiHelpers.recipeTransferHandlerHelper());
         modularUIGuiHandler.blacklistCategory(
                 IntCircuitCategory.UID,
-                GTValues.MODID + ":material_tree",
+                MaterialTreeCategory.UID,
                 VanillaRecipeCategoryUid.INFORMATION,
                 VanillaRecipeCategoryUid.FUEL);
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(modularUIGuiHandler,
@@ -255,8 +260,7 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
             }
         }
 
-        String oreByProductId = GTValues.MODID + ":" + "ore_by_product";
-        registry.addRecipes(oreByproductList, oreByProductId);
+        registry.addRecipes(oreByproductList, OreByProductCategory.UID);
         MetaTileEntity[][] machineLists = {
                 MetaTileEntities.MACERATOR,
                 MetaTileEntities.ORE_WASHER,
@@ -268,11 +272,11 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
         };
         for (MetaTileEntity[] machine : machineLists) {
             if (machine.length < GTValues.LV + 1 || machine[GTValues.LV] == null) continue;
-            registry.addRecipeCatalyst(machine[GTValues.LV].getStackForm(), oreByProductId);
+            registry.addRecipeCatalyst(machine[GTValues.LV].getStackForm(), OreByProductCategory.UID);
         }
 
         // Material Tree
-        registry.addRecipes(materialTreeList, GTValues.MODID + ":" + "material_tree");
+        registry.addRecipes(materialTreeList, MaterialTreeCategory.UID);
 
         // Ore Veins
         List<OreDepositDefinition> oreVeins = WorldGenRegistry.getOreDeposits();
@@ -281,7 +285,7 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
             oreInfoList.add(new GTOreInfo(vein));
         }
 
-        String oreSpawnID = GTValues.MODID + ":" + "ore_spawn_location";
+        String oreSpawnID = GTOreCategory.UID;
         registry.addRecipes(oreInfoList, oreSpawnID);
         registry.addRecipeCatalyst(MetaItems.PROSPECTOR_LV.getStackForm(), oreSpawnID);
         registry.addRecipeCatalyst(MetaItems.PROSPECTOR_HV.getStackForm(), oreSpawnID);
@@ -295,7 +299,7 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
             fluidVeinInfos.add(new GTFluidVeinInfo(fluidVein));
         }
 
-        String fluidVeinSpawnID = GTValues.MODID + ":" + "fluid_spawn_location";
+        String fluidVeinSpawnID = GTFluidVeinCategory.UID;
         registry.addRecipes(fluidVeinInfos, fluidVeinSpawnID);
         registry.addRecipeCatalyst(MetaItems.PROSPECTOR_HV.getStackForm(), fluidVeinSpawnID);
         registry.addRecipeCatalyst(MetaItems.PROSPECTOR_LUV.getStackForm(), fluidVeinSpawnID);
@@ -378,5 +382,43 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
                 jeiCategory.setIcon(icon);
             }
         }
+    }
+
+    /**
+     * Comparator to sort certain GT categories to the front or back of the JEI category list.
+     *
+     * @return the comparator
+     */
+    @ApiStatus.Internal
+    public static @NotNull Comparator<IRecipeCategory<?>> getRecipeCategoryComparator() {
+        List<String> backIds = GTRecipeCategory.getCategories().stream()
+                .filter(GTRecipeCategory::shouldSortToBackJEI)
+                .map(GTRecipeCategory::getUniqueID)
+                .collect(Collectors.toCollection(ArrayList::new));
+        backIds.add(IntCircuitCategory.UID);
+        backIds.add(MultiblockInfoCategory.UID);
+        backIds.add(OreByProductCategory.UID);
+        backIds.add(GTOreCategory.UID);
+        backIds.add(GTFluidVeinCategory.UID);
+        List<String> frontIds;
+        if (ConfigHolder.client.preferMaterialTreeInJEI) {
+            frontIds = Collections.singletonList(MaterialTreeCategory.UID);
+        } else {
+            frontIds = Collections.emptyList();
+        }
+
+        return Comparator.<IRecipeCategory<?>>comparingInt(category -> {
+            int index = backIds.indexOf(category.getUid());
+            if (index >= 0) {
+                return index;
+            }
+            return Integer.MIN_VALUE;
+        }).thenComparingInt(category -> {
+            int index = frontIds.indexOf(category.getUid());
+            if (index >= 0) {
+                return index;
+            }
+            return Integer.MAX_VALUE;
+        });
     }
 }

--- a/src/main/java/gregtech/integration/jei/basic/BasicRecipeCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/BasicRecipeCategory.java
@@ -39,7 +39,7 @@ public abstract class BasicRecipeCategory<T, W extends IRecipeWrapper>
     @NotNull
     @Override
     public String getUid() {
-        return getModName() + ":" + uniqueName;
+        return getModName() + "." + uniqueName;
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/jei/basic/GTFluidVeinCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/GTFluidVeinCategory.java
@@ -1,5 +1,6 @@
 package gregtech.integration.jei.basic;
 
+import gregtech.api.GTValues;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.util.GTStringUtils;
 import gregtech.api.worldgen.config.WorldGenRegistry;
@@ -20,6 +21,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class GTFluidVeinCategory extends BasicRecipeCategory<GTFluidVeinInfo, GTFluidVeinInfo> {
+
+    public static final String UID = String.format("%s.fluid_spawn_location", GTValues.MODID);
 
     private static final int SLOT_CENTER = 79;
     private static final int TEXT_START_X = 5;

--- a/src/main/java/gregtech/integration/jei/basic/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/GTOreCategory.java
@@ -1,5 +1,6 @@
 package gregtech.integration.jei.basic;
 
+import gregtech.api.GTValues;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.util.GTStringUtils;
 import gregtech.api.worldgen.config.OreDepositDefinition;
@@ -19,6 +20,8 @@ import mezz.jei.api.recipe.IRecipeWrapper;
 import org.jetbrains.annotations.NotNull;
 
 public class GTOreCategory extends BasicRecipeCategory<GTOreInfo, GTOreInfo> {
+
+    public static final String UID = String.format("%s.ore_spawn_location", GTValues.MODID);
 
     private static final int NUM_OF_SLOTS = 5;
     private static final int SLOT_WIDTH = 18;

--- a/src/main/java/gregtech/integration/jei/basic/MaterialTreeCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/MaterialTreeCategory.java
@@ -30,6 +30,8 @@ import java.util.List;
 
 public class MaterialTreeCategory extends BasicRecipeCategory<MaterialTree, MaterialTree> {
 
+    public static final String UID = String.format("%s.material_tree", GTValues.MODID);
+
     protected String materialName;
     protected String materialFormula;
     protected int materialBFTemp;

--- a/src/main/java/gregtech/integration/jei/basic/OreByProductCategory.java
+++ b/src/main/java/gregtech/integration/jei/basic/OreByProductCategory.java
@@ -31,6 +31,8 @@ import java.util.List;
 
 public class OreByProductCategory extends BasicRecipeCategory<OreByProduct, OreByProduct> {
 
+    public static final String UID = String.format("%s.ore_by_product", GTValues.MODID);
+
     protected final IDrawable slot;
     protected final IDrawable fluidSlot;
     protected final IDrawable arrowsBase;

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
@@ -42,8 +42,7 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
     }
 
     public static void registerRecipes(IModRegistry registry) {
-        registry.addRecipes(REGISTER.stream().map(MultiblockInfoRecipeWrapper::new).collect(Collectors.toList()),
-                UID);
+        registry.addRecipes(REGISTER.stream().map(MultiblockInfoRecipeWrapper::new).collect(Collectors.toList()), UID);
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 
 public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRecipeWrapper> {
 
+    public static final String UID = String.format("%s.multiblock_info", GTValues.MODID);
+
     private final IDrawable background;
     private final IDrawable icon;
     private final IGuiHelper guiHelper;
@@ -41,13 +43,13 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
 
     public static void registerRecipes(IModRegistry registry) {
         registry.addRecipes(REGISTER.stream().map(MultiblockInfoRecipeWrapper::new).collect(Collectors.toList()),
-                "gregtech:multiblock_info");
+                UID);
     }
 
     @NotNull
     @Override
     public String getUid() {
-        return "gregtech:multiblock_info";
+        return UID;
     }
 
     @NotNull

--- a/src/main/java/gregtech/integration/jei/recipe/IntCircuitCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/IntCircuitCategory.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 @MethodsReturnNonnullByDefault
 public class IntCircuitCategory implements IRecipeCategory<IntCircuitRecipeWrapper> {
 
-    public static final String UID = GTValues.MODID + ":" + MetaItems.INTEGRATED_CIRCUIT.unlocalizedName;
+    public static final String UID = GTValues.MODID + "." + MetaItems.INTEGRATED_CIRCUIT.unlocalizedName;
     private static final int SLOT_SIZE = 18;
     private static final int ROW_LENGTH = 6;
     private static final int FIRST_SLOT_SCALE = 2;

--- a/src/main/java/gregtech/mixins/jei/ModRegistryMixin.java
+++ b/src/main/java/gregtech/mixins/jei/ModRegistryMixin.java
@@ -27,7 +27,7 @@ public abstract class ModRegistryMixin {
      * @see JustEnoughItemsModule#getRecipeCategoryComparator()
      */
     @Inject(method = "createRecipeRegistry", at = @At("HEAD"), order = 100)
-    private void grs$sortRecipeCategories(CallbackInfoReturnable<RecipeRegistry> ci) {
+    private void gregtech$sortRecipeCategories(CallbackInfoReturnable<RecipeRegistry> ci) {
         recipeCategories.sort(JustEnoughItemsModule.getRecipeCategoryComparator());
     }
 }

--- a/src/main/java/gregtech/mixins/jei/ModRegistryMixin.java
+++ b/src/main/java/gregtech/mixins/jei/ModRegistryMixin.java
@@ -22,8 +22,8 @@ public abstract class ModRegistryMixin {
     private List<IRecipeCategory<?>> recipeCategories;
 
     /**
-     * @reason Sort recipe categories according to a list created and managed by GroovyScript
-     *         to allow a custom order for JEI category tabs.
+     * @reason Sort recipe categories according to rules defined by GTCEu to allow a custom order for its JEI category
+     *         tabs.
      * @see JustEnoughItemsModule#getRecipeCategoryComparator()
      */
     @Inject(method = "createRecipeRegistry", at = @At("HEAD"), order = 100)

--- a/src/main/java/gregtech/mixins/jei/ModRegistryMixin.java
+++ b/src/main/java/gregtech/mixins/jei/ModRegistryMixin.java
@@ -1,0 +1,33 @@
+package gregtech.mixins.jei;
+
+import gregtech.integration.jei.JustEnoughItemsModule;
+
+import mezz.jei.api.recipe.IRecipeCategory;
+import mezz.jei.recipes.RecipeRegistry;
+import mezz.jei.startup.ModRegistry;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(value = ModRegistry.class, remap = false)
+public abstract class ModRegistryMixin {
+
+    @Shadow
+    @Final
+    private List<IRecipeCategory<?>> recipeCategories;
+
+    /**
+     * @reason Sort recipe categories according to a list created and managed by GroovyScript
+     *         to allow a custom order for JEI category tabs.
+     * @see JustEnoughItemsModule#getRecipeCategoryComparator()
+     */
+    @Inject(method = "createRecipeRegistry", at = @At("HEAD"), order = 100)
+    private void grs$sortRecipeCategories(CallbackInfoReturnable<RecipeRegistry> ci) {
+        recipeCategories.sort(JustEnoughItemsModule.getRecipeCategoryComparator());
+    }
+}

--- a/src/main/resources/mixins.gregtech.jei.json
+++ b/src/main/resources/mixins.gregtech.jei.json
@@ -10,6 +10,7 @@
     "GhostDragAccessor",
     "IngredientGridMixin",
     "JEITooltipMixin",
+    "ModRegistryMixin",
     "StackHelperMixin"
   ],
   "client": [],


### PR DESCRIPTION
## What
Rearranges GT JEI Categories. This PR makes the recycling categories, as well as the Scanner and Research Station move to the back of the category list. This makes the regular categories for their associated machines always preferred. There is API to make any `GTRecipeCategory` be placed at the end of the category list too.

Additionally, this PR adds a client config to force the Material Tree JEI page to the front of the list, for the players who prefer it. For some reason, JEI always prefers the Crafting category over all other types if it is available on dedicated servers, so it doesn't work on a server properly. I think it's still good enough to merge even with this caveat.

The mixin priority is set to `100` so GroovyScript can apply its own very similar mixin after ours.

This PR also fixes our JEI category UIDs using `:` instead of the conventional `.` that JEI and most other mods use for their own categories.

## Outcome
Improved QOL for JEI navigation.
