### PR TITLE
Fix mtes aren't added to their small recipemap categories

### DIFF
--- a/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
+++ b/src/main/java/gregtech/integration/jei/JustEnoughItemsModule.java
@@ -363,7 +363,7 @@ public class JustEnoughItemsModule extends IntegrationSubmodule implements IModP
         }
         if (recipeMap.getSmallRecipeMap() != null) {
             registry.addRecipeCatalyst(metaTileEntity.getStackForm(),
-                    GTValues.MODID + ":" + recipeMap.getSmallRecipeMap().unlocalizedName);
+                    GTValues.MODID + "." + recipeMap.getSmallRecipeMap().unlocalizedName);
             return;
         }
 


### PR DESCRIPTION
## What
The `uniqueId` format is changed in `GTRecipeCategory` in this [commit](https://github.com/GregTechCEu/GregTech/commit/80f389d3344f3ea811fbe1b1f54127190c0b534d#diff-786330c773d657c8df06c366b8e1ad6a44063b49c902d7332c740b556ffd11abR62)
which isn't synced to `JustEnoughItemModule`