### PR TITLE
Added support for Fluidlogged API for some blocks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,6 +52,7 @@ dependencies {
     compileOnly("curse.maven:journeymap-32274:5172461") // Journeymap 5.7.1p3
     compileOnly("curse.maven:voxelmap-225179:3029445") // VoxelMap 1.9.28
     compileOnly("curse.maven:xaeros-263420:5394758") // Xaero's Minimap 24.2.0
+    compileOnly("maven.modrinth:fluidlogged-api:ArR5epY9") // Fluidlogged API 3.0.6
     compileOnly rfg.deobf("curse.maven:opencomputers-223008:5274236") // OpenComputers 1.8.5+179e1c3
     compileOnly rfg.deobf("curse.maven:hwyla-253449:2568751") // HWYLA 1.8.26-B41
     compileOnly rfg.deobf("curse.maven:baubles-227083:2518667") // Baubles 1.5.2

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -736,7 +736,7 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
     }
 
     @Override
-    protected boolean isInCreativeTab(@NotNull CreativeTabs tab) {
+    public boolean isInCreativeTab(@NotNull CreativeTabs tab) {
         return tab == CreativeTabs.SEARCH ||
                 ArrayUtils.contains(defaultCreativeTabs, tab) ||
                 additionalCreativeTabs.contains(tab);

--- a/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
+++ b/src/main/java/gregtech/api/pipenet/block/BlockPipe.java
@@ -18,6 +18,7 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockFrame;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.items.MetaItems;
+import gregtech.integration.fluidlogged_api.IFluidloggableWrapper;
 import gregtech.integration.ctm.IFacadeWrapper;
 
 import net.minecraft.block.Block;
@@ -66,7 +67,7 @@ import static gregtech.api.metatileentity.MetaTileEntity.FULL_CUBE_COLLISION;
 @SuppressWarnings("deprecation")
 public abstract class BlockPipe<PipeType extends Enum<PipeType> & IPipeType<NodeDataType>, NodeDataType,
         WorldPipeNetType extends WorldPipeNet<NodeDataType, ? extends PipeNet<NodeDataType>>> extends BuiltInRenderBlock
-                               implements ITileEntityProvider, IFacadeWrapper, IBlockAppearance {
+                               implements ITileEntityProvider, IFacadeWrapper, IBlockAppearance, IFluidloggableWrapper {
 
     protected final ThreadLocal<IPipeTile<PipeType, NodeDataType>> tileEntities = new ThreadLocal<>();
 

--- a/src/main/java/gregtech/api/util/Mods.java
+++ b/src/main/java/gregtech/api/util/Mods.java
@@ -114,6 +114,7 @@ public enum Mods {
         public static final String EXTRA_BEES = "extrabees";
         public static final String EXTRA_TREES = "extratrees";
         public static final String EXTRA_UTILITIES2 = "extrautils2";
+        public static final String FLUIDLOGGED_API = "fluidlogged_api";
         public static final String FORESTRY = "forestry";
         public static final String FORESTRY_APICULTURE = "apiculture";
         public static final String FORESTRY_ARBORICULTURE = "arboriculture";

--- a/src/main/java/gregtech/common/blocks/BlockFrame.java
+++ b/src/main/java/gregtech/common/blocks/BlockFrame.java
@@ -16,6 +16,8 @@ import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.properties.PropertyMaterial;
 import gregtech.common.creativetab.GTCreativeTabs;
 
+import gregtech.integration.fluidlogged_api.IFluidloggableWrapper;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.EnumPushReaction;
@@ -47,7 +49,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public abstract class BlockFrame extends BlockMaterialBase {
+public abstract class BlockFrame extends BlockMaterialBase implements IFluidloggableWrapper {
 
     public static final AxisAlignedBB COLLISION_BOX = new AxisAlignedBB(0.05, 0.0, 0.05, 0.95, 1.0, 0.95);
 

--- a/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
+++ b/src/main/java/gregtech/common/pipelike/cable/BlockCable.java
@@ -82,6 +82,11 @@ public class BlockCable extends BlockMaterialPipe<Insulation, WireProperties, Wo
         return insulation.modifyProperties(enabledMaterials.getOrDefault(material, getFallbackType()));
     }
 
+    @Override
+    public boolean isFluidloggable(IBlockState state, World world, BlockPos pos) {
+        return pipeType.thickness < 1.0f;
+    }
+
     @SideOnly(Side.CLIENT)
     @NotNull
     @Override

--- a/src/main/java/gregtech/integration/fluidlogged_api/IFluidloggableWrapper.java
+++ b/src/main/java/gregtech/integration/fluidlogged_api/IFluidloggableWrapper.java
@@ -1,0 +1,10 @@
+package gregtech.integration.fluidlogged_api;
+
+import git.jbredwards.fluidlogged_api.api.block.IFluidloggable;
+
+import gregtech.api.util.Mods;
+
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(modid = Mods.Names.FLUIDLOGGED_API, iface = "git.jbredwards.fluidlogged_api.api.block.IFluidloggable")
+public interface IFluidloggableWrapper extends IFluidloggable {}


### PR DESCRIPTION
## What
Added support for [Fluidlogged API](https://github.com/jbredwards/Fluidlogged-API) ([Modrint](https://modrinth.com/mod/fluidlogged-api)) for Frames and Pipes.

## Additional Information
![2025-05-21_20 38 16](https://github.com/user-attachments/assets/9c310022-3d02-4a4f-b6d3-1cca2e71ac65)


## Potential Compatibility Issues
I had to change method `isInCreativeTab` from `protected` to `public` in `gregtech.api.items.metaitem.MetaItem.java`, otherwise the project didn't compile. I can't explain why.