### PR TITLE
Fix ClassNotFound exceptions on servers due to client only class being accessed in cover code

### DIFF
--- a/src/main/java/gregtech/common/covers/ender/CoverAbstractEnderLink.java
+++ b/src/main/java/gregtech/common/covers/ender/CoverAbstractEnderLink.java
@@ -212,9 +212,9 @@ public abstract class CoverAbstractEnderLink<T extends VirtualEntry> extends Cov
                 .coverChildrenHeight()
                 .child(new ToggleButton()
                         .value(new BooleanSyncValue(this::isIoEnabled, this::setIoEnabled))
-                        .overlay(IKey.dynamic(() -> IKey.lang(this.ioEnabled ?
+                        .overlay(IKey.lang(() -> this.ioEnabled ?
                                 "behaviour.soft_hammer.enabled" :
-                                "behaviour.soft_hammer.disabled").get())
+                                "behaviour.soft_hammer.disabled")
                                 .color(Color.WHITE.darker(1)))
                         .widthRel(0.6f)
                         .left(0));

--- a/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/BaseFilterContainer.java
@@ -97,7 +97,7 @@ public abstract class BaseFilterContainer extends ItemStackHandler {
 
     protected abstract boolean isItemValid(ItemStack stack);
 
-    protected abstract String getFilterName();
+    protected abstract @NotNull IKey getFilterKey();
 
     @Override
     public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
@@ -244,7 +244,7 @@ public abstract class BaseFilterContainer extends ItemStackHandler {
                             }
                             return true;
                         }))
-                .child(IKey.dynamic(this::getFilterName)
+                .child(getFilterKey()
                         .color(CoverWithUI.UI_TEXT_COLOR)
                         .shadow(false)
                         .alignment(Alignment.CenterRight).asWidget()

--- a/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/FluidFilterContainer.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemStack;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -56,9 +57,9 @@ public class FluidFilterContainer extends BaseFilterContainer {
     }
 
     @Override
-    protected String getFilterName() {
-        return hasFilter() ?
-                getFilterStack().getDisplayName() :
-                IKey.lang("metaitem.fluid_filter.name").get();
+    protected @NotNull IKey getFilterKey() {
+        return IKey.lang(() -> hasFilter() ?
+                getFilterStack().getTranslationKey() + ".name" :
+                "metaitem.fluid_filter.name");
     }
 }

--- a/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
+++ b/src/main/java/gregtech/common/covers/filter/ItemFilterContainer.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -57,9 +58,9 @@ public class ItemFilterContainer extends BaseFilterContainer {
     }
 
     @Override
-    protected String getFilterName() {
-        return hasFilter() ?
-                getFilterStack().getDisplayName() :
-                IKey.lang("metaitem.item_filter.name").get();
+    protected @NotNull IKey getFilterKey() {
+        return IKey.lang(() -> hasFilter() ?
+                getFilterStack().getTranslationKey() + ".name" :
+                "metaitem.item_filter.name");
     }
 }


### PR DESCRIPTION
## What
Fixes `ClassNotFound` exceptions due to `LangKey#get` being inside a `DynamicKey` string supplier. `DynamicKey`'s constructor gets the string from the supplier to null check, but this ends up getting the result of the `LangKey` which has `ClientScreenHandler.getTicks()` in the `get()` method, which is annotated with `SideOnly(CLIENT)`.

## Implementation Details
Remove usage of dynamic keys in the ender cover code and change `BaseFilterContainer#getFilterName` to `getFilterKey` so a lang key can be returned directely.

## Outcome
You can use covers on servers.

## Additional Information
This affected conveyor and robot arm covers too
