### PR TITLE
Fix an empty tooltip on GT fluid slots that have no fluid

### DIFF
--- a/src/main/java/gregtech/api/mui/sync/GTFluidSyncHandler.java
+++ b/src/main/java/gregtech/api/mui/sync/GTFluidSyncHandler.java
@@ -41,6 +41,7 @@ public class GTFluidSyncHandler extends SyncHandler {
     private final IFluidTank tank;
     private Consumer<FluidStack> jeiHandler;
     private BooleanConsumer lockHandler;
+    private BooleanSupplier isLocked;
     private Supplier<FluidStack> lockedFluid;
     private FluidStack lastFluid;
     private FluidStack phantomFluid;
@@ -50,6 +51,8 @@ public class GTFluidSyncHandler extends SyncHandler {
     private BooleanSupplier showAmountInTooltip = () -> true;
     private BooleanSupplier showAmountOnSlot = () -> true;
     private BooleanSupplier drawAlwaysFull = () -> true;
+    @Nullable
+    private Consumer<@Nullable FluidStack> changeConsumer;
 
     public GTFluidSyncHandler(IFluidTank tank) {
         this.tank = tank;
@@ -57,8 +60,8 @@ public class GTFluidSyncHandler extends SyncHandler {
 
     @Override
     public void detectAndSendChanges(boolean init) {
-        var current = getFluid();
-        if (init || current == null || lastFluid == null || current.isFluidEqual(lastFluid)) {
+        FluidStack current = getFluid();
+        if (init || !GTUtility.areFluidsEqual(current, lastFluid)) {
             lastFluid = current == null ? null : current.copy();
             syncToClient(UPDATE_TANK, buffer -> NetworkUtils.writeFluidStack(buffer, current));
         } else if (lastFluid != null && current.amount != lastFluid.amount) {
@@ -84,11 +87,13 @@ public class GTFluidSyncHandler extends SyncHandler {
         });
     }
 
-    public GTFluidSyncHandler handleLocking(Supplier<FluidStack> lockedFluid, Consumer<FluidStack> jeiHandler,
-                                            BooleanConsumer lockHandler) {
+    public GTFluidSyncHandler handleLocking(@NotNull Supplier<FluidStack> lockedFluid,
+                                            @NotNull Consumer<FluidStack> jeiHandler,
+                                            @NotNull BooleanConsumer lockHandler, @NotNull BooleanSupplier isLocked) {
         this.lockedFluid = lockedFluid;
         this.jeiHandler = jeiHandler;
         this.lockHandler = lockHandler;
+        this.isLocked = isLocked;
         return this;
     }
 
@@ -194,6 +199,16 @@ public class GTFluidSyncHandler extends SyncHandler {
         return this.drawAlwaysFull.getAsBoolean();
     }
 
+    public void setChangeConsumer(@Nullable Consumer<@Nullable FluidStack> changeConsumer) {
+        this.changeConsumer = changeConsumer;
+    }
+
+    protected void onChange(@Nullable FluidStack fluidStack) {
+        if (changeConsumer != null) {
+            changeConsumer.accept(fluidStack);
+        }
+    }
+
     public @NotNull String getFormattedFluidAmount() {
         var tankFluid = this.tank.getFluid();
         return String.format("%,d", tankFluid == null ? 0 : tankFluid.amount);
@@ -220,7 +235,14 @@ public class GTFluidSyncHandler extends SyncHandler {
         return tankFluid == null ? IKey.EMPTY : KeyUtil.fluid(tankFluid);
     }
 
+    protected boolean shouldShowTooltip() {
+        if (getFluid() != null) return true;
+        return canLockFluid() && isLocked.getAsBoolean();
+    }
+
     public void handleTooltip(@NotNull RichTooltip tooltip) {
+        if (!shouldShowTooltip()) return;
+
         tooltip.addLine(getFluidNameKey());
 
         if (showAmountInTooltip()) {
@@ -249,9 +271,20 @@ public class GTFluidSyncHandler extends SyncHandler {
     public void readOnClient(int id, PacketBuffer buf) {
         switch (id) {
             case TRY_CLICK_CONTAINER -> replaceCursorItemStack(NetworkUtils.readItemStack(buf));
-            case UPDATE_TANK -> setFluid(NetworkUtils.readFluidStack(buf));
-            case UPDATE_AMOUNT -> setAmount(buf.readInt());
-            case LOCK_FLUID -> lockFluid(NetworkUtils.readFluidStack(buf), false);
+            case UPDATE_TANK -> {
+                FluidStack stack = NetworkUtils.readFluidStack(buf);
+                setFluid(stack);
+                onChange(stack);
+            }
+            case UPDATE_AMOUNT -> {
+                setAmount(buf.readInt());
+                onChange(getFluid());
+            }
+            case LOCK_FLUID -> {
+                lockFluid(NetworkUtils.readFluidStack(buf), false);
+                FluidStack stack = getFluid();
+                onChange(stack == null ? getLockedFluid() : stack);
+            }
         }
     }
 
@@ -545,7 +578,7 @@ public class GTFluidSyncHandler extends SyncHandler {
     }
 
     public boolean canLockFluid() {
-        return jeiHandler != null && lockHandler != null && lockedFluid != null;
+        return jeiHandler != null && lockHandler != null && lockedFluid != null && isLocked != null;
     }
 
     public void toggleLockFluid() {

--- a/src/main/java/gregtech/api/mui/sync/GTFluidSyncHandler.java
+++ b/src/main/java/gregtech/api/mui/sync/GTFluidSyncHandler.java
@@ -221,29 +221,25 @@ public class GTFluidSyncHandler extends SyncHandler {
 
     public @Nullable String getFluidLocalizedName() {
         var tankFluid = this.tank.getFluid();
-        if (tankFluid == null && canLockFluid())
-            tankFluid = this.lockedFluid.get();
+        if (tankFluid == null)
+            tankFluid = getLockedFluid();
 
         return tankFluid == null ? null : tankFluid.getLocalizedName();
     }
 
     public @NotNull IKey getFluidNameKey() {
         FluidStack tankFluid = tank.getFluid();
-        if (tankFluid == null && canLockFluid()) {
-            tankFluid = lockedFluid.get();
+        if (tankFluid == null) {
+            tankFluid = getLockedFluid();
         }
         return tankFluid == null ? IKey.EMPTY : KeyUtil.fluid(tankFluid);
     }
 
-    protected boolean shouldShowTooltip() {
-        if (getFluid() != null) return true;
-        return canLockFluid() && isLocked.getAsBoolean();
-    }
-
     public void handleTooltip(@NotNull RichTooltip tooltip) {
-        if (!shouldShowTooltip()) return;
-
-        tooltip.addLine(getFluidNameKey());
+        IKey nameKey = getFluidNameKey();
+        if (nameKey != IKey.EMPTY) {
+            tooltip.addLine(nameKey);
+        }
 
         if (showAmountInTooltip()) {
             tooltip.addLine(IKey.lang("gregtech.fluid.amount", getFluidAmount(), getCapacity()));

--- a/src/main/java/gregtech/api/mui/sync/GTFluidSyncHandler.java
+++ b/src/main/java/gregtech/api/mui/sync/GTFluidSyncHandler.java
@@ -61,7 +61,7 @@ public class GTFluidSyncHandler extends SyncHandler {
     @Override
     public void detectAndSendChanges(boolean init) {
         FluidStack current = getFluid();
-        if (init || !GTUtility.areFluidsEqual(current, lastFluid)) {
+        if (init || !GTUtility.areFluidStacksEqual(current, lastFluid)) {
             lastFluid = current == null ? null : current.copy();
             syncToClient(UPDATE_TANK, buffer -> NetworkUtils.writeFluidStack(buffer, current));
         } else if (lastFluid != null && current.amount != lastFluid.amount) {

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1023,4 +1023,10 @@ public class GTUtility {
         }
         return map.get(key.toWildcard());
     }
+
+    public static boolean areFluidsEqual(@Nullable FluidStack a, @Nullable FluidStack b) {
+        if (a == b) return true;
+        if (a == null) return false;
+        return a.isFluidEqual(b);
+    }
 }

--- a/src/main/java/gregtech/api/util/GTUtility.java
+++ b/src/main/java/gregtech/api/util/GTUtility.java
@@ -1024,7 +1024,7 @@ public class GTUtility {
         return map.get(key.toWildcard());
     }
 
-    public static boolean areFluidsEqual(@Nullable FluidStack a, @Nullable FluidStack b) {
+    public static boolean areFluidStacksEqual(@Nullable FluidStack a, @Nullable FluidStack b) {
         if (a == b) return true;
         if (a == null) return false;
         return a.isFluidEqual(b);

--- a/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/multiblockpart/MetaTileEntityFluidHatch.java
@@ -291,7 +291,7 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
                 setLocked(fluidStack != null);
                 this.lockedFluid = fluidStack;
                 this.fluidTank.onContentsChanged();
-            }, this::setLocked);
+            }, this::setLocked, this::isLocked);
         }
 
         return GTGuis.createPanel(this, 176, 166)

--- a/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/GTFluidSlot.java
@@ -38,11 +38,7 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
     private boolean disableBackground = false;
 
     public GTFluidSlot() {
-        tooltip().setAutoUpdate(true).titleMargin();
-        tooltipBuilder(tooltip -> {
-            if (!isSynced()) return;
-            syncHandler.handleTooltip(tooltip);
-        });
+        tooltip().titleMargin();
     }
 
     public static GTFluidSyncHandler sync(IFluidTank tank) {
@@ -57,6 +53,8 @@ public final class GTFluidSlot extends Widget<GTFluidSlot> implements Interactab
         if (syncHandler.canLockFluid() || syncHandler.isPhantom()) {
             getContext().getJeiSettings().addJeiGhostIngredientSlot(this);
         }
+        tooltipBuilder(syncHandler::handleTooltip);
+        syncHandler.setChangeConsumer($ -> markTooltipDirty());
     }
 
     public GTFluidSlot syncHandler(IFluidTank fluidTank) {


### PR DESCRIPTION
## What
In #2672, I accidentally made it so if a GT fluid slot had no fluid, it would insert an empty key into the tooltip instead of doing nothing which made it so empty slots would have a small black dot near the cursor.
Additionally makes it so these only happen when the fluid actually changes:
- rebuilding the tooltip
- syncing the fluid server -> client