### PR TITLE
Fix inverted condition in OC check

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -1123,7 +1123,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable,
     public void setMaximumOverclockVoltage(final long overclockVoltage) {
         this.overclockVoltage = overclockVoltage;
         // Overclocking is not allowed if the passed voltage is <= LV
-        this.allowOverclocking = (overclockVoltage <= GTValues.V[GTValues.LV]);
+        this.allowOverclocking = (overclockVoltage > GTValues.V[GTValues.LV]);
     }
 
     /**


### PR DESCRIPTION
Was `<=`, should have been `>`, as the comment above implies