### PR TITLE
Fix two blocks missing in the cleanroom in-world preview

### DIFF
--- a/src/main/java/gregtech/client/renderer/handler/MultiblockPreviewRenderer.java
+++ b/src/main/java/gregtech/client/renderer/handler/MultiblockPreviewRenderer.java
@@ -123,7 +123,6 @@ public class MultiblockPreviewRenderer {
                         controllerPos = new BlockPos(x, y, z);
                         previewFacing = metaTE.getFrontFacing();
                         mte = (MultiblockControllerBase) metaTE;
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
## What
As we all know...

Just shouldn't assume the controller is always at the end of one aisle
Before:
<img width="1075" height="804" alt="image" src="https://github.com/user-attachments/assets/fd6fb278-7b99-4179-b2a3-23dc968e8c1d" />

After:
<img width="1088" height="862" alt="image" src="https://github.com/user-attachments/assets/b452ccbc-e8d5-4818-8e59-e70f5154de5e" />
