### PR TITLE
remove EBF pyrometallurgy and associated materials

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -380,11 +380,9 @@ public class Materials {
     public static Material ChromiumTrioxide;
     public static Material AntimonyTrioxide;
     public static Material Zincite;
-    public static Material CupricOxide;
     public static Material CobaltOxide;
     public static Material ArsenicTrioxide;
     public static Material Massicot;
-    public static Material Ferrosilite;
     public static Material MetalMixture;
     public static Material SodiumHydroxide;
     public static Material SodiumPersulfate;
@@ -690,7 +688,6 @@ public class Materials {
      * Second Degree Compounds
      */
     public static Material Glass;
-    public static Material Perlite;
     public static Material Borax;
     public static Material Olivine;
     public static Material Opal;

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -175,7 +175,6 @@ public class ElementMaterials {
         Cobalt = new Material.Builder(23, gregtechId("cobalt"))
                 .ingot()
                 .liquid(new FluidBuilder().temperature(1768))
-                .ore() // leave for TiCon ore processing
                 .color(0x5050FA).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_DOUBLE_PLATE, GENERATE_FINE_WIRE)
                 .element(Elements.Co)

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -978,11 +978,7 @@ public class FirstDegreeMaterials {
                 .components(Zinc, 1, Oxygen, 1)
                 .build();
 
-        CupricOxide = new Material.Builder(371, gregtechId("cupric_oxide"))
-                .dust(1)
-                .color(0x0F0F0F)
-                .components(Copper, 1, Oxygen, 1)
-                .build();
+        // FREE ID 371
 
         CobaltOxide = new Material.Builder(372, gregtechId("cobalt_oxide"))
                 .dust(1)
@@ -1002,11 +998,7 @@ public class FirstDegreeMaterials {
                 .components(Lead, 1, Oxygen, 1)
                 .build();
 
-        Ferrosilite = new Material.Builder(375, gregtechId("ferrosilite"))
-                .dust(1)
-                .color(0x97632A)
-                .components(Iron, 1, Silicon, 1, Oxygen, 3)
-                .build();
+        // FREE ID 375
 
         MetalMixture = new Material.Builder(376, gregtechId("metal_mixture"))
                 .dust(1)

--- a/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
+++ b/src/main/java/gregtech/api/unification/material/materials/MaterialFlagAddition.java
@@ -15,10 +15,6 @@ public class MaterialFlagAddition {
         oreProp = Beryllium.getProperty(PropertyKey.ORE);
         oreProp.setOreByProducts(Emerald, Emerald, Thorium);
 
-        oreProp = Cobalt.getProperty(PropertyKey.ORE);
-        oreProp.setOreByProducts(CobaltOxide, Cobaltite);
-        oreProp.setWashedIn(SodiumPersulfate);
-
         oreProp = Copper.getProperty(PropertyKey.ORE);
         oreProp.setOreByProducts(Cobalt, Gold, Nickel, Gold);
         oreProp.setWashedIn(Mercury);

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -26,11 +26,7 @@ public class SecondDegreeMaterials {
                 .components(SiliconDioxide, 1)
                 .build();
 
-        Perlite = new Material.Builder(2001, gregtechId("perlite"))
-                .dust(1)
-                .color(0x1E141E)
-                .components(Obsidian, 2, Water, 1)
-                .build();
+        // FREE ID 2001
 
         Borax = new Material.Builder(2002, gregtechId("borax"))
                 .dust(1)

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -1042,61 +1042,12 @@ public class MachineRecipeLoader {
     }
 
     private static void registerBlastFurnaceMetallurgyRecipes() {
-        createSulfurDioxideRecipe(Stibnite, AntimonyTrioxide, 1500);
-        createSulfurDioxideRecipe(Sphalerite, Zincite, 1000);
-        createSulfurDioxideRecipe(Pyrite, BandedIron, 2000);
-        createSulfurDioxideRecipe(Pentlandite, Garnierite, 1000);
-
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .input(dust, Tetrahedrite)
-                .fluidInputs(Oxygen.getFluid(3000))
-                .output(dust, CupricOxide)
-                .output(dustTiny, AntimonyTrioxide, 3)
-                .fluidOutputs(SulfurDioxide.getFluid(2000))
-                .buildAndRegister();
-
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .input(dust, Cobaltite)
-                .fluidInputs(Oxygen.getFluid(3000))
-                .output(dust, CobaltOxide)
-                .output(dust, ArsenicTrioxide)
-                .fluidOutputs(SulfurDioxide.getFluid(1000))
-                .buildAndRegister();
-
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .input(dust, Galena)
-                .fluidInputs(Oxygen.getFluid(3000))
-                .output(dust, Massicot)
-                .output(nugget, Silver, 6)
-                .fluidOutputs(SulfurDioxide.getFluid(1000))
-                .buildAndRegister();
-
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .input(dust, Chalcopyrite)
-                .input(dust, SiliconDioxide)
-                .fluidInputs(Oxygen.getFluid(3000))
-                .output(dust, CupricOxide)
-                .output(dust, Ferrosilite)
-                .fluidOutputs(SulfurDioxide.getFluid(2000))
-                .buildAndRegister();
-
         BLAST_RECIPES.recipeBuilder().duration(240).EUt(VA[MV]).blastFurnaceTemp(2273)
                 .input(dust, SiliconDioxide, 3)
                 .input(dust, Carbon, 2)
                 .output(ingotHot, Silicon)
                 .chancedOutput(dust, Ash, 1111, 0)
                 .fluidOutputs(CarbonMonoxide.getFluid(2000))
-                .buildAndRegister();
-    }
-
-    private static void createSulfurDioxideRecipe(Material inputMaterial, Material outputMaterial,
-                                                  int sulfurDioxideAmount) {
-        BLAST_RECIPES.recipeBuilder().duration(120).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .input(dust, inputMaterial)
-                .fluidInputs(Oxygen.getFluid(3000))
-                .output(dust, outputMaterial)
-                .chancedOutput(dust, Ash, 1111, 0)
-                .fluidOutputs(SulfurDioxide.getFluid(sulfurDioxideAmount))
                 .buildAndRegister();
     }
 

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1811,11 +1811,9 @@ gregtech.material.potassium_dichromate=Potassium Dichromate
 gregtech.material.chromium_trioxide=Chromium Trioxide
 gregtech.material.antimony_trioxide=Antimony Trioxide
 gregtech.material.zincite=Zincite
-gregtech.material.cupric_oxide=Cupric Oxide
 gregtech.material.cobalt_oxide=Cobalt Oxide
 gregtech.material.arsenic_trioxide=Arsenic Trioxide
 gregtech.material.massicot=Massicot
-gregtech.material.ferrosilite=Ferrosilite
 gregtech.material.metal_mixture=Metal Mixture
 gregtech.material.sodium_hydroxide=Sodium Hydroxide
 gregtech.material.sodium_persulfate=Sodium Persulfate
@@ -2118,7 +2116,6 @@ gregtech.material.bauxite_slag=Bauxite Slag
 
 # Second Degree Materials
 gregtech.material.glass=Glass
-gregtech.material.perlite=Perlite
 gregtech.material.borax=Borax
 gregtech.material.olivine=Olivine
 gregtech.material.opal=Opal


### PR DESCRIPTION
Removes the pyrometallurgy recipes from the EBF, and two now useless associated materials: Ferrosilite and Cupric Oxide. These pyrometallurgy recipes are bad, have always been noob-traps, and also break stoichiometry.

Perlite has also been removed since it was entirely unused by GT.

Cobalt's Ore Property also was removed since it is unused in GT and it is highly unlikely anyone is processing the pure cobalt Tinker's Construct ore from the nether with GT machines when the nether cobaltite vein exists. Modpacks can freely re-add these materials if they rely on them.

These materials are all not valuable and are not expected to be stored in bulk, so they are also not deprecated and are outright removed instead.