### PR TITLE
Fix CCL NPE caused from an improper texture loading order

### DIFF
--- a/src/main/java/gregtech/client/ClientProxy.java
+++ b/src/main/java/gregtech/client/ClientProxy.java
@@ -133,8 +133,8 @@ public class ClientProxy extends CommonProxy {
     public static void textureStitchPre(@NotNull TextureStitchEvent.Pre event) {
         TextureMap map = event.getMap();
         GTFluidRegistration.INSTANCE.registerSprites(map);
-        PipeRenderer.initializeRestrictor(map);
         Textures.register(map);
+        PipeRenderer.initializeRestrictor(map);
         CableRenderer.INSTANCE.registerIcons(map);
         FluidPipeRenderer.INSTANCE.registerIcons(map);
         ItemPipeRenderer.INSTANCE.registerIcons(map);


### PR DESCRIPTION
## What
Fixes an NPE in CCL when shuttering pipes due to the little arrow image being registered to `PipeRenderer#RESTRICTOR_MAP` before the texture was actually loaded, which filled it with `null`s.

## Implementation Details
Move `PipeRenderer#initializeRestrictor()` after `Textures#register()`.

## Outcome
Pipes can be shuttered without making the pipes invisible and CCL exploding :carbomb:.
