### PR TITLE
Fix incorrect annotation usage for Module Container scanning

### DIFF
--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -421,7 +421,7 @@ public final class ModuleManager implements IModuleManager {
         for (ASMDataTable.ASMData data : dataSet) {
             try {
                 Class<?> clazz = Class.forName(data.getClassName());
-                if (ModuleContainer.class.isAssignableFrom(clazz)) {
+                if (IModuleContainer.class.isAssignableFrom(clazz)) {
                     registerContainer((IModuleContainer) clazz.getConstructor().newInstance());
                 } else {
                     logger.error("Module Container Class {} is not an instanceof IModuleContainer", clazz.getName());

--- a/src/main/java/gregtech/modules/ModuleManager.java
+++ b/src/main/java/gregtech/modules/ModuleManager.java
@@ -421,7 +421,7 @@ public final class ModuleManager implements IModuleManager {
         for (ASMDataTable.ASMData data : dataSet) {
             try {
                 Class<?> clazz = Class.forName(data.getClassName());
-                if (IGregTechModule.class.isAssignableFrom(clazz)) {
+                if (ModuleContainer.class.isAssignableFrom(clazz)) {
                     registerContainer((IModuleContainer) clazz.getConstructor().newInstance());
                 } else {
                     logger.error("Module Container Class {} is not an instanceof IModuleContainer", clazz.getName());


### PR DESCRIPTION
## What

This PR fixes the problem about `discoverContainers` method in `ModuleContainer` class.

## Implementation Details

In the original implementation, the `discoverContainers` method checked `IGregTechModule` interface:

```java
if (IGregTechModule.class.isAssignableFrom(clazz)) {
    registerContainer((IModuleContainer) clazz.getConstructor().newInstance());
} else {
    // ...
}
```
But this method is used to scan all `ModuleContainer` annotation (with `IModuleContainer` interface), so it should be:

```java
if (IModuleContainer.class.isAssignableFrom(clazz)) {
    registerContainer((IModuleContainer) clazz.getConstructor().newInstance());
} else {
    // ...
}
```

Then the method `registerContainer` can register the `ModuleContainer` well.