### PR TITLE
Rebalance small boilers

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamCoalBoiler.java
@@ -32,7 +32,7 @@ public class SteamCoalBoiler extends SteamBoiler implements ICategoryOverride {
 
     @Override
     protected int getBaseSteamOutput() {
-        return isHighPressure ? 300 : 120;
+        return isHighPressure ? 320 : 160;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamLavaBoiler.java
@@ -87,7 +87,7 @@ public class SteamLavaBoiler extends SteamBoiler {
 
     @Override
     protected int getBaseSteamOutput() {
-        return isHighPressure ? 600 : 240;
+        return isHighPressure ? 640 : 320;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamSolarBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamSolarBoiler.java
@@ -26,7 +26,7 @@ public class SteamSolarBoiler extends SteamBoiler {
 
     @Override
     protected int getBaseSteamOutput() {
-        return isHighPressure ? 360 : 120;
+        return isHighPressure ? 320 : 160;
     }
 
     @Override


### PR DESCRIPTION
Re-balances small boilers. The primary goal is making other boilers a better alternative comparison to solar boilers. Additionally, all boilers produce steam in multiples of 8mB/t, meaning that figuring out how many you need to produce LV and MV power is much easier. This makes the early-game experience for new players better.

Solid-Fueled Boilers are universally buffed, they were very inferior to the others. You now need 4 HP or 8 regular for 1A LV.

Liquid-Fueled Boilers are universally buffed, and are now the best boiler variant by maximum output rate. You need 2 HP or 4 regular for 1A LV.

Solar Boilers have also been changed. The regular variant is slightly better and is equivalent to the buffed regular solid boiler. The HP variant has been slightly nerfed and is now equivalent to the buffed HP solid boiler. This means you now need exactly 4 HP boilers for 1A LV instead of 3.55. In turn, this means you now need 16 for 1A MV instead of 14.22.

With liquid boilers being better, and solid boilers being made equivalent to solar, there is less pressure to always do solar boilers because of how much better they were. Players often have a lot of excess creosote, so this change better rewards them for using more interesting and not as free fuel. Solid boilers being equal to solar boilers means that players can use charcoal or coal coke from coke ovens as a supplement to their creosote power if they want, or can use coal directly. The main benefit of buffing solid boilers is that players can choose to spend fuel and not have to keep sleeping nights away more viably. Previously, one would have to spend way more resources to get the amount of power needed out of solid boilers compared to the other variants. Now, they're cheaper solar boilers but cost fuel in exchange.
