### PR TITLE
Fix JEI Highlight for Custom MUI2 Widgets

### DIFF
--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -28,9 +28,9 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.vec.Matrix4;
 import com.cleanroommc.modularui.api.MCHelper;
+import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
-import com.cleanroommc.modularui.widget.Widget;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
@@ -716,11 +716,13 @@ public class RenderUtil {
         return getTextureMap().getMissingSprite();
     }
 
-    public static <T extends Widget<?> & JeiGhostIngredientSlot<?>> void handleJeiGhostHighlight(T slot) {
+    public static void handleJeiGhostHighlight(IWidget slot) {
         if (!Mods.JustEnoughItems.isModLoaded()) return;
-        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(slot)) {
+        if (!(slot instanceof JeiGhostIngredientSlot<?>ingredientSlot)) return;
+        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() ||
+                ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
             GlStateManager.colorMask(true, true, true, false);
-            slot.drawHighlight(slot.getArea(), slot.isHovering());
+            ingredientSlot.drawHighlight(slot.getArea(), slot.isHovering());
             GlStateManager.colorMask(true, true, true, true);
         }
     }

--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -1,6 +1,7 @@
 package gregtech.client.utils;
 
 import gregtech.api.gui.resources.TextureArea;
+import gregtech.api.util.Mods;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -27,6 +28,9 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import codechicken.lib.vec.Matrix4;
 import com.cleanroommc.modularui.api.MCHelper;
+import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
+import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
+import com.cleanroommc.modularui.widget.Widget;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
@@ -710,5 +714,14 @@ public class RenderUtil {
      */
     public static @NotNull TextureAtlasSprite getMissingSprite() {
         return getTextureMap().getMissingSprite();
+    }
+
+    public static <T extends Widget<?> & JeiGhostIngredientSlot<?>> void handleJeiGhostHighlight(T slot) {
+        if (!Mods.JustEnoughItems.isModLoaded()) return;
+        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(slot)) {
+            GlStateManager.colorMask(true, true, true, false);
+            slot.drawHighlight(slot.getArea(), slot.isHovering());
+            GlStateManager.colorMask(true, true, true, true);
+        }
     }
 }

--- a/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
@@ -5,6 +5,7 @@ import gregtech.api.mui.sync.GTFluidSyncHandler;
 import gregtech.api.util.FluidTooltipUtil;
 import gregtech.api.util.GTUtility;
 import gregtech.api.util.LocalizationUtils;
+import gregtech.client.utils.RenderUtil;
 import gregtech.client.utils.TooltipHelper;
 
 import net.minecraft.client.renderer.GlStateManager;
@@ -21,7 +22,6 @@ import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.text.TextRenderer;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
-import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.RichTooltip;
@@ -139,11 +139,7 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
             GlStateManager.colorMask(true, true, true, true);
         }
 
-        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(this)) {
-            GlStateManager.colorMask(true, true, true, false);
-            drawHighlight(getArea(), isHovering());
-            GlStateManager.colorMask(true, true, true, true);
-        }
+        RenderUtil.handleJeiGhostHighlight(this);
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
@@ -21,6 +21,7 @@ import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.text.TextRenderer;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
+import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.RichTooltip;
@@ -135,6 +136,12 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
         if (isHovering()) {
             GlStateManager.colorMask(true, true, true, false);
             GuiDraw.drawRect(1, 1, getArea().w() - 2, getArea().h() - 2, widgetTheme.getSlotHoverColor());
+            GlStateManager.colorMask(true, true, true, true);
+        }
+
+        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(this)) {
+            GlStateManager.colorMask(true, true, true, false);
+            drawHighlight(getArea(), isHovering());
             GlStateManager.colorMask(true, true, true, true);
         }
     }

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
@@ -4,6 +4,7 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.utils.RenderUtil;
 import gregtech.common.metatileentities.storage.CraftingRecipeLogic;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -13,6 +14,7 @@ import com.cleanroommc.modularui.api.widget.IGuiAction;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
+import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
@@ -102,13 +104,19 @@ public class CraftingInputSlot extends Widget<CraftingOutputSlot> implements Int
     @Override
     public void draw(ModularGuiContext context, WidgetTheme widgetTheme) {
         ItemStack itemstack = this.syncHandler.getStack();
-        if (itemstack.isEmpty()) return;
+        if (!itemstack.isEmpty()) {
+            if (!this.hasIngredients) {
+                RenderUtil.renderRect(0, 0, 18, 18, 200, 0x80FF0000);
+            }
 
-        if (!this.hasIngredients) {
-            RenderUtil.renderRect(0, 0, 18, 18, 200, 0x80FF0000);
+            RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
         }
 
-        RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
+        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(this)) {
+            GlStateManager.colorMask(true, true, true, false);
+            drawHighlight(getArea(), isHovering());
+            GlStateManager.colorMask(true, true, true, true);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
@@ -4,7 +4,6 @@ import gregtech.api.util.GTUtility;
 import gregtech.client.utils.RenderUtil;
 import gregtech.common.metatileentities.storage.CraftingRecipeLogic;
 
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -14,7 +13,6 @@ import com.cleanroommc.modularui.api.widget.IGuiAction;
 import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
-import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
@@ -112,11 +110,7 @@ public class CraftingInputSlot extends Widget<CraftingOutputSlot> implements Int
             RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
         }
 
-        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(this)) {
-            GlStateManager.colorMask(true, true, true, false);
-            drawHighlight(getArea(), isHovering());
-            GlStateManager.colorMask(true, true, true, true);
-        }
+        RenderUtil.handleJeiGhostHighlight(this);
     }
 
     @Override


### PR DESCRIPTION
## What
adds JEI's green highlight for `GTFluidSlot` and `CraftingInputSlot`

## Implementation Details
`CraftingInputSlot`'s draw method is slightly re arranged

## Outcome
green highlight