### PR TITLE
Remove Muffler Inventory and Recovery Mechanics

### DIFF
--- a/src/main/java/gregtech/api/capability/IMufflerHatch.java
+++ b/src/main/java/gregtech/api/capability/IMufflerHatch.java
@@ -1,12 +1,6 @@
 package gregtech.api.capability;
 
-import net.minecraft.item.ItemStack;
-
-import java.util.List;
-
 public interface IMufflerHatch {
-
-    void recoverItemsTable(List<ItemStack> recoveryItems);
 
     /**
      * @return true if front face is free and contains only air blocks in 1x1 area

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -382,25 +382,6 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected void completeRecipe() {
-        performMufflerOperations();
-        super.completeRecipe();
-    }
-
-    protected void performMufflerOperations() {
-        if (metaTileEntity instanceof MultiblockWithDisplayBase controller) {
-            // output muffler items
-            if (controller.hasMufflerMechanics()) {
-                if (parallelRecipesPerformed > 1) {
-                    controller.outputRecoveryItems(parallelRecipesPerformed);
-                } else {
-                    controller.outputRecoveryItems();
-                }
-            }
-        }
-    }
-
-    @Override
     public long getMaxVoltage() {
         IEnergyContainer energyContainer = getEnergyContainer();
         if (!consumesEnergy()) {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -248,29 +248,21 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
     }
 
     /**
-     * Outputs the recovery items into the muffler hatch
-     */
-    public void outputRecoveryItems() {
-        IMufflerHatch muffler = getAbilities(MultiblockAbility.MUFFLER_HATCH).get(0);
-        muffler.recoverItemsTable(recoveryItems);
-    }
-
-    public void outputRecoveryItems(int parallel) {
-        IMufflerHatch muffler = getAbilities(MultiblockAbility.MUFFLER_HATCH).get(0);
-        for (int i = 0; i < parallel; i++) {
-            muffler.recoverItemsTable(recoveryItems);
-        }
-    }
-
-    /**
      * @return whether the muffler hatch's front face is free
      */
     public boolean isMufflerFaceFree() {
-        if (hasMufflerMechanics() && getAbilities(MultiblockAbility.MUFFLER_HATCH).size() == 0)
+        if (!isStructureFormed()) {
             return false;
+        }
+        if (!hasMufflerMechanics()) {
+            return false;
+        }
 
-        return isStructureFormed() && hasMufflerMechanics() &&
-                getAbilities(MultiblockAbility.MUFFLER_HATCH).get(0).isFrontFaceFree();
+        var mufflers = getAbilities(MultiblockAbility.MUFFLER_HATCH);
+        if (mufflers.isEmpty()) {
+            return false;
+        }
+        return mufflers.get(0).isFrontFaceFree();
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityMufflerHatch.java
@@ -1,14 +1,10 @@
 package gregtech.common.metatileentities.multi.multiblockpart;
 
-import gregtech.api.GTValues;
 import gregtech.api.capability.IMufflerHatch;
-import gregtech.api.items.itemhandlers.GTItemStackHandler;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.*;
-import gregtech.api.mui.GTGuis;
-import gregtech.api.util.GTTransferUtils;
 import gregtech.api.util.GTUtility;
 import gregtech.client.particle.VanillaParticleEffects;
 import gregtech.client.renderer.texture.Textures;
@@ -17,7 +13,6 @@ import gregtech.client.utils.TooltipHelper;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -25,34 +20,18 @@ import net.minecraft.world.World;
 import codechicken.lib.render.CCRenderState;
 import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
-import com.cleanroommc.modularui.api.drawable.IKey;
-import com.cleanroommc.modularui.api.widget.IWidget;
-import com.cleanroommc.modularui.factory.PosGuiData;
-import com.cleanroommc.modularui.screen.ModularPanel;
-import com.cleanroommc.modularui.value.sync.PanelSyncManager;
-import com.cleanroommc.modularui.value.sync.SyncHandlers;
-import com.cleanroommc.modularui.widgets.ItemSlot;
-import com.cleanroommc.modularui.widgets.SlotGroupWidget;
-import com.cleanroommc.modularui.widgets.layout.Grid;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart implements
                                         IMultiblockAbilityPart<IMufflerHatch>, ITieredMetaTileEntity, IMufflerHatch {
 
-    private final int recoveryChance;
-    private final GTItemStackHandler inventory;
-
     private boolean frontFaceFree;
 
     public MetaTileEntityMufflerHatch(ResourceLocation metaTileEntityId, int tier) {
         super(metaTileEntityId, tier);
-        this.recoveryChance = (int) Math.ceil((tier - 1.0f) / 8 * 100);
-        this.inventory = new GTItemStackHandler(this, (int) Math.pow(tier + 1, 2));
-        this.frontFaceFree = false;
     }
 
     @Override
@@ -63,38 +42,19 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     @Override
     public void update() {
         super.update();
-
-        if (!getWorld().isRemote) {
-            if (getOffsetTimer() % 10 == 0)
-                this.frontFaceFree = checkFrontFaceFree();
-        }
-
-        if (getWorld().isRemote && getController() instanceof MultiblockWithDisplayBase controller &&
-                controller.isActive()) {
-            VanillaParticleEffects.mufflerEffect(this, controller.getMufflerParticle());
-        }
-    }
-
-    @Override
-    public void clearMachineInventory(@NotNull List<@NotNull ItemStack> itemBuffer) {
-        clearInventory(itemBuffer, inventory);
-    }
-
-    public void recoverItemsTable(List<ItemStack> recoveryItems) {
-        for (ItemStack recoveryItem : recoveryItems) {
-            if (calculateChance()) {
-                GTTransferUtils.insertItem(inventory, recoveryItem.copy(), false);
+        if (getWorld().isRemote) {
+            if (getController() instanceof MultiblockWithDisplayBase controller && controller.isActive()) {
+                VanillaParticleEffects.mufflerEffect(this, controller.getMufflerParticle());
             }
+        } else if (getOffsetTimer() % 10 == 0) {
+            this.frontFaceFree = checkFrontFaceFree();
         }
-    }
-
-    private boolean calculateChance() {
-        return recoveryChance >= 100 || recoveryChance > GTValues.RNG.nextInt(100);
     }
 
     /**
      * @return true if front face is free and contains only air blocks in 1x1 area
      */
+    @Override
     public boolean isFrontFaceFree() {
         return frontFaceFree;
     }
@@ -102,10 +62,9 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     private boolean checkFrontFaceFree() {
         BlockPos frontPos = getPos().offset(getFrontFacing());
         IBlockState blockState = getWorld().getBlockState(frontPos);
-        MultiblockWithDisplayBase controller = (MultiblockWithDisplayBase) getController();
 
         // break a snow layer if it exists, and if this machine is running
-        if (controller != null && controller.isActive()) {
+        if (getController() instanceof MultiblockWithDisplayBase controller && controller.isActive()) {
             if (GTUtility.tryBreakSnow(getWorld(), frontPos, blockState, true)) {
                 return true;
             }
@@ -117,15 +76,15 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     @Override
     public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
         super.renderMetaTileEntity(renderState, translation, pipeline);
-        if (shouldRenderOverlay())
+        if (shouldRenderOverlay()) {
             Textures.MUFFLER_OVERLAY.renderSided(getFrontFacing(), renderState, translation, pipeline);
+        }
     }
 
     @Override
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
         tooltip.add(I18n.format("gregtech.machine.muffler_hatch.tooltip1"));
-        tooltip.add(I18n.format("gregtech.muffler.recovery_tooltip", recoveryChance));
         tooltip.add(I18n.format("gregtech.universal.enabled"));
         tooltip.add(TooltipHelper.BLINKING_RED + I18n.format("gregtech.machine.muffler_hatch.tooltip2"));
     }
@@ -148,50 +107,7 @@ public class MetaTileEntityMufflerHatch extends MetaTileEntityMultiblockPart imp
     }
 
     @Override
-    public boolean usesMui2() {
-        return true;
-    }
-
-    @Override
-    public ModularPanel buildUI(PosGuiData guiData, PanelSyncManager guiSyncManager) {
-        int rowSize = (int) Math.sqrt(this.inventory.getSlots());
-        int xOffset = rowSize == 10 ? 9 : 0;
-
-        guiSyncManager.registerSlotGroup("item_inv", rowSize);
-
-        List<List<IWidget>> widgets = new ArrayList<>();
-        for (int y = 0; y < rowSize; y++) {
-            widgets.add(new ArrayList<>());
-            for (int x = 0; x < rowSize; x++) {
-                int index = y * rowSize + x;
-                widgets.get(y).add(new ItemSlot().slot(SyncHandlers.itemSlot(this.inventory, index)
-                        .slotGroup("item_inv")
-                        .accessibility(false, true)));
-            }
-        }
-
-        // TODO: Change the position of the name when it's standardized.
-        return GTGuis.createPanel(this, 176 + xOffset * 2, 18 + 18 * rowSize + 94)
-                .child(IKey.lang(getMetaFullName()).asWidget().pos(5, 5))
-                .child(SlotGroupWidget.playerInventory().left(7).bottom(7))
-                .child(new Grid()
-                        .top(18).height(rowSize * 18)
-                        .minElementMargin(0, 0)
-                        .minColWidth(18).minRowHeight(18)
-                        .alignX(0.5f)
-                        .matrix(widgets));
-    }
-
-    @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound data) {
-        super.writeToNBT(data);
-        data.setTag("RecoveryInventory", inventory.serializeNBT());
-        return data;
-    }
-
-    @Override
-    public void readFromNBT(NBTTagCompound data) {
-        super.readFromNBT(data);
-        this.inventory.deserializeNBT(data.getCompoundTag("RecoveryInventory"));
+    protected boolean openGUIOnRightClick() {
+        return false;
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -5387,8 +5387,6 @@ gregtech.machine.muffler_hatch.uxv.name=UXV Muffler Hatch
 gregtech.machine.muffler_hatch.opv.name=OpV Muffler Hatch
 gregtech.machine.muffler_hatch.max.name=MAX Muffler Hatch
 
-gregtech.muffler.recovery_tooltip=§bRecovery Chance: §f%d%%
-
 gregtech.machine.pump_hatch.name=Pump Output Hatch
 gregtech.machine.pump_hatch.tooltip=Primitive Fluid Output for Water Pump
 


### PR DESCRIPTION
## What
Removes the muffler inventory and recovery mechanics. They only hurt performance and were effectively useless and had zero gameplay influence. We'll decide what we want to do with tiered mufflers at a later date. There was never a reason to make a muffler other than at LV.

## Potential Compatibility Issues
The inventory will remain in existing saved NBT, but will be completely inaccessible. Nothing of value would be stored there in the first place however.
