### PR TITLE
Fix regression in #2672 which made all GT material fluids unsearchable in JEI

### DIFF
--- a/src/main/java/gregtech/mixins/mui2/LangKeyMixin.java
+++ b/src/main/java/gregtech/mixins/mui2/LangKeyMixin.java
@@ -4,7 +4,6 @@ import com.cleanroommc.modularui.drawable.text.BaseKey;
 import com.cleanroommc.modularui.drawable.text.LangKey;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import org.jetbrains.annotations.NotNull;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -36,7 +35,6 @@ public abstract class LangKeyMixin extends BaseKey {
         return original.replace("/n", "\n");
     }
 
-    @Debug(export = true)
     @Inject(method = "<init>(Ljava/util/function/Supplier;Ljava/util/function/Supplier;)V",
             at = @At(value = "RETURN"))
     private void setTimeToNegativeOne(@NotNull Supplier<String> keySupplier, @NotNull Supplier<Object[]> argsSupplier,

--- a/src/main/java/gregtech/mixins/mui2/LangKeyMixin.java
+++ b/src/main/java/gregtech/mixins/mui2/LangKeyMixin.java
@@ -3,12 +3,22 @@ package gregtech.mixins.mui2;
 import com.cleanroommc.modularui.drawable.text.BaseKey;
 import com.cleanroommc.modularui.drawable.text.LangKey;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Supplier;
 
 // all this mixin does is switch newlines to the expected format
 @Mixin(value = LangKey.class, remap = false)
 public abstract class LangKeyMixin extends BaseKey {
+
+    @Shadow
+    private long time;
 
     @ModifyExpressionValue(method = "getFormatted",
                            at = @At(value = "INVOKE",
@@ -24,5 +34,13 @@ public abstract class LangKeyMixin extends BaseKey {
                                     target = "Lnet/minecraft/client/resources/I18n;format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;"))
     public String switchNewLines(String original) {
         return original.replace("/n", "\n");
+    }
+
+    @Debug(export = true)
+    @Inject(method = "<init>(Ljava/util/function/Supplier;Ljava/util/function/Supplier;)V",
+            at = @At(value = "RETURN"))
+    private void setTimeToNegativeOne(@NotNull Supplier<String> keySupplier, @NotNull Supplier<Object[]> argsSupplier,
+                                      CallbackInfo ci) {
+        time = -1;
     }
 }


### PR DESCRIPTION
## What
#2672 changed `GTFluid.GTMaterialFluid#getLocalizedName()` to call `getLocalizedKey().get()`. This works as it should during normal gameplay, but will always return `null` while minecraft is loading due to `LangKey` line 51 `this.time == ClientScreenHandler.getTicks()`. The `time` field starts at `0` but while MC is loading, `ClientScreenHandler.getTicks()` will also be `0` causing it to always return the uninitialized `string` cache. JEI creates its ingredient filter during loading, so it ends up having an empty string as the display name for all GT material fluids.

## Implementation Details
Simply sets the default `time` field in `LangKey` to `-1` instead of `0`, so it will properly translate the key while MC is loading. It will be set to 0 after the first translation is done, so the behavior is the same as before.

## Outcome
You can search for fluids in JEI again! :smiley: 

## Potential Compatibility Issues
Shouldn't be any.

Related MUI2 PR: CleanroomMC/ModularUI#159