### PR TITLE
Fix surface populator only generates in one of the chunk quadrants.

### DIFF
--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceBlockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceBlockPopulator.java
@@ -57,10 +57,14 @@ public class SurfaceBlockPopulator implements VeinChunkPopulator {
                               GridEntryInfo gridEntryInfo) {
         int stonesCount = minIndicatorAmount + (minIndicatorAmount >= maxIndicatorAmount ? 0 :
                 random.nextInt(maxIndicatorAmount - minIndicatorAmount));
+
+        int baseX = chunkX * 16 + 8;
+        int baseZ = chunkZ * 16 + 8;
+
         if (stonesCount > 0 && world.getWorldType() != WorldType.FLAT) {
             for (int i = 0; i < stonesCount; i++) {
-                int randomX = chunkX * 16 + random.nextInt(8);
-                int randomZ = chunkZ * 16 + random.nextInt(8);
+                int randomX = baseX + random.nextInt(16);
+                int randomZ = baseZ + random.nextInt(16);
 
                 boolean successful = generateSurfaceBlock(world, new BlockPos(randomX, 0, randomZ));
 

--- a/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
+++ b/src/main/java/gregtech/api/worldgen/populator/SurfaceRockPopulator.java
@@ -99,8 +99,8 @@ public class SurfaceRockPopulator implements VeinChunkPopulator {
             int baseZ = chunkZ * 16 + 8;
 
             for (int i = 0; i < stonesCount; i++) {
-                int randomX = baseX + random.nextInt(8);
-                int randomZ = baseZ + random.nextInt(8);
+                int randomX = baseX + random.nextInt(16);
+                int randomZ = baseZ + random.nextInt(16);
 
                 generateSurfaceRock(world, new BlockPos(randomX, 0, randomZ));
 


### PR DESCRIPTION
## What
<img width="942" height="1368" alt="image" src="https://github.com/user-attachments/assets/91a9be89-3762-4140-b8f5-95be705d594b" />

## Implementation Details
Check commits, quite simple.

## Outcome
See title,

## Potential Compatibility Issues
I cannot manage to make `FTBI: R` generate the overworld, so IDK if the new offset logic in `SurfaceBlockPopulator` works.
