### PR TITLE
Tierskip / energy hatch rework

### DIFF
--- a/src/main/java/gregtech/api/GTValues.java
+++ b/src/main/java/gregtech/api/GTValues.java
@@ -201,4 +201,7 @@ public class GTValues {
         return ConfigHolder.misc.specialEvents && yearMonthDay[1].equals("12") &&
                 (yearMonthDay[2].equals("24") || yearMonthDay[2].equals("25"));
     };
+
+    // todo temp
+    public static double LOG_4 = Math.log(4);
 }

--- a/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/HeatingCoilRecipeLogic.java
@@ -18,8 +18,8 @@ import static gregtech.api.recipes.logic.OverclockingLogic.heatingCoilOC;
  */
 public class HeatingCoilRecipeLogic extends MultiblockRecipeLogic {
 
-    public HeatingCoilRecipeLogic(RecipeMapMultiblockController metaTileEntity) {
-        super(metaTileEntity);
+    public HeatingCoilRecipeLogic(RecipeMapMultiblockController metaTileEntity, int tierskipLimit_) {
+        super(metaTileEntity, tierskipLimit_);
         if (!(metaTileEntity instanceof IHeatingCoil)) {
             throw new IllegalArgumentException("MetaTileEntity must be instanceof IHeatingCoil");
         }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -203,8 +203,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
 
         if (checkEnergyIn) {
             predicate = predicate.or(abilities(MultiblockAbility.INPUT_ENERGY).setMinGlobalLimited(1)
-                    .setMaxGlobalLimited(2)
-                    .setPreviewCount(1));
+                    .setMaxGlobalLimited(1).setPreviewCount(1));
         }
 
         if (checkItemIn) {

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityRegistration.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityRegistration.java
@@ -917,9 +917,9 @@ final class MetaTileEntityRegistration {
         for (int i = 0; i < endPos; i++) {
             String voltageName = GTValues.VN[i].toLowerCase();
             MetaTileEntities.ENERGY_INPUT_HATCH[i] = MetaTileEntities.registerMetaTileEntity(11120 + i,
-                    new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.input." + voltageName), i, 2, false));
+                    new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.input." + voltageName), i, 1, false));
             MetaTileEntities.ENERGY_OUTPUT_HATCH[i] = MetaTileEntities.registerMetaTileEntity(11135 + i,
-                    new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.output." + voltageName), i, 2, true));
+                    new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.output." + voltageName), i, 1, true));
 
             MetaTileEntities.ENERGY_INPUT_HATCH_4A[i] = MetaTileEntities.registerMetaTileEntity(11150 + i,
                     new MetaTileEntityEnergyHatch(gregtechId("energy_hatch.input_4a." + voltageName), i, 4, false));

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityAssemblyLine.java
@@ -92,7 +92,7 @@ public class MetaTileEntityAssemblyLine extends RecipeMapMultiblockController {
                 .where('Y', states(getCasingState())
                         .or(abilities(MultiblockAbility.INPUT_ENERGY)
                                 .setMinGlobalLimited(1)
-                                .setMaxGlobalLimited(3)))
+                                .setMaxGlobalLimited(1)))
                 .where('I', metaTileEntities(MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV]))
                 .where('G', states(getGrateState()))
                 .where('A',

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -60,7 +60,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
 
     public MetaTileEntityElectricBlastFurnace(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, RecipeMaps.BLAST_RECIPES);
-        this.recipeMapWorkable = new HeatingCoilRecipeLogic(this);
+        this.recipeMapWorkable = new HeatingCoilRecipeLogic(this, 1);
     }
 
     @Override


### PR DESCRIPTION
## What
Reworks energy hatch and tierskipping mechanics to be more intuitive and less confusing, as discussed at length on Discord

-2A Energy Hatches are now 1A
-By default, multiblocks can only accept 1 Energy Hatch instead of 2 (also fixes an oversight where the Assembly Line accepted 3 Energy Hatches)
-Multiblocks can specify the amount of tierskips they permit

Current progress: Some code is messy and needs to be cleaned up, and we still need to decide which machines should be allowed to tierskip, and also reconsider which machines should be able to accept a full 16A vs just 4A. Due to an issue with EnergyContainerList that I don't know how to fix, max recipe tier is currently completely broken

This draft PR is being created to encourage collaboration and make it less likely that we'll all forget about this

## Outcome
Energy hatch and tierskipping mechanics will be far more apparent and understandable

## Potential Compatibility Issues
Existing machines that have 2 energy hatches will unform, some machine setups may not be able to perform recipes that they used to be able to, and some addon/modpack recipes may become impossible to perform