### PR TITLE
Check OptiFine Shader at real time

### DIFF
--- a/src/api/java/net/optifine/shaders/Shaders.java
+++ b/src/api/java/net/optifine/shaders/Shaders.java
@@ -1,0 +1,6 @@
+package net.optifine.shaders;
+
+/// Adapted and minimized from OptiFine
+public class Shaders {
+    public static boolean shaderPackLoaded;
+}

--- a/src/main/java/gregtech/api/util/Mods.java
+++ b/src/main/java/gregtech/api/util/Mods.java
@@ -4,17 +4,19 @@ import gregtech.api.GTValues;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.optifine.shaders.Shaders;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -79,22 +81,25 @@ public enum Mods {
     Vintagium(Names.VINTAGIUM),
     Alfheim(Names.ALFHEIM),
 
-    // Special Optifine handler, but consolidated here for simplicity
-    Optifine(null) {
+    OptiFine(null) {
 
         @Override
         public boolean isModLoaded() {
             if (this.modLoaded == null) {
-                try {
-                    Class<?> c = Class.forName("net.optifine.shaders.Shaders");
-                    Field f = c.getDeclaredField("shaderPackLoaded");
-                    f.setAccessible(true);
-                    this.modLoaded = f.getBoolean(null);
-                } catch (Exception ignored) {
-                    this.modLoaded = false;
-                }
+                this.modLoaded = FMLCommonHandler.instance().getSide().isClient() &&
+                        FMLClientHandler.instance().hasOptifine();
             }
             return this.modLoaded;
+        }
+    },
+
+    // Special Optifine shader handler, but consolidated here for simplicity
+    ShadersMod(null) {
+
+        @Override
+        public boolean isModLoaded() {
+            // Check shader pack state at real time instead of caching it
+            return OptiFine.isModLoaded() && Shaders.shaderPackLoaded;
         }
     };
 

--- a/src/main/java/gregtech/client/model/pipeline/VertexLighterFlatSpecial.java
+++ b/src/main/java/gregtech/client/model/pipeline/VertexLighterFlatSpecial.java
@@ -134,7 +134,7 @@ public class VertexLighterFlatSpecial extends VertexLighterFlat {
             updateColor(normal[v], color[v], x, y, z, tint, multiplier);
 
             // When enabled this causes the rendering to be black with Optifine
-            if (!Mods.Optifine.isModLoaded() && diffuse) {
+            if (!Mods.ShadersMod.isModLoaded() && diffuse) {
                 float d = LightUtil.diffuseLight(normal[v][0], normal[v][1], normal[v][2]);
                 for (int i = 0; i < 3; i++) {
                     color[v][i] *= d;

--- a/src/main/java/gregtech/client/model/pipeline/VertexLighterSmoothAoSpecial.java
+++ b/src/main/java/gregtech/client/model/pipeline/VertexLighterSmoothAoSpecial.java
@@ -15,7 +15,7 @@ public class VertexLighterSmoothAoSpecial extends VertexLighterFlatSpecial {
 
     @Override
     protected void updateLightmap(float[] normal, float[] lightmap, float x, float y, float z) {
-        if (Mods.Optifine.isModLoaded()) {
+        if (Mods.ShadersMod.isModLoaded()) {
             super.updateLightmap(normal, lightmap, x, y, z);
             return;
         }
@@ -28,7 +28,7 @@ public class VertexLighterSmoothAoSpecial extends VertexLighterFlatSpecial {
     protected void updateColor(float[] normal, float[] color, float x, float y, float z, float tint, int multiplier) {
         super.updateColor(normal, color, x, y, z, tint, multiplier);
 
-        if (Mods.Optifine.isModLoaded()) {
+        if (Mods.ShadersMod.isModLoaded()) {
             return;
         }
 
@@ -146,7 +146,7 @@ public class VertexLighterSmoothAoSpecial extends VertexLighterFlatSpecial {
 
     @Override
     public void updateBlockInfo() {
-        if (Mods.Optifine.isModLoaded()) {
+        if (Mods.ShadersMod.isModLoaded()) {
             super.updateBlockInfo();
             return;
         }

--- a/src/main/java/gregtech/client/utils/BloomEffectUtil.java
+++ b/src/main/java/gregtech/client/utils/BloomEffectUtil.java
@@ -83,7 +83,7 @@ public class BloomEffectUtil {
      */
     @Contract("null -> _; !null -> !null")
     public static BlockRenderLayer getEffectiveBloomLayer(BlockRenderLayer fallback) {
-        return Mods.Optifine.isModLoaded() ? fallback : bloom;
+        return Mods.ShadersMod.isModLoaded() ? fallback : bloom;
     }
 
     /**
@@ -115,7 +115,7 @@ public class BloomEffectUtil {
      */
     @Contract("_, null -> _; _, !null -> !null")
     public static BlockRenderLayer getEffectiveBloomLayer(boolean isBloomActive, BlockRenderLayer fallback) {
-        return Mods.Optifine.isModLoaded() || !isBloomActive ? fallback : bloom;
+        return Mods.ShadersMod.isModLoaded() || !isBloomActive ? fallback : bloom;
     }
 
     /**
@@ -253,7 +253,7 @@ public class BloomEffectUtil {
                                                         @NotNull IBloomEffect render,
                                                         @Nullable Predicate<BloomRenderTicket> validityChecker,
                                                         @Nullable Supplier<World> worldContext) {
-        if (Mods.Optifine.isModLoaded()) return BloomRenderTicket.INVALID;
+        if (Mods.ShadersMod.isModLoaded()) return BloomRenderTicket.INVALID;
         BloomRenderTicket ticket = new BloomRenderTicket(setup, bloomType, render, validityChecker, worldContext);
         BLOOM_RENDER_LOCK.lock();
         try {
@@ -302,7 +302,7 @@ public class BloomEffectUtil {
                                             @NotNull Entity entity) {
         Minecraft.getMinecraft().profiler.endStartSection("BTLayer");
 
-        if (Mods.Optifine.isModLoaded()) {
+        if (Mods.ShadersMod.isModLoaded()) {
             return renderGlobal.renderBlockLayer(blockRenderLayer, partialTicks, pass, entity);
         }
 

--- a/src/main/java/gregtech/client/utils/CTMHooks.java
+++ b/src/main/java/gregtech/client/utils/CTMHooks.java
@@ -36,7 +36,7 @@ public class CTMHooks {
     public static ThreadLocal<Boolean> ENABLE = new ThreadLocal<>();
 
     public static boolean checkLayerWithOptiFine(boolean canRenderInLayer, byte layers, BlockRenderLayer layer) {
-        if (Mods.Optifine.isModLoaded()) {
+        if (Mods.ShadersMod.isModLoaded()) {
             if (canRenderInLayer) {
                 if (layer == BloomEffectUtil.getBloomLayer()) return false;
             } else if ((layers >> BloomEffectUtil.getBloomLayer().ordinal() & 1) == 1 &&
@@ -50,7 +50,7 @@ public class CTMHooks {
     public static List<BakedQuad> getQuadsWithOptiFine(List<BakedQuad> ret, BlockRenderLayer layer,
                                                        IBakedModel bakedModel, IBlockState state, EnumFacing side,
                                                        long rand) {
-        if (Mods.Optifine.isModLoaded() && CTMHooks.ENABLE.get() == null) {
+        if (Mods.ShadersMod.isModLoaded() && CTMHooks.ENABLE.get() == null) {
             if (layer == BloomEffectUtil.getBloomLayer()) {
                 return Collections.emptyList();
             } else if (layer == BloomEffectUtil.getEffectiveBloomLayer()) {

--- a/src/main/java/gregtech/client/utils/DepthTextureUtil.java
+++ b/src/main/java/gregtech/client/utils/DepthTextureUtil.java
@@ -40,7 +40,7 @@ public class DepthTextureUtil {
     private static int lastWidth, lastHeight;
 
     private static boolean shouldRenderDepthTexture() {
-        return lastBind && !Mods.Optifine.isModLoaded() && ConfigHolder.client.hookDepthTexture &&
+        return lastBind && !Mods.ShadersMod.isModLoaded() && ConfigHolder.client.hookDepthTexture &&
                 OpenGlHelper.isFramebufferEnabled();
     }
 


### PR DESCRIPTION
## What
At the moment the `Mods#Optifine` checks whether shaderpack is active by reflection, the result is cached and never changed afterwards.

https://github.com/GregTechCEu/GregTech/blob/3fc7f4232bb26adfbff5f28ba5d41ac59a7cca9b/src/main/java/gregtech/api/util/Mods.java#L82-L99

This results in issues when players turn shaders on/off *after* the cache is created. In the case where players disabled shaders, the bloom effect won't come back (since they still think the shader is on from the cached value); and in the other case where the shader is turned off afterwards, the game will come to a crash.

This PR make it so the shaderpack load state is checked at real-time, which should potentially fix the issues mentioned above.
