### PR TITLE
Fix the JEI green overlay appearing in cheat mode on phantom slots and fix the crafting station slots not having a hover overlay

### DIFF
--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -725,11 +725,13 @@ public class RenderUtil {
      * @return true if the overlay was drawn, false if not
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public static boolean handleJeiGhostHighlight(@NotNull IWidget slot) {
+    public static boolean handleJeiGhostOverlay(@NotNull IWidget slot) {
         if (!Mods.JustEnoughItems.isModLoaded()) return false;
         if (!(slot instanceof JeiGhostIngredientSlot<?>ingredientSlot)) return false;
 
-        if (ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
+        // TODO: replace the first condition with draggingValidIngredient once MUI PR 146 makes it into a release we use
+        if (ingredientSlot.castGhostIngredientIfValid(ModularUIJeiPlugin.getGhostDrag()) != null ||
+                ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
             GlStateManager.colorMask(true, true, true, false);
             ingredientSlot.drawHighlight(slot.getArea(), slot.isHovering());
             GlStateManager.colorMask(true, true, true, true);
@@ -740,13 +742,26 @@ public class RenderUtil {
     }
 
     /**
-     * Draws the gray-ish overlay over a slot when moused over
+     * Draws a gray-ish overlay over the slot 1px inwards from each side. Intended for item slots.
      * 
-     * @param slot the slot on which to draw the overlay
+     * @param slot the slot to draw the overlay above
      */
-    public static void handleSlotOverlay(@NotNull IWidget slot, @NotNull WidgetSlotTheme slotTheme) {
+    public static void drawSlotOverlay(@NotNull IWidget slot, @NotNull WidgetSlotTheme slotTheme) {
         GlStateManager.colorMask(true, true, true, false);
         GuiDraw.drawRect(1, 1, slot.getArea().w() - 2, slot.getArea().h() - 2, slotTheme.getSlotHoverColor());
         GlStateManager.colorMask(true, true, true, true);
+    }
+
+    /**
+     * Handles drawing the green JEI overlay when dragging an item, and if no item is being dragged, the overlay when
+     * mousing over the slot.
+     * 
+     * @param slot      the slot to draw the overlay above
+     * @param slotTheme the theme to get the slot overlay color from
+     */
+    public static void handleSlotOverlays(@NotNull IWidget slot, @NotNull WidgetSlotTheme slotTheme) {
+        if (!handleJeiGhostOverlay(slot) && slot.isHovering()) {
+            drawSlotOverlay(slot, slotTheme);
+        }
     }
 }

--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -729,9 +729,7 @@ public class RenderUtil {
         if (!Mods.JustEnoughItems.isModLoaded()) return false;
         if (!(slot instanceof JeiGhostIngredientSlot<?>ingredientSlot)) return false;
 
-        // TODO: replace the first condition with draggingValidIngredient once MUI PR 146 makes it into a release we use
-        if (ingredientSlot.castGhostIngredientIfValid(ModularUIJeiPlugin.getGhostDrag()) != null ||
-                ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
+        if (ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
             GlStateManager.colorMask(true, true, true, false);
             ingredientSlot.drawHighlight(slot.getArea(), slot.isHovering());
             GlStateManager.colorMask(true, true, true, true);

--- a/src/main/java/gregtech/client/utils/RenderUtil.java
+++ b/src/main/java/gregtech/client/utils/RenderUtil.java
@@ -29,8 +29,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import codechicken.lib.vec.Matrix4;
 import com.cleanroommc.modularui.api.MCHelper;
 import com.cleanroommc.modularui.api.widget.IWidget;
+import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
+import com.cleanroommc.modularui.theme.WidgetSlotTheme;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
@@ -716,14 +718,35 @@ public class RenderUtil {
         return getTextureMap().getMissingSprite();
     }
 
-    public static void handleJeiGhostHighlight(IWidget slot) {
-        if (!Mods.JustEnoughItems.isModLoaded()) return;
-        if (!(slot instanceof JeiGhostIngredientSlot<?>ingredientSlot)) return;
-        if (ModularUIJeiPlugin.hasDraggingGhostIngredient() ||
-                ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
+    /**
+     * Draws the green overlay when a valid ingredient for the slot is hovered over in JEI
+     * 
+     * @param slot the slot to draw the overlay on
+     * @return true if the overlay was drawn, false if not
+     */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean handleJeiGhostHighlight(@NotNull IWidget slot) {
+        if (!Mods.JustEnoughItems.isModLoaded()) return false;
+        if (!(slot instanceof JeiGhostIngredientSlot<?>ingredientSlot)) return false;
+
+        if (ModularUIJeiPlugin.hoveringOverIngredient(ingredientSlot)) {
             GlStateManager.colorMask(true, true, true, false);
             ingredientSlot.drawHighlight(slot.getArea(), slot.isHovering());
             GlStateManager.colorMask(true, true, true, true);
+            return true;
         }
+
+        return false;
+    }
+
+    /**
+     * Draws the gray-ish overlay over a slot when moused over
+     * 
+     * @param slot the slot on which to draw the overlay
+     */
+    public static void handleSlotOverlay(@NotNull IWidget slot, @NotNull WidgetSlotTheme slotTheme) {
+        GlStateManager.colorMask(true, true, true, false);
+        GuiDraw.drawRect(1, 1, slot.getArea().w() - 2, slot.getArea().h() - 2, slotTheme.getSlotHoverColor());
+        GlStateManager.colorMask(true, true, true, true);
     }
 }

--- a/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
@@ -8,7 +8,6 @@ import gregtech.api.util.LocalizationUtils;
 import gregtech.client.utils.RenderUtil;
 import gregtech.client.utils.TooltipHelper;
 
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fluids.FluidStack;
@@ -133,13 +132,9 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
             this.textRenderer.draw(amount);
         }
 
-        if (isHovering()) {
-            GlStateManager.colorMask(true, true, true, false);
-            GuiDraw.drawRect(1, 1, getArea().w() - 2, getArea().h() - 2, widgetTheme.getSlotHoverColor());
-            GlStateManager.colorMask(true, true, true, true);
+        if (!RenderUtil.handleJeiGhostHighlight(this) && isHovering()) {
+            RenderUtil.handleSlotOverlay(this, widgetTheme);
         }
-
-        RenderUtil.handleJeiGhostHighlight(this);
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
@@ -131,8 +131,14 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
             this.textRenderer.setPos(0, 12);
             this.textRenderer.draw(amount);
         }
+    }
 
-        RenderUtil.handleSlotOverlays(this, widgetTheme);
+    @Override
+    public void drawOverlay(ModularGuiContext context, WidgetTheme widgetTheme) {
+        super.drawOverlay(context, widgetTheme);
+        if (widgetTheme instanceof WidgetSlotTheme slotTheme) {
+            RenderUtil.handleSlotOverlays(this, slotTheme);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
@@ -132,9 +132,7 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
             this.textRenderer.draw(amount);
         }
 
-        if (!RenderUtil.handleJeiGhostHighlight(this) && isHovering()) {
-            RenderUtil.handleSlotOverlay(this, widgetTheme);
-        }
+        RenderUtil.handleSlotOverlays(this, widgetTheme);
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
@@ -16,6 +16,7 @@ import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
+import com.cleanroommc.modularui.theme.WidgetSlotTheme;
 import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.value.sync.PanelSyncManager;
 import com.cleanroommc.modularui.value.sync.SyncHandler;
@@ -110,7 +111,11 @@ public class CraftingInputSlot extends Widget<CraftingOutputSlot> implements Int
             RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
         }
 
-        RenderUtil.handleJeiGhostHighlight(this);
+        if (!RenderUtil.handleJeiGhostHighlight(this) && isHovering()) {
+            if (widgetTheme instanceof WidgetSlotTheme slotTheme) {
+                RenderUtil.handleSlotOverlay(this, slotTheme);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
@@ -110,7 +110,11 @@ public class CraftingInputSlot extends Widget<CraftingOutputSlot> implements Int
 
             RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
         }
+    }
 
+    @Override
+    public void drawOverlay(ModularGuiContext context, WidgetTheme widgetTheme) {
+        super.drawOverlay(context, widgetTheme);
         if (widgetTheme instanceof WidgetSlotTheme slotTheme) {
             RenderUtil.handleSlotOverlays(this, slotTheme);
         }

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingInputSlot.java
@@ -111,10 +111,8 @@ public class CraftingInputSlot extends Widget<CraftingOutputSlot> implements Int
             RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
         }
 
-        if (!RenderUtil.handleJeiGhostHighlight(this) && isHovering()) {
-            if (widgetTheme instanceof WidgetSlotTheme slotTheme) {
-                RenderUtil.handleSlotOverlay(this, slotTheme);
-            }
+        if (widgetTheme instanceof WidgetSlotTheme slotTheme) {
+            RenderUtil.handleSlotOverlays(this, slotTheme);
         }
     }
 

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
@@ -78,7 +78,7 @@ public class CraftingOutputSlot extends Widget<CraftingOutputSlot> implements In
         RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
 
         if (isHovering() && widgetTheme instanceof WidgetSlotTheme slotTheme) {
-            RenderUtil.handleSlotOverlay(this, slotTheme);
+            RenderUtil.drawSlotOverlay(this, slotTheme);
         }
     }
 

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
@@ -21,6 +21,7 @@ import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
+import com.cleanroommc.modularui.theme.WidgetSlotTheme;
 import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.value.sync.IntSyncValue;
@@ -75,6 +76,10 @@ public class CraftingOutputSlot extends Widget<CraftingOutputSlot> implements In
         if (itemstack.isEmpty()) return;
 
         RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
+
+        if (isHovering() && widgetTheme instanceof WidgetSlotTheme slotTheme) {
+            RenderUtil.handleSlotOverlay(this, slotTheme);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
@@ -76,7 +76,11 @@ public class CraftingOutputSlot extends Widget<CraftingOutputSlot> implements In
         if (itemstack.isEmpty()) return;
 
         RenderUtil.renderItem(itemstack, 1, 1, 16, 16);
+    }
 
+    @Override
+    public void drawOverlay(ModularGuiContext context, WidgetTheme widgetTheme) {
+        super.drawOverlay(context, widgetTheme);
         if (isHovering() && widgetTheme instanceof WidgetSlotTheme slotTheme) {
             RenderUtil.drawSlotOverlay(this, slotTheme);
         }

--- a/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
@@ -62,7 +62,7 @@ public class RecipeMemorySlot extends Widget<RecipeMemorySlot> implements Intera
         }
 
         if (isHovering() && widgetTheme instanceof WidgetSlotTheme slotTheme) {
-            RenderUtil.handleSlotOverlay(this, slotTheme);
+            RenderUtil.drawSlotOverlay(this, slotTheme);
         }
     }
 

--- a/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
@@ -60,7 +60,11 @@ public class RecipeMemorySlot extends Widget<RecipeMemorySlot> implements Intera
             GTGuiTextures.RECIPE_LOCK.draw(context, 10, 1, 8, 8, widgetTheme);
             GlStateManager.enableDepth();
         }
+    }
 
+    @Override
+    public void drawOverlay(ModularGuiContext context, WidgetTheme widgetTheme) {
+        super.drawOverlay(context, widgetTheme);
         if (isHovering() && widgetTheme instanceof WidgetSlotTheme slotTheme) {
             RenderUtil.drawSlotOverlay(this, slotTheme);
         }

--- a/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/RecipeMemorySlot.java
@@ -13,6 +13,7 @@ import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
 import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
+import com.cleanroommc.modularui.theme.WidgetSlotTheme;
 import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.widget.Widget;
@@ -58,6 +59,10 @@ public class RecipeMemorySlot extends Widget<RecipeMemorySlot> implements Intera
             GlStateManager.disableDepth();
             GTGuiTextures.RECIPE_LOCK.draw(context, 10, 1, 8, 8, widgetTheme);
             GlStateManager.enableDepth();
+        }
+
+        if (isHovering() && widgetTheme instanceof WidgetSlotTheme slotTheme) {
+            RenderUtil.handleSlotOverlay(this, slotTheme);
         }
     }
 

--- a/src/main/java/gregtech/mixins/mui2/ItemSlotMixin.java
+++ b/src/main/java/gregtech/mixins/mui2/ItemSlotMixin.java
@@ -1,0 +1,63 @@
+package gregtech.mixins.mui2;
+
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.item.ItemStack;
+
+import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
+import com.cleanroommc.modularui.value.sync.ItemSlotSH;
+import com.cleanroommc.modularui.widgets.ItemSlot;
+import mezz.jei.Internal;
+import mezz.jei.gui.ghost.GhostIngredientDrag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Debug;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+// TODO: remove once MUI PR 146 merges into a release we use
+@Debug(export = true)
+@Mixin(value = ItemSlot.class)
+public abstract class ItemSlotMixin {
+
+    @Shadow(remap = false)
+    private ItemSlotSH syncHandler;
+
+    @Redirect(method = "draw",
+              at = @At(value = "INVOKE",
+                       target = "Lcom/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin;hasDraggingGhostIngredient()Z"),
+              remap = false)
+    private boolean onlyHighlightOnValidDrag() {
+        GhostIngredientDrag<?> ingredientDrag = ModularUIJeiPlugin.getGhostDrag();
+        if (ingredientDrag == null) return false;
+        Object ingredient = ingredientDrag.getIngredient();
+        if (ingredient == null) return false;
+        return gregTech$castIfItemStack(ingredient) != null;
+    }
+
+    /**
+     * @author Zorbatron
+     * @reason Add support for dragging enchanted books from JEI
+     */
+    @Overwrite(remap = false)
+    public @Nullable ItemStack castGhostIngredientIfValid(@NotNull Object ingredient) {
+        return gregTech$castIfItemStack(ingredient);
+    }
+
+    @Unique
+    private @Nullable ItemStack gregTech$castIfItemStack(Object ingredient) {
+        if (ingredient instanceof EnchantmentData enchantmentData) {
+            ingredient = Internal.getIngredientRegistry().getIngredientHelper(enchantmentData)
+                    .getCheatItemStack(enchantmentData);
+        }
+
+        if (ingredient instanceof ItemStack itemStack) {
+            return syncHandler.isItemValid(itemStack) ? itemStack : null;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/gregtech/mixins/mui2/ModularUIJeiPluginMixin.java
+++ b/src/main/java/gregtech/mixins/mui2/ModularUIJeiPluginMixin.java
@@ -1,0 +1,23 @@
+package gregtech.mixins.mui2;
+
+import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
+import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
+import mezz.jei.config.Config;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ModularUIJeiPlugin.class)
+public class ModularUIJeiPluginMixin {
+
+    // TODO: remove this mixin when the fix from Brachy makes it into a release we use
+    @Inject(method = "hoveringOverIngredient", at = @At(value = "HEAD"), remap = false, cancellable = true)
+    private static void cancelIfCheatsOn(JeiGhostIngredientSlot<?> ingredientSlot,
+                                         CallbackInfoReturnable<Boolean> cir) {
+        if (Config.isCheatItemsEnabled()) {
+            cir.setReturnValue(false);
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/java/gregtech/mixins/mui2/ModularUIJeiPluginMixin.java
+++ b/src/main/java/gregtech/mixins/mui2/ModularUIJeiPluginMixin.java
@@ -17,7 +17,6 @@ public class ModularUIJeiPluginMixin {
                                          CallbackInfoReturnable<Boolean> cir) {
         if (Config.isCheatItemsEnabled()) {
             cir.setReturnValue(false);
-            cir.cancel();
         }
     }
 }

--- a/src/main/resources/mixins.gregtech.mui2.json
+++ b/src/main/resources/mixins.gregtech.mui2.json
@@ -11,7 +11,8 @@
     "ModularPanelMixin"
   ],
   "client": [
-    "LangKeyMixin"
+    "LangKeyMixin",
+    "ModularUIJeiPluginMixin"
   ],
   "server": []
 }

--- a/src/main/resources/mixins.gregtech.mui2.json
+++ b/src/main/resources/mixins.gregtech.mui2.json
@@ -12,7 +12,8 @@
   ],
   "client": [
     "LangKeyMixin",
-    "ModularUIJeiPluginMixin"
+    "ModularUIJeiPluginMixin",
+    "ItemSlotMixin"
   ],
   "server": []
 }


### PR DESCRIPTION
## What
- Fixes the green JEI overlay when an ingredient is hovered over when cheat mode is enabled.
- Allows dragging enchanted books into phantom slots.
- Fixes the Crafting Station slots not having an overlay when you hover over them.

## Outcome
Phantom slot overlays look nicer and have more function

## Additional Information
Remind me to remove the mixins once https://github.com/CleanroomMC/ModularUI/commit/5af9d832fdc76d009dd5418aff88bdcce2fa9159 and https://github.com/CleanroomMC/ModularUI/pull/146 make it into a release that we use.
