### PR TITLE
Fix Large Boiler Preview

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -288,8 +288,9 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
                 .where('S', selfPredicate())
                 .where('P', states(boilerType.pipeState))
                 .where('X', states(boilerType.fireboxState).setMinGlobalLimited(4)
-                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1))
-                        .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(1))
+                        .or(abilities(MultiblockAbility.IMPORT_FLUIDS).setMinGlobalLimited(1, 1))
+                        // setting this to max 2 makes the import fluids max 2 for some reason
+                        .or(abilities(MultiblockAbility.IMPORT_ITEMS).setMaxGlobalLimited(2, 1))
                         .or(autoAbilities())) // muffler, maintenance
                 .where('C', states(boilerType.casingState).setMinGlobalLimited(20)
                         .or(abilities(MultiblockAbility.EXPORT_FLUIDS).setMinGlobalLimited(1)))


### PR DESCRIPTION
## What
Fixes the JEI preview for the Large Boilers due to an oversight from #2420. Since fluid hatches have the IMPORT_ITEMS ability, they count towards the max limit and conflict with the IMPORT_FLUIDS ability predicate. The better and ideal solution (i think) would require a larger rework and discussion on ability predicates.

## Implementation Details
the max global count for `IMPORT_ITEMS` to two
set preview count for `IMPORT_ITEMS` and `IMPORT_FLUIDS` to 1

## Outcome
Large Boiler is now formed correectly in the JEI preview
