### PR TITLE
Fix Alfheim lighting engine ram usage workaround with Alfheim 1.6

### DIFF
--- a/src/api/java/dev/redstudio/alfheim/lighting/LightingEngine.java
+++ b/src/api/java/dev/redstudio/alfheim/lighting/LightingEngine.java
@@ -1,0 +1,5 @@
+package dev.redstudio.alfheim.lighting;
+
+// stub class to appease javac
+public class LightingEngine {
+}

--- a/src/main/java/gregtech/api/util/world/DummyWorld.java
+++ b/src/main/java/gregtech/api/util/world/DummyWorld.java
@@ -15,6 +15,7 @@ import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 
+import dev.redstudio.alfheim.lighting.LightingEngine;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -115,5 +116,10 @@ public class DummyWorld extends World {
     @Method(modid = Mods.Names.ALFHEIM)
     public int alfheim$getLight(BlockPos pos, boolean checkNeighbors) {
         return 15;
+    }
+
+    @Method(modid = Mods.Names.ALFHEIM)
+    public LightingEngine getAlfheim$lightingEngine() {
+        return null;
     }
 }


### PR DESCRIPTION
## What
Fixes JEI not loading when Alfheim version 1.6 is loaded due to our method of forcing its lighting engine to not be used in our dummy worlds.

## Implementation Details
Alfheim 1.6 changes the lighting engine to be lazy-loaded (using a Lombok annotation for some reason), which causes an NPE if we simply set the lighting engine to `null`. This PR overrides the Lombok-generated getter to always return null, avoiding the issue, and keeps the old method of simply setting it to null around to keep compat with Alfheim <= 1.5.

## Outcome
JEI works when recent versions of Alfheim are installed.
Fixes #2775, supersedes #2837 and #2833

## Potential Compatibility Issues
None, hopefully
