### PR TITLE
Move recycling code out of OreDictUnifier

### DIFF
--- a/src/main/java/gregtech/api/GregTechAPI.java
+++ b/src/main/java/gregtech/api/GregTechAPI.java
@@ -13,6 +13,7 @@ import gregtech.api.modules.IModuleManager;
 import gregtech.api.network.INetworkHandler;
 import gregtech.api.recipes.properties.RecipePropertyRegistry;
 import gregtech.api.sound.ISoundManager;
+import gregtech.api.unification.RecyclingManager;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.registry.IMaterialRegistryManager;
 import gregtech.api.unification.material.registry.MarkerMaterialRegistry;
@@ -58,6 +59,10 @@ public class GregTechAPI {
     /** GT's data migrations API */
     public static final MigrationAPI MIGRATIONS = new MigrationAPI();
     public static final RecipePropertyRegistry RECIPE_PROPERTIES = new RecipePropertyRegistry();
+    /**
+     * Manager for Item Recycling Data
+     */
+    public static final RecyclingManager RECYCLING_MANAGER = new RecyclingManager();
 
     /** Will be available at the Pre-Initialization stage */
     private static boolean highTier;

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -1,6 +1,7 @@
 package gregtech.api.items.metaitem;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IElectricItem;
 import gregtech.api.capability.IFilteredFluidContainer;
@@ -804,7 +805,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             if (materialInfo == null) {
                 throw new IllegalArgumentException("Cannot add null ItemMaterialInfo.");
             }
-            OreDictUnifier.registerOre(getStackForm(), materialInfo);
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(getStackForm(), materialInfo);
             return this;
         }
 

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -28,7 +28,7 @@ import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.Mods;
@@ -801,11 +801,11 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             this.unlocalizedName = unlocalizedName;
         }
 
-        public MetaValueItem setMaterialInfo(ItemMaterialInfo materialInfo) {
-            if (materialInfo == null) {
-                throw new IllegalArgumentException("Cannot add null ItemMaterialInfo.");
+        public MetaValueItem setRecyclingData(RecyclingData data) {
+            if (data == null) {
+                throw new IllegalArgumentException("Cannot add null RecyclingData.");
             }
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(getStackForm(), materialInfo);
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(getStackForm(), data);
             return this;
         }
 

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -11,8 +11,8 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.DummyContainer;
 import gregtech.api.util.GTLog;
@@ -268,9 +268,9 @@ public final class ModHandler {
         addRecipe(regName, result, isNBTClearing, isMirrored, recipe);
 
         if (withUnificationData) {
-            ItemMaterialInfo info = RecyclingHandler.getRecyclingIngredients(result.getCount(), recipe);
-            if (info != null) {
-                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(result, info);
+            RecyclingData data = RecyclingHandler.getRecyclingIngredients(result.getCount(), recipe);
+            if (data != null) {
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(result, data);
             }
         }
     }

--- a/src/main/java/gregtech/api/recipes/ModHandler.java
+++ b/src/main/java/gregtech/api/recipes/ModHandler.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.toolitem.IGTTool;
 import gregtech.api.items.toolitem.ToolHelper;
@@ -10,6 +11,7 @@ import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.DummyContainer;
@@ -266,7 +268,10 @@ public final class ModHandler {
         addRecipe(regName, result, isNBTClearing, isMirrored, recipe);
 
         if (withUnificationData) {
-            OreDictUnifier.registerOre(result, RecyclingHandler.getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialInfo info = RecyclingHandler.getRecyclingIngredients(result.getCount(), recipe);
+            if (info != null) {
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(result, info);
+            }
         }
     }
 

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.fluids.store.FluidStorageKey;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.metatileentity.MetaTileEntity;
@@ -1088,7 +1089,7 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
             ItemStack outputStack = getOutputs().get(0);
             ItemMaterialInfo info = RecyclingHandler.getRecyclingIngredients(getInputs(), outputStack.getCount());
             if (info != null) {
-                OreDictUnifier.registerOre(outputStack, info);
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(outputStack, info);
             }
         }
 

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -26,7 +26,7 @@ import gregtech.api.recipes.properties.impl.DimensionProperty;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.util.EnumValidationResult;
 import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
@@ -1087,9 +1087,9 @@ public class RecipeBuilder<R extends RecipeBuilder<R>> {
         if (hasItemRecycling()) {
             // ignore input fluids for item-only recycling
             ItemStack outputStack = getOutputs().get(0);
-            ItemMaterialInfo info = RecyclingHandler.getRecyclingIngredients(getInputs(), outputStack.getCount());
-            if (info != null) {
-                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(outputStack, info);
+            RecyclingData data = RecyclingHandler.getRecyclingIngredients(getInputs(), outputStack.getCount());
+            if (data != null) {
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(outputStack, data);
             }
         }
 

--- a/src/main/java/gregtech/api/recipes/RecyclingHandler.java
+++ b/src/main/java/gregtech/api/recipes/RecyclingHandler.java
@@ -8,8 +8,8 @@ import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterial;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.unification.stack.UnificationEntry;
 
 import net.minecraft.block.Block;
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 public class RecyclingHandler {
 
-    public static @Nullable ItemMaterialInfo getRecyclingIngredients(int outputCount, @NotNull Object... recipe) {
+    public static @Nullable RecyclingData getRecyclingIngredients(int outputCount, @NotNull Object... recipe) {
         Char2IntOpenHashMap inputCountMap = new Char2IntOpenHashMap();
         Object2LongMap<Material> materialStacksExploded = new Object2LongOpenHashMap<>();
 
@@ -75,13 +75,13 @@ public class RecyclingHandler {
             addItemStackToMaterialStacks(stack, materialStacksExploded, inputCountMap.get(lastChar));
         }
 
-        return new ItemMaterialInfo(materialStacksExploded.entrySet().stream()
+        return new RecyclingData(materialStacksExploded.entrySet().stream()
                 .map(e -> new MaterialStack(e.getKey(), e.getValue() / outputCount))
                 .sorted(Comparator.comparingLong(m -> -m.amount))
                 .collect(Collectors.toList()));
     }
 
-    public static @Nullable ItemMaterialInfo getRecyclingIngredients(List<GTRecipeInput> inputs, int outputCount) {
+    public static @Nullable RecyclingData getRecyclingIngredients(List<GTRecipeInput> inputs, int outputCount) {
         Object2LongMap<Material> materialStacksExploded = new Object2LongOpenHashMap<>();
         for (GTRecipeInput input : inputs) {
             if (input == null || input.isNonConsumable()) continue;
@@ -91,7 +91,7 @@ public class RecyclingHandler {
             addItemStackToMaterialStacks(inputStack, materialStacksExploded, inputStack.getCount());
         }
 
-        return new ItemMaterialInfo(materialStacksExploded.entrySet().stream()
+        return new RecyclingData(materialStacksExploded.entrySet().stream()
                 .map(e -> new MaterialStack(e.getKey(), e.getValue() / outputCount))
                 .sorted(Comparator.comparingLong(m -> -m.amount))
                 .collect(Collectors.toList()));
@@ -101,9 +101,9 @@ public class RecyclingHandler {
                                                      @NotNull Object2LongMap<Material> materialStacksExploded,
                                                      int inputCount) {
         // First try to get Recycling Data
-        ItemMaterialInfo info = GregTechAPI.RECYCLING_MANAGER.getRecyclingData(itemStack);
-        if (info != null) {
-            for (MaterialStack ms : info.getMaterials()) {
+        RecyclingData data = GregTechAPI.RECYCLING_MANAGER.getRecyclingData(itemStack);
+        if (data != null) {
+            for (MaterialStack ms : data.getMaterials()) {
                 if (!(ms.material instanceof MarkerMaterial)) {
                     addMaterialStack(materialStacksExploded, inputCount, ms);
                 }

--- a/src/main/java/gregtech/api/recipes/RecyclingHandler.java
+++ b/src/main/java/gregtech/api/recipes/RecyclingHandler.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes;
 
+import gregtech.api.GregTechAPI;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.items.toolitem.ToolHelper;
 import gregtech.api.recipes.ingredients.GTRecipeInput;
@@ -99,8 +100,8 @@ public class RecyclingHandler {
     private static void addItemStackToMaterialStacks(@NotNull ItemStack itemStack,
                                                      @NotNull Object2LongMap<Material> materialStacksExploded,
                                                      int inputCount) {
-        // First try to get ItemMaterialInfo
-        ItemMaterialInfo info = OreDictUnifier.getMaterialInfo(itemStack);
+        // First try to get Recycling Data
+        ItemMaterialInfo info = GregTechAPI.RECYCLING_MANAGER.getRecyclingData(itemStack);
         if (info != null) {
             for (MaterialStack ms : info.getMaterials()) {
                 if (!(ms.material instanceof MarkerMaterial)) {

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -242,8 +242,7 @@ public class OreDictUnifier {
                 return new MaterialStack(entryMaterial, entry.orePrefix.getMaterialAmount(entryMaterial));
             }
         }
-        ItemMaterialInfo info = GregTechAPI.RECYCLING_MANAGER.getRecyclingData(key);
-        return info == null ? null : info.getFirstMaterial().copy();
+        return null;
     }
 
     public static @Nullable OrePrefix getPrefix(ItemStack itemStack) {

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -62,14 +62,6 @@ public class OreDictUnifier {
         return (first, second) -> comparator.compare(new ItemAndMetadata(first), new ItemAndMetadata(second));
     }
 
-    /**
-     * @deprecated {@link RecyclingManager#registerRecyclingData(ItemStack, ItemMaterialInfo)}
-     */
-    @Deprecated
-    public static void registerOre(ItemStack itemStack, ItemMaterialInfo materialInfo) {
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(itemStack, materialInfo);
-    }
-
     public static void registerOre(ItemStack itemStack, OrePrefix orePrefix, @Nullable Material material) {
         registerOre(itemStack, orePrefix.name(), material);
     }

--- a/src/main/java/gregtech/api/unification/OreDictUnifier.java
+++ b/src/main/java/gregtech/api/unification/OreDictUnifier.java
@@ -26,8 +26,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -37,7 +35,6 @@ public class OreDictUnifier {
 
     private OreDictUnifier() {}
 
-    private static final Map<ItemAndMetadata, ItemMaterialInfo> materialUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<ItemAndMetadata, UnificationEntry> stackUnificationInfo = new Object2ObjectOpenHashMap<>();
     private static final Map<UnificationEntry, ArrayList<ItemAndMetadata>> stackUnificationItems = new Object2ObjectOpenHashMap<>();
     private static final Map<Item, ItemVariantMap.Mutable<Set<String>>> stackOreDictName = new Object2ObjectOpenHashMap<>();
@@ -65,9 +62,12 @@ public class OreDictUnifier {
         return (first, second) -> comparator.compare(new ItemAndMetadata(first), new ItemAndMetadata(second));
     }
 
+    /**
+     * @deprecated {@link RecyclingManager#registerRecyclingData(ItemStack, ItemMaterialInfo)}
+     */
+    @Deprecated
     public static void registerOre(ItemStack itemStack, ItemMaterialInfo materialInfo) {
-        if (itemStack.isEmpty()) return;
-        materialUnificationInfo.put(new ItemAndMetadata(itemStack), materialInfo);
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(itemStack, materialInfo);
     }
 
     public static void registerOre(ItemStack itemStack, OrePrefix orePrefix, @Nullable Material material) {
@@ -226,11 +226,13 @@ public class OreDictUnifier {
                 .collect(Collectors.toList());
     }
 
-    @Nullable
-    public static MaterialStack getMaterial(ItemStack itemStack) {
-        if (itemStack.isEmpty()) return null;
+    public static @Nullable MaterialStack getMaterial(ItemStack itemStack) {
+        if (itemStack.isEmpty()) {
+            return null;
+        }
+
         ItemAndMetadata key = new ItemAndMetadata(itemStack);
-        UnificationEntry entry = getOrWildcard(stackUnificationInfo, key);
+        UnificationEntry entry = GTUtility.getOrWildcardMeta(stackUnificationInfo, key);
         if (entry != null) {
             Material entryMaterial = entry.material;
             if (entryMaterial == null) {
@@ -240,27 +242,23 @@ public class OreDictUnifier {
                 return new MaterialStack(entryMaterial, entry.orePrefix.getMaterialAmount(entryMaterial));
             }
         }
-        ItemMaterialInfo info = getOrWildcard(materialUnificationInfo, key);
-        return info == null ? null : info.getMaterial().copy();
+        ItemMaterialInfo info = GregTechAPI.RECYCLING_MANAGER.getRecyclingData(key);
+        return info == null ? null : info.getFirstMaterial().copy();
     }
 
-    @Nullable
-    public static ItemMaterialInfo getMaterialInfo(ItemStack itemStack) {
-        if (itemStack.isEmpty()) return null;
-        return getOrWildcard(materialUnificationInfo, new ItemAndMetadata(itemStack));
-    }
-
-    @Nullable
-    public static OrePrefix getPrefix(ItemStack itemStack) {
-        if (itemStack.isEmpty()) return null;
-        UnificationEntry entry = getOrWildcard(stackUnificationInfo, new ItemAndMetadata(itemStack));
+    public static @Nullable OrePrefix getPrefix(ItemStack itemStack) {
+        if (itemStack.isEmpty()) {
+            return null;
+        }
+        UnificationEntry entry = GTUtility.getOrWildcardMeta(stackUnificationInfo, new ItemAndMetadata(itemStack));
         return entry != null ? entry.orePrefix : null;
     }
 
-    @Nullable
-    public static UnificationEntry getUnificationEntry(ItemStack itemStack) {
-        if (itemStack.isEmpty()) return null;
-        return getOrWildcard(stackUnificationInfo, new ItemAndMetadata(itemStack));
+    public static @Nullable UnificationEntry getUnificationEntry(ItemStack itemStack) {
+        if (itemStack.isEmpty()) {
+            return null;
+        }
+        return GTUtility.getOrWildcardMeta(stackUnificationInfo, new ItemAndMetadata(itemStack));
     }
 
     public static ItemStack getUnificated(ItemStack itemStack) {
@@ -293,12 +291,6 @@ public class OreDictUnifier {
         List<ItemStack> itemStacks = oreDictNameStacks.get(oreDictName);
         if (itemStacks == null || itemStacks.size() == 0) return ItemStack.EMPTY;
         return itemStacks.get(0).copy();
-    }
-
-    public static List<Entry<ItemStack, ItemMaterialInfo>> getAllItemInfos() {
-        return materialUnificationInfo.entrySet().stream()
-                .map(entry -> new SimpleEntry<>(entry.getKey().toItemStack(), entry.getValue()))
-                .collect(Collectors.toList());
     }
 
     public static List<ItemStack> getAll(UnificationEntry unificationEntry) {
@@ -367,21 +359,5 @@ public class OreDictUnifier {
 
         if (list.size() > 1)
             list.sort(comparator);
-    }
-
-    /**
-     * Get the value corresponding to given key or its wildcard counterpart.
-     *
-     * @param map Map
-     * @param key Key
-     * @return value corresponding to given key or its wildcard counterpart
-     */
-    @Nullable
-    private static <T> T getOrWildcard(@NotNull Map<ItemAndMetadata, T> map,
-                                       @NotNull ItemAndMetadata key) {
-        T t = map.get(key);
-        if (t != null) return t;
-        if (key.isWildcard()) return null;
-        return map.get(key.toWildcard());
     }
 }

--- a/src/main/java/gregtech/api/unification/RecyclingManager.java
+++ b/src/main/java/gregtech/api/unification/RecyclingManager.java
@@ -1,7 +1,7 @@
 package gregtech.api.unification;
 
 import gregtech.api.unification.stack.ItemAndMetadata;
-import gregtech.api.unification.stack.ItemMaterialInfo;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.util.GTUtility;
 
 import net.minecraft.item.ItemStack;
@@ -15,33 +15,33 @@ import java.util.function.BiConsumer;
 
 public final class RecyclingManager {
 
-    private final Map<ItemAndMetadata, ItemMaterialInfo> recyclingData = new Object2ObjectOpenHashMap<>();
+    private final Map<ItemAndMetadata, RecyclingData> map = new Object2ObjectOpenHashMap<>();
 
     /**
-     * @param stack        the stack to give recycling data
-     * @param materialInfo the recycling data
+     * @param stack the stack to give recycling data
+     * @param data  the recycling data
      */
-    public void registerRecyclingData(@NotNull ItemStack stack, @NotNull ItemMaterialInfo materialInfo) {
+    public void registerRecyclingData(@NotNull ItemStack stack, @NotNull RecyclingData data) {
         if (stack.isEmpty()) {
             return;
         }
-        registerRecyclingData(new ItemAndMetadata(stack), materialInfo);
+        registerRecyclingData(new ItemAndMetadata(stack), data);
     }
 
     /**
-     * @param key          the key to give recycling data
-     * @param materialInfo the recycling data
+     * @param key  the key to give recycling data
+     * @param data the recycling data
      */
     public void registerRecyclingData(@NotNull ItemAndMetadata key,
-                                      @NotNull ItemMaterialInfo materialInfo) {
-        recyclingData.put(key, materialInfo);
+                                      @NotNull RecyclingData data) {
+        map.put(key, data);
     }
 
     /**
      * @param stack the stack
      * @return the recycling data associated with the stack
      */
-    public @Nullable ItemMaterialInfo getRecyclingData(@NotNull ItemStack stack) {
+    public @Nullable RecyclingData getRecyclingData(@NotNull ItemStack stack) {
         if (stack.isEmpty()) {
             return null;
         }
@@ -52,8 +52,8 @@ public final class RecyclingManager {
      * @param key the key
      * @return the recycling data associated with the key
      */
-    public @Nullable ItemMaterialInfo getRecyclingData(@NotNull ItemAndMetadata key) {
-        return GTUtility.getOrWildcardMeta(recyclingData, key);
+    public @Nullable RecyclingData getRecyclingData(@NotNull ItemAndMetadata key) {
+        return GTUtility.getOrWildcardMeta(map, key);
     }
 
     /**
@@ -70,7 +70,7 @@ public final class RecyclingManager {
      * @param key the key whose data should be removed
      */
     public void removeRecyclingData(@NotNull ItemAndMetadata key) {
-        recyclingData.remove(key);
+        map.remove(key);
     }
 
     /**
@@ -78,7 +78,7 @@ public final class RecyclingManager {
      *
      * @param action the action to apply to each entry
      */
-    public void iterate(@NotNull BiConsumer<ItemAndMetadata, ItemMaterialInfo> action) {
-        recyclingData.forEach(action);
+    public void iterate(@NotNull BiConsumer<ItemAndMetadata, RecyclingData> action) {
+        map.forEach(action);
     }
 }

--- a/src/main/java/gregtech/api/unification/RecyclingManager.java
+++ b/src/main/java/gregtech/api/unification/RecyclingManager.java
@@ -1,0 +1,84 @@
+package gregtech.api.unification;
+
+import gregtech.api.unification.stack.ItemAndMetadata;
+import gregtech.api.unification.stack.ItemMaterialInfo;
+import gregtech.api.util.GTUtility;
+
+import net.minecraft.item.ItemStack;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public final class RecyclingManager {
+
+    private final Map<ItemAndMetadata, ItemMaterialInfo> recyclingData = new Object2ObjectOpenHashMap<>();
+
+    /**
+     * @param stack        the stack to give recycling data
+     * @param materialInfo the recycling data
+     */
+    public void registerRecyclingData(@NotNull ItemStack stack, @NotNull ItemMaterialInfo materialInfo) {
+        if (stack.isEmpty()) {
+            return;
+        }
+        registerRecyclingData(new ItemAndMetadata(stack), materialInfo);
+    }
+
+    /**
+     * @param key          the key to give recycling data
+     * @param materialInfo the recycling data
+     */
+    public void registerRecyclingData(@NotNull ItemAndMetadata key,
+                                      @NotNull ItemMaterialInfo materialInfo) {
+        recyclingData.put(key, materialInfo);
+    }
+
+    /**
+     * @param stack the stack
+     * @return the recycling data associated with the stack
+     */
+    public @Nullable ItemMaterialInfo getRecyclingData(@NotNull ItemStack stack) {
+        if (stack.isEmpty()) {
+            return null;
+        }
+        return getRecyclingData(new ItemAndMetadata(stack));
+    }
+
+    /**
+     * @param key the key
+     * @return the recycling data associated with the key
+     */
+    public @Nullable ItemMaterialInfo getRecyclingData(@NotNull ItemAndMetadata key) {
+        return GTUtility.getOrWildcardMeta(recyclingData, key);
+    }
+
+    /**
+     * @param stack the stack whose data should be removed
+     */
+    public void removeRecyclingData(@NotNull ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+        removeRecyclingData(new ItemAndMetadata(stack));
+    }
+
+    /**
+     * @param key the key whose data should be removed
+     */
+    public void removeRecyclingData(@NotNull ItemAndMetadata key) {
+        recyclingData.remove(key);
+    }
+
+    /**
+     * Iterate all registered recycling entries
+     *
+     * @param action the action to apply to each entry
+     */
+    public void iterate(@NotNull BiConsumer<ItemAndMetadata, ItemMaterialInfo> action) {
+        recyclingData.forEach(action);
+    }
+}

--- a/src/main/java/gregtech/api/unification/stack/ItemMaterialInfo.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemMaterialInfo.java
@@ -23,13 +23,6 @@ public final class ItemMaterialInfo {
     }
 
     /**
-     * @return the first composition data entry
-     */
-    public @NotNull MaterialStack getFirstMaterial() {
-        return materials.get(0);
-    }
-
-    /**
      * @return all of the composition data
      */
     public @UnmodifiableView @NotNull List<MaterialStack> getMaterials() {

--- a/src/main/java/gregtech/api/unification/stack/ItemMaterialInfo.java
+++ b/src/main/java/gregtech/api/unification/stack/ItemMaterialInfo.java
@@ -1,44 +1,47 @@
 package gregtech.api.unification.stack;
 
-import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-public class ItemMaterialInfo {
+public final class ItemMaterialInfo {
 
-    private final List<MaterialStack> materials = new ArrayList<>();
+    private final List<MaterialStack> materials;
 
-    public ItemMaterialInfo(MaterialStack... materials) {
-        this.materials.addAll(Arrays.asList(materials));
+    public ItemMaterialInfo(@NotNull MaterialStack @NotNull... materials) {
+        this(Arrays.asList(materials));
     }
 
-    public ItemMaterialInfo(List<MaterialStack> materials) {
-        this.materials.addAll(materials);
-    }
-
-    /**
-     * Returns the first MaterialStack in the "materials" list
-     */
-    public MaterialStack getMaterial() {
-        return materials.size() == 0 ? null : materials.get(0);
+    public ItemMaterialInfo(@NotNull List<MaterialStack> materials) {
+        if (materials.isEmpty()) {
+            throw new IllegalArgumentException("materials cannot be empty");
+        }
+        this.materials = materials;
     }
 
     /**
-     * Returns all MaterialStacks associated with this Object.
+     * @return the first composition data entry
      */
-    public ImmutableList<MaterialStack> getMaterials() {
-        return ImmutableList.copyOf(materials);
+    public @NotNull MaterialStack getFirstMaterial() {
+        return materials.get(0);
+    }
+
+    /**
+     * @return all of the composition data
+     */
+    public @UnmodifiableView @NotNull List<MaterialStack> getMaterials() {
+        return Collections.unmodifiableList(materials);
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ItemMaterialInfo that = (ItemMaterialInfo) o;
-        return materials.equals(that.materials);
+        if (!(o instanceof ItemMaterialInfo info)) {
+            return false;
+        }
+        return materials.equals(info.materials);
     }
 
     @Override
@@ -48,6 +51,8 @@ public class ItemMaterialInfo {
 
     @Override
     public String toString() {
-        return materials.size() == 0 ? "" : materials.get(0).material.toCamelCaseString();
+        return "ItemMaterialInfo{" +
+                "materials=" + materials +
+                '}';
     }
 }

--- a/src/main/java/gregtech/api/unification/stack/RecyclingData.java
+++ b/src/main/java/gregtech/api/unification/stack/RecyclingData.java
@@ -7,15 +7,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public final class ItemMaterialInfo {
+public final class RecyclingData {
 
     private final List<MaterialStack> materials;
 
-    public ItemMaterialInfo(@NotNull MaterialStack @NotNull... materials) {
+    public RecyclingData(@NotNull MaterialStack @NotNull... materials) {
         this(Arrays.asList(materials));
     }
 
-    public ItemMaterialInfo(@NotNull List<MaterialStack> materials) {
+    public RecyclingData(@NotNull List<MaterialStack> materials) {
         if (materials.isEmpty()) {
             throw new IllegalArgumentException("materials cannot be empty");
         }
@@ -31,10 +31,10 @@ public final class ItemMaterialInfo {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ItemMaterialInfo info)) {
+        if (!(o instanceof RecyclingData data)) {
             return false;
         }
-        return materials.equals(info.materials);
+        return materials.equals(data.materials);
     }
 
     @Override
@@ -44,7 +44,7 @@ public final class ItemMaterialInfo {
 
     @Override
     public String toString() {
-        return "ItemMaterialInfo{" +
+        return "RecyclingData{" +
                 "materials=" + materials +
                 '}';
     }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -19,6 +19,7 @@ import gregtech.api.metatileentity.registry.MTERegistry;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.ItemAndMetadata;
 
 import net.minecraft.block.BlockRedstoneWire;
 import net.minecraft.block.BlockSnow;
@@ -964,5 +965,22 @@ public class GTUtility {
     public static int combineRGB(@Range(from = 0, to = 255) int r, @Range(from = 0, to = 255) int g,
                                  @Range(from = 0, to = 255) int b) {
         return (r << 16) | (g << 8) | b;
+    }
+
+    /**
+     * @param map the map to get from
+     * @param key the key to retrieve with
+     * @return value corresponding to the given key or its wildcard counterpart
+     */
+    public static <T> @Nullable T getOrWildcardMeta(@NotNull Map<ItemAndMetadata, T> map,
+                                                    @NotNull ItemAndMetadata key) {
+        T t = map.get(key);
+        if (t != null) {
+            return t;
+        }
+        if (key.isWildcard()) {
+            return null;
+        }
+        return map.get(key.toWildcard());
     }
 }

--- a/src/main/java/gregtech/common/CommonProxy.java
+++ b/src/main/java/gregtech/common/CommonProxy.java
@@ -18,7 +18,7 @@ import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.registry.MaterialRegistry;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.ore.StoneType;
-import gregtech.api.unification.stack.ItemMaterialInfo;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.util.AssemblyLineManager;
 import gregtech.api.util.GTLog;
 import gregtech.common.blocks.BlockCompressed;
@@ -360,7 +360,7 @@ public class CommonProxy {
         MaterialInfoLoader.init();
 
         // post an event for addons to modify unification data before base GT registers recycling recipes
-        MinecraftForge.EVENT_BUS.post(new GregTechAPI.RegisterEvent<>(null, ItemMaterialInfo.class));
+        MinecraftForge.EVENT_BUS.post(new GregTechAPI.RegisterEvent<>(null, RecyclingData.class));
 
         GTLog.logger.info("Registering recipes...");
 

--- a/src/main/java/gregtech/common/items/MetaItem1.java
+++ b/src/main/java/gregtech/common/items/MetaItem1.java
@@ -20,8 +20,8 @@ import gregtech.api.unification.material.MarkerMaterials.Tier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.RandomPotionEffect;
 import gregtech.common.ConfigHolder;
@@ -116,99 +116,99 @@ public class MetaItem1 extends StandardMetaItem {
         CREDIT_NEUTRONIUM = addItem(7, "credit.neutronium").setRarity(EnumRarity.EPIC);
 
         COIN_GOLD_ANCIENT = addItem(8, "coin.gold.ancient")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Gold, M / 4)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Gold, M / 4)))
                 .setRarity(EnumRarity.RARE);
         COIN_DOGE = addItem(9, "coin.doge")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Brass, M / 4)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Brass, M / 4)))
                 .setRarity(EnumRarity.EPIC);
         COIN_CHOCOLATE = addItem(10, "coin.chocolate")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Gold, M / 4)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Gold, M / 4)))
                 .addComponents(new FoodStats(1, 0.1F, false, true, OreDictUnifier.get(OrePrefix.foil, Materials.Gold),
                         new RandomPotionEffect(MobEffects.SPEED, 200, 1, 10)));
 
         // Solidifier Shapes: ID 11-30
         SHAPE_EMPTY = addItem(11, "shape.empty")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
 
         SHAPE_MOLDS[0] = SHAPE_MOLD_PLATE = addItem(12, "shape.mold.plate")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[1] = SHAPE_MOLD_GEAR = addItem(13, "shape.mold.gear")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[2] = SHAPE_MOLD_CREDIT = addItem(14, "shape.mold.credit")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[3] = SHAPE_MOLD_BOTTLE = addItem(15, "shape.mold.bottle")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[4] = SHAPE_MOLD_INGOT = addItem(16, "shape.mold.ingot")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[5] = SHAPE_MOLD_BALL = addItem(17, "shape.mold.ball")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[6] = SHAPE_MOLD_BLOCK = addItem(18, "shape.mold.block")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[7] = SHAPE_MOLD_NUGGET = addItem(19, "shape.mold.nugget")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[8] = SHAPE_MOLD_CYLINDER = addItem(20, "shape.mold.cylinder")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[9] = SHAPE_MOLD_ANVIL = addItem(21, "shape.mold.anvil")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[10] = SHAPE_MOLD_NAME = addItem(22, "shape.mold.name")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[11] = SHAPE_MOLD_GEAR_SMALL = addItem(23, "shape.mold.gear.small")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[12] = SHAPE_MOLD_ROTOR = addItem(24, "shape.mold.rotor")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[13] = SHAPE_MOLD_RING = addItem(25, "shape.mold.ring")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[14] = SHAPE_MOLD_BOLT = addItem(26, "shape.mold.bolt")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[15] = SHAPE_MOLD_ROD = addItem(27, "shape.mold.rod")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[16] = SHAPE_MOLD_ROD_LONG = addItem(28, "shape.mold.rod_long")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[17] = SHAPE_MOLD_ROUND = addItem(29, "shape.mold.round")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
 
         // Free ID: 30
 
         // Extruder Shapes: ID 31-59
         SHAPE_EXTRUDERS[0] = SHAPE_EXTRUDER_PLATE = addItem(31, "shape.extruder.plate")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[1] = SHAPE_EXTRUDER_ROD = addItem(32, "shape.extruder.rod")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[2] = SHAPE_EXTRUDER_BOLT = addItem(33, "shape.extruder.bolt")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[3] = SHAPE_EXTRUDER_RING = addItem(34, "shape.extruder.ring")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[4] = SHAPE_EXTRUDER_CELL = addItem(35, "shape.extruder.cell")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[5] = SHAPE_EXTRUDER_INGOT = addItem(36, "shape.extruder.ingot")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[6] = SHAPE_EXTRUDER_WIRE = addItem(37, "shape.extruder.wire")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[7] = SHAPE_EXTRUDER_PIPE_TINY = addItem(38, "shape.extruder.pipe.tiny")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[8] = SHAPE_EXTRUDER_PIPE_SMALL = addItem(39, "shape.extruder.pipe.small")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[9] = SHAPE_EXTRUDER_PIPE_NORMAL = addItem(40, "shape.extruder.pipe.normal")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[10] = SHAPE_EXTRUDER_PIPE_LARGE = addItem(41, "shape.extruder.pipe.large")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[11] = SHAPE_EXTRUDER_PIPE_HUGE = addItem(42, "shape.extruder.pipe.huge")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[12] = SHAPE_EXTRUDER_BLOCK = addItem(43, "shape.extruder.block")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         // Extruder Shapes index 13-20 (inclusive), id 44-51 (inclusive) are unused
         SHAPE_EXTRUDERS[21] = SHAPE_EXTRUDER_GEAR = addItem(52, "shape.extruder.gear")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[22] = SHAPE_EXTRUDER_BOTTLE = addItem(53, "shape.extruder.bottle")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[23] = SHAPE_EXTRUDER_FOIL = addItem(54, "shape.extruder.foil")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[24] = SHAPE_EXTRUDER_GEAR_SMALL = addItem(55, "shape.extruder.gear_small")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[25] = SHAPE_EXTRUDER_ROD_LONG = addItem(56, "shape.extruder.rod_long")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_EXTRUDERS[26] = SHAPE_EXTRUDER_ROTOR = addItem(57, "shape.extruder.rotor")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
 
         // Spray Cans: ID 60-77
         SPRAY_EMPTY = addItem(61, "spray.empty");
@@ -241,7 +241,7 @@ public class MetaItem1 extends StandardMetaItem {
                         Materials.Steel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false,
                         false, false, true),
                         new ItemFluidContainer(true))
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4))) // ingot * 4
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4))) // ingot * 4
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
 
         FLUID_CELL_LARGE_ALUMINIUM = addItem(81, "large_fluid_cell.aluminium")
@@ -249,7 +249,7 @@ public class MetaItem1 extends StandardMetaItem {
                         Materials.Aluminium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, false,
                         false, false, true),
                         new ItemFluidContainer(true))
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Aluminium, M * 4))) // ingot * 4
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Aluminium, M * 4))) // ingot * 4
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
 
         FLUID_CELL_LARGE_STAINLESS_STEEL = addItem(82, "large_fluid_cell.stainless_steel")
@@ -257,7 +257,7 @@ public class MetaItem1 extends StandardMetaItem {
                         Materials.StainlessSteel.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true,
                         true, true, false, true),
                         new ItemFluidContainer(true))
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.StainlessSteel, M * 6))) // ingot * 6
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.StainlessSteel, M * 6))) // ingot * 6
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
 
         FLUID_CELL_LARGE_TITANIUM = addItem(83, "large_fluid_cell.titanium")
@@ -265,7 +265,7 @@ public class MetaItem1 extends StandardMetaItem {
                         Materials.Titanium.getProperty(PropertyKey.FLUID_PIPE).getMaxFluidTemperature(), true, true,
                         false, false, true),
                         new ItemFluidContainer(true))
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Titanium, M * 6))) // ingot * 6
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Titanium, M * 6))) // ingot * 6
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
 
         FLUID_CELL_LARGE_TUNGSTEN_STEEL = addItem(84, "large_fluid_cell.tungstensteel")
@@ -274,13 +274,13 @@ public class MetaItem1 extends StandardMetaItem {
                         true, false, false, true),
                         new ItemFluidContainer(true))
                 .setMaxStackSize(32)
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.TungstenSteel, M * 8))) // ingot * 8
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.TungstenSteel, M * 8))) // ingot * 8
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
 
         FLUID_CELL_GLASS_VIAL = addItem(85, "fluid_cell.glass_vial")
                 .addComponents(new FilteredFluidStats(1000, 1200, false, true, false, false, true),
                         new ItemFluidContainer())
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 4))) // small dust
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Glass, M / 4))) // small dust
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
 
         // Limited-Use Items: ID 89-95
@@ -293,13 +293,13 @@ public class MetaItem1 extends StandardMetaItem {
                 .setMaxStackSize(1)
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
         TOOL_LIGHTER_INVAR = addItem(91, "tool.lighter.invar")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Invar, M * 2)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Invar, M * 2)))
                 .addComponents(new LighterBehaviour(GTUtility.gregtechId("lighter_open"), true, true, true))
                 .addComponents(new FilteredFluidStats(100, true, CommonFluidFilters.LIGHTER_FUEL))
                 .setMaxStackSize(1)
                 .setCreativeTabs(GTCreativeTabs.TAB_GREGTECH_TOOLS);
         TOOL_LIGHTER_PLATINUM = addItem(92, "tool.lighter.platinum")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Platinum, M * 2)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Platinum, M * 2)))
                 .addComponents(new LighterBehaviour(GTUtility.gregtechId("lighter_open"), true, true, true))
                 .addComponents(new FilteredFluidStats(1000, true, CommonFluidFilters.LIGHTER_FUEL))
                 .setMaxStackSize(1)
@@ -310,24 +310,24 @@ public class MetaItem1 extends StandardMetaItem {
                 new ItemStack(Items.GLASS_BOTTLE), new RandomPotionEffect(MobEffects.HASTE, 800, 1, 90)));
 
         // Voltage Coils: ID 96-110
-        VOLTAGE_COIL_ULV = addItem(96, "voltage_coil.ulv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_ULV = addItem(96, "voltage_coil.ulv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Lead, M * 2), new MaterialStack(Materials.IronMagnetic, M / 2)));
-        VOLTAGE_COIL_LV = addItem(97, "voltage_coil.lv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_LV = addItem(97, "voltage_coil.lv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Steel, M * 2), new MaterialStack(Materials.IronMagnetic, M / 2)));
-        VOLTAGE_COIL_MV = addItem(98, "voltage_coil.mv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_MV = addItem(98, "voltage_coil.mv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Aluminium, M * 2), new MaterialStack(Materials.SteelMagnetic, M / 2)));
-        VOLTAGE_COIL_HV = addItem(99, "voltage_coil.hv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_HV = addItem(99, "voltage_coil.hv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.BlackSteel, M * 2), new MaterialStack(Materials.SteelMagnetic, M / 2)));
         VOLTAGE_COIL_EV = addItem(100, "voltage_coil.ev")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Platinum, M * 2),
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Platinum, M * 2),
                         new MaterialStack(Materials.NeodymiumMagnetic, M / 2)));
-        VOLTAGE_COIL_IV = addItem(101, "voltage_coil.iv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_IV = addItem(101, "voltage_coil.iv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Iridium, M * 2), new MaterialStack(Materials.NeodymiumMagnetic, M / 2)));
-        VOLTAGE_COIL_LuV = addItem(102, "voltage_coil.luv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_LuV = addItem(102, "voltage_coil.luv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Osmiridium, M * 2), new MaterialStack(Materials.SamariumMagnetic, M / 2)));
-        VOLTAGE_COIL_ZPM = addItem(103, "voltage_coil.zpm").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_ZPM = addItem(103, "voltage_coil.zpm").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Europium, M * 2), new MaterialStack(Materials.SamariumMagnetic, M / 2)));
-        VOLTAGE_COIL_UV = addItem(104, "voltage_coil.uv").setMaterialInfo(new ItemMaterialInfo(
+        VOLTAGE_COIL_UV = addItem(104, "voltage_coil.uv").setRecyclingData(new RecyclingData(
                 new MaterialStack(Materials.Tritanium, M * 2), new MaterialStack(Materials.SamariumMagnetic, M / 2)));
 
         // ???: ID 111-125
@@ -610,16 +610,16 @@ public class MetaItem1 extends StandardMetaItem {
 
         // Special Machine Components: ID 266-280
         COMPONENT_GRINDER_DIAMOND = addItem(266, "component.grinder.diamond")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 8),
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 8),
                         new MaterialStack(Materials.Diamond, M * 5)));
         COMPONENT_GRINDER_TUNGSTEN = addItem(267, "component.grinder.tungsten")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Tungsten, M * 4),
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Tungsten, M * 4),
                         new MaterialStack(Materials.VanadiumSteel, M * 8), new MaterialStack(Materials.Diamond, M)));
 
         IRON_MINECART_WHEELS = addItem(268, "minecart_wheels.iron")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Iron, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Iron, M)));
         STEEL_MINECART_WHEELS = addItem(269, "minecart_wheels.steel")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M)));
 
         // Special Eyes/Stars: ID 281-289
         QUANTUM_EYE = addItem(281, "quantumeye");
@@ -628,17 +628,17 @@ public class MetaItem1 extends StandardMetaItem {
 
         // Filters: ID 290-300
         FLUID_FILTER = addItem(290, "fluid_filter")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Zinc, M * 2)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Zinc, M * 2)))
                 .addComponents(new SimpleFluidFilterUIManager(), IFilter.factory(SimpleFluidFilter::new));
         ITEM_FILTER = addItem(291, "item_filter")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Zinc, M * 2),
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Zinc, M * 2),
                         new MaterialStack(Materials.Steel, M)))
                 .addComponents(new SimpleFilterUIManager(), IFilter.factory(SimpleItemFilter::new));
         ORE_DICTIONARY_FILTER = addItem(292, "ore_dictionary_filter")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Zinc, M * 2)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Zinc, M * 2)))
                 .addComponents(new OreDictFilterUIManager(), IFilter.factory(OreDictionaryItemFilter::new));
         SMART_FILTER = addItem(293, "smart_item_filter")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Zinc, M * 3 / 2)))
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Zinc, M * 3 / 2)))
                 .addComponents(new SmartFilterUIManager(), IFilter.factory(SmartItemFilter::new));
 
         // Functional Covers: ID 301-330
@@ -744,15 +744,15 @@ public class MetaItem1 extends StandardMetaItem {
         WOODEN_FORM_EMPTY = addItem(347, "wooden_form.empty");
         WOODEN_FORM_BRICK = addItem(348, "wooden_form.brick").addComponents(selfContainerItemProvider);
         COMPRESSED_CLAY = addItem(349, "compressed.clay")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Clay, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Clay, M)));
         COMPRESSED_COKE_CLAY = addItem(350, "compressed.coke_clay")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Clay, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Clay, M)));
         COMPRESSED_FIRECLAY = addItem(351, "compressed.fireclay")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Fireclay, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Fireclay, M)));
         FIRECLAY_BRICK = addItem(352, "brick.fireclay")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Fireclay, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Fireclay, M)));
         COKE_OVEN_BRICK = addItem(353, "brick.coke")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Clay, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Clay, M)));
 
         if (!ConfigHolder.recipes.harderBrickRecipes)
             COMPRESSED_CLAY.setInvisible();
@@ -893,7 +893,7 @@ public class MetaItem1 extends StandardMetaItem {
         // Circuit Components: ID 516-565
         VACUUM_TUBE = addItem(516, "circuit.vacuum_tube").setUnificationData(OrePrefix.circuit, Tier.ULV);
         GLASS_TUBE = addItem(517, "component.glass.tube")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Glass, M)));
         TRANSISTOR = addItem(518, "component.transistor").setUnificationData(OrePrefix.component, Component.Transistor);
         RESISTOR = addItem(519, "component.resistor").setUnificationData(OrePrefix.component, Component.Resistor);
         CAPACITOR = addItem(520, "component.capacitor").setUnificationData(OrePrefix.component, Component.Capacitor);
@@ -1033,21 +1033,21 @@ public class MetaItem1 extends StandardMetaItem {
 
         // Battery Hulls: ID 716-730
         BATTERY_HULL_LV = addItem(717, "battery.hull.lv")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.BatteryAlloy, M))); // plate
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.BatteryAlloy, M))); // plate
         BATTERY_HULL_MV = addItem(718, "battery.hull.mv")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.BatteryAlloy, M * 3))); // plate * 3
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.BatteryAlloy, M * 3))); // plate * 3
         BATTERY_HULL_HV = addItem(719, "battery.hull.hv")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.BatteryAlloy, M * 9))); // plate * 9
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.BatteryAlloy, M * 9))); // plate * 9
         BATTERY_HULL_SMALL_VANADIUM = addItem(720, "battery.hull.ev")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.RedSteel, M * 2)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.RedSteel, M * 2)));
         BATTERY_HULL_MEDIUM_VANADIUM = addItem(721, "battery.hull.iv")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.RoseGold, M * 6)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.RoseGold, M * 6)));
         BATTERY_HULL_LARGE_VANADIUM = addItem(722, "battery.hull.luv")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.BlueSteel, M * 18)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.BlueSteel, M * 18)));
         BATTERY_HULL_MEDIUM_NAQUADRIA = addItem(723, "battery.hull.zpm")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Europium, M * 6)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Europium, M * 6)));
         BATTERY_HULL_LARGE_NAQUADRIA = addItem(724, "battery.hull.uv")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Americium, M * 18)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Americium, M * 18)));
 
         // Batteries: 731-775
         BATTERY_ULV_TANTALUM = addItem(731, "battery.re.ulv.tantalum")
@@ -1188,14 +1188,14 @@ public class MetaItem1 extends StandardMetaItem {
 
         // Extra molds 1006-1010
         SHAPE_MOLDS[18] = SHAPE_MOLD_PIPE_TINY = addItem(1006, "shape.mold.pipe.tiny")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[19] = SHAPE_MOLD_PIPE_SMALL = addItem(1007, "shape.mold.pipe.small")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[20] = SHAPE_MOLD_PIPE_NORMAL = addItem(1008, "shape.mold.pipe.normal")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[21] = SHAPE_MOLD_PIPE_LARGE = addItem(1009, "shape.mold.pipe.large")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
         SHAPE_MOLDS[22] = SHAPE_MOLD_PIPE_HUGE = addItem(1010, "shape.mold.pipe.huge")
-                .setMaterialInfo(new ItemMaterialInfo(new MaterialStack(Materials.Steel, M * 4)));
+                .setRecyclingData(new RecyclingData(new MaterialStack(Materials.Steel, M * 4)));
     }
 }

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -1,6 +1,6 @@
 package gregtech.loaders;
 
-import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
@@ -23,98 +23,98 @@ import static gregtech.common.metatileentities.MetaTileEntities.LONG_DIST_ITEM_E
 public class MaterialInfoLoader {
 
     public static void init() {
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.CUPRONICKEL),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.CUPRONICKEL),
                 new ItemMaterialInfo(new MaterialStack(Materials.Cupronickel, M * 8), // double wire
                         new MaterialStack(Materials.Bronze, M * 2), // foil
                         new MaterialStack(Materials.TinAlloy, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.KANTHAL),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.KANTHAL),
                 new ItemMaterialInfo(new MaterialStack(Materials.Kanthal, M * 8), // double wire
                         new MaterialStack(Materials.Aluminium, M * 2), // foil
                         new MaterialStack(Materials.Copper, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NICHROME),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NICHROME),
                 new ItemMaterialInfo(new MaterialStack(Materials.Nichrome, M * 8), // double wire
                         new MaterialStack(Materials.StainlessSteel, M * 2), // foil
                         new MaterialStack(Materials.Aluminium, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.RTM_ALLOY),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.RTM_ALLOY),
                 new ItemMaterialInfo(new MaterialStack(Materials.RTMAlloy, M * 8), // double wire
                         new MaterialStack(Materials.VanadiumSteel, M * 2), // foil
                         new MaterialStack(Materials.Nichrome, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.HSS_G),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.HSS_G),
                 new ItemMaterialInfo(new MaterialStack(Materials.HSSG, M * 8), // double wire
                         new MaterialStack(Materials.TungstenCarbide, M * 2), // foil
                         new MaterialStack(Materials.Tungsten, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH),
                 new ItemMaterialInfo(new MaterialStack(Materials.Naquadah, M * 8), // double wire
                         new MaterialStack(Materials.Osmium, M * 2), // foil
                         new MaterialStack(Materials.TungstenSteel, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TRINIUM),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TRINIUM),
                 new ItemMaterialInfo(new MaterialStack(Materials.Trinium, M * 8), // double wire
                         new MaterialStack(Materials.NaquadahEnriched, M * 2), // foil
                         new MaterialStack(Materials.Naquadah, M)) // ingot
         );
-        OreDictUnifier.registerOre(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TRITANIUM),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TRITANIUM),
                 new ItemMaterialInfo(new MaterialStack(Materials.Tritanium, M * 8), // double wire
                         new MaterialStack(Materials.Naquadria, M * 2), // foil
                         new MaterialStack(Materials.Trinium, M)) // ingot
         );
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[0].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[0].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.WroughtIron, M * 8), // plate
                 new MaterialStack(Materials.RedAlloy, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[1].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[1].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Steel, M * 8), // plate
                 new MaterialStack(Materials.Tin, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[2].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[2].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Aluminium, M * 8), // plate
                 new MaterialStack(Materials.Copper, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[3].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[3].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.StainlessSteel, M * 8), // plate
                 new MaterialStack(Materials.Gold, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[4].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[4].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Titanium, M * 8), // plate
                 new MaterialStack(Materials.Aluminium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[5].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[5].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.TungstenSteel, M * 8), // plate
                 new MaterialStack(Materials.Platinum, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[6].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[6].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.RhodiumPlatedPalladium, M * 8), // plate
                 new MaterialStack(Materials.NiobiumTitanium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[7].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[7].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.NaquadahAlloy, M * 8), // plate
                 new MaterialStack(Materials.VanadiumGallium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[8].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[8].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Darmstadtium, M * 8), // plate
                 new MaterialStack(Materials.YttriumBariumCuprate, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.HULL[9].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[9].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Neutronium, M * 8), // plate
                 new MaterialStack(Materials.Europium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        OreDictUnifier.registerOre(MetaTileEntities.ENERGY_INPUT_HATCH[3].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[3].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.StainlessSteel, M * 8), // plate
                 new MaterialStack(Materials.Gold, M * 2), // single cable
                 new MaterialStack(Materials.Rubber, M * 4), // plate
@@ -122,7 +122,7 @@ public class MaterialInfoLoader {
                 new MaterialStack(Materials.SteelMagnetic, M / 2) // rod
         ));
 
-        OreDictUnifier.registerOre(MetaTileEntities.ENERGY_INPUT_HATCH[4].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[4].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Titanium, M * 8), // plate
                 new MaterialStack(Materials.Aluminium, M * 2), // single cable
                 new MaterialStack(Materials.Rubber, M * 4), // plate
@@ -130,7 +130,7 @@ public class MaterialInfoLoader {
                 new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
         ));
 
-        OreDictUnifier.registerOre(MetaTileEntities.ENERGY_INPUT_HATCH[5].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[5].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.TungstenSteel, M * 8), // plate
                 new MaterialStack(Materials.Platinum, M), // single cable
                 new MaterialStack(Materials.Tungsten, M), // single cable
@@ -139,7 +139,7 @@ public class MaterialInfoLoader {
                 new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
         ));
 
-        OreDictUnifier.registerOre(MetaTileEntities.ENERGY_OUTPUT_HATCH[3].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[3].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.StainlessSteel, M * 8), // plate
                 new MaterialStack(Materials.Gold, 3 * M), // single cable + spring
                 new MaterialStack(Materials.Rubber, M * 2), // plate
@@ -147,7 +147,7 @@ public class MaterialInfoLoader {
                 new MaterialStack(Materials.SteelMagnetic, M / 2) // rod
         ));
 
-        OreDictUnifier.registerOre(MetaTileEntities.ENERGY_OUTPUT_HATCH[4].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[4].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.Titanium, M * 8), // plate
                 new MaterialStack(Materials.Aluminium, 3 * M), // single cable + spring
                 new MaterialStack(Materials.Rubber, M * 2), // plate
@@ -155,7 +155,7 @@ public class MaterialInfoLoader {
                 new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
         ));
 
-        OreDictUnifier.registerOre(MetaTileEntities.ENERGY_OUTPUT_HATCH[5].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[5].getStackForm(), new ItemMaterialInfo(
                 new MaterialStack(Materials.TungstenSteel, M * 8), // plate
                 new MaterialStack(Materials.Platinum, M), // single cable
                 new MaterialStack(Materials.Tungsten, M * 2), // spring
@@ -164,7 +164,7 @@ public class MaterialInfoLoader {
                 new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
         ));
 
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.CLEANROOM_CASING.getItemVariant(BlockCleanroomCasing.CasingType.PLASCRETE),
                 new ItemMaterialInfo(
                         new MaterialStack(Materials.Steel, (M * 2) / ConfigHolder.recipes.casingsPerCraft), // frame /
@@ -177,7 +177,7 @@ public class MaterialInfoLoader {
                                                                                                         // config
                 ));
 
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.TRANSPARENT_CASING.getItemVariant(BlockGlassCasing.CasingType.CLEANROOM_GLASS),
                 new ItemMaterialInfo(
                         new MaterialStack(Materials.Steel, (M * 2) / ConfigHolder.recipes.casingsPerCraft), // frame /
@@ -189,7 +189,7 @@ public class MaterialInfoLoader {
                         new MaterialStack(Materials.Glass, M / ConfigHolder.recipes.casingsPerCraft) // 1 block / config
                 ));
 
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.METAL_CASING.getItemVariant(BlockMetalCasing.MetalCasingType.PTFE_INERT_CASING),
                 new ItemMaterialInfo(
                         new MaterialStack(Materials.Steel, (M * 8) / ConfigHolder.recipes.casingsPerCraft), // casing /
@@ -198,389 +198,389 @@ public class MaterialInfoLoader {
                                                                                         // recipe)
                 ));
 
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.METAL_CASING.getItemVariant(BlockMetalCasing.MetalCasingType.PRIMITIVE_BRICKS),
                 new ItemMaterialInfo(new MaterialStack(Materials.Fireclay, M * 4)));
 
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.BATTERY_BLOCK.getItemVariant(BlockBatteryPart.BatteryPartType.EMPTY_TIER_I),
                 new ItemMaterialInfo(
                         new MaterialStack(Materials.Ultimet, M * 2 + M * 6 + (M / 9 * 24)))); // frame + 6 plates + 24
                                                                                               // screws
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.BATTERY_BLOCK.getItemVariant(BlockBatteryPart.BatteryPartType.EMPTY_TIER_II),
                 new ItemMaterialInfo(
                         new MaterialStack(Materials.Ruridit, M * 2 + M * 6 + (M / 9 * 24)))); // frame + 6 plates + 24
                                                                                               // screws
-        OreDictUnifier.registerOre(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.BATTERY_BLOCK.getItemVariant(BlockBatteryPart.BatteryPartType.EMPTY_TIER_III),
                 new ItemMaterialInfo(
                         new MaterialStack(Materials.Neutronium, M * 2 + M * 6 + (M / 9 * 24)))); // frame + 6 plates +
                                                                                                  // 24 screws
 
-        OreDictUnifier.registerOre(LONG_DIST_ITEM_ENDPOINT.getStackForm(),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(LONG_DIST_ITEM_ENDPOINT.getStackForm(),
                 new ItemMaterialInfo(new MaterialStack(Tin, M * 6), // large pipe
                         new MaterialStack(Steel, M * 8))); // 4 plates + 1 gear
 
-        OreDictUnifier.registerOre(LONG_DIST_FLUID_ENDPOINT.getStackForm(),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(LONG_DIST_FLUID_ENDPOINT.getStackForm(),
                 new ItemMaterialInfo(new MaterialStack(Bronze, M * 6), // large pipe
                         new MaterialStack(Steel, M * 8))); // 4 plates + 1 gear
 
-        OreDictUnifier.registerOre(new ItemStack(MetaBlocks.LD_ITEM_PIPE),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(MetaBlocks.LD_ITEM_PIPE),
                 new ItemMaterialInfo(new MaterialStack(Tin, M * 6 * 2 / 64), // 2 large pipe / 64
                         new MaterialStack(Steel, M * 8 / 64))); // 8 steel plate / 64
 
-        OreDictUnifier.registerOre(new ItemStack(MetaBlocks.LD_FLUID_PIPE),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(MetaBlocks.LD_FLUID_PIPE),
                 new ItemMaterialInfo(new MaterialStack(Bronze, M * 6 * 2 / 64), // 2 large pipe / 64
                         new MaterialStack(Steel, M * 8 / 64))); // 8 steel plate / 64
 
         if (ConfigHolder.recipes.hardAdvancedIronRecipes) {
-            OreDictUnifier.registerOre(new ItemStack(Items.IRON_DOOR, 1), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_DOOR, 1), new ItemMaterialInfo(
                     new MaterialStack(Materials.Iron, M * 4 + (M * 3 / 16)), // 4 iron plates + 1 iron bars
                     new MaterialStack(Materials.Steel, M / 9))); // tiny steel dust
         } else {
-            OreDictUnifier.registerOre(new ItemStack(Items.IRON_DOOR, 1),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_DOOR, 1),
                     new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
         }
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
-        OreDictUnifier.registerOre(new ItemStack(Blocks.SANDSTONE_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.SANDSTONE_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
-        OreDictUnifier.registerOre(new ItemStack(Blocks.RED_SANDSTONE_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.RED_SANDSTONE_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_BRICK_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_BRICK_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
-        OreDictUnifier.registerOre(new ItemStack(Blocks.QUARTZ_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.QUARTZ_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.NetherQuartz, M * 6))); // dust
-        OreDictUnifier.registerOre(new ItemStack(Blocks.BRICK_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BRICK_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Brick, M * 6))); // dust
-        OreDictUnifier.registerOre(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Netherrack, M * 6))); // dust
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 0),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 0),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 2),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 2),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 3),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 3),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 4),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 4),
                 new ItemMaterialInfo(new MaterialStack(Materials.Brick, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 5),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 5),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 6),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 6),
                 new ItemMaterialInfo(new MaterialStack(Materials.Netherrack, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_SLAB, 1, 7),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 7),
                 new ItemMaterialInfo(new MaterialStack(Materials.NetherQuartz, M * 2)));
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.LEVER, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LEVER, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M / 9), new MaterialStack(Materials.Wood, 1814400L)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.WOODEN_BUTTON, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_BUTTON, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M / 9)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_BUTTON, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_BUTTON, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 9)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.REDSTONE_TORCH, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.REDSTONE_TORCH, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Wood, M / 2), new MaterialStack(Materials.Redstone, M)));
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.RAIL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.RAIL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 3 / 16)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.GOLDEN_RAIL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.GOLDEN_RAIL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.DETECTOR_RAIL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DETECTOR_RAIL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ACTIVATOR_RAIL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ACTIVATOR_RAIL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M / 2)));
 
         if (ConfigHolder.recipes.hardRedstoneRecipes) {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Wood, M), new MaterialStack(Materials.Iron, M / 2)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Stone, M), new MaterialStack(Materials.Iron, M * 6 / 8)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Gold, M), new MaterialStack(Materials.Steel, M)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Iron, M), new MaterialStack(Materials.Steel, M)));
         } else {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 2)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 2)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
         }
 
-        OreDictUnifier.registerOre(new ItemStack(Items.WHEAT, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WHEAT, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wheat, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.HAY_BLOCK, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HAY_BLOCK, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wheat, M * 9)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.SNOWBALL, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.SNOWBALL, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Water, M / 4)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.SNOW, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.SNOW, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Water, M)));
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.PACKED_ICE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.PACKED_ICE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Ice, M * 2)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.BOOK, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.BOOK, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));
-        OreDictUnifier.registerOre(new ItemStack(Items.WRITABLE_BOOK, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WRITABLE_BOOK, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));
-        OreDictUnifier.registerOre(new ItemStack(Items.ENCHANTED_BOOK, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.ENCHANTED_BOOK, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.BOOKSHELF, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BOOKSHELF, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Paper, M * 9), new MaterialStack(Materials.Wood, M * 6)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_APPLE, 1, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_APPLE, 1, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 72))); // block
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_APPLE, 1, 0),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_APPLE, 1, 0),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 8))); // ingot
 
-        OreDictUnifier.registerOre(new ItemStack(Items.MINECART, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.MINECART, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5)));
-        OreDictUnifier.registerOre(new ItemStack(Items.CHEST_MINECART, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHEST_MINECART, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 5), new MaterialStack(Materials.Wood, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.FURNACE_MINECART, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.FURNACE_MINECART, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 5), new MaterialStack(Materials.Stone, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.TNT_MINECART, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.TNT_MINECART, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5)));
-        OreDictUnifier.registerOre(new ItemStack(Items.HOPPER_MINECART, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.HOPPER_MINECART, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 10), new MaterialStack(Materials.Wood, M * 8)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.CAULDRON, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CAULDRON, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 7)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.IRON_BARS, 8, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.IRON_BARS, 8, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 3 / 16)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.IRON_TRAPDOOR, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.IRON_TRAPDOOR, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.BUCKET, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.BUCKET, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 3)));
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ANVIL, 1, 0),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ANVIL, 1, 0),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 31)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ANVIL, 1, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ANVIL, 1, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 22)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.ANVIL, 1, 2),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ANVIL, 1, 2),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 13)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.HOPPER, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HOPPER, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 5), new MaterialStack(Materials.Wood, M * 8)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.GLASS_BOTTLE),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GLASS_BOTTLE),
                 new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STAINED_GLASS, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STAINED_GLASS, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.GLASS, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.GLASS, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STAINED_GLASS_PANE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STAINED_GLASS_PANE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 3))); // dust tiny
-        OreDictUnifier.registerOre(new ItemStack(Blocks.GLASS_PANE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.GLASS_PANE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 3))); // dust tiny
 
-        OreDictUnifier.registerOre(new ItemStack(Items.FLOWER_POT, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.FLOWER_POT, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Brick, M * 3)));
-        OreDictUnifier.registerOre(new ItemStack(Items.PAINTING, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.PAINTING, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.ITEM_FRAME, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.ITEM_FRAME, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.COBBLESTONE_WALL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.COBBLESTONE_WALL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
-        OreDictUnifier.registerOre(new ItemStack(Items.END_CRYSTAL, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.END_CRYSTAL, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Glass, M * 7), new MaterialStack(Materials.EnderEye, M)));
 
         if (ConfigHolder.recipes.hardToolArmorRecipes) {
-            OreDictUnifier.registerOre(new ItemStack(Items.CLOCK, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CLOCK, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Gold, (13 * M) / 8), // M + ring + 3 * bolt
                             new MaterialStack(Materials.Redstone, M)));
 
-            OreDictUnifier.registerOre(new ItemStack(Items.COMPASS, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.COMPASS, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Iron, (4 * M) / 3), // M + 3*screw
                     new MaterialStack(Materials.RedAlloy, M / 8), // bolt
                     new MaterialStack(Materials.Zinc, M / 4))); // ring
         } else {
-            OreDictUnifier.registerOre(new ItemStack(Items.CLOCK, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CLOCK, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Gold, M * 4), new MaterialStack(Materials.Redstone, M)));
-            OreDictUnifier.registerOre(new ItemStack(Items.COMPASS, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.COMPASS, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Iron, M * 4), new MaterialStack(Materials.Redstone, M)));
         }
 
         if (ConfigHolder.recipes.hardMiscRecipes) {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.BEACON, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BEACON, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.NetherStar, (7 * M) / 4), // M + lens
                     new MaterialStack(Materials.Obsidian, M * 3),
                     new MaterialStack(Materials.Glass, M * 4)));
 
-            OreDictUnifier.registerOre(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Diamond, M * 4),
                     new MaterialStack(Materials.Obsidian, M * 3),
                     new MaterialStack(Materials.Paper, M * 9)));
 
-            OreDictUnifier.registerOre(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Wood, M * 8), // chest
                     new MaterialStack(Materials.Obsidian, M * 9 * 6), // 6 dense plates
                     new MaterialStack(Materials.EnderEye, M)));
         } else {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.BEACON, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BEACON, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.NetherStar, M),
                             new MaterialStack(Materials.Obsidian, M * 3), new MaterialStack(Materials.Glass, M * 5)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 2),
                             new MaterialStack(Materials.Obsidian, M * 4), new MaterialStack(Materials.Paper, M * 3)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.EnderEye, M), new MaterialStack(Materials.Obsidian, M * 8)));
         }
 
-        OreDictUnifier.registerOre(new ItemStack(Blocks.FURNACE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.FURNACE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STONEBRICK, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONEBRICK, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.COBBLESTONE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.COBBLESTONE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.LADDER, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LADDER, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.BOWL, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.BOWL, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M / 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.SIGN, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.SIGN, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.CHEST, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.CHEST, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.TRAPPED_CHEST, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.TRAPPED_CHEST, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Iron, M / 2))); // ring
 
         if (ConfigHolder.recipes.hardMiscRecipes) {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.NOTEBLOCK, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NOTEBLOCK, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.RedAlloy, M / 2))); // rod
-            OreDictUnifier.registerOre(new ItemStack(Blocks.JUKEBOX, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.JUKEBOX, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Diamond, M / 8), // bolt
                     new MaterialStack(Materials.Iron, (17 * M) / 4), // gear + ring
                     new MaterialStack(Materials.RedAlloy, M)));
         } else {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.NOTEBLOCK, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NOTEBLOCK, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Redstone, M)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.JUKEBOX, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.JUKEBOX, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Diamond, M)));
         }
-        OreDictUnifier.registerOre(new ItemStack(Blocks.REDSTONE_LAMP, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.REDSTONE_LAMP, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Glowstone, M * 4), new MaterialStack(Materials.Redstone, M * 4))); // dust
-        OreDictUnifier.registerOre(new ItemStack(Blocks.CRAFTING_TABLE, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.CRAFTING_TABLE, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.PISTON, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.PISTON, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M * 4), new MaterialStack(Materials.Wood, M * 3)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STICKY_PISTON, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STICKY_PISTON, 1, W), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M * 4), new MaterialStack(Materials.Wood, M * 3)));
         if (ConfigHolder.recipes.hardRedstoneRecipes) {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.DISPENSER, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DISPENSER, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 2),
                             new MaterialStack(Materials.RedAlloy, M / 2),
                             new MaterialStack(Materials.Iron, M * 4 + M / 4)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.DROPPER, 1, W),
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DROPPER, 1, W),
                     new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 2),
                             new MaterialStack(Materials.RedAlloy, M / 2),
                             new MaterialStack(Materials.Iron, M * 2 + M * 3 / 4)));
         } else {
-            OreDictUnifier.registerOre(new ItemStack(Blocks.DISPENSER, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DISPENSER, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Redstone, M)));
-            OreDictUnifier.registerOre(new ItemStack(Blocks.DROPPER, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DROPPER, 1, W), new ItemMaterialInfo(
                     new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Redstone, M)));
         }
 
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_HELMET, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HELMET, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_CHESTPLATE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_CHESTPLATE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_LEGGINGS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_LEGGINGS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 7)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_BOOTS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_BOOTS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_HORSE_ARMOR, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HORSE_ARMOR, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_SHOVEL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_SHOVEL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_PICKAXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_PICKAXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_AXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_SWORD, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.IRON_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HOE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Iron, M * 2), new MaterialStack(Materials.Wood, M / 2)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_HELMET, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HELMET, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 5)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_CHESTPLATE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_CHESTPLATE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_LEGGINGS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_LEGGINGS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 7)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_BOOTS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_BOOTS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_HORSE_ARMOR, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HORSE_ARMOR, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_SHOVEL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_SHOVEL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Gold, M), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_PICKAXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_PICKAXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Gold, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_AXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Gold, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_SWORD, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Gold, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.GOLDEN_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HOE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Gold, M * 2), new MaterialStack(Materials.Wood, M / 2)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_HELMET, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HELMET, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 5)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_CHESTPLATE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_CHESTPLATE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_LEGGINGS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_LEGGINGS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 7)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_BOOTS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_BOOTS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_HORSE_ARMOR, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HORSE_ARMOR, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 8)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_SHOVEL, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_SHOVEL, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Diamond, M), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_PICKAXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_PICKAXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Diamond, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_AXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Diamond, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_SWORD, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Diamond, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.DIAMOND_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HOE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Diamond, M * 2), new MaterialStack(Materials.Wood, M / 2)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.CHAINMAIL_HELMET, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_HELMET, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5 / 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.CHAINMAIL_CHESTPLATE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_CHESTPLATE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.CHAINMAIL_LEGGINGS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_LEGGINGS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 7 / 4)));
-        OreDictUnifier.registerOre(new ItemStack(Items.CHAINMAIL_BOOTS, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_BOOTS, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Iron, M)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.WOODEN_SHOVEL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_SHOVEL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M + M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.WOODEN_PICKAXE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_PICKAXE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 3 + M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.WOODEN_AXE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_AXE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 3 + M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.WOODEN_HOE, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_HOE, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2 + M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.WOODEN_SWORD, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_SWORD, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2 + M / 4)));
 
-        OreDictUnifier.registerOre(new ItemStack(Items.STONE_SHOVEL, 1),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_SHOVEL, 1),
                 new ItemMaterialInfo(new MaterialStack(Materials.Stone, M), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.STONE_PICKAXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_PICKAXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.STONE_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_AXE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.STONE_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_HOE, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        OreDictUnifier.registerOre(new ItemStack(Items.STONE_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_SWORD, 1), new ItemMaterialInfo(
                 new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Wood, M / 4)));
 
         WoodRecipeLoader.registerUnificationInfo();

--- a/src/main/java/gregtech/loaders/MaterialInfoLoader.java
+++ b/src/main/java/gregtech/loaders/MaterialInfoLoader.java
@@ -2,8 +2,8 @@ package gregtech.loaders;
 
 import gregtech.api.GregTechAPI;
 import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.*;
 import gregtech.common.blocks.BlockWireCoil.CoilType;
@@ -24,149 +24,155 @@ public class MaterialInfoLoader {
 
     public static void init() {
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.CUPRONICKEL),
-                new ItemMaterialInfo(new MaterialStack(Materials.Cupronickel, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.Cupronickel, M * 8), // double wire
                         new MaterialStack(Materials.Bronze, M * 2), // foil
                         new MaterialStack(Materials.TinAlloy, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.KANTHAL),
-                new ItemMaterialInfo(new MaterialStack(Materials.Kanthal, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.Kanthal, M * 8), // double wire
                         new MaterialStack(Materials.Aluminium, M * 2), // foil
                         new MaterialStack(Materials.Copper, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NICHROME),
-                new ItemMaterialInfo(new MaterialStack(Materials.Nichrome, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.Nichrome, M * 8), // double wire
                         new MaterialStack(Materials.StainlessSteel, M * 2), // foil
                         new MaterialStack(Materials.Aluminium, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.RTM_ALLOY),
-                new ItemMaterialInfo(new MaterialStack(Materials.RTMAlloy, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.RTMAlloy, M * 8), // double wire
                         new MaterialStack(Materials.VanadiumSteel, M * 2), // foil
                         new MaterialStack(Materials.Nichrome, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.HSS_G),
-                new ItemMaterialInfo(new MaterialStack(Materials.HSSG, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.HSSG, M * 8), // double wire
                         new MaterialStack(Materials.TungstenCarbide, M * 2), // foil
                         new MaterialStack(Materials.Tungsten, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.NAQUADAH),
-                new ItemMaterialInfo(new MaterialStack(Materials.Naquadah, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.Naquadah, M * 8), // double wire
                         new MaterialStack(Materials.Osmium, M * 2), // foil
                         new MaterialStack(Materials.TungstenSteel, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TRINIUM),
-                new ItemMaterialInfo(new MaterialStack(Materials.Trinium, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.Trinium, M * 8), // double wire
                         new MaterialStack(Materials.NaquadahEnriched, M * 2), // foil
                         new MaterialStack(Materials.Naquadah, M)) // ingot
         );
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaBlocks.WIRE_COIL.getItemVariant(CoilType.TRITANIUM),
-                new ItemMaterialInfo(new MaterialStack(Materials.Tritanium, M * 8), // double wire
+                new RecyclingData(new MaterialStack(Materials.Tritanium, M * 8), // double wire
                         new MaterialStack(Materials.Naquadria, M * 2), // foil
                         new MaterialStack(Materials.Trinium, M)) // ingot
         );
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[0].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[0].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.WroughtIron, M * 8), // plate
                 new MaterialStack(Materials.RedAlloy, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[1].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[1].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.Steel, M * 8), // plate
                 new MaterialStack(Materials.Tin, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[2].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[2].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.Aluminium, M * 8), // plate
                 new MaterialStack(Materials.Copper, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[3].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[3].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.StainlessSteel, M * 8), // plate
                 new MaterialStack(Materials.Gold, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[4].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[4].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.Titanium, M * 8), // plate
                 new MaterialStack(Materials.Aluminium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[5].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[5].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.TungstenSteel, M * 8), // plate
                 new MaterialStack(Materials.Platinum, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[6].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[6].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.RhodiumPlatedPalladium, M * 8), // plate
                 new MaterialStack(Materials.NiobiumTitanium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[7].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[7].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.NaquadahAlloy, M * 8), // plate
                 new MaterialStack(Materials.VanadiumGallium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[8].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[8].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.Darmstadtium, M * 8), // plate
                 new MaterialStack(Materials.YttriumBariumCuprate, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[9].getStackForm(), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.HULL[9].getStackForm(), new RecyclingData(
                 new MaterialStack(Materials.Neutronium, M * 8), // plate
                 new MaterialStack(Materials.Europium, M), // single cable
                 new MaterialStack(Materials.Rubber, M * 2))); // plate
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[3].getStackForm(), new ItemMaterialInfo(
-                new MaterialStack(Materials.StainlessSteel, M * 8), // plate
-                new MaterialStack(Materials.Gold, M * 2), // single cable
-                new MaterialStack(Materials.Rubber, M * 4), // plate
-                new MaterialStack(Materials.BlackSteel, M * 2), // fine wire
-                new MaterialStack(Materials.SteelMagnetic, M / 2) // rod
-        ));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[3].getStackForm(),
+                new RecyclingData(
+                        new MaterialStack(Materials.StainlessSteel, M * 8), // plate
+                        new MaterialStack(Materials.Gold, M * 2), // single cable
+                        new MaterialStack(Materials.Rubber, M * 4), // plate
+                        new MaterialStack(Materials.BlackSteel, M * 2), // fine wire
+                        new MaterialStack(Materials.SteelMagnetic, M / 2) // rod
+                ));
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[4].getStackForm(), new ItemMaterialInfo(
-                new MaterialStack(Materials.Titanium, M * 8), // plate
-                new MaterialStack(Materials.Aluminium, M * 2), // single cable
-                new MaterialStack(Materials.Rubber, M * 4), // plate
-                new MaterialStack(Materials.TungstenSteel, M * 2), // fine wire
-                new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
-        ));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[4].getStackForm(),
+                new RecyclingData(
+                        new MaterialStack(Materials.Titanium, M * 8), // plate
+                        new MaterialStack(Materials.Aluminium, M * 2), // single cable
+                        new MaterialStack(Materials.Rubber, M * 4), // plate
+                        new MaterialStack(Materials.TungstenSteel, M * 2), // fine wire
+                        new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
+                ));
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[5].getStackForm(), new ItemMaterialInfo(
-                new MaterialStack(Materials.TungstenSteel, M * 8), // plate
-                new MaterialStack(Materials.Platinum, M), // single cable
-                new MaterialStack(Materials.Tungsten, M), // single cable
-                new MaterialStack(Materials.Rubber, M * 4), // plate
-                new MaterialStack(Materials.Iridium, M * 2), // fine wire
-                new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
-        ));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_INPUT_HATCH[5].getStackForm(),
+                new RecyclingData(
+                        new MaterialStack(Materials.TungstenSteel, M * 8), // plate
+                        new MaterialStack(Materials.Platinum, M), // single cable
+                        new MaterialStack(Materials.Tungsten, M), // single cable
+                        new MaterialStack(Materials.Rubber, M * 4), // plate
+                        new MaterialStack(Materials.Iridium, M * 2), // fine wire
+                        new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
+                ));
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[3].getStackForm(), new ItemMaterialInfo(
-                new MaterialStack(Materials.StainlessSteel, M * 8), // plate
-                new MaterialStack(Materials.Gold, 3 * M), // single cable + spring
-                new MaterialStack(Materials.Rubber, M * 2), // plate
-                new MaterialStack(Materials.BlackSteel, M * 2), // fine wire
-                new MaterialStack(Materials.SteelMagnetic, M / 2) // rod
-        ));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[3].getStackForm(),
+                new RecyclingData(
+                        new MaterialStack(Materials.StainlessSteel, M * 8), // plate
+                        new MaterialStack(Materials.Gold, 3 * M), // single cable + spring
+                        new MaterialStack(Materials.Rubber, M * 2), // plate
+                        new MaterialStack(Materials.BlackSteel, M * 2), // fine wire
+                        new MaterialStack(Materials.SteelMagnetic, M / 2) // rod
+                ));
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[4].getStackForm(), new ItemMaterialInfo(
-                new MaterialStack(Materials.Titanium, M * 8), // plate
-                new MaterialStack(Materials.Aluminium, 3 * M), // single cable + spring
-                new MaterialStack(Materials.Rubber, M * 2), // plate
-                new MaterialStack(Materials.TungstenSteel, M * 2), // fine wire
-                new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
-        ));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[4].getStackForm(),
+                new RecyclingData(
+                        new MaterialStack(Materials.Titanium, M * 8), // plate
+                        new MaterialStack(Materials.Aluminium, 3 * M), // single cable + spring
+                        new MaterialStack(Materials.Rubber, M * 2), // plate
+                        new MaterialStack(Materials.TungstenSteel, M * 2), // fine wire
+                        new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
+                ));
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[5].getStackForm(), new ItemMaterialInfo(
-                new MaterialStack(Materials.TungstenSteel, M * 8), // plate
-                new MaterialStack(Materials.Platinum, M), // single cable
-                new MaterialStack(Materials.Tungsten, M * 2), // spring
-                new MaterialStack(Materials.Rubber, M * 2), // plate
-                new MaterialStack(Materials.Iridium, M * 2), // fine wire
-                new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
-        ));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(MetaTileEntities.ENERGY_OUTPUT_HATCH[5].getStackForm(),
+                new RecyclingData(
+                        new MaterialStack(Materials.TungstenSteel, M * 8), // plate
+                        new MaterialStack(Materials.Platinum, M), // single cable
+                        new MaterialStack(Materials.Tungsten, M * 2), // spring
+                        new MaterialStack(Materials.Rubber, M * 2), // plate
+                        new MaterialStack(Materials.Iridium, M * 2), // fine wire
+                        new MaterialStack(Materials.NeodymiumMagnetic, M / 2) // rod
+                ));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.CLEANROOM_CASING.getItemVariant(BlockCleanroomCasing.CasingType.PLASCRETE),
-                new ItemMaterialInfo(
+                new RecyclingData(
                         new MaterialStack(Materials.Steel, (M * 2) / ConfigHolder.recipes.casingsPerCraft), // frame /
                                                                                                             // config
                         new MaterialStack(Materials.Polyethylene, (M * 6) / ConfigHolder.recipes.casingsPerCraft), // 6
@@ -179,7 +185,7 @@ public class MaterialInfoLoader {
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.TRANSPARENT_CASING.getItemVariant(BlockGlassCasing.CasingType.CLEANROOM_GLASS),
-                new ItemMaterialInfo(
+                new RecyclingData(
                         new MaterialStack(Materials.Steel, (M * 2) / ConfigHolder.recipes.casingsPerCraft), // frame /
                                                                                                             // config
                         new MaterialStack(Materials.Polyethylene, (M * 6) / ConfigHolder.recipes.casingsPerCraft), // 6
@@ -191,7 +197,7 @@ public class MaterialInfoLoader {
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.METAL_CASING.getItemVariant(BlockMetalCasing.MetalCasingType.PTFE_INERT_CASING),
-                new ItemMaterialInfo(
+                new RecyclingData(
                         new MaterialStack(Materials.Steel, (M * 8) / ConfigHolder.recipes.casingsPerCraft), // casing /
                                                                                                             // config
                         new MaterialStack(Materials.Polytetrafluoroethylene, M * 3 / 2) // 1.5 ingots PTFE (fluid in
@@ -200,387 +206,403 @@ public class MaterialInfoLoader {
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.METAL_CASING.getItemVariant(BlockMetalCasing.MetalCasingType.PRIMITIVE_BRICKS),
-                new ItemMaterialInfo(new MaterialStack(Materials.Fireclay, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Fireclay, M * 4)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.BATTERY_BLOCK.getItemVariant(BlockBatteryPart.BatteryPartType.EMPTY_TIER_I),
-                new ItemMaterialInfo(
+                new RecyclingData(
                         new MaterialStack(Materials.Ultimet, M * 2 + M * 6 + (M / 9 * 24)))); // frame + 6 plates + 24
                                                                                               // screws
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.BATTERY_BLOCK.getItemVariant(BlockBatteryPart.BatteryPartType.EMPTY_TIER_II),
-                new ItemMaterialInfo(
+                new RecyclingData(
                         new MaterialStack(Materials.Ruridit, M * 2 + M * 6 + (M / 9 * 24)))); // frame + 6 plates + 24
                                                                                               // screws
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
                 MetaBlocks.BATTERY_BLOCK.getItemVariant(BlockBatteryPart.BatteryPartType.EMPTY_TIER_III),
-                new ItemMaterialInfo(
+                new RecyclingData(
                         new MaterialStack(Materials.Neutronium, M * 2 + M * 6 + (M / 9 * 24)))); // frame + 6 plates +
                                                                                                  // 24 screws
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(LONG_DIST_ITEM_ENDPOINT.getStackForm(),
-                new ItemMaterialInfo(new MaterialStack(Tin, M * 6), // large pipe
+                new RecyclingData(new MaterialStack(Tin, M * 6), // large pipe
                         new MaterialStack(Steel, M * 8))); // 4 plates + 1 gear
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(LONG_DIST_FLUID_ENDPOINT.getStackForm(),
-                new ItemMaterialInfo(new MaterialStack(Bronze, M * 6), // large pipe
+                new RecyclingData(new MaterialStack(Bronze, M * 6), // large pipe
                         new MaterialStack(Steel, M * 8))); // 4 plates + 1 gear
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(MetaBlocks.LD_ITEM_PIPE),
-                new ItemMaterialInfo(new MaterialStack(Tin, M * 6 * 2 / 64), // 2 large pipe / 64
+                new RecyclingData(new MaterialStack(Tin, M * 6 * 2 / 64), // 2 large pipe / 64
                         new MaterialStack(Steel, M * 8 / 64))); // 8 steel plate / 64
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(MetaBlocks.LD_FLUID_PIPE),
-                new ItemMaterialInfo(new MaterialStack(Bronze, M * 6 * 2 / 64), // 2 large pipe / 64
+                new RecyclingData(new MaterialStack(Bronze, M * 6 * 2 / 64), // 2 large pipe / 64
                         new MaterialStack(Steel, M * 8 / 64))); // 8 steel plate / 64
 
         if (ConfigHolder.recipes.hardAdvancedIronRecipes) {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_DOOR, 1), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_DOOR, 1), new RecyclingData(
                     new MaterialStack(Materials.Iron, M * 4 + (M * 3 / 16)), // 4 iron plates + 1 iron bars
                     new MaterialStack(Materials.Steel, M / 9))); // tiny steel dust
         } else {
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_DOOR, 1),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
+                    new RecyclingData(new MaterialStack(Materials.Iron, M * 2)));
         }
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
+                new RecyclingData(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.SANDSTONE_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
+                new RecyclingData(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.RED_SANDSTONE_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
+                new RecyclingData(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_BRICK_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
+                new RecyclingData(new MaterialStack(Materials.Stone, (3 * M) / 2))); // dust small
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.QUARTZ_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.NetherQuartz, M * 6))); // dust
+                new RecyclingData(new MaterialStack(Materials.NetherQuartz, M * 6))); // dust
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BRICK_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Brick, M * 6))); // dust
+                new RecyclingData(new MaterialStack(Materials.Brick, M * 6))); // dust
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NETHER_BRICK_STAIRS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Netherrack, M * 6))); // dust
+                new RecyclingData(new MaterialStack(Materials.Netherrack, M * 6))); // dust
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 0),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 2),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 3),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 4),
-                new ItemMaterialInfo(new MaterialStack(Materials.Brick, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Brick, M * 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 5),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 6),
-                new ItemMaterialInfo(new MaterialStack(Materials.Netherrack, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Netherrack, M * 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_SLAB, 1, 7),
-                new ItemMaterialInfo(new MaterialStack(Materials.NetherQuartz, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.NetherQuartz, M * 2)));
 
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LEVER, 1, W), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LEVER, 1, W), new RecyclingData(
                 new MaterialStack(Materials.Stone, M / 9), new MaterialStack(Materials.Wood, 1814400L)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_BUTTON, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M / 9)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M / 9)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_BUTTON, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M / 9)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.REDSTONE_TORCH, 1, W), new ItemMaterialInfo(
-                new MaterialStack(Materials.Wood, M / 2), new MaterialStack(Materials.Redstone, M)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M / 9)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.REDSTONE_TORCH, 1, W),
+                new RecyclingData(
+                        new MaterialStack(Materials.Wood, M / 2), new MaterialStack(Materials.Redstone, M)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.RAIL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 3 / 16)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 3 / 16)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.GOLDEN_RAIL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Gold, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DETECTOR_RAIL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ACTIVATOR_RAIL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M / 2)));
 
         if (ConfigHolder.recipes.hardRedstoneRecipes) {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Wood, M), new MaterialStack(Materials.Iron, M / 2)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Stone, M), new MaterialStack(Materials.Iron, M * 6 / 8)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Gold, M), new MaterialStack(Materials.Steel, M)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Iron, M), new MaterialStack(Materials.Steel, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Wood, M), new MaterialStack(Materials.Iron, M / 2)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Stone, M), new MaterialStack(Materials.Iron, M * 6 / 8)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
+                    new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
+                    new RecyclingData(new MaterialStack(Materials.Gold, M), new MaterialStack(Materials.Steel, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
+                    new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
+                    new RecyclingData(new MaterialStack(Materials.Iron, M), new MaterialStack(Materials.Steel, M)));
         } else {
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.WOODEN_PRESSURE_PLATE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
+                    new RecyclingData(new MaterialStack(Materials.Wood, M * 2)));
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONE_PRESSURE_PLATE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 2)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 2)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
+                    new RecyclingData(new MaterialStack(Materials.Stone, M * 2)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
+                    new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, 1, W),
+                    new RecyclingData(new MaterialStack(Materials.Gold, M * 2)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(
+                    new ItemStack(Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 1, W),
+                    new RecyclingData(new MaterialStack(Materials.Iron, M * 2)));
         }
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WHEAT, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wheat, M)));
+                new RecyclingData(new MaterialStack(Materials.Wheat, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HAY_BLOCK, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wheat, M * 9)));
+                new RecyclingData(new MaterialStack(Materials.Wheat, M * 9)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.SNOWBALL, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Water, M / 4)));
+                new RecyclingData(new MaterialStack(Materials.Water, M / 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.SNOW, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Water, M)));
+                new RecyclingData(new MaterialStack(Materials.Water, M)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.PACKED_ICE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Ice, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Ice, M * 2)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.BOOK, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));
+                new RecyclingData(new MaterialStack(Materials.Paper, M * 3)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WRITABLE_BOOK, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));
+                new RecyclingData(new MaterialStack(Materials.Paper, M * 3)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.ENCHANTED_BOOK, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Paper, M * 3)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BOOKSHELF, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Paper, M * 3)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BOOKSHELF, 1), new RecyclingData(
                 new MaterialStack(Materials.Paper, M * 9), new MaterialStack(Materials.Wood, M * 6)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_APPLE, 1, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 72))); // block
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 72))); // block
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_APPLE, 1, 0),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 8))); // ingot
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 8))); // ingot
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.MINECART, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHEST_MINECART, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 5)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHEST_MINECART, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 5), new MaterialStack(Materials.Wood, M * 8)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.FURNACE_MINECART, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.FURNACE_MINECART, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 5), new MaterialStack(Materials.Stone, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.TNT_MINECART, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.HOPPER_MINECART, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 5)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.HOPPER_MINECART, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 10), new MaterialStack(Materials.Wood, M * 8)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CAULDRON, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 7)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 7)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.IRON_BARS, 8, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 3 / 16)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 3 / 16)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.IRON_TRAPDOOR, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.BUCKET, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 3)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 3)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ANVIL, 1, 0),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 31)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 31)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ANVIL, 1, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 22)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 22)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ANVIL, 1, 2),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 13)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HOPPER, 1, W), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 13)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HOPPER, 1, W), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 5), new MaterialStack(Materials.Wood, M * 8)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GLASS_BOTTLE),
-                new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
+                new RecyclingData(new MaterialStack(Materials.Glass, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STAINED_GLASS, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
+                new RecyclingData(new MaterialStack(Materials.Glass, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.GLASS, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Glass, M)));
+                new RecyclingData(new MaterialStack(Materials.Glass, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STAINED_GLASS_PANE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 3))); // dust tiny
+                new RecyclingData(new MaterialStack(Materials.Glass, M / 3))); // dust tiny
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.GLASS_PANE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Glass, M / 3))); // dust tiny
+                new RecyclingData(new MaterialStack(Materials.Glass, M / 3))); // dust tiny
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.FLOWER_POT, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Brick, M * 3)));
+                new RecyclingData(new MaterialStack(Materials.Brick, M * 3)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.PAINTING, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.ITEM_FRAME, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.COBBLESTONE_WALL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.END_CRYSTAL, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Stone, M)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.END_CRYSTAL, 1), new RecyclingData(
                 new MaterialStack(Materials.Glass, M * 7), new MaterialStack(Materials.EnderEye, M)));
 
         if (ConfigHolder.recipes.hardToolArmorRecipes) {
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CLOCK, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Gold, (13 * M) / 8), // M + ring + 3 * bolt
+                    new RecyclingData(new MaterialStack(Materials.Gold, (13 * M) / 8), // M + ring + 3 * bolt
                             new MaterialStack(Materials.Redstone, M)));
 
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.COMPASS, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.COMPASS, 1, W), new RecyclingData(
                     new MaterialStack(Materials.Iron, (4 * M) / 3), // M + 3*screw
                     new MaterialStack(Materials.RedAlloy, M / 8), // bolt
                     new MaterialStack(Materials.Zinc, M / 4))); // ring
         } else {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CLOCK, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CLOCK, 1, W), new RecyclingData(
                     new MaterialStack(Materials.Gold, M * 4), new MaterialStack(Materials.Redstone, M)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.COMPASS, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.COMPASS, 1, W), new RecyclingData(
                     new MaterialStack(Materials.Iron, M * 4), new MaterialStack(Materials.Redstone, M)));
         }
 
         if (ConfigHolder.recipes.hardMiscRecipes) {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BEACON, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BEACON, 1, W), new RecyclingData(
                     new MaterialStack(Materials.NetherStar, (7 * M) / 4), // M + lens
                     new MaterialStack(Materials.Obsidian, M * 3),
                     new MaterialStack(Materials.Glass, M * 4)));
 
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Diamond, M * 4),
-                    new MaterialStack(Materials.Obsidian, M * 3),
-                    new MaterialStack(Materials.Paper, M * 9)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Diamond, M * 4),
+                            new MaterialStack(Materials.Obsidian, M * 3),
+                            new MaterialStack(Materials.Paper, M * 9)));
 
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Wood, M * 8), // chest
-                    new MaterialStack(Materials.Obsidian, M * 9 * 6), // 6 dense plates
-                    new MaterialStack(Materials.EnderEye, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENDER_CHEST, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Wood, M * 8), // chest
+                            new MaterialStack(Materials.Obsidian, M * 9 * 6), // 6 dense plates
+                            new MaterialStack(Materials.EnderEye, M)));
         } else {
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.BEACON, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.NetherStar, M),
+                    new RecyclingData(new MaterialStack(Materials.NetherStar, M),
                             new MaterialStack(Materials.Obsidian, M * 3), new MaterialStack(Materials.Glass, M * 5)));
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENCHANTING_TABLE, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 2),
+                    new RecyclingData(new MaterialStack(Materials.Diamond, M * 2),
                             new MaterialStack(Materials.Obsidian, M * 4), new MaterialStack(Materials.Paper, M * 3)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENDER_CHEST, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.EnderEye, M), new MaterialStack(Materials.Obsidian, M * 8)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.ENDER_CHEST, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.EnderEye, M), new MaterialStack(Materials.Obsidian, M * 8)));
         }
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.FURNACE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 8)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STONEBRICK, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.COBBLESTONE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.MOSSY_COBBLESTONE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M)));
+                new RecyclingData(new MaterialStack(Materials.Stone, M)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.LADDER, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.BOWL, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M / 4)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M / 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.SIGN, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.CHEST, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 8)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.TRAPPED_CHEST, 1, W), new ItemMaterialInfo(
-                new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Iron, M / 2))); // ring
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 8)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.TRAPPED_CHEST, 1, W),
+                new RecyclingData(
+                        new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Iron, M / 2))); // ring
 
         if (ConfigHolder.recipes.hardMiscRecipes) {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NOTEBLOCK, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.RedAlloy, M / 2))); // rod
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.JUKEBOX, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NOTEBLOCK, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.RedAlloy, M / 2))); // rod
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.JUKEBOX, 1, W), new RecyclingData(
                     new MaterialStack(Materials.Diamond, M / 8), // bolt
                     new MaterialStack(Materials.Iron, (17 * M) / 4), // gear + ring
                     new MaterialStack(Materials.RedAlloy, M)));
         } else {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NOTEBLOCK, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Redstone, M)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.JUKEBOX, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.NOTEBLOCK, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Redstone, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.JUKEBOX, 1, W), new RecyclingData(
                     new MaterialStack(Materials.Wood, M * 8), new MaterialStack(Materials.Diamond, M)));
         }
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.REDSTONE_LAMP, 1, W), new ItemMaterialInfo(
-                new MaterialStack(Materials.Glowstone, M * 4), new MaterialStack(Materials.Redstone, M * 4))); // dust
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.REDSTONE_LAMP, 1, W),
+                new RecyclingData(
+                        new MaterialStack(Materials.Glowstone, M * 4), new MaterialStack(Materials.Redstone, M * 4))); // dust
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.CRAFTING_TABLE, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.PISTON, 1, W), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 2)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.PISTON, 1, W), new RecyclingData(
                 new MaterialStack(Materials.Stone, M * 4), new MaterialStack(Materials.Wood, M * 3)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STICKY_PISTON, 1, W), new ItemMaterialInfo(
-                new MaterialStack(Materials.Stone, M * 4), new MaterialStack(Materials.Wood, M * 3)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STICKY_PISTON, 1, W),
+                new RecyclingData(
+                        new MaterialStack(Materials.Stone, M * 4), new MaterialStack(Materials.Wood, M * 3)));
         if (ConfigHolder.recipes.hardRedstoneRecipes) {
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DISPENSER, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 2),
+                    new RecyclingData(new MaterialStack(Materials.Stone, M * 2),
                             new MaterialStack(Materials.RedAlloy, M / 2),
                             new MaterialStack(Materials.Iron, M * 4 + M / 4)));
             GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DROPPER, 1, W),
-                    new ItemMaterialInfo(new MaterialStack(Materials.Stone, M * 2),
+                    new RecyclingData(new MaterialStack(Materials.Stone, M * 2),
                             new MaterialStack(Materials.RedAlloy, M / 2),
                             new MaterialStack(Materials.Iron, M * 2 + M * 3 / 4)));
         } else {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DISPENSER, 1, W), new ItemMaterialInfo(
-                    new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Redstone, M)));
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DROPPER, 1, W), new ItemMaterialInfo(
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DISPENSER, 1, W),
+                    new RecyclingData(
+                            new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Redstone, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.DROPPER, 1, W), new RecyclingData(
                     new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Redstone, M)));
         }
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HELMET, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 5)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_CHESTPLATE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 8)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_LEGGINGS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 7)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 7)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_BOOTS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HORSE_ARMOR, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 8)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_SHOVEL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_PICKAXE, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Iron, M), new MaterialStack(Materials.Wood, M / 2)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_PICKAXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_AXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_SWORD, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.IRON_HOE, 1), new RecyclingData(
                 new MaterialStack(Materials.Iron, M * 2), new MaterialStack(Materials.Wood, M / 2)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HELMET, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 5)));
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 5)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_CHESTPLATE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 8)));
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_LEGGINGS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 7)));
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 7)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_BOOTS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HORSE_ARMOR, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M * 8)));
+                new RecyclingData(new MaterialStack(Materials.Gold, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_SHOVEL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Gold, M), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_PICKAXE, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Gold, M), new MaterialStack(Materials.Wood, M / 2)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_PICKAXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Gold, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_AXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Gold, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_SWORD, 1), new RecyclingData(
                 new MaterialStack(Materials.Gold, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.GOLDEN_HOE, 1), new RecyclingData(
                 new MaterialStack(Materials.Gold, M * 2), new MaterialStack(Materials.Wood, M / 2)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HELMET, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 5)));
+                new RecyclingData(new MaterialStack(Materials.Diamond, M * 5)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_CHESTPLATE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 8)));
+                new RecyclingData(new MaterialStack(Materials.Diamond, M * 8)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_LEGGINGS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 7)));
+                new RecyclingData(new MaterialStack(Materials.Diamond, M * 7)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_BOOTS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Diamond, M * 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HORSE_ARMOR, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Diamond, M * 8)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_SHOVEL, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Diamond, M * 8)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_SHOVEL, 1), new RecyclingData(
                 new MaterialStack(Materials.Diamond, M), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_PICKAXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_PICKAXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Diamond, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_AXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Diamond, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_SWORD, 1), new RecyclingData(
                 new MaterialStack(Materials.Diamond, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.DIAMOND_HOE, 1), new RecyclingData(
                 new MaterialStack(Materials.Diamond, M * 2), new MaterialStack(Materials.Wood, M / 2)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_HELMET, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 5 / 4)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 5 / 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_CHESTPLATE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 2)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_LEGGINGS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M * 7 / 4)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M * 7 / 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.CHAINMAIL_BOOTS, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Iron, M)));
+                new RecyclingData(new MaterialStack(Materials.Iron, M)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_SHOVEL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M + M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M + M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_PICKAXE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 3 + M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 3 + M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_AXE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 3 + M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 3 + M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_HOE, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2 + M / 2)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 2 + M / 2)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.WOODEN_SWORD, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Wood, M * 2 + M / 4)));
+                new RecyclingData(new MaterialStack(Materials.Wood, M * 2 + M / 4)));
 
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_SHOVEL, 1),
-                new ItemMaterialInfo(new MaterialStack(Materials.Stone, M), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_PICKAXE, 1), new ItemMaterialInfo(
+                new RecyclingData(new MaterialStack(Materials.Stone, M), new MaterialStack(Materials.Wood, M / 2)));
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_PICKAXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Stone, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_AXE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_AXE, 1), new RecyclingData(
                 new MaterialStack(Materials.Stone, M * 3), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_HOE, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_HOE, 1), new RecyclingData(
                 new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Wood, M / 2)));
-        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_SWORD, 1), new ItemMaterialInfo(
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Items.STONE_SWORD, 1), new RecyclingData(
                 new MaterialStack(Materials.Stone, M * 2), new MaterialStack(Materials.Wood, M / 4)));
 
         WoodRecipeLoader.registerUnificationInfo();

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -7,8 +7,8 @@ import gregtech.api.unification.material.MarkerMaterials.Color;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTLog;
 import gregtech.common.blocks.MetaBlocks;
@@ -43,9 +43,9 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Items.CLAY_BALL), OrePrefix.ingot, Materials.Clay);
         OreDictUnifier.registerOre(new ItemStack(Items.FLINT), OrePrefix.gem, Materials.Flint);
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HARDENED_CLAY, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Clay, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Clay, M * 4)));
         GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, W),
-                new ItemMaterialInfo(new MaterialStack(Materials.Clay, M * 4)));
+                new RecyclingData(new MaterialStack(Materials.Clay, M * 4)));
 
         for (Material material : new Material[] { Materials.Wood, Materials.TreatedWood }) {
             for (ItemStack woodPlateStack : OreDictUnifier.getAll(new UnificationEntry(OrePrefix.plate, material))) {

--- a/src/main/java/gregtech/loaders/OreDictionaryLoader.java
+++ b/src/main/java/gregtech/loaders/OreDictionaryLoader.java
@@ -1,5 +1,6 @@
 package gregtech.loaders;
 
+import gregtech.api.GregTechAPI;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.MarkerMaterials;
 import gregtech.api.unification.material.MarkerMaterials.Color;
@@ -41,9 +42,9 @@ public class OreDictionaryLoader {
         OreDictUnifier.registerOre(new ItemStack(Blocks.BRICK_BLOCK), OrePrefix.block, Materials.Brick);
         OreDictUnifier.registerOre(new ItemStack(Items.CLAY_BALL), OrePrefix.ingot, Materials.Clay);
         OreDictUnifier.registerOre(new ItemStack(Items.FLINT), OrePrefix.gem, Materials.Flint);
-        OreDictUnifier.registerOre(new ItemStack(Blocks.HARDENED_CLAY, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.HARDENED_CLAY, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Clay, M * 4)));
-        OreDictUnifier.registerOre(new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, W),
+        GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, W),
                 new ItemMaterialInfo(new MaterialStack(Materials.Clay, M * 4)));
 
         for (Material material : new Material[] { Materials.Wood, Materials.TreatedWood }) {

--- a/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/RecyclingRecipes.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
@@ -15,7 +16,6 @@ import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.BlastProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTUtility;
@@ -48,12 +48,9 @@ public class RecyclingRecipes {
     // TODO - Work on durations and EUt's
 
     public static void init() {
-        for (Entry<ItemStack, ItemMaterialInfo> entry : OreDictUnifier.getAllItemInfos()) {
-            ItemStack itemStack = entry.getKey();
-            ItemMaterialInfo materialInfo = entry.getValue();
-            List<MaterialStack> materialStacks = new ArrayList<>(materialInfo.getMaterials());
-            registerRecyclingRecipes(itemStack, materialStacks, false, null);
-        }
+        GregTechAPI.RECYCLING_MANAGER.iterate((itemAndMetadata, materialInfo) -> {
+            registerRecyclingRecipes(itemAndMetadata.toItemStack(), materialInfo.getMaterials(), false, null);
+        });
     }
 
     public static void registerRecyclingRecipes(ItemStack input, List<MaterialStack> components,

--- a/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
@@ -1,6 +1,7 @@
 package gregtech.loaders.recipe;
 
 import gregtech.api.GTValues;
+import gregtech.api.GregTechAPI;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
@@ -171,7 +172,7 @@ public class WoodRecipeLoader {
             OreDictUnifier.registerOre(entry.planks, plank, entry.material);
         }
         if (entry.addPlanksUnificationInfo) {
-            OreDictUnifier.registerOre(entry.planks, new ItemMaterialInfo(new MaterialStack(entry.material, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.planks, new ItemMaterialInfo(new MaterialStack(entry.material, M)));
         }
 
         if (!entry.door.isEmpty()) {
@@ -179,7 +180,7 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.door, door, entry.material);
             }
             if (entry.addDoorsUnificationInfo) {
-                OreDictUnifier.registerOre(entry.door, ConfigHolder.recipes.hardWoodRecipes ?
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.door, ConfigHolder.recipes.hardWoodRecipes ?
                         new ItemMaterialInfo(new MaterialStack(entry.material, M * 2),
                                 new MaterialStack(Materials.Iron, M / 9)) : // screw
                         new ItemMaterialInfo(new MaterialStack(entry.material, M * 2)));
@@ -191,7 +192,7 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.slab, slab, entry.material);
             }
             if (entry.addSlabsUnificationInfo) {
-                OreDictUnifier.registerOre(entry.slab, new ItemMaterialInfo(new MaterialStack(entry.material, M / 2)));
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.slab, new ItemMaterialInfo(new MaterialStack(entry.material, M / 2)));
             }
         }
 
@@ -200,7 +201,7 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.fence, fence, entry.material);
             }
             if (entry.addFencesUnificationInfo) {
-                OreDictUnifier.registerOre(entry.fence, new ItemMaterialInfo(new MaterialStack(entry.material, M)));
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.fence, new ItemMaterialInfo(new MaterialStack(entry.material, M)));
             }
         }
 
@@ -209,7 +210,7 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.fenceGate, fenceGate, entry.material);
             }
             if (entry.addFenceGatesUnificationInfo) {
-                OreDictUnifier.registerOre(entry.fenceGate,
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.fenceGate,
                         new ItemMaterialInfo(new MaterialStack(entry.material, M * 3)));
             }
         }
@@ -219,13 +220,13 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.stairs, stair, entry.material);
             }
             if (entry.addStairsUnificationInfo) {
-                OreDictUnifier.registerOre(entry.stairs,
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.stairs,
                         new ItemMaterialInfo(new MaterialStack(entry.material, (3 * M) / 2)));
             }
         }
 
         if (!entry.boat.isEmpty() && entry.addBoatsUnificationInfo) {
-            OreDictUnifier.registerOre(entry.boat, new ItemMaterialInfo(new MaterialStack(entry.material, M * 5)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.boat, new ItemMaterialInfo(new MaterialStack(entry.material, M * 5)));
         }
     }
 

--- a/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodRecipeLoader.java
@@ -6,8 +6,8 @@ import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.unification.stack.ItemMaterialInfo;
 import gregtech.api.unification.stack.MaterialStack;
+import gregtech.api.unification.stack.RecyclingData;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
@@ -172,7 +172,8 @@ public class WoodRecipeLoader {
             OreDictUnifier.registerOre(entry.planks, plank, entry.material);
         }
         if (entry.addPlanksUnificationInfo) {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.planks, new ItemMaterialInfo(new MaterialStack(entry.material, M)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.planks,
+                    new RecyclingData(new MaterialStack(entry.material, M)));
         }
 
         if (!entry.door.isEmpty()) {
@@ -181,9 +182,9 @@ public class WoodRecipeLoader {
             }
             if (entry.addDoorsUnificationInfo) {
                 GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.door, ConfigHolder.recipes.hardWoodRecipes ?
-                        new ItemMaterialInfo(new MaterialStack(entry.material, M * 2),
+                        new RecyclingData(new MaterialStack(entry.material, M * 2),
                                 new MaterialStack(Materials.Iron, M / 9)) : // screw
-                        new ItemMaterialInfo(new MaterialStack(entry.material, M * 2)));
+                        new RecyclingData(new MaterialStack(entry.material, M * 2)));
             }
         }
 
@@ -192,7 +193,8 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.slab, slab, entry.material);
             }
             if (entry.addSlabsUnificationInfo) {
-                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.slab, new ItemMaterialInfo(new MaterialStack(entry.material, M / 2)));
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.slab,
+                        new RecyclingData(new MaterialStack(entry.material, M / 2)));
             }
         }
 
@@ -201,7 +203,8 @@ public class WoodRecipeLoader {
                 OreDictUnifier.registerOre(entry.fence, fence, entry.material);
             }
             if (entry.addFencesUnificationInfo) {
-                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.fence, new ItemMaterialInfo(new MaterialStack(entry.material, M)));
+                GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.fence,
+                        new RecyclingData(new MaterialStack(entry.material, M)));
             }
         }
 
@@ -211,7 +214,7 @@ public class WoodRecipeLoader {
             }
             if (entry.addFenceGatesUnificationInfo) {
                 GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.fenceGate,
-                        new ItemMaterialInfo(new MaterialStack(entry.material, M * 3)));
+                        new RecyclingData(new MaterialStack(entry.material, M * 3)));
             }
         }
 
@@ -221,12 +224,13 @@ public class WoodRecipeLoader {
             }
             if (entry.addStairsUnificationInfo) {
                 GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.stairs,
-                        new ItemMaterialInfo(new MaterialStack(entry.material, (3 * M) / 2)));
+                        new RecyclingData(new MaterialStack(entry.material, (3 * M) / 2)));
             }
         }
 
         if (!entry.boat.isEmpty() && entry.addBoatsUnificationInfo) {
-            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.boat, new ItemMaterialInfo(new MaterialStack(entry.material, M * 5)));
+            GregTechAPI.RECYCLING_MANAGER.registerRecyclingData(entry.boat,
+                    new RecyclingData(new MaterialStack(entry.material, M * 5)));
         }
     }
 


### PR DESCRIPTION
## What
Moves Recycling code out of OreDictUnifier, and improves some of the related code.

`OreDictUnifier.getMaterial()` is only ever used with the intention that the ItemStack passed in is a "material item," meaning it is the item form of some material. There is no obvious expectation that it should ever return a material for non-material items that have recycling data, so I changed its behavior to be more intuitive and align with the common expectations. I did not notice any obvious change to any of our recycling recipes, and I do not expect any issues in the other places it's used.

## Outcome
Less confusion with `OreDictUnifier.registerOre()` sometimes being used for recycling and other times being for Ore Dictionary entries.
