### PR TITLE
Fix Packet Data Memory Leak

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -60,9 +60,6 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity implemen
         IBlockState blockState = getBlockType().getStateFromMeta(getBlockMetadata());
         if (canNotifyWorld()) {
             world.notifyBlockUpdate(getPos(), blockState, blockState, 0);
-        } else if (!updates.isEmpty()) {
-            // cannot send, so clear only if there's any data
-            updates.clear();
         }
     }
 
@@ -71,7 +68,13 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity implemen
         if (updates.size() > 10 && getWorld() instanceof WorldServer server) {
             int x = getPos().getX() >> 4;
             int z = getPos().getZ() >> 4;
-            return server.getPlayerChunkMap().contains(x, z);
+            if (server.getPlayerChunkMap().contains(x, z)) {
+                return true;
+            } else {
+                // cannot send, so clear
+                updates.clear();
+                return false;
+            }
         }
         return false;
     }

--- a/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
+++ b/src/main/java/gregtech/api/metatileentity/SyncedTileEntityBase.java
@@ -60,18 +60,18 @@ public abstract class SyncedTileEntityBase extends BlockStateTileEntity implemen
         IBlockState blockState = getBlockType().getStateFromMeta(getBlockMetadata());
         if (canNotifyWorld()) {
             world.notifyBlockUpdate(getPos(), blockState, blockState, 0);
-        } else {
-            // cannot send, so clear
+        } else if (!updates.isEmpty()) {
+            // cannot send, so clear only if there's any data
             updates.clear();
         }
     }
 
     private boolean canNotifyWorld() {
-        if (getWorld() instanceof WorldServer server) {
+        // short circuit with packet size to avoid too many hash lookups and instanceof casts
+        if (updates.size() > 10 && getWorld() instanceof WorldServer server) {
             int x = getPos().getX() >> 4;
             int z = getPos().getZ() >> 4;
-            // short circuit with packet size to avoid too many hash lookups
-            return updates.size() < 10 || server.getPlayerChunkMap().contains(x, z);
+            return server.getPlayerChunkMap().contains(x, z);
         }
         return false;
     }

--- a/src/main/java/gregtech/api/network/PacketDataList.java
+++ b/src/main/java/gregtech/api/network/PacketDataList.java
@@ -5,6 +5,8 @@ import net.minecraft.nbt.NBTTagList;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+
 /**
  * An optimised data structure backed by two arrays.
  * This is essentially equivalent to <code>List<Pair<Integer, byte[]>></code>, but more efficient.
@@ -84,9 +86,8 @@ public class PacketDataList {
      * remove all data packets
      */
     public void clear() {
-        for (int i = 0; i < this.size; i++) {
-            this.data[i] = null;
-        }
+        Arrays.fill(this.discriminators, 0);
+        Arrays.fill(this.data, null);
         this.size = 0;
     }
 


### PR DESCRIPTION
## What
Fixes a server-side issue where packet data will build up when in chunks *outside of render distance* but *force-loaded* (with FTB utils, etc).

## Implementation Details
checks the player chunk map if it contains the chunk pos of the updating TE
checks the packet size to reduce hash lookups
clears discriminator data in packet data list as well as byte data and size

## Outcome
packets no longer eat your ram
